### PR TITLE
[WFCORE-4212] Upgrade to Galleon and WildFly Galleon Plugins 3.0.0.CR1

### DIFF
--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -645,17 +645,6 @@
                 <artifactId>wildfly-galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>feature-spec-build</id>
-                        <goals>
-                            <goal>generate-feature-specs</goal>
-                        </goals>
-                        <phase>compile</phase>
-                        <configuration>
-                            <fork-embedded>${galleon.fork.embedded}</fork-embedded>
-                            <output-dir>${basedir}/target/resources/features</output-dir>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>feature-pack-build</id>
                         <goals>
                             <goal>build-feature-pack</goal>
@@ -663,6 +652,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <release-name>WildFly Core</release-name>
+                            <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                         </configuration>
                     </execution>
                 </executions>

--- a/core-galleon-pack/src/main/resources/configs/domain/domain.xml/config.xml
+++ b/core-galleon-pack/src/main/resources/configs/domain/domain.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="domain.xml" model="domain">
+    <feature-group name="domain"/>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/domain/model.xml
+++ b/core-galleon-pack/src/main/resources/configs/domain/model.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="domain">
+    <props>
+        <prop name="config.branch-is-batch" value="true"/>
+        <prop name="config.merge-independent-branches" value="true"/>
+        <prop name="--empty-domain-config" value=""/>
+        <prop name="--remove-existing-domain-config" value=""/>
+        <prop name="--empty-host-config" value=""/>
+        <prop name="--remove-existing-host-config" value=""/>
+    </props>
+    <packages>
+        <package name="product.conf" optional="true"/>
+        <package name="misc.domain"/>
+        <package name="org.jboss.as.domain-management"/>
+        <!-- is not required but useful even if elytron subsystem is not installed -->
+        <package name="org.wildfly.security.elytron"/>
+        <!-- cleanup runtime dirs -->
+        <package name="cleanup.domain.config.history.dir" optional="true"/>
+        <package name="cleanup.domain.servers.dir" optional="true"/>
+        <package name="cleanup.domain.log.dir" optional="true"/>
+        <package name="cleanup.domain.data.dir" optional="true"/>
+    </packages>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/host/host-master.xml/config.xml
+++ b/core-galleon-pack/src/main/resources/configs/host/host-master.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-master.xml" model="host">
+    <feature-group name="host-master"/>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/host/host-slave.xml/config.xml
+++ b/core-galleon-pack/src/main/resources/configs/host/host-slave.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-slave.xml" model="host">
+    <feature-group name="host-slave"/>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/host/host.xml/config.xml
+++ b/core-galleon-pack/src/main/resources/configs/host/host.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host.xml" model="host">
+    <feature-group name="host"/>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/host/model.xml
+++ b/core-galleon-pack/src/main/resources/configs/host/model.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="host">
+    <config-deps>
+        <config-dep id="domain-dep" model="domain"/>
+    </config-deps>
+    <props>
+        <prop name="config.branch-is-batch" value="true"/>
+        <prop name="config.merge-independent-branches" value="true"/>
+        <prop name="--domain-config" value="domain.xml"/>
+        <prop name="--empty-host-config" value=""/>
+        <prop name="--remove-existing-host-config" value=""/>
+    </props>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/standalone/model.xml
+++ b/core-galleon-pack/src/main/resources/configs/standalone/model.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="standalone">
+    <props>
+        <prop name="config.branch-is-batch" value="true"/>
+        <prop name="config.merge-independent-branches" value="true"/>
+        <!-- <prop name="config.merge-same-deps-branches" value="true"/> -->
+        <prop name="--admin-only" value=""/>
+        <prop name="--internal-empty-config" value=""/>
+        <prop name="--internal-remove-config" value=""/>
+    </props>
+    <packages>
+        <package name="product.conf" optional="true"/>
+        <package name="misc.standalone"/>
+        <package name="org.jboss.as.standalone"/>
+        <package name="org.jboss.as.domain-management"/>
+        <!-- is not required but useful even if elytron subsystem is not installed -->
+        <package name="org.wildfly.security.elytron"/>
+        <!-- cleanup runtime dirs -->
+        <package name="cleanup.standalone.config.history.dir" optional="true"/>
+        <package name="cleanup.standalone.log.dir" optional="true"/>
+        <package name="cleanup.standalone.data.dir" optional="true"/>
+        <package name="cleanup.standalone.tmp.vfs" optional="true"/>
+    </packages>
+</config>

--- a/core-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/core-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
+    <feature-group name="standalone"/>
+</config>

--- a/core-galleon-pack/src/main/resources/feature_groups/base-security-realms.xml
+++ b/core-galleon-pack/src/main/resources/feature_groups/base-security-realms.xml
@@ -5,7 +5,7 @@
             <param name="security-realm" value="ManagementRealm"/>
             <param name="map-groups-to-roles" value="false"/>
             <feature spec="core-service.management.security-realm.authentication.local">
-                <param name="default-user" value="&quot;\$local&quot;"/>
+                <param name="default-user" value="$local"/>
                 <param name="skip-group-loading" value="true"/>
             </feature>
             <feature spec="core-service.management.security-realm.authentication.properties">
@@ -18,7 +18,7 @@
         <feature spec="core-service.management.security-realm">
             <param name="security-realm" value="ApplicationRealm"/>
             <feature spec="core-service.management.security-realm.authentication.local">
-                <param name="default-user" value="&quot;\$local&quot;"/>
+                <param name="default-user" value="$local"/>
                 <param name="allowed-users" value="*"/>
                 <param name="skip-group-loading" value="true"/>
             </feature>

--- a/core-galleon-pack/src/main/resources/feature_groups/elytron-common.xml
+++ b/core-galleon-pack/src/main/resources/feature_groups/elytron-common.xml
@@ -15,7 +15,7 @@
     </feature>
     <feature spec="subsystem.elytron.identity-realm">
         <param name="identity-realm" value="local" />
-        <param name="identity" value="&quot;\$local&quot;" />
+        <param name="identity" value="$local" />
     </feature>
     <feature spec="subsystem.elytron.file-audit-log">
         <param name="file-audit-log" value="local-audit" />

--- a/core-galleon-pack/src/main/resources/packages/cleanup.domain.data.dir/pm/wildfly/tasks.xml
+++ b/core-galleon-pack/src/main/resources/packages/cleanup.domain.data.dir/pm/wildfly/tasks.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
-    <delete path="domain/data" recursive="true"/>
+    <delete path="domain/data/auto-start" recursive="true"/>
+    <delete path="domain/data/content" if-empty="true"/>
+    <delete path="domain/data/kernel" recursive="true"/>
+    <delete path="domain/data" if-empty="true"/>
 </tasks>

--- a/core-galleon-pack/src/main/resources/packages/cleanup.standalone.data.dir/pm/wildfly/tasks.xml
+++ b/core-galleon-pack/src/main/resources/packages/cleanup.standalone.data.dir/pm/wildfly/tasks.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
-    <delete path="standalone/data" recursive="true"/>
+    <delete path="standalone/data/kernel" recursive="true"/>
+    <delete path="standalone/data/content" if-empty="true"/>
+    <delete path="standalone/data" if-empty="true"/>
 </tasks>

--- a/core-galleon-pack/wildfly-feature-pack-build.xml
+++ b/core-galleon-pack/wildfly-feature-pack-build.xml
@@ -29,73 +29,12 @@
         <group name="org.wildfly.core"/>
     </package-schemas>
 
-    <config model="standalone">
-        <props>
-            <prop name="config.branch-is-batch" value="true"/>
-            <prop name="config.merge-independent-branches" value="true"/>
-            <!-- <prop name="config.merge-same-deps-branches" value="true"/> -->
-            <prop name="--admin-only" value=""/>
-            <prop name="--internal-empty-config" value=""/>
-            <prop name="--internal-remove-config" value=""/>
-        </props>
-        <packages>
-            <package name="product.conf" optional="true"/>
-            <package name="misc.standalone"/>
-            <package name="org.jboss.as.standalone"/>
-            <package name="org.jboss.as.domain-management"/>
-            <!-- is not required but useful even if elytron subsystem is not installed -->
-            <package name="org.wildfly.security.elytron"/>
-            <!-- cleanup runtime dirs -->
-            <package name="cleanup.standalone.config.history.dir" optional="true"/>
-            <package name="cleanup.standalone.log.dir" optional="true"/>
-            <package name="cleanup.standalone.data.dir" optional="true"/>
-            <package name="cleanup.standalone.tmp.vfs" optional="true"/>
-        </packages>
-    </config>
-
-    <config model="domain">
-        <props>
-            <prop name="config.branch-is-batch" value="true"/>
-            <prop name="config.merge-independent-branches" value="true"/>
-            <prop name="--empty-domain-config" value=""/>
-            <prop name="--remove-existing-domain-config" value=""/>
-            <prop name="--empty-host-config" value=""/>
-            <prop name="--remove-existing-host-config" value=""/>
-        </props>
-        <packages>
-            <package name="product.conf" optional="true"/>
-            <package name="misc.domain"/>
-            <package name="org.jboss.as.domain-management"/>
-            <!-- is not required but useful even if elytron subsystem is not installed -->
-            <package name="org.wildfly.security.elytron"/>
-            <!-- cleanup runtime dirs -->
-            <package name="cleanup.domain.config.history.dir" optional="true"/>
-            <package name="cleanup.domain.servers.dir" optional="true"/>
-            <package name="cleanup.domain.log.dir" optional="true"/>
-            <package name="cleanup.domain.data.dir" optional="true"/>
-        </packages>
-    </config>
-
-    <config model="host">
-        <config-deps>
-            <config-dep id="domain-dep" model="domain"/>
-        </config-deps>
-        <props>
-            <prop name="config.branch-is-batch" value="true"/>
-            <prop name="config.merge-independent-branches" value="true"/>
-            <prop name="--domain-config" value="domain.xml"/>
-            <prop name="--empty-host-config" value=""/>
-            <prop name="--remove-existing-host-config" value=""/>
-        </props>
-    </config>
-
     <config name="standalone.xml" model="standalone">
         <!-- config name is the resulting xml file name which can be changed by setting the property below
         <props>
             <prop name="- -server-config" value="standalone-custom.xml"/>
         </props>
         -->
-        <feature-group name="standalone"/>
     </config>
 
     <config name="domain.xml" model="domain">
@@ -104,7 +43,6 @@
             <prop name="- -domain-config" value="domain-custom.xml"/>
         </props>
         -->
-        <feature-group name="domain"/>
     </config>
 
     <config name="host.xml" model="host">
@@ -113,16 +51,10 @@
             <prop name="- -host-config" value="host-custom.xml"/>
         </props>
         -->
-        <feature-group name="host"/>
     </config>
 
-    <config name="host-master.xml" model="host">
-        <feature-group name="host-master"/>
-    </config>
-
-    <config name="host-slave.xml" model="host">
-        <feature-group name="host-slave"/>
-    </config>
+    <config name="host-master.xml" model="host"/>
+    <config name="host-slave.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>2.0.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>3.0.0.CR1</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>2.0.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>3.0.0.CR1</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4212

Key changes here are:
* generate-feature-specs goal merged into build-feature-pack;
* default config definitions moved from wildfly-feature-pack-build.xml to their own files (and from the generated feature-pack.xml to their own files).