### PR TITLE
[WFCORE-4195] override requiresRuntime method to always return true i…

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRoleWriteAttributeHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRoleWriteAttributeHandler.java
@@ -80,6 +80,9 @@ class HostScopedRoleWriteAttributeHandler extends AbstractWriteAttributeHandler<
         constraint.setAllowedHosts(hosts);
     }
 
-
+    @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return true;
+    }
 }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleWriteAttributeHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleWriteAttributeHandler.java
@@ -79,5 +79,8 @@ class ServerGroupScopedRoleWriteAttributeHandler extends AbstractWriteAttributeH
         }
     }
 
-
+    @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return true;
+    }
 }


### PR DESCRIPTION
…n HostScopedRoleWriteAttributeHandler and ServerGroupScopedRoleWriteAttributeHandler

Please see issue https://issues.jboss.org/browse/WFCORE-4195
This overrides requiresRuntime method to always return true in HostScopedRoleWriteAttributeHandler and ServerGroupScopedRoleWriteAttributeHandler