### PR TITLE
[WFCORE-4177] Default subsystem test reverse controller tests to Addi…

### DIFF
--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -649,7 +649,7 @@ final class SubsystemTestDelegate {
         private ModelTestOperationValidatorFilter.Builder operationValidationExcludeBuilder;
         private boolean persistXml = true;
         private boolean skipReverseCheck;
-        private AdditionalInitialization reverseCheckConfig;
+        private AdditionalInitialization reverseCheckConfig = AdditionalInitialization.MANAGEMENT;
         private ModelFixer reverseCheckModelFixer;
         private OperationFixer reverseCheckOperationFixer = operation -> operation;
 


### PR DESCRIPTION
…tionalInitialization.MANAGEMENT

https://issues.jboss.org/browse/WFCORE-4177

Don't force subsystem test authors to add legacyKernelServicesInitializer.configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null) just to avoid a test of config model management invoking runtime code.