### PR TITLE
Fix for WFCORE-4240, CLI, failed interactive enable-ssl commands put the server in reload state

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/InteractiveSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/InteractiveSecurityBuilder.java
@@ -377,7 +377,7 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
         // REMOVE WHEN WFCORE-3491 is fixed.
         if (keyStoreName != null) {
             ModelNode req = ElytronUtil.removeKeyStore(ctx, keyStoreName);
-            SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+            SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER, false);
         }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/SSLSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/SSLSecurityBuilder.java
@@ -386,7 +386,7 @@ public abstract class SSLSecurityBuilder implements SecurityCommand.FailureConsu
             // REMOVE WHEN WFCORE-3491 is fixed.
             if (generatedTrustStore != null) {
                 ModelNode req = ElytronUtil.removeKeyStore(ctx, generatedTrustStore);
-                SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+                SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER, false);
             }
         } catch (Exception ex) {
             builder.append("Error while cleaning up key-stores " + ex).append("\n");


### PR DESCRIPTION
- Force reload when removing key-store.
- Added test.