### PR TITLE
[WFCORE-4173] Register socket-binding bound attributes as read-only

### DIFF
--- a/server/src/main/java/org/jboss/as/server/services/net/BindingRuntimeHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingRuntimeHandlers.java
@@ -41,13 +41,13 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
- * {@code SocketBinding} metric handlers.
+ * {@code SocketBinding} runtime handlers.
  *
  * @author Emanuel Muckenhuber
  */
-public final class BindingMetricHandlers {
+public final class BindingRuntimeHandlers {
 
-    abstract static class AbstractBindingMetricsHandler implements OperationStepHandler {
+    abstract static class AbstractBindingRuntimeHandler implements OperationStepHandler {
 
         /** {@inheritDoc} */
         @Override
@@ -62,7 +62,7 @@ public final class BindingMetricHandlers {
                     final ServiceController<?> controller = context.getServiceRegistry(false).getRequiredService(svcName);
                     if(controller != null && controller.getState() == ServiceController.State.UP) {
                         final SocketBinding binding = SocketBinding.class.cast(controller.getValue());
-                        AbstractBindingMetricsHandler.this.execute(operation, binding, result);
+                        AbstractBindingRuntimeHandler.this.execute(operation, binding, result);
                     } else {
                         result.set(getNoMetrics());
                     }
@@ -75,7 +75,7 @@ public final class BindingMetricHandlers {
         abstract ModelNode getNoMetrics();
     }
 
-    public static class BoundHandler extends AbstractBindingMetricsHandler {
+    public static class BoundHandler extends AbstractBindingRuntimeHandler {
 
         public static final String ATTRIBUTE_NAME = "bound";
         public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.BOOLEAN)
@@ -101,7 +101,7 @@ public final class BindingMetricHandlers {
 
     }
 
-    public static class BoundAddressHandler extends AbstractBindingMetricsHandler {
+    public static class BoundAddressHandler extends AbstractBindingRuntimeHandler {
 
         public static final String ATTRIBUTE_NAME = "bound-address";
         public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.STRING)
@@ -129,7 +129,7 @@ public final class BindingMetricHandlers {
         }
     }
 
-    public static class BoundPortHandler extends AbstractBindingMetricsHandler {
+    public static class BoundPortHandler extends AbstractBindingRuntimeHandler {
 
         public static final String ATTRIBUTE_NAME = "bound-port";
         public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.INT)
@@ -159,7 +159,7 @@ public final class BindingMetricHandlers {
         }
     }
 
-    private BindingMetricHandlers() {
+    private BindingRuntimeHandlers() {
         //
     }
 

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
@@ -57,10 +57,10 @@ public class SocketBindingResourceDefinition extends AbstractSocketBindingResour
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
 
-        // Metrics
-        resourceRegistration.registerMetric(BindingMetricHandlers.BoundHandler.ATTRIBUTE_DEFINITION, BindingMetricHandlers.BoundHandler.INSTANCE);
-        resourceRegistration.registerMetric(BindingMetricHandlers.BoundAddressHandler.ATTRIBUTE_DEFINITION, BindingMetricHandlers.BoundAddressHandler.INSTANCE);
-        resourceRegistration.registerMetric(BindingMetricHandlers.BoundPortHandler.ATTRIBUTE_DEFINITION, BindingMetricHandlers.BoundPortHandler.INSTANCE);
+        // Runtime read only attributes
+        resourceRegistration.registerReadOnlyAttribute(BindingRuntimeHandlers.BoundHandler.ATTRIBUTE_DEFINITION, BindingRuntimeHandlers.BoundHandler.INSTANCE);
+        resourceRegistration.registerReadOnlyAttribute(BindingRuntimeHandlers.BoundAddressHandler.ATTRIBUTE_DEFINITION, BindingRuntimeHandlers.BoundAddressHandler.INSTANCE);
+        resourceRegistration.registerReadOnlyAttribute(BindingRuntimeHandlers.BoundPortHandler.ATTRIBUTE_DEFINITION, BindingRuntimeHandlers.BoundPortHandler.INSTANCE);
     }
 
     @Override


### PR DESCRIPTION
bound, bound-port and bound-address are not registered as runtime
read-only attribute as they do not qualify as metrics.

Rename BindingMetricHandlers to BindingRuntimeHandlers to avoid any
confusion.

JIRA: https://issues.jboss.org/browse/WFCORE-4173