### PR TITLE
[WFCORE-4242] allow empty values for Elytron security identity attrib…

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
@@ -232,6 +232,7 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                 .build();
 
         static final SimpleAttributeDefinition VALUE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.VALUE, ModelType.STRING, false)
+                .setMinSize(0)
                 .build();
 
         static final SimpleListAttributeDefinition VALUES = new SimpleListAttributeDefinition.Builder(ElytronDescriptionConstants.VALUE, VALUE)

--- a/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
@@ -200,6 +200,38 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
     }
 
     @Test
+    public void testAddEmptyAttributeValue() throws Exception {
+        KernelServices services = createKernelServicesBuilder(null)
+                .setSubsystemXmlResource("identity-management.xml")
+                .build();
+        String principalName = "plainUser";
+        PathAddress realmAddress = getSecurityRealmAddress("FileSystemRealm");
+        ModelNode operation = createAddIdentityOperation(realmAddress, principalName);
+        ModelNode result = services.executeOperation(operation);
+
+        assertSuccessful(result);
+
+        operation = createAddAttributeOperation(realmAddress, principalName, "name", "John Smith");
+        result = services.executeOperation(operation);
+        assertSuccessful(result);
+
+        operation = createAddAttributeOperation(realmAddress, principalName, "phoneNumber", "");
+        result = services.executeOperation(operation);
+        assertSuccessful(result);
+
+        operation = createReadIdentityOperation(realmAddress, principalName);
+        result = services.executeOperation(operation);
+        assertSuccessful(result);
+
+        ModelNode resultNode = result.get(RESULT);
+        ModelNode attributesNode = resultNode.get(ATTRIBUTES);
+
+        assertTrue(attributesNode.isDefined());
+        assertAttributeValue(attributesNode, "name", "John Smith");
+        assertAttributeValue(attributesNode, "phoneNumber", "");
+    }
+
+    @Test
     public void testRemoveAttribute() throws Exception {
         KernelServices services = createKernelServicesBuilder(null)
                 .setSubsystemXmlResource("identity-management.xml")


### PR DESCRIPTION
…utes

JIRA: https://issues.jboss.org/browse/WFCORE-4242

Security identity in Elytron can have attributes associated with it. Right now, when adding attribute through CLI, values must have a minimum length of 1 character. However, it makes sense to allow empty value for an attribute (e.g., for the case where some information is optional so we may not have all the values)