### PR TITLE
[WFCORE-4183][WFCORE-4184]][WFCORE-4186] Fix problem of incorrectly including runtime-only attri…

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/test/TestUtils.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/TestUtils.java
@@ -45,8 +45,13 @@ public class TestUtils {
     public static AttributeDefinition createAttribute(String name, ModelType type) {
         return createAttribute(name, type, null, false);
     }
+
     public static AttributeDefinition createNillableAttribute(String name, ModelType type) {
-        return createAttribute(name, type, null, true);
+        return createNillableAttribute(name, type, false);
+    }
+
+    public static AttributeDefinition createNillableAttribute(String name, ModelType type, boolean runtimeOnly) {
+        return createAttribute(name, type, null, runtimeOnly, false, true);
     }
 
     public static AttributeDefinition createAttribute(String name, ModelType type, String groupName) {

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/AccessAuthorizationTransformationTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/AccessAuthorizationTransformationTestCase.java
@@ -71,7 +71,8 @@ public class AccessAuthorizationTransformationTestCase extends AbstractCoreModel
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
-        checkCoreModelTransformation(mainServices, modelVersion);
+        checkCoreModelTransformation(mainServices, modelVersion, new RbacModelFixer(modelVersion), null);
+
         mainServices.shutdown();
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
@@ -239,14 +239,20 @@ public class DomainDeploymentOverlayTransformersTestCase extends AbstractCoreMod
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
-        checkCoreModelTransformation(mainServices, modelVersion, MODEL_FIXER, MODEL_FIXER);
+        Fixer fixer = new Fixer(modelVersion);
+        checkCoreModelTransformation(mainServices, modelVersion, fixer, fixer);
 
     }
 
-    private final ModelFixer MODEL_FIXER = new ModelFixer() {
+    private class Fixer extends RbacModelFixer {
+
+        Fixer(ModelVersion modelVersion) {
+            super(modelVersion);
+        }
 
         @Override
         public ModelNode fixModel(ModelNode modelNode) {
+            modelNode = super.fixModel(modelNode);
             modelNode.remove(SOCKET_BINDING_GROUP);
             modelNode.remove(PROFILE);
             return modelNode;

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
@@ -118,11 +118,13 @@ public class JvmTransformersTestCase extends AbstractCoreModelTest {
 
         boolean allowResourceTransformation = !isIgnoredResourceListAvailableAtRegistration()
                 || modelVersion.getMajor() >= 3;
+
+        final ModelFixer fixer = new Fixer(modelVersion);
         try {
             checkCoreModelTransformation(mainServices,
                     modelVersion,
-                    FIXER,
-                    FIXER);
+                    fixer,
+                    fixer);
             if (!allowResourceTransformation) {
                 Assert.fail("Resource transformation did not fail");
             }
@@ -138,8 +140,8 @@ public class JvmTransformersTestCase extends AbstractCoreModelTest {
             mainServices.executeOperation(op, ModelController.OperationTransactionControl.COMMIT);
             checkCoreModelTransformation(mainServices,
                     modelVersion,
-                    FIXER,
-                    FIXER);
+                    fixer,
+                    fixer);
         }
         mainServices.shutdown();
     }
@@ -176,10 +178,15 @@ public class JvmTransformersTestCase extends AbstractCoreModelTest {
         return modelVersion.getMajor() >= 1 && modelVersion.getMinor() >= 4;
     }
 
-    private ModelFixer FIXER = new ModelFixer() {
+    private class Fixer extends RbacModelFixer {
+
+        Fixer(ModelVersion modelVersion) {
+            super(modelVersion);
+        }
 
         @Override
         public ModelNode fixModel(ModelNode modelNode) {
+            modelNode = super.fixModel(modelNode);
             modelNode.remove(SOCKET_BINDING_GROUP);
             if (!isIgnoredResourceListAvailableAtRegistration()) {
                 modelNode.get(SERVER_GROUP, "test", JVM, "full").remove(LAUNCH_COMMAND.getName());

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
@@ -94,7 +94,8 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
-        ModelNode legacyModel = checkCoreModelTransformation(mainServices, modelVersion, StandardServerGroupInitializers.MODEL_FIXER, StandardServerGroupInitializers.MODEL_FIXER);
+        ModelFixer fixer = new StandardServerGroupInitializers.Fixer(modelVersion);
+        ModelNode legacyModel = checkCoreModelTransformation(mainServices, modelVersion, fixer, fixer);
         ModelNode properties = legacyModel;
         if (serverGroup) {
             properties = legacyModel.get(SERVER_GROUP, "test");
@@ -160,9 +161,10 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
         }
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, config);
 
-        checkCoreModelTransformation(mainServices, modelVersion, null, new ModelFixer() {
+        checkCoreModelTransformation(mainServices, modelVersion, new RbacModelFixer(modelVersion), new RbacModelFixer(modelVersion) {
             @Override
             public ModelNode fixModel(ModelNode modelNode) {
+                modelNode = super.fixModel(modelNode);
                 modelNode.remove(SOCKET_BINDING_GROUP);
                 if (!allowExpressions()) {
                     modelNode =  resolve(modelNode);

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
@@ -25,6 +25,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 
 import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
@@ -34,12 +35,12 @@ import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.ModelWriteSanitizer;
 import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
 import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
-import org.jboss.as.model.test.ModelFixer;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -96,14 +97,19 @@ public class StandardServerGroupInitializers {
         return legacyKernelServicesInitializer;
     }
 
-    public static final ModelFixer MODEL_FIXER = new ModelFixer() {
+    public static class Fixer extends AbstractCoreModelTest.RbacModelFixer {
+
+        public Fixer(ModelVersion transformFromVersion) {
+            super(transformFromVersion);
+        }
 
         @Override
         public ModelNode fixModel(ModelNode modelNode) {
+            modelNode = super.fixModel(modelNode);
             modelNode.remove(SOCKET_BINDING_GROUP);
             modelNode.remove(PROFILE);
             return modelNode;
         }
-    };
+    }
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessConstraintResources.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessConstraintResources.java
@@ -40,7 +40,6 @@ import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConstraint;
 import org.jboss.as.controller.access.constraint.SensitiveTargetConstraint;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
-import org.jboss.as.controller.access.constraint.VaultExpressionSensitivityConfig;
 import org.jboss.as.controller.access.management.AccessConstraintUtilizationRegistry;
 import org.jboss.as.controller.registry.Resource;
 
@@ -64,7 +63,7 @@ public class AccessConstraintResources {
 
     // Vault Expression Resource
     public static final PathElement VAULT_PATH_ELEMENT = PathElement.pathElement(CONSTRAINT, VAULT_EXPRESSION);
-    public static final Resource VAULT_RESOURCE = SensitivityResourceDefinition.createVaultExpressionResource(VaultExpressionSensitivityConfig.INSTANCE, VAULT_PATH_ELEMENT);
+    public static final Resource VAULT_RESOURCE = SensitivityResourceDefinition.createVaultExpressionResource();
 
     private static volatile Map<String, Map<String, SensitivityClassification>> classifications;
     private static volatile Map<String, Map<String, ApplicationTypeConfig>> applicationTypes;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ApplicationClassificationConfigResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ApplicationClassificationConfigResourceDefinition.java
@@ -157,7 +157,6 @@ public class ApplicationClassificationConfigResourceDefinition extends SimpleRes
         @Override
         public ModelNode getModel() {
             ModelNode model = new ModelNode();
-            model.get(DEFAULT_APPLICATION.getName()).set(applicationType.isDefaultApplication());
             model.get(CONFIGURED_APPLICATION.getName()).set(getBoolean(applicationType.getConfiguredApplication()));
             return model;
         }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestUtils.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestUtils.java
@@ -447,8 +447,8 @@ public class ModelTestUtils {
             if (!copy.hasDefined(key)) {
                 copy.remove(key);
             } else if (copy.get(key).getType() == ModelType.OBJECT) {
-                boolean undefined = true;
                 for (ModelNode mn : model.get(key).asList()) {
+                    boolean undefined = true;
                     Property p = mn.asProperty();
                     if (p.getValue().getType() != ModelType.OBJECT) { continue; }
                     for (String subKey : new HashSet<String>(p.getValue().keys())) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/slavereconnect/DeploymentScenario.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/slavereconnect/DeploymentScenario.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HASH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_SERIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_CLIENT_CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PLATFORM_MBEAN;
@@ -300,6 +301,7 @@ public class DeploymentScenario extends ReconnectTestScenario {
         ModelNode readResource = Util.createEmptyOperation(READ_RESOURCE_OPERATION,
                 PathAddress.pathAddress(MANAGEMENT_CLIENT_CONTENT, ROLLOUT_PLANS));
         readResource.get(RECURSIVE).set(true);
+        readResource.get(INCLUDE_RUNTIME).set(true);
         return DomainTestUtils.executeForResult(readResource, client);
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationTransformationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationTransformationTestCase.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_FAILURE_DESCRIPTIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MICRO_VERSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MINOR_VERSION;
@@ -113,6 +114,7 @@ public class OperationTransformationTestCase {
         executeForResult(subsystemAdd, client);
         // Check master version
         final ModelNode mExt = create(READ_RESOURCE_OPERATION, extension.append(PathElement.pathElement(SUBSYSTEM, VersionedExtensionCommon.SUBSYSTEM_NAME)));
+        mExt.get(INCLUDE_RUNTIME).set(true);
         assertVersion(executeForResult(mExt, client), ModelVersion.create(2));
 
         // Create subsystem in the ignored profile for further use


### PR DESCRIPTION
…butes in read-resource by dropping support for invalid-for-years-now inclusion of attributes without a ManagementResourceRegistration entry.

https://issues.jboss.org/browse/WFCORE-4183

Also fixes TestUtils.createNillableAttribute, which wasn't actually creating a nillable attribute, it was creating a runtime-only one.

In addition, this cleans up additional problems discovered during tests of WFCORE-4183, wherein transformer tests would fail because the test's read of a transformed domain model would include some runtime-only values, while the WFCORE-4183 fix meant the read-resource result it was comparing to would not. So, the transformed domain model read needs to be fixed:

https://issues.jboss.org/browse/WFCORE-4185
https://issues.jboss.org/browse/WFCORE-4186

Further, the comparison utility itself had a bug, which fixing all of the above brought to the surface:

https://issues.jboss.org/browse/WFCORE-4184