### PR TITLE
[WFCORE-4166] HttpListenerRegistryService is not exposed via a capability

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
@@ -55,8 +55,8 @@ import org.jboss.as.host.controller.HostControllerEnvironment;
 import org.jboss.as.host.controller.HostControllerService;
 import org.jboss.as.host.controller.resources.HttpManagementResourceDefinition;
 import org.jboss.as.network.NetworkInterfaceBinding;
-import org.jboss.as.remoting.HttpListenerRegistryService;
 import org.jboss.as.remoting.RemotingHttpUpgradeService;
+import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementChannelRegistryService;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ExternalManagementRequestExecutor;
@@ -145,7 +145,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
                         NetworkInterfaceBinding.class, service.getSecureInterfaceInjector(), secureInterfaceName)
                 .addDependency(DomainModelControllerService.SERVICE_NAME, ModelController.class, service.getModelControllerInjector())
                 .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, service.getControlledProcessStateServiceInjector())
-                .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, service.getListenerRegistry())
+                .addDependency(RemotingServices.HTTP_LISTENER_REGISTRY, ListenerRegistry.class, service.getListenerRegistry())
                 .addDependency(requestProcessorName, ManagementHttpRequestProcessor.class, service.getRequestProcessorValue())
                 .addDependency(ManagementWorkerService.SERVICE_NAME, XnioWorker.class, service.getWorker())
                 .addDependency(ExternalManagementRequestExecutor.SERVICE_NAME, Executor.class, service.getManagementExecutor())

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Capabilities.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Capabilities.java
@@ -23,10 +23,16 @@
 package org.jboss.as.remoting;
 
 /**
+ * Class to hold capabilities provided by and required by resources within this package.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 final class Capabilities {
+    static final String HTTP_LISTENER_REGISTRY_CAPABILITY_NAME = "org.wildfly.remoting.http-listener-registry";
+
+    static final String REMOTING_ENDPOINT_CAPABILITY_NAME = "org.wildfly.remoting.endpoint";
+
+    static final String IO_WORKER_CAPABILITY_NAME = "org.wildfly.io.worker";
 
     static final String AUTHENTICATION_CONTEXT_CAPABILITY = "org.wildfly.security.authentication-context";
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpListenerRegistryService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpListenerRegistryService.java
@@ -17,10 +17,12 @@ import org.jboss.msc.service.StopContext;
  */
 public class HttpListenerRegistryService implements Service<ListenerRegistry> {
 
+    @Deprecated
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("http", "listener", "registry");
 
     public static void install(final ServiceTarget serviceTarget) {
-        serviceTarget.addService(SERVICE_NAME, new HttpListenerRegistryService())
+        serviceTarget.addService(RemotingServices.HTTP_LISTENER_REGISTRY, new HttpListenerRegistryService())
+                .addAliases(SERVICE_NAME)
                 .install();
     }
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
@@ -117,7 +117,7 @@ public class RemotingHttpUpgradeService implements Service<RemotingHttpUpgradeSe
         ServiceBuilder<RemotingHttpUpgradeService> serviceBuilder = serviceTarget.addService(UPGRADE_SERVICE_NAME.append(remotingConnectorName), service)
                 .setInitialMode(ServiceController.Mode.PASSIVE)
                 .addDependency(HTTP_UPGRADE_REGISTRY.append(httpConnectorName), ChannelUpgradeHandler.class, service.injectedRegistry)
-                .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, service.listenerRegistry)
+                .addDependency(RemotingServices.HTTP_LISTENER_REGISTRY, ListenerRegistry.class, service.listenerRegistry)
                 .addDependency(endpointName, Endpoint.class, service.injectedEndpoint);
 
         if (securityRealm != null) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.RemotingSubsystemRootResource.HTTP_LISTENER_REGISTRY_CAPABILITY;
+import static org.jboss.as.remoting.RemotingSubsystemRootResource.REMOTING_ENDPOINT_CAPABILITY;
+
 import javax.net.ssl.SSLContext;
 
 import org.jboss.as.controller.OperationContext;
@@ -39,6 +42,8 @@ import org.xnio.StreamConnection;
 import org.xnio.XnioWorker;
 import org.xnio.channels.AcceptingChannel;
 
+import io.undertow.server.ListenerRegistry;
+
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -49,13 +54,15 @@ public class RemotingServices {
     public static final ServiceName REMOTING_BASE = ServiceName.JBOSS.append("remoting");
 
     /** The name of the endpoint service installed by the remoting subsystem.  */
-    public static final ServiceName SUBSYSTEM_ENDPOINT = RemotingSubsystemRootResource.REMOTING_ENDPOINT_CAPABILITY.getCapabilityServiceName(Endpoint.class);//REMOTING_BASE.append("endpoint", "subsystem");
+    public static final ServiceName SUBSYSTEM_ENDPOINT = REMOTING_ENDPOINT_CAPABILITY.getCapabilityServiceName(Endpoint.class);//REMOTING_BASE.append("endpoint", "subsystem");
 
     /** The base name of the connector services */
     private static final ServiceName CONNECTOR_BASE = REMOTING_BASE.append("connector");
 
     /** The base name of the stream server services */
     private static final ServiceName SERVER_BASE = REMOTING_BASE.append("server");
+
+    public static final ServiceName HTTP_LISTENER_REGISTRY = HTTP_LISTENER_REGISTRY_CAPABILITY.getCapabilityServiceName(ListenerRegistry.class);
 
     /**
      * Create the service name for a connector

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
@@ -23,6 +23,8 @@
 package org.jboss.as.remoting;
 
 
+import static org.jboss.as.remoting.Capabilities.IO_WORKER_CAPABILITY_NAME;
+import static org.jboss.as.remoting.RemotingSubsystemRootResource.REMOTING_ENDPOINT_CAPABILITY;
 import static org.jboss.as.remoting.RemotingSubsystemRootResource.WORKER;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -81,8 +83,8 @@ class RemotingSubsystemAdd extends AbstractAddStepHandler {
             }
         }
 
-        context.getCapabilityServiceTarget().addCapability(RemotingSubsystemRootResource.REMOTING_ENDPOINT_CAPABILITY, endpointService)
-                .addCapabilityRequirement(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, XnioWorker.class, endpointService.getWorker(), workerName)
+        context.getCapabilityServiceTarget().addCapability(REMOTING_ENDPOINT_CAPABILITY, endpointService)
+                .addCapabilityRequirement(IO_WORKER_CAPABILITY_NAME, XnioWorker.class, endpointService.getWorker(), workerName)
                 .install();
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
@@ -21,6 +21,10 @@
 */
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.Capabilities.HTTP_LISTENER_REGISTRY_CAPABILITY_NAME;
+import static org.jboss.as.remoting.Capabilities.IO_WORKER_CAPABILITY_NAME;
+import static org.jboss.as.remoting.Capabilities.REMOTING_ENDPOINT_CAPABILITY_NAME;
+
 import java.util.logging.Level;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -55,14 +59,18 @@ import org.jboss.remoting3.RemotingOptions;
 import org.wildfly.extension.io.OptionAttributeDefinition;
 import org.xnio.Option;
 
+import io.undertow.server.ListenerRegistry;
+
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
 
-    static final String IO_WORKER_CAPABILITY = "org.wildfly.io.worker";
     static final RuntimeCapability<Void> REMOTING_ENDPOINT_CAPABILITY =
-            RuntimeCapability.Builder.of("org.wildfly.remoting.endpoint", Endpoint.class).build();
+            RuntimeCapability.Builder.of(REMOTING_ENDPOINT_CAPABILITY_NAME, Endpoint.class).build();
+
+    static final RuntimeCapability<Void> HTTP_LISTENER_REGISTRY_CAPABILITY =
+            RuntimeCapability.Builder.of(HTTP_LISTENER_REGISTRY_CAPABILITY_NAME, ListenerRegistry.class).build();
 
     private static final String ENDPOINT = "endpoint";
 
@@ -72,7 +80,7 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setValidator(new StringLengthValidator(1))
             .setDefaultValue(new ModelNode("default"))
-            .setCapabilityReference(IO_WORKER_CAPABILITY, REMOTING_ENDPOINT_CAPABILITY)
+            .setCapabilityReference(IO_WORKER_CAPABILITY_NAME, REMOTING_ENDPOINT_CAPABILITY)
             .build();
 
     private static final OptionAttributeDefinition SEND_BUFFER_SIZE = createOptionAttribute("send-buffer-size", RemotingOptions.SEND_BUFFER_SIZE, new ModelNode(RemotingOptions.DEFAULT_SEND_BUFFER_SIZE));
@@ -139,7 +147,7 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
                 .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
-                .setCapabilities(REMOTING_ENDPOINT_CAPABILITY)
+                .setCapabilities(REMOTING_ENDPOINT_CAPABILITY, HTTP_LISTENER_REGISTRY_CAPABILITY)
         );
         this.attributes = attributes;
     }

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -36,6 +36,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.remoting.Capabilities.IO_WORKER_CAPABILITY_NAME;
 import static org.jboss.as.remoting.RemotingSubsystemTestUtil.DEFAULT_ADDITIONAL_INITIALIZATION;
 import static org.jboss.as.remoting.RemotingSubsystemTestUtil.HC_ADDITIONAL_INITIALIZATION;
 import static org.junit.Assert.assertEquals;
@@ -327,14 +328,14 @@ public class RemotingLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
                 super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
 
                 Map<String, Class> capabilities = new HashMap<>();
-                capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
+                capabilities.put(buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME,
                         "default-remoting"), XnioWorker.class);
 
                 if (legacyParser) {
                     // Deal with the fact that legacy parsers will add the io extension/subsystem
                     RemotingSubsystemTestUtil.registerIOExtension(extensionRegistry, rootRegistration);
                 } else {
-                    capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
+                    capabilities.put(buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME,
                             RemotingSubsystemRootResource.WORKER.getDefaultValue().asString()), XnioWorker.class);
                 }
 

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -30,6 +30,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.remoting.Capabilities.IO_WORKER_CAPABILITY_NAME;
 import static org.jboss.as.remoting.RemotingSubsystemTestUtil.DEFAULT_ADDITIONAL_INITIALIZATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -337,9 +338,9 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
             protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
                 super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
                 Map<String, Class> capabilities = new HashMap<>();
-                capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
+                capabilities.put(buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME,
                         RemotingSubsystemRootResource.WORKER.getDefaultValue().asString()), XnioWorker.class);
-                capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
+                capabilities.put(buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME,
                         "default-remoting"), XnioWorker.class);
                 AdditionalInitialization.registerServiceCapabilities(capabilityRegistry, capabilities);
             }

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
@@ -24,6 +24,7 @@ package org.jboss.as.remoting;
 
 import static org.jboss.as.controller.capability.RuntimeCapability.buildDynamicCapabilityName;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.remoting.Capabilities.IO_WORKER_CAPABILITY_NAME;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ModelOnlyAddStepHandler;
@@ -51,10 +52,10 @@ class RemotingSubsystemTestUtil {
 
     static final AdditionalInitialization DEFAULT_ADDITIONAL_INITIALIZATION =
             AdditionalInitialization.withCapabilities(
-                    buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
+                    buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME,
                     RemotingSubsystemRootResource.WORKER.getDefaultValue().asString()),
                     // This one is specified in one of the test configs
-                    buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"),
+                    buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME, "default-remoting"),
                     buildDynamicCapabilityName("org.wildfly.network.outbound-socket-binding", "dummy-outbound-socket"),
                     buildDynamicCapabilityName("org.wildfly.network.outbound-socket-binding", "other-outbound-socket"),
                     buildDynamicCapabilityName("org.wildfly.network.socket-binding", "remoting")
@@ -74,7 +75,7 @@ class RemotingSubsystemTestUtil {
                     super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
                     AdditionalInitialization.registerCapabilities(capabilityRegistry,
                             // This one is specified in one of the test configs
-                            buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"));
+                            buildDynamicCapabilityName(IO_WORKER_CAPABILITY_NAME, "default-remoting"));
 
                     // Deal with the fact that legacy parsers will add the io extension/subsystem
                     registerIOExtension(extensionRegistry, rootRegistration);

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Executor;
 
 import javax.net.ssl.SSLContext;
 
-import io.undertow.server.ListenerRegistry;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.ControlledProcessStateService;
@@ -53,8 +52,8 @@ import org.jboss.as.domain.http.server.ManagementHttpRequestProcessor;
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.network.SocketBindingManager;
-import org.jboss.as.remoting.HttpListenerRegistryService;
 import org.jboss.as.remoting.RemotingHttpUpgradeService;
+import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementChannelRegistryService;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ExternalManagementRequestExecutor;
@@ -74,6 +73,8 @@ import org.jboss.msc.service.ServiceName;
 import org.wildfly.security.auth.server.HttpAuthenticationFactory;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.xnio.XnioWorker;
+
+import io.undertow.server.ListenerRegistry;
 
 
 /**
@@ -138,7 +139,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
         CapabilityServiceBuilder<HttpManagement> undertowBuilder = serviceTarget.addCapability(EXTENSIBLE_HTTP_MANAGEMENT_CAPABILITY, undertowService).addDependency(Services.JBOSS_SERVER_CONTROLLER, ModelController.class, undertowService.getModelControllerInjector())
                 .addCapabilityRequirement("org.wildfly.management.socket-binding-manager", SocketBindingManager.class, undertowService.getSocketBindingManagerInjector())
                 .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, undertowService.getControlledProcessStateServiceInjector())
-                .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, undertowService.getListenerRegistry())
+                .addDependency(RemotingServices.HTTP_LISTENER_REGISTRY, ListenerRegistry.class, undertowService.getListenerRegistry())
                 .addDependency(requestProcessorName, ManagementHttpRequestProcessor.class, undertowService.getRequestProcessorValue())
                 .addDependency(ManagementWorkerService.SERVICE_NAME, XnioWorker.class, undertowService.getWorker())
                 .addDependency(ExternalManagementRequestExecutor.SERVICE_NAME, Executor.class, undertowService.getManagementExecutor())


### PR DESCRIPTION
- Add a capability for HttpListenerRegistryService and change the old service references to use the service exposed by the new capability 
- Move existing remoting capability names to the Capabilities class
- Expose the capability service name via RemotingServices

Jira issue: https://issues.jboss.org/browse/WFCORE-4166