### PR TITLE
[WFCORE-3966] JwtValidator jku and kid header parameters

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -249,10 +249,12 @@ interface ElytronDescriptionConstants {
     String KEY_TYPE = "key-type";
     String KEY_MANAGER = "key-manager";
     String KEY_MANAGERS = "key-managers";
+    String KEY_MAP = "key-map";
     String KEY_SIZE = "key-size";
     String KEY_STORE = "key-store";
     String KEY_STORE_REALM = "key-store-realm";
     String KEY_STORES = "key-stores";
+    String KID = "kid";
 
     String LAST_ACCESSED_TIME = "last-accessed-time";
     String LAYER = "layer";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -87,6 +87,15 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
         transformAutoFlush(builder, FILE_AUDIT_LOG);
         transformAutoFlush(builder, PERIODIC_ROTATING_FILE_AUDIT_LOG);
         transformAutoFlush(builder, SIZE_ROTATING_FILE_AUDIT_LOG);
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM))
+            .getAttributeBuilder()
+            .addRejectCheck(new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(Collections.singletonMap(ElytronDescriptionConstants.HOST_NAME_VERIFICATION_POLICY,
+                RejectAttributeChecker.DEFINED)), ElytronDescriptionConstants.JWT)
+            .addRejectCheck(new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(Collections.singletonMap(ElytronDescriptionConstants.SSL_CONTEXT,
+                RejectAttributeChecker.DEFINED)), ElytronDescriptionConstants.JWT)
+            .addRejectCheck(new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(Collections.singletonMap(ElytronDescriptionConstants.KEY_MAP,
+                RejectAttributeChecker.DEFINED)), ElytronDescriptionConstants.JWT)
+            .end();
     }
 
     private static void transformAutoFlush(ResourceTransformationDescriptionBuilder builder, final String resourceName) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -29,6 +29,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.OAUTH2_I
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.AUDIENCE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.CERTIFICATE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.ISSUER;
+import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.KEY_MAP;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.KEY_STORE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.PUBLIC_KEY;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
@@ -38,21 +39,33 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshallers;
+import org.jboss.as.controller.AttributeParsers;
+import org.jboss.as.controller.MapAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -61,6 +74,7 @@ import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
@@ -71,11 +85,15 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.value.InjectedValue;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.wildfly.common.iteration.CodePointIterator;
 import org.wildfly.extension.elytron.TokenRealmDefinition.OAuth2IntrospectionValidatorAttributes.HostnameVerificationPolicy;
 import org.wildfly.security.auth.realm.token.TokenSecurityRealm;
 import org.wildfly.security.auth.realm.token.validator.JwtValidator;
 import org.wildfly.security.auth.realm.token.validator.OAuth2IntrospectValidator;
 import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.pem.Pem;
+import org.wildfly.security.pem.PemEntry;
 
 /**
  * A {@link ResourceDefinition} for a {@link SecurityRealm} capable of validating and extracting identities from security tokens.
@@ -89,6 +107,19 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .setMinSize(1)
             .setRestartAllServices()
+            .build();
+
+    protected static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT, ModelType.STRING, true)
+            .setCapabilityReference(SSL_CONTEXT_CAPABILITY, SECURITY_REALM_CAPABILITY)
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setValidator(new StringLengthValidator(1))
+            .build();
+
+    static final SimpleAttributeDefinition HOSTNAME_VERIFICATION_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HOST_NAME_VERIFICATION_POLICY, ModelType.STRING, true)
+            .setValidator(new EnumValidator<>(HostnameVerificationPolicy.class, true, true))
+            .setAllowExpression(true)
+            .setMinSize(1)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     static class JwtValidatorAttributes {
@@ -129,9 +160,30 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .setMinSize(1)
                 .build();
 
-        static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{ISSUER, AUDIENCE, PUBLIC_KEY};
+        static final PropertiesAttributeDefinition KEY_MAP = new PropertiesAttributeDefinition.Builder(ElytronDescriptionConstants.KEY_MAP, true)
+                .setAllowExpression(true)
+                .setMinSize(1)
+                .setAttributeParser(new AttributeParsers.PropertiesParser(null, ElytronDescriptionConstants.KEY, false) {
+                    @Override
+                    public void parseSingleElement(MapAttributeDefinition attribute, XMLExtendedStreamReader reader, ModelNode operation) throws XMLStreamException {
+                        final String[] array = ParseUtils.requireAttributes(reader, ElytronDescriptionConstants.KID, ElytronDescriptionConstants.PUBLIC_KEY);
+                        ModelNode paramVal = operation.get(attribute.getName()).get(array[0]);
+                        paramVal.set(array[1]);
+                        ParseUtils.requireNoContent(reader);
+                    }
+                })
+                .setAttributeMarshaller(new AttributeMarshallers.PropertiesAttributeMarshaller(null, null, false) {
+                    @Override
+                    public void marshallSingleElement(AttributeDefinition attribute, ModelNode property, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+                        writer.writeEmptyElement(ElytronDescriptionConstants.KEY);
+                        writer.writeAttribute(ElytronDescriptionConstants.KID, property.asProperty().getName());
+                        writer.writeAttribute(ElytronDescriptionConstants.PUBLIC_KEY, property.asProperty().getValue().asString());
+                    }
+                })
+                .setRestartAllServices()
+                .build();
 
-        static final ObjectTypeAttributeDefinition JWT_VALIDATOR = new ObjectTypeAttributeDefinition.Builder(JWT, ISSUER, AUDIENCE, PUBLIC_KEY, KEY_STORE, CERTIFICATE)
+        static final ObjectTypeAttributeDefinition JWT_VALIDATOR = new ObjectTypeAttributeDefinition.Builder(JWT, ISSUER, AUDIENCE, PUBLIC_KEY, KEY_STORE, CERTIFICATE, SSL_CONTEXT, HOSTNAME_VERIFICATION_POLICY, KEY_MAP)
                 .setRequired(false)
                 .setRestartAllServices()
                 .build();
@@ -158,19 +210,6 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .build();
 
-        protected static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT, ModelType.STRING, true)
-                .setCapabilityReference(SSL_CONTEXT_CAPABILITY, SECURITY_REALM_CAPABILITY)
-                .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                .setValidator(new StringLengthValidator(1))
-                .build();
-
-        static final SimpleAttributeDefinition HOSTNAME_VERIFICATION_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HOST_NAME_VERIFICATION_POLICY, ModelType.STRING, true)
-                .setValidator(new EnumValidator<>(HostnameVerificationPolicy.class, true, true))
-                .setAllowExpression(true)
-                .setMinSize(1)
-                .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                .build();
-
         static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{CLIENT_ID, CLIENT_SECRET, INTROSPECTION_URL, SSL_CONTEXT, HOSTNAME_VERIFICATION_POLICY};
 
         static final ObjectTypeAttributeDefinition OAUTH2_INTROSPECTION_VALIDATOR = new ObjectTypeAttributeDefinition.Builder(OAUTH2_INTROSPECTION, CLIENT_ID, CLIENT_SECRET, INTROSPECTION_URL, SSL_CONTEXT, HOSTNAME_VERIFICATION_POLICY)
@@ -179,7 +218,8 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .build();
 
         enum HostnameVerificationPolicy {
-            ANY((s, sslSession) -> true);
+            ANY((s, sslSession) -> true),
+            DEFAULT(HttpsURLConnection.getDefaultHostnameVerifier());
 
             private final HostnameVerifier verifier;
 
@@ -240,24 +280,59 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 InjectedValue<KeyStore> keyStoreInjector = new InjectedValue<>();
                 String keyStoreName = KEY_STORE.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
                 String certificateAlias = CERTIFICATE.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
+                String sslContextRef = SSL_CONTEXT.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
+                String hostNameVerificationPolicy = HOSTNAME_VERIFICATION_POLICY.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
+                InjectedValue<SSLContext> sslContextInjector = new InjectedValue<>();
+                ModelNode keyMap = KEY_MAP.resolveModelAttribute(context, jwtValidatorNode);
+                Map<String, PublicKey> namedKeys = new LinkedHashMap<>();
+                if (keyMap.isDefined()) {
+                    Set<String> kids = keyMap.keys();
+
+                    if (kids.size() > 0) {
+                        for (String kid : kids) {
+                            ROOT_LOGGER.warn("KID: " + kid + "\n");
+                            byte[] pemKey = keyMap.get(kid).asString().getBytes(StandardCharsets.UTF_8);
+
+                            Iterator<PemEntry<?>> pemEntryIterator = Pem.parsePemContent(CodePointIterator.ofUtf8Bytes(pemKey));
+                            PublicKey namedPublicKey = null;
+                            try {
+                                namedPublicKey = pemEntryIterator.next().tryCast(PublicKey.class);
+                            } catch (Exception e) {
+                                throw new RuntimeException("Failed to parse PEM public key with kid: " + kid, e);
+
+                            }
+                            if (namedPublicKey == null) {
+                                throw new RuntimeException("Failed to parse PEM public key with kid: " + kid);
+                            }
+
+                            namedKeys.put(kid, namedPublicKey);
+                        }
+                    }
+
+                }
 
                 service = new TrivialService<>(new TrivialService.ValueSupplier<SecurityRealm>() {
                     @Override
                     public SecurityRealm get() throws StartException {
                         JwtValidator.Builder jwtValidatorBuilder = JwtValidator.builder();
-
                         if (issuer != null) {
                             jwtValidatorBuilder.issuer(issuer);
                         }
-
                         if (audience != null) {
                             jwtValidatorBuilder.audience(audience);
                         }
-
                         if (publicKey != null) {
                             jwtValidatorBuilder.publicKey(publicKey.getBytes(StandardCharsets.UTF_8));
                         }
-
+                        if (sslContextRef != null) {
+                            jwtValidatorBuilder.useSslContext(sslContextInjector.getOptionalValue());
+                        }
+                        if (hostNameVerificationPolicy != null) {
+                            jwtValidatorBuilder.useSslHostnameVerifier(HostnameVerificationPolicy.valueOf(hostNameVerificationPolicy).getVerifier());
+                        }
+                        if (namedKeys.size() > 0) {
+                            jwtValidatorBuilder.publicKeys(namedKeys);
+                        }
                         KeyStore keyStore = keyStoreInjector.getOptionalValue();
 
                         if (keyStore != null) {
@@ -293,14 +368,19 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                             KeyStore.class, keyStoreInjector);
                 }
 
+                if (sslContextRef != null) {
+                    String runtimeCapability = RuntimeCapability.buildDynamicCapabilityName(SSL_CONTEXT_CAPABILITY, sslContextRef);
+                    serviceBuilder.addDependency(context.getCapabilityServiceName(runtimeCapability, SSLContext.class), SSLContext.class, sslContextInjector);
+                }
+
                 serviceBuilder.addAliases(aliasServiceName).install();
             } else if (operation.hasDefined(OAUTH2_INTROSPECTION)) {
                 ModelNode oAuth2IntrospectionNode = OAuth2IntrospectionValidatorAttributes.OAUTH2_INTROSPECTION_VALIDATOR.resolveModelAttribute(context, operation);
                 String clientId = OAuth2IntrospectionValidatorAttributes.CLIENT_ID.resolveModelAttribute(context, oAuth2IntrospectionNode).asString();
                 String clientSecret = OAuth2IntrospectionValidatorAttributes.CLIENT_SECRET.resolveModelAttribute(context, oAuth2IntrospectionNode).asString();
                 String introspectionUrl = OAuth2IntrospectionValidatorAttributes.INTROSPECTION_URL.resolveModelAttribute(context, oAuth2IntrospectionNode).asString();
-                String sslContextRef = OAuth2IntrospectionValidatorAttributes.SSL_CONTEXT.resolveModelAttribute(context, oAuth2IntrospectionNode).asStringOrNull();
-                String hostNameVerificationPolicy = OAuth2IntrospectionValidatorAttributes.HOSTNAME_VERIFICATION_POLICY.resolveModelAttribute(context, oAuth2IntrospectionNode).asStringOrNull();
+                String sslContextRef = SSL_CONTEXT.resolveModelAttribute(context, oAuth2IntrospectionNode).asStringOrNull();
+                String hostNameVerificationPolicy = HOSTNAME_VERIFICATION_POLICY.resolveModelAttribute(context, oAuth2IntrospectionNode).asStringOrNull();
                 InjectedValue<SSLContext> sslContextInjector = new InjectedValue<>();
 
                 service = new TrivialService<>(new TrivialService.ValueSupplier<SecurityRealm>() {

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -792,7 +792,10 @@ elytron.token-realm.jwt.issuer=A list of strings representing the issuers suppor
 elytron.token-realm.jwt.audience=A list of strings representing the audiences supported by this configuration. During validation JWT tokens must have an 'aud' claim that contains one of the values defined here.
 elytron.token-realm.jwt.public-key=A public key in PEM Format. During validation, if a public key is provided, signature will be verified based on the key you provided here.
 elytron.token-realm.jwt.key-store=A key store from where the certificate with a public key should be loaded from.
+elytron.token-realm.jwt.key-map=A map of named public keys for token verification.
 elytron.token-realm.jwt.certificate=The name of the certificate with a public key to load from the key store.
+elytron.token-realm.jwt.client-ssl-context=The SSL context to be used for fetching jku keys using HTTPS.
+elytron.token-realm.jwt.host-name-verification-policy=A policy that defines how host names should be verified when using HTTPS. Allowed values: "ANY".
 # OAuth2 Introspection Validator Complex Attribute
 elytron.token-realm.oauth2-introspection=A token validator to be used in conjunction with a token-based realm that handles OAuth2 Access Tokens and validates them using an endpoint compliant with OAuth2 Token Introspection specification(RFC-7662).
 elytron.token-realm.oauth2-introspection.client-id=The identifier of the client on the OAuth2 Authorization Server.

--- a/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
@@ -1553,6 +1553,26 @@
                 A token validator to be used in conjunction with a token-based realm that handles security tokens based on the JWT/JWS standard.
             </xs:documentation>
         </xs:annotation>
+        <xs:sequence>
+            <xs:element name="key" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="kid" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The JWK kid. Tokens with the same kid will use this public key for signature verification.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="public-key" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                RSA public key in PEM format.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
         <xs:attribute name="issuer" type="stringListType" use="optional">
             <xs:annotation>
                 <xs:documentation>
@@ -1585,6 +1605,20 @@
             <xs:annotation>
                 <xs:documentation>
                     The name of the certificate with a public key to load from the key store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="client-ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A predefined client-ssl-context that will be used to connect to the jwks endpoint specifien in jku token claim. This configuration is mandatory if you want to use remote keys with jku.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host-name-verification-policy" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A policy that defines how host names should be verified when using HTTPS for fetching jwks. Allowed values: "ANY".
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -107,6 +107,12 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                 )
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SIZE_ROTATING_FILE_AUDIT_LOG, "audit6")),
                         new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM, "SslTokenRealm")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM, "KeyMapTokenRealm")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE
                 ));
     }
 

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -15,4 +15,19 @@
         <size-rotating-file-audit-log name="audit5" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="true" autoflush="false" />
         <size-rotating-file-audit-log name="audit6" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="false" autoflush="true" />
     </audit-logging>
+    <security-realms>
+        <token-realm name="SslTokenRealm">
+            <jwt host-name-verification-policy="ANY" client-ssl-context="ClientContext"/>
+        </token-realm>
+        <token-realm name="KeyMapTokenRealm">
+            <jwt>
+                <key kid="1" public-key="-----BEGIN PUBLIC KEY-----MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgF1mQenACcf3tWRJ8nugSIXXdlgaAh3xf6K1ak8r4fI7vigfzYa/+OfvJeKgWL/fO1PTkYAqyDfxi+k3AORQRE3I0zqQoZBhtm99ZPluZGRU9+COLlbIK3Uac0K/t1dEjo9Cb2EMHyHBaaX3mwmS296zHyDFVDEm7Sw1G98TLnz9AgMBAAE=-----END PUBLIC KEY-----"/>
+            </jwt>
+        </token-realm>
+    </security-realms>
+    <tls>
+        <client-ssl-contexts>
+            <client-ssl-context name="ClientContext"/>
+        </client-ssl-contexts>
+    </tls>
 </subsystem>


### PR DESCRIPTION
This pull request supersedes https://github.com/wildfly/wildfly-core/pull/3501 which can be closed.

https://issues.jboss.org/browse/WFCORE-3966
https://issues.jboss.org/browse/EAP7-1068

Requires ELY-1551
https://issues.jboss.org/browse/ELY-1551