### PR TITLE
[WFCORE-4202] org.jboss.msc module optional dependencies issues

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
@@ -37,14 +37,10 @@
     <dependencies>
         <!-- for java.beans -->
         <module name="java.desktop"/>
+
         <module name="java.management"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
-
-        <!-- Optional deps -->
-
-        <module name="javax.inject.api" optional="true"/>
-        <module name="org.jboss.threads" optional="true"/>
-        <module name="org.jboss.vfs" optional="true"/>
+        <module name="org.jboss.threads"/>
     </dependencies>
 </module>


### PR DESCRIPTION
- `org.jboss.threads` is required by `ServiceContainerImpl` by the class constructor. This constructor is always called in wildfly-core by `BootstrapImpl` and by `HostControllerBootstrap` to register the shutdownhook. 
That means, when wildfly starts an embedded server, standalone instance or a domain, the shutdownhook is always registered, and that makes `org.jboss.threads` mandatory in `org.jboss.msc` from the point of view of wildfly. We can argue that the org.jboss.msc.Version main class declared in the module does not need it, but I think, it is irrelevant in this context.
- `javax.inject.api` and `org.jboss.vfs` are not used by jboss-msc.jar, so we can remove them

Jira issue: https://issues.jboss.org/browse/WFCORE-4202