### PR TITLE
[WFCORE-4198] Remove unneeded org.dom4j module dependency.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
@@ -38,7 +38,6 @@
         <module name="java.xml"/>
         <module name="javax.mail.api" optional="true"/>
         <module name="javax.jms.api" optional="true"/>
-        <module name="org.dom4j" optional="true"/>
         <module name="org.jboss.logmanager"/>
         <module name="org.jboss.modules"/>
     </dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4198