### PR TITLE
[WFCORE-4144] Add a 'default-ssl-context' attribute to the Elytron subsystem referencing the SSLContext to be globally registered.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/DefaultSSLContextService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DefaultSSLContextService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import static org.wildfly.extension.elytron.SecurityActions.doPrivileged;
+
+import java.security.PrivilegedAction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * A simple {@link Service} to take an {@link SSLContext} and register it as the process wide default.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class DefaultSSLContextService implements Service {
+
+    static final ServiceName SERVICE_NAME = ElytronExtension.BASE_SERVICE_NAME.append(ElytronDescriptionConstants.SSL_CONTEXT_REGISTRATION);
+
+    private final Supplier<SSLContext> defaultSSLContextSupplier;
+    private final Consumer<SSLContext> valueConsumer;
+
+    DefaultSSLContextService(Supplier<SSLContext> defaultSSLContextSupplier, Consumer<SSLContext> valueConsumer) {
+        this.defaultSSLContextSupplier = defaultSSLContextSupplier;
+        this.valueConsumer = valueConsumer;
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        final SSLContext sslContext = defaultSSLContextSupplier.get();
+        doPrivileged((PrivilegedAction<Void>) () -> {
+            SSLContext.setDefault(sslContext);
+            return null;
+        });
+        valueConsumer.accept(sslContext);
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        // We can't set the default back to 'null' as that would cause a NullPointerException.
+    }
+
+}

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -499,6 +499,7 @@ interface ElytronDescriptionConstants {
     String SIZE_ROTATING_FILE_AUDIT_LOG = "size-rotating-file-audit-log";
     String SQL = "sql";
     String SSL_CONTEXT = "ssl-context";
+    String SSL_CONTEXT_REGISTRATION = "ssl-context-registration";
     String SSL_SESSION = "ssl-session";
     String SNI_MAPPING = "sni-mapping";
     String STAGING = "staging";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -20,6 +20,8 @@ package org.wildfly.extension.elytron;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import javax.net.ssl.SSLContext;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
@@ -65,6 +67,7 @@ public class ElytronExtension implements Extension {
      * The attachment key that is used for associating the authentication context with a deployment context.
      */
     public static final AttachmentKey<AuthenticationContext> AUTHENTICATION_CONTEXT_KEY = AttachmentKey.create(AuthenticationContext.class);
+    public static final AttachmentKey<SSLContext> SSL_CONTEXT_KEY = AttachmentKey.create(SSLContext.class);
 
     static final ModelVersion ELYTRON_1_2_0 = ModelVersion.create(1, 2);
     static final ModelVersion ELYTRON_2_0_0 = ModelVersion.create(2);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser5_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser5_0.java
@@ -55,6 +55,7 @@ public class ElytronSubsystemParser5_0 extends ElytronSubsystemParser4_0 {
                 .addAttribute(ElytronDefinition.DISALLOWED_PROVIDERS)
                 .addAttribute(ElytronDefinition.SECURITY_PROPERTIES, new AttributeParsers.PropertiesParser(null, SECURITY_PROPERTY, true), new AttributeMarshallers.PropertiesAttributeMarshaller(null, SECURITY_PROPERTY, true))
                 .addAttribute(ElytronDefinition.REGISTER_JASPI_FACTORY)
+                .addAttribute(ElytronDefinition.DEFAULT_SSL_CONTEXT)
                 .addChild(getAuthenticationClientParser())
                 .addChild(getProviderParser())
                 .addChild(getAuditLoggingParser())

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -82,6 +82,8 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
         ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(ELYTRON_5_0_0, ELYTRON_4_0_0);
         builder.getAttributeBuilder()
             .setDiscard(DiscardAttributeChecker.ALWAYS, ElytronDefinition.REGISTER_JASPI_FACTORY)
+            .addRejectCheck(RejectAttributeChecker.DEFINED, ElytronDescriptionConstants.DEFAULT_SSL_CONTEXT)
+            .setDiscard(DiscardAttributeChecker.UNDEFINED, ElytronDefinition.DEFAULT_SSL_CONTEXT)
             .end();
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.JASPI_CONFIGURATION));
         transformAutoFlush(builder, FILE_AUDIT_LOG);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLContextDependencyProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLContextDependencyProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import javax.net.ssl.SSLContext;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+
+/**
+ * A simple {@link DeploymentUnitProcessor} to ensure deployments wait until the default {@link SSLContext} has been registered.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class SSLContextDependencyProcessor implements DeploymentUnitProcessor {
+
+    /**
+     * @see org.jboss.as.server.deployment.DeploymentUnitProcessor#deploy(org.jboss.as.server.deployment.DeploymentPhaseContext)
+     */
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        phaseContext.addDeploymentDependency(DefaultSSLContextService.SERVICE_NAME, ElytronExtension.SSL_CONTEXT_KEY);
+    }
+
+    /**
+     * @see org.jboss.as.server.deployment.DeploymentUnitProcessor#undeploy(org.jboss.as.server.deployment.DeploymentUnit)
+     */
+    @Override
+    public void undeploy(DeploymentUnit context) {}
+
+}

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -8,6 +8,7 @@ elytron.initial-providers=Reference to the Providers that should be registered a
 elytron.final-providers=Reference to the Providers that should be registered after all existing Providers.
 elytron.disallowed-providers=A list of providers that are not allowed, and will be removed from the providers list.
 elytron.register-jaspi-factory=Should the Elytron JASPI factory be globally registered?
+elytron.default-ssl-context=Reference to the SSLContext which should be globally registered as the default.
 
 #######################
 # Security Properties #

--- a/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
@@ -82,6 +82,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="default-ssl-context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to an SSLContext which should be globally registered as the default.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <!--

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -88,6 +88,7 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testRejectingTransformersEAP720() throws Exception {
         testRejectingTransformers(EAP_7_2_0_TEMP, "elytron-transformers-4.0-reject.xml", new FailedOperationTransformationConfig()
+                .addFailedAttribute(SUBSYSTEM_ADDRESS, new FailedOperationTransformationConfig.NewAttributesConfig(ElytronDefinition.DEFAULT_SSL_CONTEXT))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.JASPI_CONFIGURATION, "minimal")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.FILE_AUDIT_LOG, "audit1")),

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -312,17 +312,22 @@ public class TlsTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testSslServiceNoAuth() throws Throwable {
-        testCommunication("ServerSslContextNoAuth", "ClientSslContextNoAuth", "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost", null);
+        testCommunication("ServerSslContextNoAuth", "ClientSslContextNoAuth", false, "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost", null);
+    }
+
+    @Test
+    public void testSslServiceNoAuth_Default() throws Throwable {
+        testCommunication("ServerSslContextNoAuth", "ClientSslContextNoAuth", true, "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost", null);
     }
 
     @Test
     public void testSslServiceAuth() throws Throwable {
-        testCommunication("ServerSslContextAuth", "ClientSslContextAuth", "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost", "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly");
+        testCommunication("ServerSslContextAuth", "ClientSslContextAuth", false, "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost", "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly");
     }
 
     @Test(expected = SSLHandshakeException.class)
     public void testSslServiceAuthRequiredButNotProvided() throws Throwable {
-        testCommunication("ServerSslContextAuth", "ClientSslContextNoAuth", "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly", "");
+        testCommunication("ServerSslContextAuth", "ClientSslContextNoAuth", false, "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly", "");
     }
 
     @Test
@@ -419,9 +424,9 @@ public class TlsTestCase extends AbstractSubsystemTest {
         return sslContext;
     }
 
-    private void testCommunication(String serverContextName, String clientContextName, String expectedServerPrincipal, String expectedClientPrincipal) throws Throwable {
+    private void testCommunication(String serverContextName, String clientContextName, boolean defaultClient, String expectedServerPrincipal, String expectedClientPrincipal) throws Throwable {
         SSLContext serverContext = getSslContext(serverContextName);
-        SSLContext clientContext = getSslContext(clientContextName);
+        SSLContext clientContext = defaultClient ? SSLContext.getDefault() : getSslContext(clientContextName);
 
         ServerSocket listeningSocket = serverContext.getServerSocketFactory().createServerSocket();
         listeningSocket.bind(new InetSocketAddress("localhost", TESTING_PORT));

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-5.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-5.0.xml
@@ -17,7 +17,7 @@
   -->
 
 <!-- for needs of DomainTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:5.0" register-jaspi-factory="false">
+<subsystem xmlns="urn:wildfly:elytron:5.0" register-jaspi-factory="false" default-ssl-context="client">
     <security-domains>
         <security-domain name="MyDomain" default-realm="FileRealm" realm-mapper="MyRealmMapper" permission-mapper="MyPermissionMapper"
                          pre-realm-principal-transformer="NameRewriterXY" post-realm-principal-transformer="NameRewriterYU" trusted-security-domains="AnotherDomain">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:5.0">
+<subsystem xmlns="urn:wildfly:elytron:5.0" default-ssl-context="ClientContext">
     <jaspi>
         <jaspi-configuration name="minimal">
             <server-auth-modules>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -1,5 +1,5 @@
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:5.0">
+<subsystem xmlns="urn:wildfly:elytron:5.0" default-ssl-context="ClientSslContextNoAuth">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="com.ibm.crypto.provider.IBMJCE com.ibm.jsse.IBMJSSEProvider com.ibm.jsse2.IBMJSSEProvider2 com.ibm.security.jgss.IBMJGSSProvider com.ibm.security.cert.IBMCertPath com.ibm.security.cmskeystore.CMSProvider com.ibm.security.jgss.mech.spnego.IBMSPNEGO" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -1,5 +1,5 @@
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:5.0">
+<subsystem xmlns="urn:wildfly:elytron:5.0" default-ssl-context="ClientSslContextNoAuth">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="com.sun.net.ssl.internal.ssl.Provider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:5.0">
+<subsystem xmlns="urn:wildfly:elytron:5.0" default-ssl-context="client">
     <providers>
         <provider-loader name="custom-loader" />
     </providers>

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -474,6 +474,7 @@ public enum Phase {
     public static final int CONFIGURE_DEFERRED_PHASE                    = 0x0300;
     public static final int CONFIGURE_SINGLETON_DEPLOYMENT              = 0x0400;
     public static final int CONFIGURE_AUTHENTICATION_CONTEXT            = 0x0500;
+    public static final int CONFIGURE_DEFAULT_SSL_CONTEXT               = 0x0580;
     public static final int CONFIGURE_DISTRIBUTABLE_WEB                 = 0x0600;
 
     // FIRST_MODULE_USE


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4144

Proposal https://github.com/wildfly/wildfly-proposals/pull/133