### PR TITLE
[WFCORE-4120] Do not allow adding a module as extension when the module does not contain an extension

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -72,7 +72,6 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.ServiceName;
@@ -1762,16 +1761,16 @@ public interface ControllerLogger extends BasicLogger {
     IllegalStateException notADirectory(String path);
 
     /**
-     * Creates an exception indicating no {@code path/className} was found for the module identifier.
+     * Creates an exception indicating no {@code path/className} was found for the module name.
      *
-     * @param path      the path of the SPI.
-     * @param className the class name.
-     * @param id        the module identifier.
+     * @param path        the path of the SPI.
+     * @param className   the class name.
+     * @param moduleName  the module name.
      *
      * @return an {@link IllegalStateException} for the error.
      */
     @Message(id = 153, value = "No %s%s found for %s")
-    IllegalStateException notFound(String path, String className, ModuleIdentifier id);
+    IllegalStateException notFound(String path, String className, String moduleName);
 
     /**
      * Creates an exception indicating an asynchronous operation cannot execute without an executor.

--- a/controller/src/main/java/org/jboss/as/controller/parsing/DeferredExtensionContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/DeferredExtensionContext.java
@@ -122,7 +122,7 @@ public class DeferredExtensionContext {
                 }
             }
             if (!initialized) {
-                throw ControllerLogger.ROOT_LOGGER.notFound("META-INF/services/", Extension.class.getName(), module.getIdentifier());
+                throw ControllerLogger.ROOT_LOGGER.notFound("META-INF/services/", Extension.class.getName(), module.getName());
             }
             return null;
         } catch (final ModuleLoadException e) {


### PR DESCRIPTION
It was possible to add extensions for modules that do not contain an extension. This patch validates that the module has an extension before adding it.

Jira issue: https://issues.jboss.org/browse/WFCORE-4120