### PR TITLE
[WFCORE-4208] / [WFCORE-4209] / [WFCORE-4210] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.7.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.3.0.CR3</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.5.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.7.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.3.0.CR3</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.3.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.5.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.7.0.CR3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.7.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.3.0.CR3</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4208
https://issues.jboss.org/browse/WFCORE-4209
https://issues.jboss.org/browse/WFCORE-4210

No changes were made to WildFly Elytron Tool other than component upgrades to bring dependencies in-line with WildFly Core versions, including the upgrade to WildFly Elytron 1.7.0.Final.

        Release Notes - WildFly Elytron - Version 1.7.0.Final
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1680'>ELY-1680</a>] -         IBM, failing KeyStoreSuiteChild.testGetCertificateChainBinary
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1709'>ELY-1709</a>] -         Release WildFly Elytron 1.7.0.Final
</li>
</ul>


        Release Notes - Elytron Web - Version 1.3.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-34'>ELYWEB-34</a>] -         Upgrade WildFly Elytron to 1.7.0.Final
</li>
</ul>
                                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-33'>ELYWEB-33</a>] -         Release Elytron Web 1.3.0.Final
</li>
</ul>