### PR TITLE
WIP: [EAP7-1100] Add the ability for the CLI SSL security commands to be a…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -100,6 +100,8 @@ public class Util {
     public static final String BYTES = "bytes";
     public static final String CAPABILITY_REFERENCE = "capability-reference";
     public static final String CAPABILITY_REGISTRY = "capability-registry";
+    public static final String CERTIFICATE_AUTHORITY = "certificate-authority";
+    public static final String CERTIFICATE_AUTHORITY_ACCOUNT = "certificate-authority-account";
     public static final String CHILDREN = "children";
     public static final String CHILD_TYPE = "child-type";
     public static final String CLEAR_TEXT = "clear-text";
@@ -109,6 +111,7 @@ public class Util {
     public static final String CONFIGURED = "configured";
     public static final String CONSTANT_REALM_MAPPER = "constant-realm-mapper";
     public static final String CONSTANT_ROLE_MAPPER = "constant-role-mapper";
+    public static final String CONTACT_URLS = "contact-urls";
     public static final String CONTENT = "content";
     public static final String CORE_SERVICE = "core-service";
     public static final String CREDENTIAL_REFERENCE = "credential-reference";
@@ -199,6 +202,7 @@ public class Util {
     public static final String OPERATION = "operation";
     public static final String OPERATIONS = "operations";
     public static final String OPERATION_HEADERS = "operation-headers";
+    public static final String OBTAIN_CERTIFICATE = "obtain-certificate";
     public static final String OUTCOME = "outcome";
     public static final String PATH = "path";
     public static final String PEM = "pem";
@@ -309,6 +313,8 @@ public class Util {
     public static final String DESCRIPTION_RESPONSE = "DESCRIPTION_RESPONSE";
 
     public static final String NOT_OPERATOR = "!";
+    public static final String DOMAIN_NAMES = "domain-names";
+    public static final String AGREE_TO_TERMS_OF_SERVICE = "agree-to-terms-of-service";
 
     private static TerminalColor ERROR_COLOR;
     private static TerminalColor SUCCESS_COLOR;

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
@@ -89,6 +89,8 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
     public static final String OPT_MECHANISMS_ORDER = "mechanisms-order";
     public static final String OPT_MECHANISM = "mechanism";
     public static final String OPT_SUPER_USER = "super-user";
+    public static final String OPT_LETS_ENCRYPT = "lets-encrypt";
+    public static final String OPT_CA_ACCOUNT = "ca-account";
 
     public static final String OPT_ROLES = "roles";
 
@@ -294,6 +296,15 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
                 } catch (Exception ex) {
                     return Collections.emptyList();
                 }
+            }
+        }
+
+        public static class CaAccountNameCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return ElytronUtil.getCaAccountNames(completerInvocation.getCommandContext().
+                        getModelControllerClient());
             }
         }
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
@@ -1223,4 +1223,61 @@ public abstract class ElytronUtil {
         builder.addNode(Util.CONSTANT_ROLE_MAPPER, name);
         return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
     }
+
+    public static ModelNode addCertificateAuthorityAccount(CommandContext ctx, String name, String password, String alias, String keyStoreName, List<String> contactUrls) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.CERTIFICATE_AUTHORITY_ACCOUNT, name);
+        builder.getModelNode().get(Util.CONTACT_URLS).set(createModelNodes(contactUrls));
+        builder.addProperty(Util.KEY_STORE, keyStoreName);
+        builder.addProperty(Util.ALIAS, alias);
+        builder.getModelNode().get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(password));
+        return builder.buildRequest();
+    }
+
+    private static List<ModelNode> createModelNodes(List<String> items) {
+        List<ModelNode> modelNodes = new ArrayList<>();
+        for (String item : items) {
+            if(!item.isEmpty()) {
+                modelNodes.add(new ModelNode(item));
+            }
+        }
+        return modelNodes;
+    }
+
+    public static ModelNode removeCertificateAuthorityAccount(CommandContext ctx, String name) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.REMOVE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.CERTIFICATE_AUTHORITY_ACCOUNT, name);
+        return builder.buildRequest();
+    }
+
+    public static ModelNode obtainCertificateRequest(CommandContext ctx,
+                                                     String keyStoreName,
+                                                     String alias,
+                                                     String password,
+                                                     List<String> domainNames,
+                                                     String certificateAuthorityAccount,
+                                                     boolean agreedToTOS,
+                                                     int key_size,
+                                                     String key_algorithm) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.OBTAIN_CERTIFICATE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, keyStoreName);
+        builder.addProperty(Util.ALIAS, alias);
+        builder.getModelNode().get(Util.DOMAIN_NAMES).set(createModelNodes(domainNames));
+        builder.addProperty(Util.CERTIFICATE_AUTHORITY_ACCOUNT, certificateAuthorityAccount);
+        builder.addProperty(Util.AGREE_TO_TERMS_OF_SERVICE, String.valueOf(agreedToTOS));
+        builder.getModelNode().get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(password));
+        builder.addProperty(Util.ALGORITHM, key_algorithm);
+        builder.addProperty(Util.KEY_SIZE, String.valueOf(key_size));
+        return builder.buildRequest();
+    }
+
+    public static List<String> getCaAccountNames(ModelControllerClient client) {
+        return getNames(client, Util.CERTIFICATE_AUTHORITY_ACCOUNT);
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/InteractiveSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/InteractiveSecurityBuilder.java
@@ -16,6 +16,8 @@ limitations under the License.
 package org.jboss.as.cli.impl.aesh.cmd.security.model;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.aesh.command.CommandException;
@@ -23,7 +25,6 @@ import org.aesh.readline.Prompt;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
-import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
 import org.jboss.as.cli.impl.aesh.cmd.security.ssl.PromptFileCompleter;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
@@ -103,13 +104,29 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
 
     private final String defaultKeyStoreFile;
     private final String defaultTrustStoreFile;
+    private final boolean useLetsEncrypt;
+    private final String caAccount;
 
+    private String accountKeyStoreName;
+    private String accountKeyStoreFile;
+    private String accountKeyStorePassword;
+    private String certAuthorityAccountName;
+    private List<String> contactUrls;
+    private String certAuthorityAccountPassword;
+    private String certAuthorityAccountAlias;
+    private boolean agreedToTOS = false;
+    private List<String> domainNames;
+
+    private static final String defaultAccountKeyStoreFile = "accounts.keystore.jks";
+    private static final String defaultCertAuthorityAccountName = "CertAuthorityAccount";
     private static final String KEY_ALG = "RSA";
-    private static final int KEY_SIZE = 1024;
+    private static final int KEY_SIZE = 2048;
 
-    public InteractiveSecurityBuilder(String defaultKeyStoreFile, String defaultTrustStoreFile) throws CommandException {
+    public InteractiveSecurityBuilder(String defaultKeyStoreFile, String defaultTrustStoreFile, boolean useLetsEncrypt, String caAccount) throws CommandException {
         this.defaultKeyStoreFile = defaultKeyStoreFile;
         this.defaultTrustStoreFile = defaultTrustStoreFile;
+        this.useLetsEncrypt = useLetsEncrypt;
+        this.caAccount = caAccount;
     }
 
     public InteractiveSecurityBuilder setCommandInvocation(CLICommandInvocation commandInvocation) {
@@ -130,25 +147,106 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
             clientCertificate = File.separator + PLACE_HOLDER;
             trustStorePassword = PLACE_HOLDER;
             trustStoreFileName = PLACE_HOLDER;
+            accountKeyStoreFile = PLACE_HOLDER;
+            accountKeyStorePassword = PLACE_HOLDER;
+            certAuthorityAccountName = PLACE_HOLDER;
+            contactUrls = new ArrayList<>();
+            contactUrls.add(PLACE_HOLDER);
+            certAuthorityAccountPassword = PLACE_HOLDER;
+            certAuthorityAccountAlias = PLACE_HOLDER;
+            agreedToTOS = true;
+            domainNames = new ArrayList<>();
+            domainNames.add(PLACE_HOLDER);
         } else {
             ctx.printLine("Please provide required pieces of information to enable SSL:");
         }
         String relativeTo = Util.JBOSS_SERVER_CONFIG_DIR;
+        String id = UUID.randomUUID().toString();
         boolean ok = false;
+
+        //Use Let's Encrypt CA Account
+        if(useLetsEncrypt && caAccount != null) {
+            certAuthorityAccountName = caAccount;
+        }
+        //Let's Encrypt account KS and certAuthAccount prompts
+        if(useLetsEncrypt && caAccount == null) {
+            ctx.print("\nLet's Encrypt account key-store:");
+            //then account key store
+            while (accountKeyStoreFile == null) {
+                accountKeyStoreFile = commandInvocation.inputLine(new Prompt("File name (default " + defaultAccountKeyStoreFile + "): "));
+                if (accountKeyStoreFile != null && accountKeyStoreFile.length() == 0) {
+                    accountKeyStoreFile = defaultAccountKeyStoreFile;
+                }
+            }
+
+            //then accountKeyStorePassword
+            while (accountKeyStorePassword == null) {
+                accountKeyStorePassword = commandInvocation.inputLine(new Prompt("Password (blank generated): "));
+                if (accountKeyStorePassword != null && accountKeyStorePassword.length() == 0) {
+                    accountKeyStorePassword = SSLSecurityBuilder.generateRandomPassword();
+                }
+            }
+
+            // then Let's Encrypt certificate authority account:
+            ctx.print("\nLet's Encrypt certificate authority account:");
+            //then account name
+            while (certAuthorityAccountName == null) {
+                certAuthorityAccountName = commandInvocation.inputLine(new Prompt("Account name (default " + defaultCertAuthorityAccountName + "): "));
+                if (certAuthorityAccountName != null && certAuthorityAccountName.length() == 0) {
+                    certAuthorityAccountName = defaultCertAuthorityAccountName;
+                }
+            }
+
+            //then contactUrls / email
+            while (contactUrls == null || contactUrls.size() < 1) {
+                String emails = commandInvocation.inputLine(new Prompt("Contact email(s) [admin@example.com,info@example.com]: "));
+                contactUrls = parseEmails(emails);
+            }
+
+            //then certAuthorityAccountPassword
+            while (certAuthorityAccountPassword == null) {
+                certAuthorityAccountPassword = commandInvocation.inputLine(new Prompt("Password (blank generated): "));
+                if (certAuthorityAccountPassword != null && certAuthorityAccountPassword.length() == 0) {
+                    certAuthorityAccountPassword = SSLSecurityBuilder.generateRandomPassword();
+                }
+            }
+
+            while (certAuthorityAccountAlias == null) {
+                certAuthorityAccountAlias = commandInvocation.inputLine(new Prompt("Alias (blank generated): "));
+                if (certAuthorityAccountAlias != null && certAuthorityAccountAlias.length() == 0) {
+                    certAuthorityAccountAlias = "account-key-store-alias-" + id;
+                }
+            }
+
+            if (!buildRequest) {
+                //then Let's Encrypt TOS (https://community.letsencrypt.org/tos)
+                String reply = null;
+                while (reply == null) {
+                    ctx.print("\nLet's Encrypt TOS (https://community.letsencrypt.org/tos)");
+
+                    reply = commandInvocation.inputLine(new Prompt("Do you agree to Let's Encrypt terms of service? y/n:"));
+                    if (reply != null && reply.equals("y")) {
+                        agreedToTOS = true;
+                        break;
+                    } else if (reply != null && !reply.equals("n")) {
+                        reply = null;
+                    }
+                }
+                if (!agreedToTOS) {
+                    throw new CommandException("Ignoring, command not executed.");
+                }
+            }
+        }
+
         Long v = null;
         String certName;
         String csrName;
+        ctx.print("\nCertificate info:");
         // First keystore file name
         while (keyStoreFile == null) {
             keyStoreFile = commandInvocation.inputLine(new Prompt("Key-store file name (default " + defaultKeyStoreFile + "): "));
             if (keyStoreFile != null && keyStoreFile.length() == 0) {
                 keyStoreFile = defaultKeyStoreFile;
-            }
-            //Check that we are not going to corrupt existing key-stores that are referencing the exact same file.
-            List<String> ksNames = ElytronUtil.findMatchingKeyStores(ctx, new File(keyStoreFile), relativeTo);
-            if (!ksNames.isEmpty()) {
-                throw new CommandException("Error, the file " + keyStoreFile + " is already referenced from " + ksNames
-                        + " resources. Use " + SecurityCommand.formatOption(OPT_KEY_STORE_NAME) + " option or choose another file name.");
             }
         }
         int i = keyStoreFile.indexOf(".");
@@ -168,23 +266,35 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
             }
         }
 
-        // then prompt for dn
-        if (dn == null) {
-            dn = new DNWizard().buildDN();
-        }
+        if(useLetsEncrypt) {
+            //then prompt for domainName
+            while (domainNames == null || domainNames.size() < 1) {
+                String domains = commandInvocation.inputLine(new Prompt("Your domain name(s) (must be accessible by the Let's Encrypt server at 80 & 443 ports) [example.com,second.example.com]: "));
+                domainNames = parseItemsFromString(domains, "example.com,second.example.com");
+            }
 
-        // then validity
-        while (validity == null) {
-            validity = commandInvocation.inputLine(new Prompt("Validity (in days, blank default): "));
-            if (validity != null) {
-                if (validity.length() == 0) {
-                    v = null;
-                } else {
-                    try {
-                        v = Long.parseLong(validity);
-                    } catch (NumberFormatException e) {
-                        ctx.printLine("Invalid number " + validity);
-                        validity = null;
+            //then set validity to 90 - this is default Let's Encrypt setting
+            validity = "90";
+        } else {
+            // then prompt for dn
+            if (dn == null) {
+                dn = new DNWizard().buildDN();
+            }
+
+
+            // then validity
+            while (validity == null) {
+                validity = commandInvocation.inputLine(new Prompt("Validity (in days, blank default): "));
+                if (validity != null) {
+                    if (validity.length() == 0) {
+                        v = null;
+                    } else {
+                        try {
+                            v = Long.parseLong(validity);
+                        } catch (NumberFormatException e) {
+                            ctx.printLine("Invalid number " + validity);
+                            validity = null;
+                        }
                     }
                 }
             }
@@ -194,7 +304,7 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
         while (alias == null) {
             alias = commandInvocation.inputLine(new Prompt("Alias (blank generated): "));
             if (alias != null && alias.length() == 0) {
-                alias = "alias-" + UUID.randomUUID().toString();
+                alias = "alias-" + id;
             }
         }
 
@@ -272,12 +382,32 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
             }
         }
 
+        keyStoreName = "key-store-" + id;
+        accountKeyStoreName = "account-key-store-" + id;
+        setKeyManagerName("key-manager-" + id);
+        setSSLContextName("ssl-context-" + id);
+
         if (!buildRequest) {
             String reply = null;
             while (reply == null) {
+                if(useLetsEncrypt && caAccount == null) {
+                    ctx.printLine("\nLet's Encrypt options:" + "\n"
+                            + "account key store name: " + accountKeyStoreName + "\n"
+                            + "password: " + accountKeyStorePassword + "\n"
+                            + "Account keystore file " + accountKeyStoreFile + " will be generated in server configuration directory." + "\n"
+                            + "Let's Encrypt Certificate authority account name: " + certAuthorityAccountName + "\n"
+                            + "Contact urls: " + contactUrls + "\n"
+                            + "password: " + certAuthorityAccountPassword + "\n"
+                            + "alias: " + certAuthorityAccountAlias + "\n"
+                            + "You provided agreement to Let's Encrypt terms of service." + "\n"
+                    );
+                } else if (caAccount != null) {
+                    ctx.printLine("Let's Encrypt Certificate authority account name: " + certAuthorityAccountName + "\n");
+                }
+
                 ctx.printLine("\nSSL options:");
                 ctx.printLine("key store file: " + keyStoreFile + "\n"
-                        + "distinguished name: " + dn + "\n"
+                        + (useLetsEncrypt ?  "domain name: " + domainNames + "\n" : "distinguished name: " + dn + "\n")
                         + "password: " + password + "\n"
                         + "validity: " + (validity.length() == 0 ? "default" : validity) + "\n"
                         + "alias: " + alias);
@@ -286,9 +416,15 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
                     ctx.printLine("trust store file: " + trustStoreFileName);
                     ctx.printLine("trust store password: " + trustStorePassword);
                 }
-                ctx.printLine("Server keystore file " + keyStoreFile
-                        + ", certificate file " + certName + " and " + csrName
-                        + " file will be generated in server configuration directory.");
+                if (useLetsEncrypt) {
+                    ctx.printLine("Certificate will be obtained from Let's Encrypt server and will be valid for 90 days." + "\n"
+                            + "Server keystore file a will be generated in server configuration directory.");
+
+                } else {
+                    ctx.printLine("Server keystore file " + keyStoreFile
+                            + ", certificate file " + certName + " and " + csrName
+                            + " file will be generated in server configuration directory.");
+                }
                 if (mutual) {
                     ctx.printLine("Server truststore file " + trustStoreFileName + " will be generated in server configuration directory.");
                 }
@@ -307,12 +443,6 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
         }
 
         String type = DefaultResourceNames.buildDefaultKeyStoreType(null, ctx);
-
-        String id = UUID.randomUUID().toString();
-        setKeyManagerName("key-manager-" + id);
-        setSSLContextName("ssl-context-" + id);
-
-        keyStoreName = "key-store-" + id;
         ModelNode request = ElytronUtil.addKeyStore(ctx, keyStoreName, new File(keyStoreFile), relativeTo, password, type, false, null);
         try {
             // For now that is a workaround because we can't add and call operation in same composite.
@@ -322,33 +452,77 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
             } else {
                 SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
             }
-            // Hard coded algorithm and key size.
-            ModelNode request2 = ElytronUtil.generateKeyPair(ctx, keyStoreName, dn, alias, v, KEY_ALG, KEY_SIZE);
-            addStep(request2, new FailureDescProvider() {
-                @Override
-                public String stepFailedDescription() {
-                    return "Generating key-pair from "
-                            + keyStoreName;
+
+            //Let's encrypt requests
+            if(useLetsEncrypt) {
+                //Create Let's encrypt account-key-store and certificate authority account
+                if (caAccount == null) {
+                    ModelNode requestAddAccKS = ElytronUtil.addKeyStore(ctx, accountKeyStoreName, new File(accountKeyStoreFile), relativeTo, accountKeyStorePassword, type, false, null);
+                    ModelNode requestAddCertAuthAcc = ElytronUtil.addCertificateAuthorityAccount(ctx, certAuthorityAccountName, certAuthorityAccountPassword, certAuthorityAccountAlias, accountKeyStoreName, contactUrls);
+                    // For now that is a workaround because we can't add and call operation in same composite.
+                    // REMOVE WHEN WFCORE-3491 is fixed.
+                    if(buildRequest) {
+                        addStep(requestAddAccKS, NO_DESC);
+                        addStep(requestAddCertAuthAcc, NO_DESC);
+                    } else {
+                        SecurityCommand.execute(ctx, requestAddAccKS, new SecurityCommand.FailureConsumer() {
+
+                            @Override
+                            public void failureOccured(CommandContext ctx, ModelNode reply) throws CommandException {
+                                throw new CommandException(Util.getFailureDescription(reply) + " " + requestAddAccKS.asString());
+                            }
+                        });
+                        SecurityCommand.execute(ctx, requestAddCertAuthAcc, new SecurityCommand.FailureConsumer() {
+
+                            @Override
+                            public void failureOccured(CommandContext ctx, ModelNode reply) throws CommandException {
+                                throw new CommandException(Util.getFailureDescription(reply) + " " + requestAddCertAuthAcc.asString());
+                            }
+                        });
+                    }
+                    needKeyStoreStore(accountKeyStoreName);
                 }
-            });
-            needKeyStoreStore(keyStoreName);
-            final String cName = certName;
-            ModelNode request4 = ElytronUtil.exportCertificate(ctx, keyStoreName, new File(certName), relativeTo, alias, true);
-            addFinalstep(request4, new FailureDescProvider() {
-                @Override
-                public String stepFailedDescription() {
-                    return "Exporting certificate " + cName
-                            + " from key-store " + keyStoreName;
-                }
-            });
-            ModelNode request5 = ElytronUtil.generateSigningRequest(ctx, keyStoreName, new File(csrName), relativeTo, alias);
-            addFinalstep(request5, new FailureDescProvider() {
-                @Override
-                public String stepFailedDescription() {
-                    return "Generating signing request "
-                            + " from key-store " + keyStoreName;
-                }
-            });
+
+                needKeyStoreStore(keyStoreName);
+
+                //Now we’re ready to start obtaining and managing certificates
+                ModelNode request3 = ElytronUtil.obtainCertificateRequest(ctx, keyStoreName, alias, password, domainNames, certAuthorityAccountName, agreedToTOS, KEY_SIZE, KEY_ALG);
+                addStep(request3, new FailureDescProvider() {
+                    @Override
+                    public String stepFailedDescription() {
+                        return "Obtaining certificate from Let's Encrypt for keystore "
+                                + keyStoreName;
+                    }
+                });
+            } else {
+                // Hard coded algorithm and key size.
+                ModelNode request2 = ElytronUtil.generateKeyPair(ctx, keyStoreName, dn, alias, v, KEY_ALG, KEY_SIZE);
+                addStep(request2, new FailureDescProvider() {
+                    @Override
+                    public String stepFailedDescription() {
+                        return "Generating key-pair from "
+                                + keyStoreName;
+                    }
+                });
+                needKeyStoreStore(keyStoreName);
+                final String cName = certName;
+                ModelNode request4 = ElytronUtil.exportCertificate(ctx, keyStoreName, new File(certName), relativeTo, alias, true);
+                addFinalstep(request4, new FailureDescProvider() {
+                    @Override
+                    public String stepFailedDescription() {
+                        return "Exporting certificate " + cName
+                                + " from key-store " + keyStoreName;
+                    }
+                });
+                ModelNode request5 = ElytronUtil.generateSigningRequest(ctx, keyStoreName, new File(csrName), relativeTo, alias);
+                addFinalstep(request5, new FailureDescProvider() {
+                    @Override
+                    public String stepFailedDescription() {
+                        return "Generating signing request "
+                                + " from key-store " + keyStoreName;
+                    }
+                });
+            }
             // Two way certificate
             if (clientCertificate != null) {
                 setTrustedCertificatePath(new File(clientCertificate));
@@ -367,6 +541,31 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
         super.buildRequest(ctx, buildRequest);
     }
 
+    private List<String> parseEmails(String emails) {
+        List<String> emailsList = parseItemsFromString(emails, "admin@example.com,info@example.com");
+        List<String> urls = new ArrayList<>();
+        if (emailsList != null) {
+            for (String email : emailsList) {
+                if (email.contains("@")) {
+                    urls.add("mailto:".concat(email));
+                }
+            }
+        }
+        return urls;
+    }
+
+    private List<String> parseItemsFromString(String items, String example) {
+        List<String> itemsList = null;
+        if (items != null) {
+            if (items.length() == 0) {
+                items = example;
+            }
+            itemsList = Arrays.asList(items.split(","));
+        }
+
+        return itemsList;
+    }
+
     @Override
     protected KeyStore buildKeyStore(CommandContext ctx, boolean buildRequest) throws Exception {
         return new KeyStore(keyStoreName, password, alias, false);
@@ -376,6 +575,12 @@ public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
     public void doFailureOccured(CommandContext ctx) throws Exception {
         // REMOVE WHEN WFCORE-3491 is fixed.
         if (keyStoreName != null) {
+            if(useLetsEncrypt && caAccount == null) {
+                ModelNode req = ElytronUtil.removeCertificateAuthorityAccount(ctx, certAuthorityAccountName);
+                SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+                req = ElytronUtil.removeKeyStore(ctx, accountKeyStoreName);
+                SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+            }
             ModelNode req = ElytronUtil.removeKeyStore(ctx, keyStoreName);
             SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/AbstractEnableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/AbstractEnableSSLCommand.java
@@ -28,12 +28,14 @@ import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_CA_ACCOUNT;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_INTERACTIVE;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PASSWORD;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PATH;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PATH_RELATIVE_TO;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_TYPE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_LETS_ENCRYPT;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_KEY_MANAGER_NAME;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_KEY_STORE_NAME;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_SSL_CONTEXT_NAME;
@@ -120,6 +122,13 @@ public abstract class AbstractEnableSSLCommand implements Command<CLICommandInvo
 
     @Option(name = OPT_INTERACTIVE, hasValue = false, activator = OptionActivators.InteractiveActivator.class)
     boolean interactive;
+
+    @Option(name = OPT_LETS_ENCRYPT, hasValue = false, activator = OptionActivators.LetsEncryptActivator.class)
+    boolean useLetsEncrypt;
+
+    @Option(name = OPT_CA_ACCOUNT,  completer = OptionCompleters.CaAccountNameCompleter.class,
+            activator = OptionActivators.CaAccountActivator.class)
+    String caAccount;
 
     protected abstract void secure(CommandContext ctx, SSLSecurityBuilder ssl) throws CommandException;
 
@@ -243,7 +252,9 @@ public abstract class AbstractEnableSSLCommand implements Command<CLICommandInvo
             }
             checkKeyStoreOperationsSupported(ctx, OPT_INTERACTIVE);
             builder = new InteractiveSecurityBuilder(getDefaultKeyStoreFileName(ctx),
-                    getDefaultTrustStoreFileName(ctx));
+                    getDefaultTrustStoreFileName(ctx),
+                    useLetsEncrypt,
+                    caAccount);
         }
 
         if (trustedCertificatePath != null) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/OptionActivators.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/OptionActivators.java
@@ -22,6 +22,7 @@ import org.jboss.as.cli.Util;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_INTERACTIVE;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PATH;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_LETS_ENCRYPT;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUSTED_CERTIFICATE_PATH;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUST_STORE_NAME;
@@ -248,4 +249,19 @@ public interface OptionActivators {
             return false;
         }
     }
+
+    public static class LetsEncryptActivator extends AbstractDependOptionActivator {
+
+        public LetsEncryptActivator() {
+            super(false, OPT_INTERACTIVE);
+        }
+    }
+
+    public static class CaAccountActivator extends AbstractDependOptionActivator {
+
+        public CaAccountActivator() {
+            super(false, OPT_INTERACTIVE, OPT_LETS_ENCRYPT);
+        }
+    }
+
 }


### PR DESCRIPTION
…ble to obtain a server certificate from Let's Encrypt

WFCORE issue: https://issues.jboss.org/browse/WFCORE-4227
EAP issue: https://issues.jboss.org/browse/EAP7-1100
Analysis document: https://github.com/wildfly/wildfly-proposals/pull/156
Community documentation: TBD

Add the ability for the CLI SSL security commands to be able to obtain a server certificate from Let's Encrypt. 