### PR TITLE
[WFCORE-3905] Improve SuspendController code

### DIFF
--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1324,6 +1324,10 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 271, value = "Git error: %s")
     void errorUsingGit(@Cause Throwable cause, String message);
 
+    @LogMessage(level = INFO)
+    @Message(id = 272, value = "Suspending server")
+    void suspendingServer();
+
     ////////////////////////////////////////////////
     //Messages without IDs
 

--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -78,8 +78,10 @@ public class SuspendController implements Service<SuspendController> {
         }
         if (timeoutMillis > 0) {
             ServerLogger.ROOT_LOGGER.suspendingServer(timeoutMillis);
-        } else {
+        } else if (timeoutMillis < 0) {
             ServerLogger.ROOT_LOGGER.suspendingServerWithNoTimeout();
+        } else {
+            ServerLogger.ROOT_LOGGER.suspendingServer();
         }
         state = State.PRE_SUSPEND;
         //we iterate a copy, in case a listener tries to register a new listener
@@ -100,8 +102,8 @@ public class SuspendController implements Service<SuspendController> {
             for (ServerActivity activity : activities) {
                 activity.preSuspend(cb);
             }
-            timer = new Timer();
             if (timeoutMillis > 0) {
+                timer = new Timer();
                 timer.schedule(new TimerTask() {
                     @Override
                     public void run() {
@@ -166,7 +168,7 @@ public class SuspendController implements Service<SuspendController> {
         return state;
     }
 
-    synchronized void activityPaused() {
+    private synchronized void activityPaused() {
         --outstandingCount;
         handlePause();
     }
@@ -185,7 +187,7 @@ public class SuspendController implements Service<SuspendController> {
         }
     }
 
-    synchronized void timeout() {
+    private synchronized void timeout() {
         if (timer != null) {
             timer.cancel();
             timer = null;


### PR DESCRIPTION
Minor fixes for SuspendController

1. The Timer allocated at L103 is pointless unless timeoutMillis > 0
2. activityPaused() and timeout() can be private
3. The logging message L80-L82 is incorrect if timeoutMillis == 0

Jira issue: https://issues.jboss.org/browse/WFCORE-3905