### PR TITLE
[WFCORE-4129] WFLYSRV0266: Server home is set to... info msg in domain for RPM installation

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -438,15 +438,6 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                     throw ServerLogger.ROOT_LOGGER.couldNotCreateServerBaseDirectory(tmp);
                 }
             }
-            try {
-                Path resolved = tmp.toPath().toRealPath();
-                if (!tmp.toPath().equals(resolved)){ //WFCORE-2652
-                    ServerLogger.ROOT_LOGGER.serverHomeMismatch(tmp.toPath(), resolved);
-                    tmp = resolved.toFile();
-                }
-            } catch (IOException e) {
-                //
-            }
             serverBaseDir = tmp;
 
             tmp = getFileFromProperty(SERVER_CONFIG_DIR, props);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1298,9 +1298,9 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 265, value = "Invalid value '%s' for system property '%s' -- value must be a non-negative integer")
     void invalidPoolCoreSize(String val, String configSysProp);
 
-    @LogMessage(level = WARN)
-    @Message(id = 266, value = "Server home is set to '%s', but server real home is '%s' - unpredictable results may occur.")
-    void serverHomeMismatch(Path passed, Path real);
+//    @LogMessage(level = WARN)
+//    @Message(id = 266, value = "Server home is set to '%s', but server real home is '%s' - unpredictable results may occur.")
+//    void serverHomeMismatch(Path passed, Path real);
 
     @Message(id = 267, value = "Cannot mount resource root '%s', is it really an archive?")
     XMLStreamException archiveMountFailed(String path, @Cause ZipException cause);


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4129

This reduces the side effect in Linux where the symbolic link is used
