### PR TITLE
[WFCORE-4247] Bump the domain management version to 10.0

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
@@ -87,12 +87,15 @@ public enum Namespace {
     DOMAIN_8_0(8, "urn:jboss:domain:8.0"),
 
     // WF 15
-    DOMAIN_9_0(8, "urn:jboss:domain:9.0");
+    DOMAIN_9_0(9, "urn:jboss:domain:9.0"),
+
+    // WF 16
+    DOMAIN_10_0(10, "urn:jboss:domain:10.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DOMAIN_9_0;
+    public static final Namespace CURRENT = DOMAIN_10_0;
 
     public static final Namespace[] ALL_NAMESPACES = domainValues();
 

--- a/core-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/core-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/core-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0" name="master">
+<host xmlns="urn:jboss:domain:10.0" name="master">
 
     <extensions>
         <?EXTENSIONS?>

--- a/core-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/core-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0" name="master">
+<host xmlns="urn:jboss:domain:10.0" name="master">
 
     <extensions>
         <?EXTENSIONS?>

--- a/core-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/core-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/constraints.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/constraints.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
 
    <management>
       <access-control provider="rbac">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/domain-all.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/domain-all.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <management>
         <access-control provider="rbac" use-identity-roles="true" permission-combination-policy="rejecting">
             <server-group-scoped-roles>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/domain-transform-no-rbac-provider.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/domain-transform-no-rbac-provider.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <management>
         <access-control provider="simple" permission-combination-policy="rejecting">
             <server-group-scoped-roles>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/domain-transform-rbac-provider.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/domain-transform-rbac-provider.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <management>
         <access-control provider="rbac">
             <role-mapping>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
    <management>
       <access-control provider="rbac" use-identity-roles="true" permission-combination-policy="rejecting">
          <role-mapping>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/auditlog/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/auditlog/host.xml
@@ -23,7 +23,7 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <configuration-changes max-history="3" />
         <audit-log>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/auditlog/host_credential_reference.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/auditlog/host_credential_reference.xml
@@ -23,7 +23,7 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <configuration-changes max-history="3" />
         <audit-log>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/auditlog/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/auditlog/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <configuration-changes max-history="3" />
         <audit-log>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/host.xml
@@ -23,7 +23,7 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <audit-log>
             <formatters>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <audit-log>
             <formatters>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/domain-deployments.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/domain-deployments.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <deployments>
         <deployment name="myFirstApp" runtime-name="abc.war">
             <content sha1="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/domain-exploded-deployments.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/domain-exploded-deployments.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 <deployments>
         <deployment name="myThirdApp" runtime-name="ghi.war">
             <content sha1="12345678901234567890" archive="false"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <deployments>
         <deployment name="myFirstApp" runtime-name="abc.war">
             <content sha1="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone_duplicate.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone_duplicate.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <deployments>
         <deployment name="myFirstApp" runtime-name="abc.war">
             <content sha1="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
@@ -4,7 +4,7 @@
 This is the shipped configuration with the extensions and profiles removed  
  -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <deployment-overlays>
         <deployment-overlay name="test-overlay">
             <content path="/test/123" content="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
@@ -4,7 +4,7 @@
 This is the shipped configuration with the extensions and profiles removed  
  -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <deployment-overlays>
         <deployment-overlay name="test-overlay">
             <content path="/test/123" content="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <deployment-overlays>
         <deployment-overlay name="test-overlay">
             <content path="/test/123" content="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager-ac.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager-ac.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-remote-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-remote-domain-manager.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-default-interface.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-default-interface.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <vault code="${vault.code:somevault}">
         <vault-option name="abc" value="${vault-option:def}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-secure-interface.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-secure-interface.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-server-ssl.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-server-ssl.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/hostexclude/domain-host-excludes.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/hostexclude/domain-host-excludes.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <host-excludes>
         <host-exclude name="WildFly10" active-server-groups="a b" active-socket-binding-groups="c d e">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain-empty.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <interfaces>
     </interfaces>
 </domain>        

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <interfaces>
         <interface name="loopback">
             <inet-address value="127.0.0.1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <interfaces>
         <interface name="loopback">
             <inet-address value="127.0.0.1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-empty.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
    <server-groups>
 	  <server-group name="test" profile="test">
          <jvm name="empty"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-full.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-full.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
    <server-groups>
 	  <server-group name="test" profile="test">
          <jvm name="full" java-home="javaHome" type="SUN" env-classpath-ignored="true">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <server-groups>
         <server-group name="test" profile="test">
             <jvm name="full" java-home="${mytest.java-home:javaHome}" env-classpath-ignored="${mytest.env-classpath-ignored:true}">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-global.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-global.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-empty.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-full.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-full.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/host_legacy.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/host_legacy.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/standalone_legacy.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/standalone_legacy.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-empty.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <paths/>
 </domain>        

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <paths>
         <path name="empty"/>
         <path name="absolute" path="${test.exp:/}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <paths>
          <path name="empty"/>
          <path name="absolute" path="/"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
 
     <paths>
        <path name="absolute" path="${test.exp:/}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <paths>
          <path name="absolute" path="${test.exp:/}"/>
          <path name="relative" path="${test.exp:test}" relative-to="path"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/profile/domain-transform.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/profile/domain-transform.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <profiles>
         <profile name="testA">
         </profile>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/profile/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/profile/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <profiles>
         <profile name="testA">
         </profile>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/kerberos-host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/kerberos-host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <!-- Kerberos Security Realm Definition -->

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/kerberos-standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/kerberos-standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <!-- Kerberos Security Realm Definition -->

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-host-noforce.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-host-noforce.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-standalone-noforce.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-standalone-noforce.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ldap-standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ssl-host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ssl-host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <!-- Set of realms using file based stores. -->

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ssl-standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ssl-standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <!-- Set of realms using file based stores. -->

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ssl-standalone_credential_reference.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/ssl-standalone_credential_reference.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <management>
         <security-realms>
             <!-- Set of realms using file based stores. -->

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/users-standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/security/users-standalone.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- This is the shipped configuration with the extensions and subsystems removed -->
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-deployments.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-deployments.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <deployments>
         <deployment name="test-deployment" runtime-name="foo.war">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-duplicate-runtime-names.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-duplicate-runtime-names.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <deployments>
         <deployment name="test-deployment" runtime-name="foo.war">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <deployments>
         <deployment name="test-deployment" runtime-name="foo.war">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <deployments>
         <deployment name="test-deployment" runtime-name="foo.war">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/domain.xml
@@ -4,7 +4,7 @@
 This is the shipped configuration with the extensions and profiles removed  
  -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <system-properties>
         <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
         <property name="java.net.preferIPv4Stack" value="true"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- This is the shipped configuration as-is -->
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- This is the shipped configuration with the extensions and subsystems removed -->
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain-transform.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain-transform.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <interfaces>
         <interface name="public"/>
         <interface name="management"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <interfaces>
         <interface name="public"/>
         <interface name="management"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/host.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
     <!--  The native interface is always required by the parser -->
     <management>
         <management-interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <interfaces>
         <interface name="public"/>
         <interface name="management"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties-with-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <server-groups>
         <server-group name="test" profile="test">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <server-groups>
         <server-group name="test" profile="test">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties-with-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <system-properties>
         <property name="sys.prop.test.one" value="ONE"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <system-properties>
         <property name="sys.prop.test.one" value="1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-server-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-server-systemproperties.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-systemproperties.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
     <system-properties>
         <property name="sys.prop.test.one" value="1"/>
         <property name="sys.prop.test.two" value="2" boot-time="true"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/standalone-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/standalone-systemproperties.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
     <system-properties>
         <property name="sys.prop.test.one" value="1"/>
         <property name="sys.prop.test.two" value="2"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:9.0">
+<host xmlns="urn:jboss:domain:10.0">
 
     <vault code="somevault" module="org.jboss.test.blah">
         <vault-option name="xyz" value="zxc"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:9.0">
+<server xmlns="urn:jboss:domain:10.0">
 
 	<vault code="somevault" module="org.jboss.test.blah">
         <vault-option name="xyz" value="zxc"/>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -79,15 +79,17 @@ public final class DomainXml implements XMLElementReader<List<ModelNode>>, XMLEl
             case 8:
                 new DomainXml_8(extensionXml, extensionRegistry, readerNS).readElement(reader, nodes);
                 break;
-            default:
+            case 9:
                 new DomainXml_9(extensionXml, extensionRegistry, readerNS).readElement(reader, nodes);
                 break;
+            default:
+                new DomainXml_10(extensionXml, extensionRegistry, readerNS).readElement(reader, nodes);
         }
     }
 
     @Override
     public void writeContent(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context) throws XMLStreamException {
-        new DomainXml_9(extensionXml, extensionRegistry, CURRENT).writeContent(writer, context);
+        new DomainXml_10(extensionXml, extensionRegistry, CURRENT).writeContent(writer, context);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_10.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_10.java
@@ -20,19 +20,32 @@ import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHORIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_ORGANIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HASH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_EXCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_CLIENT_CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLANS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.parsing.Namespace.CURRENT;
 import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequiredElement;
@@ -67,8 +80,11 @@ import org.jboss.as.controller.parsing.ExtensionXml;
 import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
+import org.jboss.as.controller.parsing.WriteUtils;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
+import org.jboss.as.domain.controller.resources.DomainRootDefinition;
 import org.jboss.as.domain.controller.resources.HostExcludeResourceDefinition;
 import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
@@ -76,6 +92,7 @@ import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefiniti
 import org.jboss.as.domain.management.parsing.AccessControlXml;
 import org.jboss.as.domain.management.parsing.ManagementXml;
 import org.jboss.as.domain.management.parsing.ManagementXmlDelegate;
+import org.jboss.as.server.controller.resources.DeploymentAttributes;
 import org.jboss.as.server.parsing.CommonXml;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -90,7 +107,7 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  * @author Emanuel Muckenhuber
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-final class DomainXml_9 extends CommonXml implements ManagementXmlDelegate {
+final class DomainXml_10 extends CommonXml implements ManagementXmlDelegate {
 
 
     private final AccessControlXml accessControlXml;
@@ -99,7 +116,7 @@ final class DomainXml_9 extends CommonXml implements ManagementXmlDelegate {
     private final ExtensionXml extensionXml;
     private final ExtensionRegistry extensionRegistry;
 
-    DomainXml_9(final ExtensionXml extensionXml, final ExtensionRegistry extensionRegistry, final Namespace namespace) {
+    DomainXml_10(final ExtensionXml extensionXml, final ExtensionRegistry extensionRegistry, final Namespace namespace) {
         super(new DomainSocketBindingsXml());
         accessControlXml = AccessControlXml.newInstance(namespace);
         this.extensionXml = extensionXml;
@@ -120,6 +137,81 @@ final class DomainXml_9 extends CommonXml implements ManagementXmlDelegate {
             }
         }
         throw unexpectedElement(reader);
+    }
+
+    void writeContent(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context) throws XMLStreamException {
+        ModelNode modelNode = context.getModelNode();
+
+        writer.writeStartDocument();
+        writer.writeStartElement(Element.DOMAIN.getLocalName());
+
+        writer.writeDefaultNamespace(CURRENT.getUriString());
+        writeNamespaces(writer, modelNode);
+        writeSchemaLocation(writer, modelNode);
+
+        DomainRootDefinition.NAME.marshallAsAttribute(modelNode, false, writer);
+        if (modelNode.hasDefined(DOMAIN_ORGANIZATION)) {
+            DomainRootDefinition.ORGANIZATION_IDENTIFIER.marshallAsAttribute(modelNode, writer);
+        }
+
+        if (modelNode.hasDefined(EXTENSION)) {
+            extensionXml.writeExtensions(writer, modelNode.get(EXTENSION));
+        }
+        if (modelNode.hasDefined(SYSTEM_PROPERTY)) {
+            writeProperties(writer, modelNode.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, false);
+        }
+        if (modelNode.hasDefined(PATH)) {
+            writePaths(writer, modelNode.get(PATH), true);
+        }
+
+        if (modelNode.hasDefined(CORE_SERVICE) && modelNode.get(CORE_SERVICE).hasDefined(MANAGEMENT)) {
+            // We use CURRENT here as we only support writing the most recent.
+            ManagementXml managementXml = ManagementXml.newInstance(CURRENT, this, true);
+            managementXml.writeManagement(writer, modelNode.get(CORE_SERVICE, MANAGEMENT), true);
+        }
+
+        if (modelNode.hasDefined(PROFILE)) {
+            writer.writeStartElement(Element.PROFILES.getLocalName());
+            ModelNode profiles = modelNode.get(PROFILE);
+            for (final String profile : profiles.keys()) {
+                writeProfile(writer, profile, profiles.get(profile), context);
+            }
+            writer.writeEndElement();
+        }
+        if (modelNode.hasDefined(INTERFACE)) {
+            writeInterfaces(writer, modelNode.get(INTERFACE));
+        }
+        if (modelNode.hasDefined(SOCKET_BINDING_GROUP)) {
+            writer.writeStartElement(Element.SOCKET_BINDING_GROUPS.getLocalName());
+            ModelNode sbgs = modelNode.get(SOCKET_BINDING_GROUP);
+            for (final String sbg : sbgs.keys()) {
+                writeSocketBindingGroup(writer, sbgs.get(sbg), sbg);
+            }
+            writer.writeEndElement();
+        }
+        if (modelNode.hasDefined(DEPLOYMENT)) {
+            writeDomainDeployments(writer, modelNode.get(DEPLOYMENT));
+        }
+        if (modelNode.hasDefined(DEPLOYMENT_OVERLAY)) {
+            writeDeploymentOverlays(writer, modelNode.get(DEPLOYMENT_OVERLAY));
+        }
+        if (modelNode.hasDefined(SERVER_GROUP)) {
+            writer.writeStartElement(Element.SERVER_GROUPS.getLocalName());
+            ModelNode sgs = modelNode.get(SERVER_GROUP);
+            for (final String sg : sgs.keys()) {
+                writeServerGroup(writer, sg, sgs.get(sg));
+            }
+            writer.writeEndElement();
+        }
+        if (modelNode.hasDefined(HOST_EXCLUDE)) {
+            writeHostExcludes(writer, modelNode.get(HOST_EXCLUDE));
+        }
+        if (modelNode.hasDefined(MANAGEMENT_CLIENT_CONTENT)) {
+            writeManagementClientContent(writer, modelNode.get(MANAGEMENT_CLIENT_CONTENT));
+        }
+
+        writer.writeEndElement();
+        writer.writeEndDocument();
     }
 
     private void readDomainElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list) throws XMLStreamException {
@@ -602,6 +694,106 @@ final class DomainXml_9 extends CommonXml implements ManagementXmlDelegate {
         list.add(addOp);
     }
 
+    private void writeProfile(final XMLExtendedStreamWriter writer, final String profileName, final ModelNode profileNode, final ModelMarshallingContext context) throws XMLStreamException {
+
+        writer.writeStartElement(Element.PROFILE.getLocalName());
+        writer.writeAttribute(Attribute.NAME.getLocalName(), profileName);
+        ProfileResourceDefinition.INCLUDES.getMarshaller().marshallAsAttribute(ProfileResourceDefinition.INCLUDES, profileNode, false, writer);
+
+        writeSubsystems(profileNode, writer, context);
+
+        writer.writeEndElement();
+    }
+
+    private void writeDomainDeployments(final XMLExtendedStreamWriter writer, final ModelNode modelNode) throws XMLStreamException {
+
+        final Set<String> deploymentNames = modelNode.keys();
+        if (deploymentNames.size() > 0) {
+            writer.writeStartElement(Element.DEPLOYMENTS.getLocalName());
+            for (String uniqueName : deploymentNames) {
+                final ModelNode deployment = modelNode.get(uniqueName);
+                writer.writeStartElement(Element.DEPLOYMENT.getLocalName());
+                WriteUtils.writeAttribute(writer, Attribute.NAME, uniqueName);
+                DeploymentAttributes.RUNTIME_NAME.marshallAsAttribute(deployment, writer);
+                final List<ModelNode> contentItems = deployment.require(CONTENT).asList();
+                for (ModelNode contentItem : contentItems) {
+                    writeContentItem(writer, contentItem);
+                }
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeServerGroupDeployments(final XMLExtendedStreamWriter writer, final ModelNode modelNode) throws XMLStreamException {
+
+        final Set<String> deploymentNames = modelNode.keys();
+        if (deploymentNames.size() > 0) {
+            writer.writeStartElement(Element.DEPLOYMENTS.getLocalName());
+            for (String uniqueName : deploymentNames) {
+                final ModelNode deployment = modelNode.get(uniqueName);
+                writer.writeStartElement(Element.DEPLOYMENT.getLocalName());
+                WriteUtils.writeAttribute(writer, Attribute.NAME, uniqueName);
+                DeploymentAttributes.RUNTIME_NAME.marshallAsAttribute(deployment, writer);
+                DeploymentAttributes.ENABLED.marshallAsAttribute(deployment, writer);
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeServerGroup(final XMLExtendedStreamWriter writer, final String groupName, final ModelNode group) throws XMLStreamException {
+        writer.writeStartElement(Element.SERVER_GROUP.getLocalName());
+        writer.writeAttribute(Attribute.NAME.getLocalName(), groupName);
+
+        ServerGroupResourceDefinition.PROFILE.marshallAsAttribute(group, writer);
+        ServerGroupResourceDefinition.MANAGEMENT_SUBSYSTEM_ENDPOINT.marshallAsAttribute(group, writer);
+
+        // JVM
+        if (group.hasDefined(JVM)) {
+            for (final Property jvm : group.get(JVM).asPropertyList()) {
+                JvmXml.writeJVMElement(writer, jvm.getName(), jvm.getValue());
+                break; // TODO just write the first !?
+            }
+        }
+
+        // Socket binding ref
+        if (group.hasDefined(SOCKET_BINDING_GROUP) || group.hasDefined(SOCKET_BINDING_PORT_OFFSET)) {
+            writer.writeStartElement(Element.SOCKET_BINDING_GROUP.getLocalName());
+            ServerGroupResourceDefinition.SOCKET_BINDING_GROUP.marshallAsAttribute(group, writer);
+            ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET.marshallAsAttribute(group, writer);
+            ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE.marshallAsAttribute(group, writer);
+            writer.writeEndElement();
+        }
+
+        if (group.hasDefined(DEPLOYMENT)) {
+            writeServerGroupDeployments(writer, group.get(DEPLOYMENT));
+        }
+        if (group.hasDefined(DEPLOYMENT_OVERLAY)) {
+            writeDeploymentOverlays(writer, group.get(DEPLOYMENT_OVERLAY));
+            WriteUtils.writeNewLine(writer);
+        }
+        // System properties
+        if (group.hasDefined(SYSTEM_PROPERTY)) {
+            writeProperties(writer, group.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, false);
+        }
+
+        writer.writeEndElement();
+    }
+
+    private void writeManagementClientContent(XMLExtendedStreamWriter writer, ModelNode modelNode) throws XMLStreamException {
+        boolean hasRolloutPlans = modelNode.hasDefined(ROLLOUT_PLANS) && modelNode.get(ROLLOUT_PLANS).hasDefined(HASH);
+        boolean mustWrite = hasRolloutPlans; // || other elements we may add later
+        if (mustWrite) {
+            writer.writeStartElement(Element.MANAGEMENT_CLIENT_CONTENT.getLocalName());
+            if (hasRolloutPlans) {
+                writer.writeEmptyElement(Element.ROLLOUT_PLANS.getLocalName());
+                writer.writeAttribute(Attribute.SHA1.getLocalName(), HashUtil.bytesToHexString(modelNode.get(ROLLOUT_PLANS).get(HASH).asBytes()));
+            }
+            writer.writeEndElement();
+        }
+    }
+
     /*
      * ManagamentXmlDelegate Methods
      */
@@ -860,5 +1052,42 @@ final class DomainXml_9 extends CommonXml implements ManagementXmlDelegate {
         }
 
         requireNoContent(reader);
+    }
+
+    private void writeHostExcludes(XMLExtendedStreamWriter writer, ModelNode modelNode) throws XMLStreamException {
+        writer.writeStartElement(Element.HOST_EXCLUDES.getLocalName());
+        for (String exclude : modelNode.keys()) {
+            writer.writeStartElement(Element.HOST_EXCLUDE.getLocalName());
+            writer.writeAttribute(Attribute.NAME.getLocalName(), exclude);
+            ModelNode excludeNode = modelNode.get(exclude);
+            HostExcludeResourceDefinition.ACTIVE_SERVER_GROUPS.getMarshaller()
+                    .marshall(HostExcludeResourceDefinition.ACTIVE_SERVER_GROUPS, excludeNode, false, writer);
+            HostExcludeResourceDefinition.ACTIVE_SOCKET_BINDING_GROUPS.getMarshaller()
+                    .marshall(HostExcludeResourceDefinition.ACTIVE_SOCKET_BINDING_GROUPS, excludeNode, false, writer);
+            if (HostExcludeResourceDefinition.HOST_RELEASE.isMarshallable(excludeNode)) {
+                writer.writeEmptyElement(Element.HOST_RELEASE.getLocalName());
+                HostExcludeResourceDefinition.HOST_RELEASE.marshallAsAttribute(excludeNode, writer);
+            } else {
+                writer.writeStartElement(Element.HOST_API_VERSION.getLocalName());
+                HostExcludeResourceDefinition.MANAGEMENT_MAJOR_VERSION.marshallAsAttribute(excludeNode, writer);
+                HostExcludeResourceDefinition.MANAGEMENT_MINOR_VERSION.marshallAsAttribute(excludeNode, writer);
+                HostExcludeResourceDefinition.MANAGEMENT_MICRO_VERSION.marshallAsAttribute(excludeNode, writer);
+                writer.writeEndElement();
+            }
+
+            if (HostExcludeResourceDefinition.EXCLUDED_EXTENSIONS.isMarshallable(excludeNode)) {
+                writer.writeStartElement(Element.EXCLUDED_EXTENSIONS.getLocalName());
+                for (ModelNode ext : excludeNode.get(HostExcludeResourceDefinition.EXCLUDED_EXTENSIONS.getName()).asList()) {
+                    if (ext.isDefined()) {
+                        writer.writeEmptyElement(Element.EXTENSION.getLocalName());
+                        writer.writeAttribute(Attribute.MODULE.getLocalName(), ext.asString());
+                    }
+                }
+                writer.writeEndElement();
+            }
+
+            writer.writeEndElement();
+        }
+        writer.writeEndElement();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -90,16 +90,18 @@ public final class HostXml implements XMLElementReader<List<ModelNode>>, XMLElem
             case 8:
                 new HostXml_8(defaultHostControllerName, runningMode, isCachedDc, extensionRegistry, extensionXml, readerNS).readElement(reader, operationList);
                 break;
-            default:
+            case 9:
                 new HostXml_9(defaultHostControllerName, runningMode, isCachedDc, extensionRegistry, extensionXml, readerNS).readElement(reader, operationList);
                 break;
+            default:
+                new HostXml_10(defaultHostControllerName, runningMode, isCachedDc, extensionRegistry, extensionXml, readerNS).readElement(reader, operationList);
         }
     }
 
     @Override
     public void writeContent(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context)
             throws XMLStreamException {
-        new HostXml_9(defaultHostControllerName, runningMode, isCachedDc, extensionRegistry, extensionXml, CURRENT).writeContent(writer, context);
+        new HostXml_10(defaultHostControllerName, runningMode, isCachedDc, extensionRegistry, extensionXml, CURRENT).writeContent(writer, context);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_10.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_10.java
@@ -23,25 +23,38 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DIR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_CONTROLLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_UPGRADE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED_RESOURCES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED_RESOURCE_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IS_DOMAIN_CONTROLLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOOPBACK;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NATIVE_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ORGANIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SSL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATIC_DISCOVERY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT;
+import static org.jboss.as.controller.parsing.Namespace.CURRENT;
 import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.missingOneOf;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
@@ -67,6 +80,7 @@ import java.util.Set;
 import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.Util;
@@ -76,6 +90,8 @@ import org.jboss.as.controller.parsing.ExtensionXml;
 import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
+import org.jboss.as.controller.parsing.WriteUtils;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.as.domain.management.parsing.AuditLogXml;
 import org.jboss.as.domain.management.parsing.ManagementXml;
 import org.jboss.as.domain.management.parsing.ManagementXmlDelegate;
@@ -87,6 +103,7 @@ import org.jboss.as.host.controller.model.host.AdminOnlyDomainConfigPolicy;
 import org.jboss.as.host.controller.model.host.HostResourceDefinition;
 import org.jboss.as.host.controller.operations.DomainControllerWriteAttributeHandler;
 import org.jboss.as.host.controller.operations.HostAddHandler;
+import org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler;
 import org.jboss.as.host.controller.resources.HttpManagementResourceDefinition;
 import org.jboss.as.host.controller.resources.NativeManagementResourceDefinition;
 import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
@@ -99,6 +116,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 /**
  * Parser and marshaller for host controller configuration xml documents (e.g. host.xml) that use the urn:jboss:domain:9.0 schema.
@@ -107,7 +125,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  * @author <a href="mailto:jperkins@jboss.com">James R. Perkins</a>
  */
-final class HostXml_9 extends CommonXml implements ManagementXmlDelegate {
+final class HostXml_10 extends CommonXml implements ManagementXmlDelegate {
 
     private final AuditLogXml auditLogDelegate;
 
@@ -118,8 +136,8 @@ final class HostXml_9 extends CommonXml implements ManagementXmlDelegate {
     private final ExtensionXml extensionXml;
     private final Namespace namespace;
 
-    HostXml_9(String defaultHostControllerName, RunningMode runningMode, boolean isCachedDC,
-              final ExtensionRegistry extensionRegistry, final ExtensionXml extensionXml, final Namespace namespace) {
+    HostXml_10(String defaultHostControllerName, RunningMode runningMode, boolean isCachedDC,
+               final ExtensionRegistry extensionRegistry, final ExtensionXml extensionXml, final Namespace namespace) {
         super(new SocketBindingsXml.HostSocketBindingsXml());
         this.auditLogDelegate = AuditLogXml.newInstance(namespace, true);
         this.defaultHostControllerName = defaultHostControllerName;
@@ -146,6 +164,103 @@ final class HostXml_9 extends CommonXml implements ManagementXmlDelegate {
             }
         }
         throw unexpectedElement(reader);
+    }
+
+    void writeContent(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context)
+            throws XMLStreamException {
+
+        final ModelNode modelNode = context.getModelNode();
+
+        writer.writeStartDocument();
+        writer.writeStartElement(Element.HOST.getLocalName());
+
+        writer.writeDefaultNamespace(Namespace.CURRENT.getUriString());
+        writeNamespaces(writer, modelNode);
+        writeSchemaLocation(writer, modelNode);
+
+        if (modelNode.hasDefined(NAME)) {
+            HostResourceDefinition.NAME.marshallAsAttribute(modelNode, writer);
+        }
+        if (modelNode.hasDefined(ORGANIZATION)) {
+            HostResourceDefinition.ORGANIZATION_IDENTIFIER.marshallAsAttribute(modelNode, writer);
+        }
+
+        if (modelNode.hasDefined(EXTENSION)) {
+            extensionXml.writeExtensions(writer, modelNode.get(EXTENSION));
+        }
+
+        if (modelNode.hasDefined(SYSTEM_PROPERTY)) {
+            writeProperties(writer, modelNode.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, false);
+        }
+
+        if (modelNode.hasDefined(PATH)) {
+            writePaths(writer, modelNode.get(PATH), false);
+        }
+
+        boolean hasCoreServices = modelNode.hasDefined(CORE_SERVICE);
+        if (hasCoreServices && modelNode.get(CORE_SERVICE).hasDefined(VAULT)) {
+            writeVault(writer, modelNode.get(CORE_SERVICE, VAULT));
+        }
+
+        if (hasCoreServices) {
+            ManagementXml managementXml = ManagementXml.newInstance(CURRENT, this, false);
+            managementXml.writeManagement(writer, modelNode.get(CORE_SERVICE, MANAGEMENT), true);
+        }
+
+        if (modelNode.hasDefined(DOMAIN_CONTROLLER)) {
+            ModelNode ignoredResources = null;
+            ModelNode discoveryOptions = null;
+            if (hasCoreServices && modelNode.get(CORE_SERVICE).hasDefined(IGNORED_RESOURCES)
+                    && modelNode.get(CORE_SERVICE, IGNORED_RESOURCES).hasDefined(IGNORED_RESOURCE_TYPE)) {
+                ignoredResources = modelNode.get(CORE_SERVICE, IGNORED_RESOURCES, IGNORED_RESOURCE_TYPE);
+            }
+            if (hasCoreServices && modelNode.get(CORE_SERVICE).hasDefined(DISCOVERY_OPTIONS)
+                    && modelNode.get(CORE_SERVICE, DISCOVERY_OPTIONS).hasDefined(ModelDescriptionConstants.OPTIONS)) {
+                // List of discovery option types and names, in the order they were provided
+                discoveryOptions = modelNode.get(CORE_SERVICE, DISCOVERY_OPTIONS, ModelDescriptionConstants.OPTIONS);
+            }
+            writeDomainController(writer, modelNode.get(DOMAIN_CONTROLLER), ignoredResources, discoveryOptions);
+        }
+
+        if (modelNode.hasDefined(INTERFACE)) {
+            writeInterfaces(writer, modelNode.get(INTERFACE));
+        }
+        if (modelNode.hasDefined(JVM)) {
+            writer.writeStartElement(Element.JVMS.getLocalName());
+            ModelNode jvms = modelNode.get(JVM);
+            for (final String jvm : jvms.keys()) {
+                JvmXml.writeJVMElement(writer, jvm, jvms.get(jvm));
+            }
+            writer.writeEndElement();
+        }
+
+        if (modelNode.hasDefined(SERVER_CONFIG)) {
+            writer.writeStartElement(Element.SERVERS.getLocalName());
+            // Write the directory grouping
+            HostResourceDefinition.DIRECTORY_GROUPING.marshallAsAttribute(modelNode, writer);
+            writeServers(writer, modelNode.get(SERVER_CONFIG));
+            writer.writeEndElement();
+        } else if (modelNode.hasDefined(DIRECTORY_GROUPING)) {
+            // In case there are no servers defined, write an empty element, preserving the directory grouping
+            writer.writeEmptyElement(Element.SERVERS.getLocalName());
+            HostResourceDefinition.DIRECTORY_GROUPING.marshallAsAttribute(modelNode, writer);
+        }
+
+        writeHostProfile(writer, context);
+
+        if (modelNode.hasDefined(SOCKET_BINDING_GROUP)) {
+            Set<String> groups = modelNode.get(SOCKET_BINDING_GROUP).keys();
+            if (groups.size() > 1) {
+                throw ControllerLogger.ROOT_LOGGER.multipleModelNodes(SOCKET_BINDING_GROUP);
+            }
+            for (String group : groups) {
+                writeSocketBindingGroup(writer, modelNode.get(SOCKET_BINDING_GROUP, group), group);
+            }
+        }
+
+
+        writer.writeEndElement();
+        writer.writeEndDocument();
     }
 
     private void readHostElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
@@ -1323,6 +1438,174 @@ final class HostXml_9 extends CommonXml implements ManagementXmlDelegate {
         }
     }
 
+    private void writeDomainController(final XMLExtendedStreamWriter writer, final ModelNode modelNode, ModelNode ignoredResources,
+                                       ModelNode discoveryOptions) throws XMLStreamException {
+        writer.writeStartElement(Element.DOMAIN_CONTROLLER.getLocalName());
+        if (modelNode.hasDefined(LOCAL)) {
+            if (discoveryOptions != null) {
+                writer.writeStartElement(Element.LOCAL.getLocalName());
+                writeDiscoveryOptions(writer, discoveryOptions);
+                writer.writeEndElement();
+            } else {
+                writer.writeEmptyElement(Element.LOCAL.getLocalName());
+            }
+        } else if (modelNode.hasDefined(REMOTE)) {
+            writer.writeStartElement(Element.REMOTE.getLocalName());
+            final ModelNode remote = modelNode.get(REMOTE);
+            RemoteDomainControllerAddHandler.PROTOCOL.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.HOST.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.PORT.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.AUTHENTICATION_CONTEXT.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.SECURITY_REALM.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.USERNAME.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.IGNORE_UNUSED_CONFIG.marshallAsAttribute(remote, writer);
+            RemoteDomainControllerAddHandler.ADMIN_ONLY_POLICY.marshallAsAttribute(remote, writer);
+
+            if (ignoredResources != null) {
+                writeIgnoredResources(writer, ignoredResources);
+            }
+            if (discoveryOptions != null) {
+                writeDiscoveryOptions(writer, discoveryOptions);
+            }
+            writer.writeEndElement();
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeIgnoredResources(XMLExtendedStreamWriter writer, ModelNode ignoredTypes) throws XMLStreamException {
+        for (String ignoredName : ignoredTypes.keys()) {
+
+            ModelNode ignored = ignoredTypes.get(ignoredName);
+
+            ModelNode names = ignored.hasDefined(NAMES) ? ignored.get(NAMES) : null;
+            boolean hasNames = names != null && names.asInt() > 0;
+            if (hasNames) {
+                writer.writeStartElement(Element.IGNORED_RESOURCE.getLocalName());
+            } else {
+                writer.writeEmptyElement(Element.IGNORED_RESOURCE.getLocalName());
+            }
+
+            writer.writeAttribute(Attribute.TYPE.getLocalName(), ignoredName);
+            IgnoredDomainTypeResourceDefinition.WILDCARD.marshallAsAttribute(ignored, writer);
+
+            if (hasNames) {
+                for (ModelNode name : names.asList()) {
+                    writer.writeEmptyElement(Element.INSTANCE.getLocalName());
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), name.asString());
+                }
+                writer.writeEndElement();
+            }
+        }
+    }
+
+    private void writeDiscoveryOptions(XMLExtendedStreamWriter writer, ModelNode discoveryOptions) throws XMLStreamException {
+        writer.writeStartElement(Element.DISCOVERY_OPTIONS.getLocalName());
+        for (Property property : discoveryOptions.asPropertyList()) {
+            final String type = property.getName().equals(STATIC_DISCOVERY) ? STATIC_DISCOVERY : DISCOVERY_OPTION;
+            final Element element = Element.forName(type);
+            final String optionName = property.getValue().get(ModelDescriptionConstants.NAME).asString();
+
+            switch (element) {
+                case STATIC_DISCOVERY: {
+                    final ModelNode staticDiscoveryOption = property.getValue();
+                    writer.writeStartElement(element.getLocalName());
+                    WriteUtils.writeAttribute(writer, Attribute.NAME, optionName);
+                    StaticDiscoveryResourceDefinition.PROTOCOL.marshallAsAttribute(staticDiscoveryOption, writer);
+                    StaticDiscoveryResourceDefinition.HOST.marshallAsAttribute(staticDiscoveryOption, writer);
+                    StaticDiscoveryResourceDefinition.PORT.marshallAsAttribute(staticDiscoveryOption, writer);
+                    writer.writeEndElement();
+                    break;
+                }
+                case DISCOVERY_OPTION: {
+                    final ModelNode discoveryOption = property.getValue();
+                    writer.writeStartElement(element.getLocalName());
+                    WriteUtils.writeAttribute(writer, Attribute.NAME, optionName);
+                    DiscoveryOptionResourceDefinition.CODE.marshallAsAttribute(discoveryOption, writer);
+                    DiscoveryOptionResourceDefinition.MODULE.marshallAsAttribute(discoveryOption, writer);
+                    if (discoveryOption.hasDefined(PROPERTIES)) {
+                        writeDiscoveryOptionProperties(writer, discoveryOption.get(PROPERTIES));
+                    }
+                    writer.writeEndElement();
+                    break;
+                }
+                default:
+                    throw new RuntimeException(ControllerLogger.ROOT_LOGGER.unknownChildType(element.getLocalName()));
+            }
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeDiscoveryOptionProperties(XMLExtendedStreamWriter writer, ModelNode discoveryOptionProperties) throws XMLStreamException {
+        for (String property : discoveryOptionProperties.keys()) {
+            writer.writeStartElement(Element.PROPERTY.getLocalName());
+            WriteUtils.writeAttribute(writer, Attribute.NAME, property);
+            WriteUtils.writeAttribute(writer, Attribute.VALUE, discoveryOptionProperties.get(property).asString());
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeServers(final XMLExtendedStreamWriter writer, final ModelNode modelNode) throws XMLStreamException {
+
+        for (String serverName : modelNode.keys()) {
+            final ModelNode server = modelNode.get(serverName);
+
+            writer.writeStartElement(Element.SERVER.getLocalName());
+
+            WriteUtils.writeAttribute(writer, Attribute.NAME, serverName);
+            ServerConfigResourceDefinition.GROUP.marshallAsAttribute(server, writer);
+            ServerConfigResourceDefinition.AUTO_START.marshallAsAttribute(server, writer);
+            ServerConfigResourceDefinition.UPDATE_AUTO_START_WITH_SERVER_STATUS.marshallAsAttribute(server, writer);
+            if (server.hasDefined(PATH)) {
+                writePaths(writer, server.get(PATH), false);
+            }
+            if (server.hasDefined(SYSTEM_PROPERTY)) {
+                writeProperties(writer, server.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, false);
+            }
+            if (server.hasDefined(INTERFACE)) {
+                writeInterfaces(writer, server.get(INTERFACE));
+            }
+            if (server.hasDefined(JVM)) {
+                for (final Property jvm : server.get(JVM).asPropertyList()) {
+                    JvmXml.writeJVMElement(writer, jvm.getName(), jvm.getValue());
+                    break; // TODO just write the first !?
+                }
+            }
+            if (server.hasDefined(SOCKET_BINDING_GROUP) || server.hasDefined(SOCKET_BINDING_PORT_OFFSET) || server.hasDefined(SOCKET_BINDING_DEFAULT_INTERFACE)) {
+                writer.writeStartElement(Element.SOCKET_BINDINGS.getLocalName());
+                ServerConfigResourceDefinition.SOCKET_BINDING_GROUP.marshallAsAttribute(server, writer);
+                ServerConfigResourceDefinition.SOCKET_BINDING_PORT_OFFSET.marshallAsAttribute(server, writer);
+                ServerConfigResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE.marshallAsAttribute(server, writer);
+                writer.writeEndElement();
+            }
+            if (server.hasDefined(SSL, LOOPBACK)) {
+                ModelNode ssl = server.get(SSL, LOOPBACK);
+                writer.writeStartElement(Element.SSL.getLocalName());
+                SslLoopbackResourceDefinition.SSL_PROTOCOCOL.marshallAsAttribute(ssl, writer);
+                SslLoopbackResourceDefinition.TRUST_MANAGER_ALGORITHM.marshallAsAttribute(ssl, writer);
+                SslLoopbackResourceDefinition.TRUSTSTORE_TYPE.marshallAsAttribute(ssl, writer);
+                SslLoopbackResourceDefinition.TRUSTSTORE_PATH.marshallAsAttribute(ssl, writer);
+                SslLoopbackResourceDefinition.TRUSTSTORE_PASSWORD.marshallAsAttribute(ssl, writer);
+                writer.writeEndElement();
+            }
+
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeHostProfile(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context)
+            throws XMLStreamException {
+
+        final ModelNode profileNode = context.getModelNode();
+        // In case there are no subsystems defined
+        if (!profileNode.hasDefined(SUBSYSTEM)) {
+            return;
+        }
+
+        writer.writeStartElement(Element.PROFILE.getLocalName());
+        writeSubsystems(profileNode, writer, context);
+        writer.writeEndElement();
+    }
+
     /*
      * ManagamentXmlDelegate Methods
      */
@@ -1367,4 +1650,61 @@ final class HostXml_9 extends CommonXml implements ManagementXmlDelegate {
 
         return true;
     }
+
+    @Override
+    public boolean writeNativeManagementProtocol(XMLExtendedStreamWriter writer, ModelNode protocol) throws XMLStreamException {
+
+        writer.writeStartElement(Element.NATIVE_INTERFACE.getLocalName());
+        NativeManagementResourceDefinition.SASL_AUTHENTICATION_FACTORY.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SSL_CONTEXT.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SASL_PROTOCOL.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SERVER_NAME.marshallAsAttribute(protocol, writer);
+
+        writer.writeEmptyElement(Element.SOCKET.getLocalName());
+        NativeManagementResourceDefinition.INTERFACE.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.NATIVE_PORT.marshallAsAttribute(protocol, writer);
+
+        writer.writeEndElement();
+
+        return true;
+    }
+
+    @Override
+    public boolean writeHttpManagementProtocol(XMLExtendedStreamWriter writer, ModelNode protocol) throws XMLStreamException {
+
+        writer.writeStartElement(Element.HTTP_INTERFACE.getLocalName());
+        HttpManagementResourceDefinition.HTTP_AUTHENTICATION_FACTORY.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SSL_CONTEXT.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.ALLOWED_ORIGINS.getMarshaller().marshallAsAttribute(
+                HttpManagementResourceDefinition.ALLOWED_ORIGINS, protocol, true, writer);
+        HttpManagementResourceDefinition.SASL_PROTOCOL.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SERVER_NAME.marshallAsAttribute(protocol, writer);
+
+        if (HttpManagementResourceDefinition.HTTP_UPGRADE.isMarshallable(protocol)) {
+            writer.writeEmptyElement(Element.HTTP_UPGRADE.getLocalName());
+            HttpManagementResourceDefinition.ENABLED.marshallAsAttribute(protocol.require(HTTP_UPGRADE), writer);
+            HttpManagementResourceDefinition.SASL_AUTHENTICATION_FACTORY.marshallAsAttribute(protocol.require(HTTP_UPGRADE), writer);
+        }
+
+        writer.writeEmptyElement(Element.SOCKET.getLocalName());
+        HttpManagementResourceDefinition.INTERFACE.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.HTTP_PORT.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.HTTPS_PORT.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SECURE_INTERFACE.marshallAsAttribute(protocol, writer);
+
+        writer.writeEndElement();
+
+        return true;
+    }
+
+    @Override
+    public boolean writeAuditLog(XMLExtendedStreamWriter writer, ModelNode auditLog) throws XMLStreamException {
+        auditLogDelegate.writeAuditLog(writer, auditLog);
+
+        return true;
+    }
+
 }

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -119,9 +119,11 @@ public final class StandaloneXml implements XMLElementReader<List<ModelNode>>, X
             case 8:
                 new StandaloneXml_8(extensionHandler, readerNS, deferredExtensionContext, parsingOptions).readElement(reader, operationList);
                 break;
-            default:
+            case 9:
                 new StandaloneXml_9(extensionHandler, readerNS, deferredExtensionContext, parsingOptions).readElement(reader, operationList);
                 break;
+            default:
+                new StandaloneXml_10(extensionHandler, readerNS, deferredExtensionContext, parsingOptions).readElement(reader, operationList);
         }
 
     }
@@ -129,7 +131,7 @@ public final class StandaloneXml implements XMLElementReader<List<ModelNode>>, X
     @Override
     public void writeContent(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context)
             throws XMLStreamException {
-        new StandaloneXml_9(extensionHandler, CURRENT, deferredExtensionContext, parsingOptions).writeContent(writer, context);
+        new StandaloneXml_10(extensionHandler, CURRENT, deferredExtensionContext, parsingOptions).writeContent(writer, context);
     }
 
     class DefaultExtensionHandler implements ExtensionHandler {

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_10.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_10.java
@@ -20,8 +20,15 @@ import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHORIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_UPGRADE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NATIVE_INTERFACE;
@@ -29,8 +36,13 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ORGANIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT;
+import static org.jboss.as.controller.parsing.Namespace.CURRENT;
 import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.nextElement;
@@ -39,6 +51,7 @@ import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.server.controller.resources.ServerRootResourceDefinition.ORGANIZATION_IDENTIFIER;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +65,7 @@ import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.Attribute;
@@ -60,11 +74,14 @@ import org.jboss.as.controller.parsing.Element;
 import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
+import org.jboss.as.controller.parsing.WriteUtils;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefinition;
 import org.jboss.as.domain.management.parsing.AccessControlXml;
 import org.jboss.as.domain.management.parsing.AuditLogXml;
 import org.jboss.as.domain.management.parsing.ManagementXml;
 import org.jboss.as.domain.management.parsing.ManagementXmlDelegate;
+import org.jboss.as.server.controller.resources.DeploymentAttributes;
 import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.server.mgmt.HttpManagementResourceDefinition;
@@ -74,6 +91,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 /**
  * Parser and marshaller for standalone server configuration xml documents (e.g. standalone.xml) that use the urn:jboss:domain:9.0 schema.
@@ -82,7 +100,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-final class StandaloneXml_9 extends CommonXml implements ManagementXmlDelegate {
+final class StandaloneXml_10 extends CommonXml implements ManagementXmlDelegate {
 
     private final AccessControlXml accessControlXml;
     private final StandaloneXml.ParsingOption[] parsingOptions;
@@ -91,7 +109,7 @@ final class StandaloneXml_9 extends CommonXml implements ManagementXmlDelegate {
     private ExtensionHandler extensionHandler;
     private final DeferredExtensionContext deferredExtensionContext;
 
-    StandaloneXml_9(ExtensionHandler extensionHandler, Namespace namespace, DeferredExtensionContext deferredExtensionContext, StandaloneXml.ParsingOption... options) {
+    StandaloneXml_10(ExtensionHandler extensionHandler, Namespace namespace, DeferredExtensionContext deferredExtensionContext, StandaloneXml.ParsingOption... options) {
         super(new SocketBindingsXml.ServerSocketBindingsXml());
         this.namespace = namespace;
         this.extensionHandler = extensionHandler;
@@ -633,6 +651,120 @@ final class StandaloneXml_9 extends CommonXml implements ManagementXmlDelegate {
         }
     }
 
+    void writeContent(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context)
+            throws XMLStreamException {
+
+        ModelNode modelNode = context.getModelNode();
+        writer.writeStartDocument();
+        writer.writeStartElement(Element.SERVER.getLocalName());
+
+        if (modelNode.hasDefined(NAME)) {
+            ServerRootResourceDefinition.NAME.marshallAsAttribute(modelNode, false, writer);
+        }
+
+        if (modelNode.hasDefined(ORGANIZATION_IDENTIFIER.getName())) {
+            ServerRootResourceDefinition.ORGANIZATION_IDENTIFIER.marshallAsAttribute(modelNode, false, writer);
+        }
+
+        writer.writeDefaultNamespace(CURRENT.getUriString());
+        writeNamespaces(writer, modelNode);
+        writeSchemaLocation(writer, modelNode);
+
+        if (modelNode.hasDefined(EXTENSION)) {
+            extensionHandler.writeExtensions(writer, modelNode.get(EXTENSION));
+        }
+
+        if (modelNode.hasDefined(SYSTEM_PROPERTY)) {
+            writeProperties(writer, modelNode.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, true);
+        }
+
+        if (modelNode.hasDefined(PATH)) {
+            writePaths(writer, modelNode.get(PATH), false);
+        }
+
+        if (modelNode.hasDefined(CORE_SERVICE) && modelNode.get(CORE_SERVICE).hasDefined(VAULT)) {
+            writeVault(writer, modelNode.get(CORE_SERVICE, VAULT));
+        }
+
+        if (modelNode.hasDefined(CORE_SERVICE)) {
+            ManagementXml managementXml = ManagementXml.newInstance(CURRENT, this, false);
+            managementXml.writeManagement(writer, modelNode.get(CORE_SERVICE, MANAGEMENT), true);
+        }
+
+        writeServerProfile(writer, context);
+
+        if (modelNode.hasDefined(INTERFACE)) {
+            writeInterfaces(writer, modelNode.get(INTERFACE));
+        }
+
+        if (modelNode.hasDefined(SOCKET_BINDING_GROUP)) {
+            Set<String> groups = modelNode.get(SOCKET_BINDING_GROUP).keys();
+            if (groups.size() > 1) {
+                throw ControllerLogger.ROOT_LOGGER.multipleModelNodes(SOCKET_BINDING_GROUP);
+            }
+            for (String group : groups) {
+                writeSocketBindingGroup(writer, modelNode.get(SOCKET_BINDING_GROUP, group), group);
+            }
+        }
+
+        if (modelNode.hasDefined(DEPLOYMENT)) {
+            writeServerDeployments(writer, modelNode.get(DEPLOYMENT));
+            WriteUtils.writeNewLine(writer);
+        }
+
+        if (modelNode.hasDefined(DEPLOYMENT_OVERLAY)) {
+            writeDeploymentOverlays(writer, modelNode.get(DEPLOYMENT_OVERLAY));
+            WriteUtils.writeNewLine(writer);
+        }
+        writer.writeEndElement();
+        writer.writeEndDocument();
+    }
+
+    private void writeServerDeployments(final XMLExtendedStreamWriter writer, final ModelNode modelNode)
+            throws XMLStreamException {
+
+        boolean deploymentWritten = false;
+        for (String deploymentName : modelNode.keys()) {
+
+            final ModelNode deployment = modelNode.get(deploymentName);
+            if (!deployment.isDefined()) {
+                continue;
+            }
+
+            if (!deploymentWritten) {
+                writer.writeStartElement(Element.DEPLOYMENTS.getLocalName());
+                deploymentWritten = true;
+            }
+
+            writer.writeStartElement(Element.DEPLOYMENT.getLocalName());
+            WriteUtils.writeAttribute(writer, Attribute.NAME, deploymentName);
+            DeploymentAttributes.RUNTIME_NAME.marshallAsAttribute(deployment, writer);
+            DeploymentAttributes.ENABLED.marshallAsAttribute(deployment, writer);
+            final List<ModelNode> contentItems = deployment.require(CONTENT).asList();
+            for (ModelNode contentItem : contentItems) {
+                writeContentItem(writer, contentItem);
+            }
+            writer.writeEndElement();
+        }
+        if (deploymentWritten) {
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeServerProfile(final XMLExtendedStreamWriter writer, final ModelMarshallingContext context)
+            throws XMLStreamException {
+
+        final ModelNode profileNode = context.getModelNode();
+        // In case there are no subsystems defined
+        if (!profileNode.hasDefined(SUBSYSTEM)) {
+            return;
+        }
+
+        writer.writeStartElement(Element.PROFILE.getLocalName());
+        writeSubsystems(profileNode, writer, context);
+        writer.writeEndElement();
+    }
+
     /*
      * ManagamentXmlDelegate Methods
      */
@@ -740,6 +872,76 @@ final class StandaloneXml_9 extends CommonXml implements ManagementXmlDelegate {
     public boolean parseAuditLog(XMLExtendedStreamReader reader, ModelNode address, List<ModelNode> list)
             throws XMLStreamException {
         auditLogDelegate.parseAuditLog(reader, address, namespace, list);
+
+        return true;
+    }
+
+    @Override
+    public boolean writeNativeManagementProtocol(XMLExtendedStreamWriter writer, ModelNode protocol) throws XMLStreamException {
+
+        writer.writeStartElement(Element.NATIVE_INTERFACE.getLocalName());
+        NativeManagementResourceDefinition.SASL_AUTHENTICATION_FACTORY.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SSL_CONTEXT.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SASL_PROTOCOL.marshallAsAttribute(protocol, writer);
+        NativeManagementResourceDefinition.SERVER_NAME.marshallAsAttribute(protocol, writer);
+
+        if (NativeManagementResourceDefinition.SOCKET_BINDING.isMarshallable(protocol)) {
+            writer.writeEmptyElement(Element.SOCKET_BINDING.getLocalName());
+            NativeManagementResourceDefinition.SOCKET_BINDING.marshallAsAttribute(protocol, writer);
+        }
+
+        writer.writeEndElement();
+
+        return true;
+    }
+
+    @Override
+    public boolean writeHttpManagementProtocol(XMLExtendedStreamWriter writer, ModelNode protocol) throws XMLStreamException {
+
+        writer.writeStartElement(Element.HTTP_INTERFACE.getLocalName());
+        HttpManagementResourceDefinition.HTTP_AUTHENTICATION_FACTORY.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SSL_CONTEXT.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SASL_PROTOCOL.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.SERVER_NAME.marshallAsAttribute(protocol, writer);
+
+        boolean consoleEnabled = protocol.get(ModelDescriptionConstants.CONSOLE_ENABLED).asBoolean(true);
+        if (!consoleEnabled) {
+            HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
+        }
+
+        HttpManagementResourceDefinition.ALLOWED_ORIGINS.getMarshaller().marshallAsAttribute(
+                HttpManagementResourceDefinition.ALLOWED_ORIGINS, protocol, true, writer);
+
+        if (HttpManagementResourceDefinition.HTTP_UPGRADE.isMarshallable(protocol)) {
+            writer.writeEmptyElement(Element.HTTP_UPGRADE.getLocalName());
+            HttpManagementResourceDefinition.ENABLED.marshallAsAttribute(protocol.require(HTTP_UPGRADE), writer);
+            HttpManagementResourceDefinition.SASL_AUTHENTICATION_FACTORY.marshallAsAttribute(protocol.require(HTTP_UPGRADE), writer);
+        }
+
+        if (HttpManagementResourceDefinition.SOCKET_BINDING.isMarshallable(protocol)
+                || HttpManagementResourceDefinition.SECURE_SOCKET_BINDING.isMarshallable(protocol)) {
+            writer.writeEmptyElement(Element.SOCKET_BINDING.getLocalName());
+            HttpManagementResourceDefinition.SOCKET_BINDING.marshallAsAttribute(protocol, writer);
+            HttpManagementResourceDefinition.SECURE_SOCKET_BINDING.marshallAsAttribute(protocol, writer);
+        }
+
+        writer.writeEndElement();
+
+        return true;
+    }
+
+    @Override
+    public boolean writeAccessControl(XMLExtendedStreamWriter writer, ModelNode accessAuthorization) throws XMLStreamException {
+        accessControlXml.writeAccessControl(writer, accessAuthorization);
+
+        return true;
+    }
+
+    @Override
+    public boolean writeAuditLog(XMLExtendedStreamWriter writer, ModelNode auditLog) throws XMLStreamException {
+        auditLogDelegate.writeAuditLog(writer, auditLog);
 
         return true;
     }

--- a/server/src/main/resources/schema/wildfly-config_10_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_10_0.xsd
@@ -1,0 +1,5032 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:10.0"
+           targetNamespace="urn:jboss:domain:10.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+
+    <xs:element name="domain">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the master document specifying the core configuration
+                for the servers in a domain. There should be one such master
+                document per domain, available to the host controller that
+                is configured to act as the domain controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="paths" type="named-pathsType" minOccurs="0" maxOccurs="1" />
+                <xs:element name="management" type="domain-managementType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="profiles" type="profilesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="interfaces" type="named-interfacesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="socket-binding-groups" type="socket-binding-groupsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployments" type="domain-deploymentsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="domain-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="server-groups" type="server-groupsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="host-excludes" type="host-excludesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management-client-content" type="management-client-contentType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional" default="Unnamed Domain">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for the domain controller. Useful for administrators who need to work with multiple domains.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="domain-organization" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the organization running this domain.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="host">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for a document configuring a host controller and
+                the group of servers under the control of that host controller.
+                The standard usage would be for a domain to have one such host controller
+                on each physical (or virtual) host machine. Emphasis in this
+                document is on enumerating the servers, configuring items that
+                are specific to the host environment (e.g. IP addresses), and
+                on any server-specific configuration settings.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0"/>
+                <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1" />
+                <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management" type="host-managementType" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="domain-controller" type="domain-controllerType"/>
+                <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0"/>
+                <xs:element name="jvms" type="jvmsType" minOccurs="0"/>
+                <xs:element name="servers" type="serversType" minOccurs="0"/>
+                <xs:element name="profile" type="host-profileType" minOccurs="0"/>
+                <xs:element name="socket-binding-group" type="host-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for this host's host controller. Must be unique across the domain.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="organization" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the organization running this host.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="server">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for a document specifying the configuration
+                of a single "standalone" server that does not operate
+                as part of a domain.
+
+                Note that this element is distinct from the 'serverType'
+                specified in this schema. The latter type forms part of the
+                configuration of a server that operates as part of a domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management" type="server-managementType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="profile" type="standalone-profileType" minOccurs="0"/>
+                <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployments" type="server-deploymentsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="standalone-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for this server.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="organization" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the organization running this server.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="base-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                Domain-wide default configuration settings for the management of standalone servers and a Host Controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="configuration-changes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration for the history of configuration changes.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="max-history" type="xs:integer" use="optional" default="10">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Number of configuration changes that are available in history.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="identity" type="identityType" minOccurs="0" />
+            <xs:element name="security-realms" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="security-realm" type="security-realmType" minOccurs="1"
+                                    maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outbound-connections" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="ldap" type="ldapConnectionType" minOccurs="1" /> <!-- TODO minOccurs only while ldap is only supported connection. -->
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="host-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for the management of a Host Controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-managementType">
+                <xs:sequence>
+                    <xs:element name="audit-log" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence minOccurs="0">
+                                <xs:element name="formatters" type="audit-log-formattersType"/>
+                                <xs:element name="handlers" type="audit-log-handlersType"/>
+                                <xs:element name="logger" type="audit-log-loggerType"/>
+                                <xs:element name="server-logger" type="audit-log-loggerType" minOccurs="0"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="management-interfaces" type="host-management-interfacesType" minOccurs="1"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="server-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for the management of standalone server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-managementType">
+                <xs:sequence>
+                    <xs:element name="audit-log" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence minOccurs="0">
+                                <xs:element name="formatters" type="audit-log-formattersType"/>
+                                <xs:element name="handlers" type="audit-log-handlersType"/>
+                                <xs:element name="logger" type="audit-log-loggerType"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="management-interfaces" type="server-management-interfacesType" minOccurs="0"/>
+                    <xs:element name="access-control" type="server-access-controlType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="domain-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for domain-wide management.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="access-control" type="domain-access-controlType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ldapConnectionType">
+        <xs:annotation>
+            <xs:documentation>
+                The LDAP connection definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" />
+            <xs:element name="search-credential-reference" type="credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The credential reference to use when connecting to perform a search.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The URL to connect to ldap.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The distinguished name to use when connecting to LDAP to perform searches.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-credential" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The credential to use when connecting to perform a search.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a
+                    connection to the LDAP server.
+
+                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-context-factory" type="xs:string" default="com.sun.jndi.ldap.LdapCtxFactory">
+            <xs:annotation>
+                <xs:documentation>
+                    The initial context factory to establish the LdapContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="referrals" default="IGNORE" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines how referrals should be handled if encountered when using this connection, by default they are
+                    ignored.
+
+                    If set to FOLLOW then if referrals are encountered using this connection they will automatically be followed. Apart from the alternative
+                    location if set to FOLLOW it is assumed the remainder of settings for this connection can be applied to the connection
+                    for the referral.
+
+                    Finally if this option is set to THROW an exception is thrown by the connection when referrals are encountered, the security realm will then
+                    use information from the Exception to identify an alternative connection to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="IGNORE" />
+                    <xs:enumeration value="FOLLOW" />
+                    <xs:enumeration value="THROW" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="handles-referrals-for" type="urlListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A space seaparated list of URLs that this connection will handle referrals for.
+
+                    Note: Only the prototocol, host and port should be specified in the URLs.  The LDAP connections are not ordered so a single URL should only
+                    be listed against a single connection, if multpile connections are defined as handling the same URL which connection will be selected is undefined
+                    and subject to change.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="always-send-client-cert" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where an LDAPS connection is established for the purpose of validating the provided credential by default the local servers certificate is not sent to 
+                    avoid inadvertently authenticating as the server.
+
+                    This attribute can be set to true to ensure the local servers certificate is always sent where this is required independently of the authentication 
+                    based on the credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="urlListType">
+        <xs:annotation>
+            <xs:documentation>A list of URLs.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
+
+    <xs:complexType name="security-realmType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a security realm for securing access to the management interfaces.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="plug-ins" type="plug-insType" minOccurs="0" />
+            <xs:element name="server-identities" type="server-identitiesType" minOccurs="0" />
+            <xs:element name="authentication" type="authenticationType" minOccurs="0" />
+            <xs:element name="authorization" type="authorizationType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this security-realm, each security-realm must be assigned a unique name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="plug-insType">
+        <xs:annotation>
+            <xs:documentation>
+                List of modules to be searched for supported security realm plug-ins.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="plug-in" type="plug-inType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="plug-inType">
+        <xs:attribute name="module" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The name of the module.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="plug-inAuthType">
+        <xs:annotation>
+            <xs:documentation>
+                This type defines which plug in will be used to handle either the loading of the
+                authentication data or authorization data during the authentication process.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The properties to be made available to the plug-in.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The short name of the plug-in as already dynamically registered by being referenced
+                    in the plug-ins element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mechanism" default="DIGEST" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    By default plug-ins will be assumed to be used with the DIGEST authentication mechanism,
+                    this attribute can override the plug-in for use with the PLAIN mechanism.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="DIGEST" />
+                    <xs:enumeration value="PLAIN" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authorizationType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration defining how to load the authorization information for the authenticated user.
+
+                After a user has been authenticated additional information such as groups or roles can be loaded and
+                associated with the user for subsequent authorization checks, this type is used to define
+                how the roles are loaded.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0">
+            <xs:element name="properties" type="propertiesFileType" minOccurs="0" />
+            <xs:element name="plug-in" type="plug-inAuthType" minOccurs="0" />
+            <xs:element name="ldap" type="ldapAuthorizationType" minOccurs="0" />
+        </xs:choice>
+        <xs:attribute name="map-groups-to-roles" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The membership information loaded is the authenticated identities group membership, commonly there
+                    is a 1:1 mapping between group membership and the applicable roles, this attribute allows for the
+                    mapping to be performed automatically.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-identitiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the identities that represent the server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="ssl" type="sslType" minOccurs="0" />
+            <xs:element name="secret" type="secretType" minOccurs="0" />
+            <xs:element name="kerberos" type="kerberosIdentityType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="kerberosIdentityType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a servers Kerberos identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="keytab">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to an individual keytab.
+
+                            On handling the authentication for an incoming request two pieces of information are known, the protocol and the name of the host
+                            this server is acting as.  For HTTP requests the protocol will always be HTTP, for requests over Remoting by default the protocol will
+                            be 'remote' although this can be overridden.
+
+                            At the time authentication is going to be handled the keytab will be selected as follows: -
+                             1 - Iterate the list of keytabs and identity one where the for-hosts attribute contains an entry matching protocol/hostname.
+                             2 - Iterate the list of keytabs and identify one where the name of the principal matches matches protocol/hostname.
+                             3 - Iterate the list of keytabs and identity one where the for-hosts attribute contains an entry matching hostname.
+                             4 - Iterate the list of keytabs and identify one where the hostname portion of the principal matches the hostname of the request.
+                             5 - Use the keytab where for-hosts is set to '*'.
+
+                            If no match is found no keytab will be selected and Kerberos will not be available for communication as that host.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:attribute name="path" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The path of the keytab.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="relative-to" use="optional" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The name of another previously named path, or of one of the
+                                standard paths provided by the system. If 'relative-to' is
+                                provided, the value of the 'path' attribute is treated as
+                                relative to the path specified by this attribute.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="principal" use="required" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The name of the principal represented by the keytab.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="for-hosts" use="optional" type="stringListType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                A space separated list of the host names this keytab can be used for.  Can also be set to '*' if applicable for all hosts if a better match is not found.
+
+                                If multiple keytabs are defined as handling the same host which one is selected is undefined and subject to change,
+                                for predictability you should ensure that no more than one keytab is defined per host.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="stringListType">
+        <xs:annotation>
+            <xs:documentation>A list of String.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="secretType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the secret/password-based identity of this server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by as protection parameter for the Credential Store.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The secret / password - Base64 Encoded
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="sslType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the SSL identity of this server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="engine" type="engineType" minOccurs="0" />
+            <xs:element name="keystore" type="realmExtendedKeyStoreType" />
+        </xs:sequence>
+        <xs:attribute name="protocol" type="xs:string" default="TLS">
+            <xs:annotation>
+                <xs:documentation>
+                    The protocol to use when creating the SSLContext.
+
+                    Note: This is separate from the enabled protocols on the underlying SSLEngine, to configure those add the engine specific configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="engineType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration options specific to the
+                unlerlying SSLEngine created for request handling.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enabled-protocols" use="optional" type="stringListType" default="TLSv1 TLSv1.1 TLSv1.2">
+            <xs:annotation>
+                <xs:documentation>
+                    A space separated list of protocols that may be enabled on the SSLEngine handling requests.
+
+                    At runtime the intersection of the available protocols and the protocols specified here will be used, if that
+                    results in an empy list an error will be reported.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled-cipher-suites" use="optional" type="stringListType">
+            <xs:annotation>
+                <xs:documentation>
+                    A space separated list of cipher suites that may be enabled on the SSLEngine handling requests.
+
+                    At runtime the intersection of the available suites and the suites specified here will be used, if that
+                    results in an empy list an error will be reported.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                The keystore configuration for the server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="keystore-password-credential-reference" type="credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential reference to be used by as protection parameter for the Keystore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="keystore-password" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The password to open the keystore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="extendedKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                This is a more complex keystore definition which also allows for an alias
+                and key password to be specified.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="keyStoreType">
+                <xs:sequence>
+                    <xs:element name="key-password-credential-reference" type="credentialReferenceType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Credential reference to be used by as protection parameter when loading keys from the keystore.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="alias" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The alias of the entry to use from the keystore, if specified all remaining
+                            entries in the keystore will be ignored.
+
+                            Note: The use of aliases is only available for JKS based stores, for other store types this will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-password" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The password to use when loading keys from the keystore.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="generate-self-signed-certificate-host" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If this is set and the key store does not exist then a new keystore will be created and a
+                            self signed certificate will be generated. The host name for the self signed certificate
+                            will be the value of this attribute.
+
+                            This is not intended for production use.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="realmKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An extension of keyStoreType used by realms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="keyStoreType">
+                <xs:attribute name="provider" type="xs:string" default="JKS">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The provider for the store, the default is a file based JKS store.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="realmExtendedKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An extension of keyStoreType used by realms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="extendedKeyStoreType">
+                <xs:attribute name="provider" type="xs:string" default="JKS">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The provider for the store, the default is a file based JKS store.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this
+                            attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="auditKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An extension of keyStoreType used for audit logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="keyStoreType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this
+                            attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="auditExtendedKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit specific extension of the extended key store type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="extendedKeyStoreType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this
+                            attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="localType">
+        <xs:annotation>
+            <xs:documentation>
+                This type definition is used to control the local authentication mechanism.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="default-user" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    When using the local mechanism it is optional for the client side to send an
+                    authentication user name - this attribute specifies the user name to be assumed
+                    if the remote client does not send one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="allowed-users" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A comma separated list of users that can be specified by the client when connecting
+                    using the local authentication mechanism.
+
+                    If a default user has been specified then that user is automatically added to the
+                    allowed list.  If both default-user and allowed-users are omitted despite the mechanism
+                    being enabled no incoming connection attemps using the mechanism will succeed.
+
+                    If any user name should be accepted the value should be set to "*".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="skip-group-loading" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    After authentication has occurred the username of the authenticated user is then passed
+                    to the configured authorization mechanism to load the group membership information for
+                    the authenticated user.
+
+                    As the local authenitication mechanism is a special case with an artificial identifier
+                    for the authenticated user this can cause problems during group loading where a user
+                    with the same name does not exist.
+
+                    Setting this attribute to 'false' will disable the loading of groups for the local user.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the server side authentication mechanisms.
+
+                Optionally one truststore can be defined and one username/password based store can be defined.
+                Authentication will first attempt to use the truststore and if this is not available will fall back
+                to the username/password authentication.
+
+                If none of these are specified the only available mechanism will be the local mechanism for the
+                Native interface and the HTTP interface will not be accessible.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="truststore" type="realmKeyStoreType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of a keystore to use to create a trust manager to verify clients.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="local" type="localType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration to enable the local authentication mechanism, if this element
+                        is omitted then local authentication will be disabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="kerberos" type="kerberosAuthenticationType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration to enable Kerberos authentication.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0">
+                <xs:element name="jaas" type="jaasAuthenticationType" minOccurs="0" />
+                <xs:element name="ldap" type="ldapAuthenticationType" minOccurs="0" />
+                <xs:element name="properties" type="propertiesAuthenticationType" minOccurs="0" />
+                <xs:element name="users" type="usersAuthenticationType" minOccurs="0" />
+                <xs:element name="plug-in" type="plug-inAuthType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="kerberosAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to enable Kerberos for
+                authentication.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="remove-realm" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When a user is authenticated using Kerberos typically their identity will be represented in the form username@REALM,
+                    setting this option to true will strip the @REALM part of the name.
+
+                    This may be desired to bring the names in-line with username/password based authentication if used in parallel.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jaasAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to use a JAAS based configuration for authentication.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name identifying the jaas configuration of LoginModules.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="assign-groups" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When JAAS is delegated to for authentication a user is also assigned a set of roles,
+                    if this attribute is set to true then those roles will be assigned to the user a groups.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="baseLdapAuthType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                The base type used for LDAP authentication and authorization definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="connection" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the connection to use to connect to LDAP.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to use LDAP as the user repository.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="baseLdapAuthType">
+                <xs:sequence>
+                    <xs:element name="cache" type="ldapCacheType" minOccurs="0" />
+                    <xs:choice>
+                        <xs:element name="username-filter">
+                            <xs:complexType>
+                                <xs:attribute name="attribute" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the attribute to search for the user, this filter will then perform
+                                            a simple search where the username entered by the user matches the attribute
+                                            specified here.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="advanced-filter">
+                            <xs:complexType>
+                                <xs:attribute name="filter" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The fully defined filter to be used to search for the user based on their entered
+                                            user ID. The filter should contain a variable in the form {0} - this will be
+                                            replaced with the username supplied by the user.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                </xs:sequence>
+                <xs:attribute name="base-dn" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The base distinguished name to commence the search for the user.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="recursive" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should the search be recursive.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="user-dn" type="xs:string" default="dn">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the attribute which is the users distinguished name.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="username-load" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            This attribute is independent of the filtering configuration, if this attribute is set then after
+                            the users entry in LDAP is identified this attribute will be read to discover the users actual username.
+
+                            This is optional but could be useful in a few scenarios e.g. authenticate with an e-mail address but be identified by a username,
+                            correcting the case of an entered username or even in the future ensuring consistency after a different
+                            authentication approach.
+
+                            Note: This value will become the username used for any subsequent group loading.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="allow-empty-passwords" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should users be allowed to supply an empty password? Some LDAP servers will
+                            allow an anonymous bind
+                            so an empty password could appear as a successful authentication
+                            even though no password was sent to verify.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAuthorizationType">
+        <xs:complexContent>
+            <xs:extension base="baseLdapAuthType">
+                <xs:sequence>
+                    <xs:element name="username-to-dn" type="ldapUserSearchType" minOccurs="0" />
+                    <xs:element name="group-search" type="ldapGroupSearchType" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="baseLdapSearchType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type of common attributes used for
+                LDAP searches.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="base-dn" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The base distinguished name to commence the search.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recursive" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should the search be recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapUserSearchType">
+        <xs:annotation>
+            <xs:documentation>
+                Search definition to locate a user from
+                the supplied username.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="cache" type="ldapCacheType" minOccurs="0" />
+            <xs:choice>
+                <xs:element name="username-is-dn" />
+                <xs:element name="username-filter">
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="baseLdapSearchType">
+                                <xs:attribute name="user-dn-attribute" type="xs:string" use="optional" default="dn">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The attribute on the user entry which is their distinguished name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="attribute" type="xs:string" use="optional" default="uid">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the attribute to search for the user, this filter will then perform a
+                                            simple search where the username entered by the user matches the attribute specified here.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="advanced-filter">
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="baseLdapSearchType">
+                                <xs:attribute name="user-dn-attribute" type="xs:string" use="optional" default="dn">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The attribute on the user entry which is their distinguished name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="filter" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The fully defined filter to be used to search for the user based on their entered user
+                                            ID. The filter should contain a variable in
+                                            the form {0} - this will be replaced with the username
+                                            supplied by the user.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="force" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If the username was already converted to a distinguished name during authentication this attribute forces
+                    the search to be repeated
+                    before loading group information.
+
+                    This would most likely be required if a different LDAP server
+                    was being used to load group information as was used for authentication.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="groupMode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SIMPLE" />
+            <xs:enumeration value="DISTINGUISHED_NAME" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="membershipFilterType">
+        <xs:attribute name="principal-attribute" type="xs:string" default="member">
+            <xs:annotation>
+                <xs:documentation>
+                    The attribute on the group entry that references the principal.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapGroupSearchType">
+        <xs:sequence>
+            <xs:element name="cache" type="ldapCacheType" minOccurs="0" />
+            <xs:choice>
+                <xs:element name="group-to-principal">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Group search definition where an attribute on the group references the principal.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="baseLdapSearchType">
+                                <xs:sequence>
+                                    <xs:element name="membership-filter" type="membershipFilterType" minOccurs="1" />
+                                </xs:sequence>
+                                <xs:attribute name="search-by" type="groupMode" default="DISTINGUISHED_NAME">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Should searching use the simple name or distinguished name of the principal.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="prefer-original-connection" type="xs:boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            After a referral has been followed should the original LDAP connection defined for
+                                            group loading be used or should the connection from the last referral be used instead.
+
+                                            By default each attempt to load a group will revert back to the original connection as defined
+                                            in the configuration, however setting this attribute to false will cause subsequent searches to
+                                            use the connection of the last referral.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="principal-to-group">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Group search definition where an attribute on the principal references the group.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:attribute name="group-attribute" type="xs:string" default="memberOf">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The name of the attribute on the principal that references the group.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="prefer-original-connection" type="xs:boolean" default="true">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    After a referral has been followed should the original LDAP connection defined for
+                                    group loading be used or should the connection from the last referral be used instead.
+
+                                    By default each attempt to load a group will revert back to the original connection as defined
+                                    in the configuration, however setting this attribute to false will cause subsequent searches to
+                                    use the connection of the last referral.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="skip-missing-groups" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    If an entry references non-existent groups then authentication is aborted due to the inability to
+                                    query a users complete set of groups, setting this option to true allows for non-existent groups
+                                    to be silently ignored.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="parse-group-name-from-dn" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Extract the groupe name from the distinguished name instead of requesting it.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="group-name" type="groupMode" use="optional" default="SIMPLE">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the form the name of the group should take, either it's simple name or it's complete
+                    distringuished name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="iterative" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should any group searching be iterative, i.e. should additional searches be performed to identify the
+                    groups that the groups are members of.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="group-dn-attribute" type="xs:string" default="dn">
+            <xs:annotation>
+                <xs:documentation>
+                    On the group entry which of it's attributes is it's distingushed name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="group-name-attribute" type="xs:string" default="uid">
+            <xs:annotation>
+                <xs:documentation>
+                    On the group entry which of it's attributes is it's simple name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="cacheType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="by-search-time" />
+            <xs:enumeration value="by-access-time" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="ldapCacheType">
+        <xs:attribute name="type" type="cacheType" default="by-search-time">
+            <xs:annotation>
+                <xs:documentation>
+                    The type of cache, by-search-time and the entries are evicted based on search time and search order, by-access-time and
+                    the entires are evicted based on the time they were last accessed.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="eviction-time" type="xs:int" default="900">
+            <xs:annotation>
+                <xs:documentation>
+                    The time until an entry is evicted from the cache in seconds, a time of &lt;=0 means no eviction based
+                    on time.
+
+                    If items are not going to be evicted based on time then max-cache-size should be set otherwise the cache
+                    could grow without restriction.
+
+                    Note: The eviction time is handled on a best-efforts basis, during times of many concurrent authentications
+                    there could be small delay before the evictions fire.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cache-failures" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should non IO failures be cached? e.g. should searches for a non-existent user be cached to avoid
+                    repeating the same search.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-cache-size" type="xs:int" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of items to hold in the cache before items are evicted, or &lt;=0 where the size of
+                    the cache is unlimited.
+
+                    This value should be higher than the anticipated cache size for current users otherwise items
+                    will be continually evicted.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="usersAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                A set of users
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="user" type="userType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="userType">
+        <xs:annotation>
+            <xs:documentation>
+                A single user.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="password" type="xs:string" />
+        </xs:choice>
+        <xs:attribute name="username" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The users username.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesFileType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of a location of a properties file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The path of the properties file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of users stored within properties files.
+
+                The entries within the properties file are username={credentials} with each user
+                being specified on it's own line.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="propertiesFileType">
+                <xs:attribute name="plain-text" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Are the credentials within the properties file stored in plain text, if not
+                            the {credential} is expected to be the hex encoded Digest hash
+                            of 'username : realm : password'.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+   <xs:complexType name="audit-log-formattersType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of management operation audit logging formatters.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="json-formatter" type="json-audit-log-formatterType"/>
+        </xs:choice>
+   </xs:complexType>
+
+   <xs:complexType name="base-audit-log-formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Shared configuration for audit log formatters..
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+               <xs:documentation>
+                  The name of the formatter. Must be unique across all types of formatter
+                  (there is only the JSON formatter at present but more are planned for the
+                  future)
+               </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="include-date" type="xs:boolean" default="true">
+            <xs:annotation>
+               <xs:documentation>
+                  Whether or not to include the date in the formatted log record
+               </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="date-format" type="xs:string" default="yyyy-MM-dd HH:mm:ss">
+            <xs:annotation>
+               <xs:documentation>
+                  The date format to use as understood by {@link java.text.SimpleDateFormat}.
+                  Will be ignored if include-date="false".
+               </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="date-separator" type="xs:string" default=" - ">
+            <xs:annotation>
+               <xs:documentation>
+                  The separator between the date and the rest of the formatted log message.
+                  Will be ignored if include-date="false".
+               </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="json-audit-log-formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a JSON formatter for the audit log.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-audit-log-formatterType">
+	        <xs:attribute name="compact" type="xs:boolean" default="false">
+		            <xs:annotation>
+		               <xs:documentation>
+		                   If true will format the JSON on one line. There may still be
+		                   values containing new lines, so if having the whole record on
+		                   one line is important, set escape-new-line or escape-control-characters to true.
+		               </xs:documentation>
+		            </xs:annotation>
+		        </xs:attribute>
+              <xs:attribute name="escape-new-line" type="xs:boolean" default="false">
+                  <xs:annotation>
+                     <xs:documentation>
+                         If true will escape all new lines with the ascii code in octal,
+                         e.g. #012.
+                     </xs:documentation>
+                  </xs:annotation>
+              </xs:attribute>
+              <xs:attribute name="escape-control-characters" type="xs:boolean" default="false">
+                  <xs:annotation>
+                     <xs:documentation>
+                         If true will escape all control characters (ascii entries with a decimal
+                         value less than 32) with the ascii code in octal, e.g.'\n\ becomes '#012'.
+                         If this is true, it will override escape-new-line="false"
+                     </xs:documentation>
+                  </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+   </xs:complexType>
+
+    <xs:complexType name="audit-log-handlersType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of management operation audit logging handlers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="file-handler" type="file-audit-log-handlerType"/>
+            <xs:element name="size-rotating-file-handler" type="size-rotating-file-audit-log-handlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodic-rotating-file-audit-log-handlerType"/>
+            <xs:element name="syslog-handler" type="syslog-audit-log-handlerType"/>
+            <xs:element name="in-memory-handler">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation>
+                            Configuration of a in memory handler for the audit log.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The name of the handler. The name must be unique across all types of handler.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="max-history" type="xs:integer" default="10">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The number of logging entries stored in memory.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="base-audit-log-handlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Common configuration of a handler for the audit log.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the handler. The name must be unique across all types of handler.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="formatter" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the formatter to use for the handler.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-failure-count" type="xs:string" default="10">
+            <xs:annotation>
+                <xs:documentation>
+                    The number of logging failures before this handler is disabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="abstract-file-audit-log-handlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a simple file handler for the audit log. This writes to a local file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-audit-log-handlerType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the audit log.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="file-audit-log-handlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a simple file handler for the audit log. This writes to a local file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstract-file-audit-log-handlerType">
+                <xs:attribute name="rotate-at-startup" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether or not should an old log file be rotated during a handler initialization.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="size-rotating-file-audit-log-handlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a size rotating file handler for the audit log. This writes to a local file,
+                rotating the log after the size of the file grows beyond a certain point and keeping
+                a fixed number of backups..
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstract-file-audit-log-handlerType">
+                <xs:attribute name="rotate-size" type="sizeType" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The size at which to rotate the log file.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="max-backup-index" type="xs:positiveInteger" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of backups to keep.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="periodic-rotating-file-audit-log-handlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a periodic rotating file handler for the audit log. This writes to a local file,
+                rotating the log after a time period derived from the given suffix string,
+                which should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstract-file-audit-log-handlerType">
+                <xs:attribute name="suffix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The suffix string in a format which can be understood by java.text.SimpleDateFormat.
+                            The period of the rotation is automatically calculated based on the suffix.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="sizeType">
+        <xs:annotation>
+            <xs:documentation>A positive number optionally followed by one of [bBkKmMgGtT]</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]+[bBkKmMgGtT]?"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="syslog-audit-log-handlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a syslog file handler for the audit log on a server. This writes to syslog server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-audit-log-handlerType">
+                <xs:choice minOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The configuration of the protocol to use communication with the syslog server. See your
+                            syslog provider's documentation for configuration options.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:element name="udp" type="udp-audit-log-protocolType">
+                    </xs:element>
+                    <xs:element name="tcp" type="tcp-audit-log-protocolType">
+                    </xs:element>
+                    <xs:element name="tls" type="tls-audit-log-protocolType">
+                    </xs:element>
+                </xs:choice>
+                <xs:attribute name="syslog-format" default="RFC5424">
+		            <xs:annotation>
+		                <xs:documentation>
+		                    The format to use for the syslog messages. See your syslog provider's documentation for what is supported.
+		                </xs:documentation>
+		            </xs:annotation>
+		            <xs:simpleType>
+		                <xs:restriction base="xs:token">
+		                    <xs:enumeration value="RFC5424">
+		                        <xs:annotation>
+		                            <xs:documentation>Format the syslog data according to the RFC-5424 standard</xs:documentation>
+		                        </xs:annotation>
+		                    </xs:enumeration>
+		                    <xs:enumeration value="RFC3164">
+		                        <xs:annotation>
+		                            <xs:documentation>Format the syslog data according to the RFC-3164 standard</xs:documentation>
+		                        </xs:annotation>
+		                    </xs:enumeration>
+		                </xs:restriction>
+		            </xs:simpleType>
+		        </xs:attribute>
+		        <xs:attribute name="max-length" type="xs:int">
+		          <xs:annotation>
+		             <xs:documentation>
+		                The maximum length in bytes a log message, including the header, is allowed to be. If undefined, it will default to 1024 bytes if the syslog-format is RFC3164, or 2048 bytes if the syslog-format is RFC5424.
+		             </xs:documentation>
+		          </xs:annotation>
+		        </xs:attribute>
+              <xs:attribute name="truncate" type="xs:boolean" default="true">
+                <xs:annotation>
+                   <xs:documentation>
+                      Whether or not a message, including the header, should truncate the message if the length in bytes is greater than the maximum length. If set to false messages will be split and sent with the same header values.
+                   </xs:documentation>
+                </xs:annotation>
+              </xs:attribute>
+              <xs:attribute name="facility" default="USER_LEVEL">
+                <xs:annotation>
+                   <xs:documentation>
+                      The facility to use for syslog logging as defined in section 6.2.1 of RFC-5424, and section 4.1.1 of RFC-3164.
+                      The numerical values in the enumeration entries, is the numerical value as defined in the RFC.
+                   </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+	                <xs:restriction base="xs:token">
+		                <xs:enumeration value="KERNEL">
+			                <xs:annotation>
+			                   <xs:documentation>0</xs:documentation>
+			                </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="USER_LEVEL">
+                         <xs:annotation>
+                            <xs:documentation>1</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="MAIL_SYSTEM">
+                         <xs:annotation>
+                            <xs:documentation>2</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="SYSTEM_DAEMONS">
+                         <xs:annotation>
+                            <xs:documentation>3</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="SECURITY">
+                         <xs:annotation>
+                            <xs:documentation>4</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="SYSLOGD">
+                         <xs:annotation>
+                            <xs:documentation>5</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LINE_PRINTER">
+                         <xs:annotation>
+                            <xs:documentation>6</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="NETWORK_NEWS">
+                         <xs:annotation>
+                            <xs:documentation>7</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="UUCP">
+                         <xs:annotation>
+                            <xs:documentation>8</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="CLOCK_DAEMON">
+                         <xs:annotation>
+                            <xs:documentation>9</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="SECURITY2">
+                         <xs:annotation>
+                            <xs:documentation>10</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="FTP_DAEMON">
+                         <xs:annotation>
+                            <xs:documentation>11</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="NTP">
+                         <xs:annotation>
+                            <xs:documentation>12</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOG_AUDIT">
+                         <xs:annotation>
+                            <xs:documentation>13</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOG_ALERT">
+                         <xs:annotation>
+                            <xs:documentation>14</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="CLOCK_DAEMON2">
+                         <xs:annotation>
+                            <xs:documentation>15</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_0">
+                         <xs:annotation>
+                            <xs:documentation>16</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_1">
+                         <xs:annotation>
+                            <xs:documentation>17</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_2">
+                         <xs:annotation>
+                            <xs:documentation>18</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_3">
+                         <xs:annotation>
+                            <xs:documentation>19</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_4">
+                         <xs:annotation>
+                            <xs:documentation>20</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_5">
+                         <xs:annotation>
+                            <xs:documentation>21</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_6">
+                         <xs:annotation>
+                            <xs:documentation>22</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+		                <xs:enumeration value="LOCAL_USE_7">
+                         <xs:annotation>
+                            <xs:documentation>23</xs:documentation>
+                         </xs:annotation>
+		                </xs:enumeration>
+	                </xs:restriction>
+                </xs:simpleType>
+              </xs:attribute>
+              <xs:attribute name="app-name" type="xs:string">
+                <xs:annotation>
+                   <xs:documentation>
+                      The application name to add to the syslog records as defined in section 6.2.5 of RFC-5424. If not specified it will default to the name of the product.
+                   </xs:documentation>
+                </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-audit-log-protocolType">
+        <xs:attribute name="host" default="localhost">
+            <xs:annotation>
+                <xs:documentation>
+                    The host of the syslog server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" default="514">
+            <xs:annotation>
+                <xs:documentation>
+                    The port of the syslog server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="udp-audit-log-protocolType">
+        <xs:annotation>
+            <xs:documentation>Configure udp as the protocol for communicating with the syslog server</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-audit-log-protocolType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="tcp-audit-log-protocolType">
+        <xs:annotation>
+            <xs:documentation>Configure tcp as the protocol for communicating with the syslog server</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-audit-log-protocolType">
+                <xs:attribute name="message-transfer" default="NON_TRANSPARENT_FRAMING">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The message transfer setting as described in section 3.4 of RFC-6587. See your syslog provider's
+                            documentation for what is supported
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                            <xs:enumeration value="OCTET_COUNTING">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Use the octet counting format for message transfer as described in section 3.4.1 of RFC-6587.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="NON_TRANSPARENT_FRAMING">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Use the non-transparent-framing format for message transfer as described in section 3.4.1 of RFC-6587.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="reconnect-timeout" type="xs:int" default="-1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If a connection drop is detected, the number of seconds to wait before reconnecting. A negative number means
+                            don't reconnect automatically.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="tls-audit-log-protocolType">
+        <xs:annotation>
+            <xs:documentation>Configure tls as the protocol for communicating with the syslog server</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="tcp-audit-log-protocolType">
+                <xs:sequence>
+                    <xs:element name="truststore" type="auditKeyStoreType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Configuration of a keystore to use to create a trust manager to verify the server
+                                certificate for encrypted communications. If the server certificate is signed off by a
+                                signing authority, tls can be used without a truststore.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="client-certificate-store" type="auditExtendedKeyStoreType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Configuration of a keystore containing a client certificate and a private key, e.g. in
+                                PKCS12 format. This turns on authenticating the clients against the syslog server.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="audit-log-loggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of management operation audit logging configuration coming from the model controller core.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="handlers" type="audit-log-handlers-refType"/>
+        </xs:choice>
+        <xs:attribute name="log-boot" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether operations should be logged on boot.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="log-read-only" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether operations that do not modify the configuration or any runtime services should be logged.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether audit logging is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="audit-log-handlers-refType">
+        <xs:annotation>
+            <xs:documentation>
+                References to audit-log-handlers defined in the audit-log-handlers section
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0">
+            <xs:element name="handler" type="audit-log-handler-refType" minOccurs="0"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="audit-log-handler-refType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to an audit-log-handler defined in the audit-log-appenders section
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="host-management-interfacesType">
+        <xs:sequence>
+            <xs:element name="native-interface" type="host-native-management-interfaceType" minOccurs="0"/>
+            <xs:element name="http-interface" type="host-http-management-interfaceType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="management-interfaceType">
+        <xs:attribute name="ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the SSLContext to use for this management interface.
+
+                    If this is not set then the SSLContext will be obtained from any referenced security-realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The security realm to use for this management interface, the capabilities
+                    of the security realm will be queried to identify the authentication mechanism(s) to
+                    offer.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-protocol" type="xs:string" use="optional" default="remote">
+            <xs:annotation>
+                <xs:documentation>
+                    Where Remoting is accepting incomming connections part of the authentication process
+                    advertises the name of the protocol in use, by default this is 'remote' but this attribute
+                    can be set if an alternative is required.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="server-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Where Remoting is accepting incomming connection the initial exchange and the authentication
+                    process both advertise the name of the server, by default this is derived from the address Remoting
+                    is listening on but this attribute can be set to override the name.
+                 </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-interfaceType" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="http-upgrade" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                HTTP Upgrade configuration on the management interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Is HTTP Upgrade to 'remote' enabled.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="sasl-authentication-factory" type="xs:string" use="optional">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The SASL authentication policy to secure connections upgraded from HTTP.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="http-authentication-factory" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The HTTP authentication factory to use to secure normal HTTP requests.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-interfaceType" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:attribute name="sasl-authentication-factory" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The SASL server authentication policy to secure connections upgraded from HTTP.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-native-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a host's exposed native management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="native-management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="socket" type="native-management-socketType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Network interface on which the host's socket for
+                    management communication should be opened.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-socketType">
+                <xs:attribute name="port" type="xs:int" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for native
+                            management communication should be opened.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-http-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a host's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="http-management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="socket" type="host-http-management-socketType"/>
+                </xs:sequence>
+                <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-socketType">
+                <xs:attribute name="port" type="xs:int" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for
+                            management communication should be opened.
+
+                            If not specified the port will not be opened.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="secure-port" type="xs:int" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for HTTPS
+                            management communication should be opened.
+
+                            If not specified the port will not be opened.
+
+                            If specified an ssl-context or security-realm will be
+                            required to obtain the SSL configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-http-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="http-management-socketType">
+                <xs:attribute name="secure-interface" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Network interface on which the host's socket for
+                            HTTPS management communication should be opened
+                            if a different interface should be used from that
+                            specified by the 'interface' attribute.
+
+                            If not specified the interface specified by the 'interface'
+                            attribute will be used.
+
+                            Has no effect if the 'secure-port' attribute is not set.
+
+                            If specified with a different value from the 'interface'
+                            attribute, redirect of HTTPS requests received on the HTTP
+                            socket to the HTTPS address will not be supported.
+
+                            If specified an ssl-context or security-realm will be
+                            required to obtain the SSL configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="server-management-interfacesType">
+        <xs:sequence>
+            <xs:element name="native-remoting-interface" type="management-remoting-interfaceType" minOccurs="0"/>
+            <xs:element name="native-interface" type="server-native-management-interfaceType" minOccurs="0"/>
+            <xs:element name="http-interface" type="server-http-management-interfaceType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-native-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="native-management-interfaceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the socket to use for the native management interface is a choice
+                        between a direct configuration of the address and port, or a reference to a socket-binding
+                        configuration in the server's socket-binding-group element. The latter is the recommended
+                        approach as it makes it easier to avoid port conflicts by taking advantage of the
+                        socket-binding-group's port-offset configuration. Direct configuration of the address and
+                        ports is deprecated and is only provided to preserve backward compatibility.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:choice>
+                    <xs:element name="socket" type="native-management-socketType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use 'socket-binding'
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="socket-binding" type="native-management-socket-binding-refType"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-socket-binding-refType">
+        <xs:annotation>
+            <xs:documentation>
+                Reference to the configuration of the socket to be used by a standalone server's exposed native management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="native" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-http-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a standalone server's exposed HTTP/HTTPS management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="http-management-interfaceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the socket to use for the HTTP/HTTPS management interface is a choice
+                        between a direct configuration of the address and ports, or a reference to socket-binding
+                        configurations in the server's socket-binding-group element. The latter is the recommended
+                        approach as it makes it easier to avoid port conflicts by taking advantage of the
+                        socket-binding-group's port-offset configuration. Direct configuration of the address and
+                        ports is deprecated and is only provided to preserve backward compatibility.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:choice>
+                    <xs:element name="socket" type="http-management-socketType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use 'socket-binding'
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="socket-binding" type="http-management-socket-binding-refType"/>
+                </xs:choice>
+                <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="allowed-origins" type="urlListType" use="optional" >
+                    <xs:annotation>
+                        <xs:documentation>
+                            A space separated list of Origins that will be trusted to send request to the management
+                            API once the user is authenticated. This is used following the Cross-Origin Resource Sharing
+                            recommendation (http://www.w3.org/TR/access-control/).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-socket-binding-refType">
+        <xs:annotation>
+            <xs:documentation>
+                Reference to the configurations of the sockets to be used by a standalone server's exposed HTTP and HTTPS management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="http" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group to use for a HTTP socket.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="https" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group to use for a HTTPS socket.
+
+                    Note: When specified the interface must also be configured to reference an ssl-context or a security realm with a configured keystore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="management-remoting-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Makes the native management interface available via the connectors set up in the remoting subsystem,
+                using the remoting subsystem's endpoint. This should only be used for a server not for a HC/DC.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controllerType">
+        <xs:choice>
+            <xs:element name="local" type="domain-controller-localType"/>
+            <xs:element name="remote" type="domain-controller-remoteType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controller-localType">
+        <xs:sequence>
+            <xs:element name="discovery-options" type="discovery-optionsType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controller-remoteType">
+        <xs:sequence>
+            <xs:element name="ignored-resources" type="ignored-resourcesType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="discovery-options" type="discovery-optionsType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="protocol" type="remote-protocol-type" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                     The remote domain controller's protocol. If not set, a discovery option must be provided,
+                    or the --cached-dc startup option must be used, or the --admin-only startup option must be used
+                    with the 'admin-only-policy' attribute set to a value other than 'fetch-from-master'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host" type="xs:string" use="optional" >
+            <xs:annotation>
+                <xs:documentation>
+                    The remote domain controller's host name. If not set, a discovery option must be provided,
+                    or the --cached-dc startup option must be used, or the --admin-only startup option must be used
+                    with the 'admin-only-policy' attribute set to a value other than 'fetch-from-master'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:integer" use="optional" >
+            <xs:annotation>
+                <xs:documentation>
+                    The remote domain controller's port. If not set, a discovery option must be provided,
+                    or the --cached-dc startup option must be used, or the --admin-only startup option must be used
+                    with the 'admin-only-policy' attribute set to a value other than 'fetch-from-master'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the authentication-context to use when establishing the remote connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-realm" type="xs:string" use="optional" />
+        <xs:attribute name="username" type="xs:string" use="optional" />
+        <xs:attribute name="ignore-unused-configuration" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    When set to true, this instructs the master Host Controller to not forward configuration and
+                    operations for profiles, socket binding groups and server groups which do not affect our servers.
+                    Setting to false will ensure that all of this configuration information is copied. Note that using
+                    the '--backup' startup option on the command line will set this to false if the value is unspecified
+                    in host.xml. If the value is specified in host.xml, then using '--backup' will not override the
+                    specified value (for example: setting ignore-unused-configuration="true" and using --backup will
+                    not override the value of ignore-unused-configuration, which will remain true). If --backup is not
+                    used, this value will be true at runtime.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="admin-only-policy" type="admin-only-policyType" default="allow-no-config">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Policy options for how a slave host controller started in 'admin-only' mode and
+                    without the use of the '--cached-dc' startup option should deal with the absence
+                    of a local copy of the domain-wide configuration.
+
+                    This question is particularly relevant when fine grained management operation
+                    authorization scheme is used, as the configuration for management authorization
+                    in a managed domain comes from the domain wide configuration.
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="admin-only-policyType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="allow-no-config">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        Allow the host to function without any domain wide configuration.
+
+                        The management authorization configuration system (which is ordinarily
+                        configured according to policies set in the domain wide configuration)
+                        will use default settings, whereby user who can authenticate to the security
+                        realm associated with the management interface to which they connect
+                        will have all permissions.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="fetch-from-master">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        Unless the --cached-dc startup option was used, contact the master host controller to pull down
+                        the current domain wide configuration, but do not actually register with the master as a member
+                        of the domain. If the master cannot be reached, the start of the host controller will fail.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="require-local-config">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        Require the presence of a locally cached copy of the domain wide configuration
+                        policy. If not present, the start of the host controller will fail.
+
+                        The '--cached-dc' startup option is used to indicate to the host controller
+                        process that a locally cached copy of the domain wide configuration
+                        policy should be used.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="ignored-resourcesType">
+        <xs:annotation>
+            <xs:documentation>
+                Provides names of direct child resources of the domain root resource requests for which the
+                Host Controller should ignore. Only relevant on a slave Host Controller. Configuring such
+                "ignored resources" may help allow a Host Controller from an earlier release to function as a
+                slave to a master Host Controller running a later release, by letting the slave ignore portions
+                of the configuration its version of the software cannot understand. This strategy can only be
+                successful if the servers managed by the slave Host Controller do not reference any of the
+                ignored configuration.
+
+                Supports the following attributes:
+
+                type -- the type of resource (e.g. 'profile' or 'socket-binding-group') certain instances of which
+                should be ignored. The value corresponds to the 'key' portion of the first element in the
+                resource's address (e.g. 'profile' in the address /profile=ha/subsystem=web)
+
+                wildcard -- if 'true', all resources of the given type should be ignored.
+
+                Child elements list the names of specific instances of the given type of resource
+                that should be ignored. Each element in the list corresponds to the 'value' portion of
+                the first element in the resource's address (e.g. 'ha' in the address /profile=ha/subsystem=web.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="instance" type="ignored-resource-instanceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="wildcard" type="xs:boolean" use="optional" default="false" />
+        <xs:attribute name="names" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="ignored-resource-instanceType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a specific instances of a particular type of resource that should be ignored.
+                The 'name' attribute corresponds to the 'value' portion of the first element in the resource's address
+                (e.g. 'ha' in the address /profile=ha/subsystem=web.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="discovery-optionsType">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="discovery-option" type="discovery-optionType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="static-discovery" type="static-discoveryType" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-optionType">
+        <xs:sequence>
+            <xs:element name="property" type="propertyType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name for this domain controller discovery option.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="code" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The fully qualified class name for the DiscoveryOption implementation.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The module from which the DiscoveryOption implementation should be loaded. If not provided,
+                    the DiscoveryOption implementation must be available from the Host Controller's own module.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="static-discoveryType">
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name for this domain controller discovery option.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocol" type="remote-protocol-type" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                     The remote domain controller's protocol.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote domain controller's host name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote domain controller's port.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serversType">
+        <xs:sequence>
+            <xs:element name="server" type="serverType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="directory-grouping" default="by-server" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="by-server">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Indicates each server's writable directories should be grouped under the server's name
+                                in the domain/servers directory. This is the default option.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="by-type">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Indicates each server's writable directories should be grouped based on their "type"
+                                (i.e. "data", "log", "tmp") with directories of a given type for all servers appearing
+                                in the domain level directory for that type, e.g. domain/data/servers/server-name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverType">
+        <xs:all>
+            <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1" />
+
+            <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0"/>
+            <xs:element name="socket-bindings" type="server-socket-bindingsType" minOccurs="0"/>
+
+            <!--<xs:element name="loggers" type="loggersType" minOccurs="0"/>-->
+            <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0"/>
+            <xs:element name="jvm" minOccurs="0" type="serverJvmType"/>
+
+            <xs:element name="ssl" minOccurs="0" type="server-sslType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the SSLContext used for the connection from the application server back to it's host controller.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="group" type="xs:string" use="required"/>
+        <xs:attribute name="auto-start" type="xs:boolean" default="true"/>
+        <xs:attribute name="update-auto-start-with-server-status" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Iif the server last status (STARTED or STOPPED) is to be used to define the value of auto-start.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-sslType">
+        <xs:attribute name="ssl-protocol" type="xs:string" default="TLS">
+            <xs:annotation>
+                <xs:documentation>
+                    The protocol to initialise the SSLContext, if 'Default' is specified the JVM wide default SSLContext will be used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trust-manager-algorithm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The algorithm to use when initialising the TrustManagerFactory.
+
+                    If not specified the JVM default is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="truststore-type" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The type of the trust store.
+
+                    If not specified the JVM default is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="truststore-path" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The fully qualified path to the truststore.
+
+                    If not specified the no file will be used to initialise the truststore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="truststore-password" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The password to open the truststore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-socket-bindingsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                Server-specific overrides to the default socket binding configuration inherited from the server group.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding-group" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    The socket binding group to use for the server. If undefined, the socket binding group
+                    specified for the server group is used.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" default="0" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Increment to apply to the base port values defined in the
+                    referenced socket binding group to derive the values to use on this
+                    server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one, overiding the one defined
+                    in the socket-binding-group referenced.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="extensionsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of extension modules.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="extension" type="extensionType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="extensionType">
+        <xs:annotation>
+            <xs:documentation>
+                A module that extends the standard capabilities of a domain
+                or a standalone server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="module" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The name of the module</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupsType">
+        <xs:sequence>
+            <xs:element name="server-group" type="server-groupType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupType">
+        <xs:sequence>
+            <xs:element name="jvm" type="namedJvmType" minOccurs="0"/>
+            <xs:element name="socket-binding-group" type="socket-binding-group-refType" minOccurs="1"/>
+
+            <xs:element name="deployments" type="server-groupDeploymentsType" minOccurs="0"/>
+            <xs:element name="deployment-overlays" type="server-group-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="system-properties" minOccurs="0" type="properties-with-boottime"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the server group
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="profile" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the profile this server is running.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="management-subsystem-endpoint" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Set to true to have servers belonging to the server group connect back to the host controller using the
+                    endpoint from their remoting subsystem. The subsystem must be preset for this to
+                    work.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupDeploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of deployments that have been mapped to a server-group.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="base-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupDeploymentType">
+        <xs:annotation>
+            <xs:documentation>A deployment that has been mapped to a server group.</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-deploymentType">
+                <!--  TODO clarify what a value of 'false' means -->
+                <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>Whether the deployment deploy automatically when the server starts up.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-deploymentType">
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>Unique identifier of the deployment. Must be unique across all deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="runtime-name" use="required">
+            <xs:annotation>
+                <xs:documentation>Name by which the deployment will be known within a running server.of the deployment.
+                    Does not need to be unique across all deployments in the domain, although it must be unique within
+                    an individual server. For example, two different deployments running on different servers in
+                    the domain could both have a 'runtime-name' of 'example.war', with one having a 'name'
+                    of 'example.war_v1' and another with an 'name' of 'example.war_v2'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-deploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of deployments that have been mapped to a server.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="server-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-deploymentType">
+        <xs:annotation>
+            <xs:documentation>A deployment that has been mapped to a server.</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-deploymentType">
+                <xs:sequence>
+                    <!-- TODO: maxOccurs should be unbounded once overlays are in place -->
+                    <xs:choice maxOccurs="1">
+                        <xs:element name="content" type="contentType"/>
+                        <xs:element name="fs-archive" type="fs-archiveType"/>
+                        <xs:element name="fs-exploded" type="fs-explodedType"/>
+                    </xs:choice>
+                </xs:sequence>
+                <!--  TODO clarify what a value of 'false' means -->
+                <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>Whether the deployment deploy automatically when the server starts up.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="contentType">
+        <xs:attribute name="sha1" use="required">
+            <xs:annotation>
+                <xs:documentation>The checksum of the content</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="fs-archiveType">
+        <xs:annotation>
+            <xs:documentation>Archived content found on the filesystem</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fs-baseType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="fs-baseType">
+        <xs:complexContent>
+            <xs:extension base="pathType"/>
+        </xs:complexContent>
+        <!-- TODO: make path required
+        <xs:complexContent>
+            <xs:restriction base="pathType">
+                <xs:attribute name="path" use="required"/>
+            </xs:restriction>
+        </xs:complexContent>
+        -->
+    </xs:complexType>
+
+    <xs:complexType name="fs-explodedType">
+        <xs:annotation>
+            <xs:documentation>Exploded content found on the filesystem</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fs-baseType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of domain-level deployments</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="domain-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deploymentType">
+        <xs:annotation>
+            <xs:documentation>Deployment represents anything that can be deployed (e.g. an application such as EJB-JAR,
+                WAR, EAR,
+                any kind of standard archive such as RAR or JBoss-specific deployment),
+                which can be enabled or disabled on a domain level.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-deploymentType">
+                <xs:sequence>
+                    <!-- TODO: maxOccurs should be unbounded once overlays are in place -->
+                    <xs:choice maxOccurs="1">
+                        <xs:element name="content" type="contentType"/>
+                        <xs:element name="fs-archive" type="fs-archiveType"/>
+                        <xs:element name="fs-exploded" type="fs-explodedType"/>
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- TODO this is not used anywhere yet -->
+    <xs:complexType name="clustersType">
+        <xs:complexContent>
+            <xs:extension base="server-groupType">
+                <xs:sequence>
+                    <xs:element name="partition-name" type="xs:string"/>
+                    <xs:element name="state-transfer-timeout" type="xs:integer"/>
+                    <xs:element name="method-call-timeout" type="xs:integer"/>
+                </xs:sequence>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- domain-configuration related definitions -->
+    <xs:complexType name="domain-configurationType">
+        <xs:annotation>
+            <xs:documentation>The domain controller/server bootstrap configuration</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="bootstrapURI"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="bootstrapURI" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>The URI for bootstrapping a domain server</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="profilesType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of profiles available for use in the domain</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="profile" type="domain-profileType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A profile declaration may include configuration
+                        elements from other namespaces for the subsystems that make up the profile.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Name of the profile</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includes" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A profile may include another profile. Overriding of included profiles is not supported.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:any namespace="##other">
+                    <xs:annotation>
+                        <xs:documentation>A profile declaration may include configuration
+                            elements from other namespaces for the subsystems that make up the profile.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="host-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems that will be run on the host</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:any namespace="##other">
+                    <xs:annotation>
+                        <xs:documentation>A profile declaration may include configuration
+                            elements from other namespaces for the subsystems that make up the profile.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- general socket definition -->
+    <xs:complexType name="socket-binding-groupsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket binding groups</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding-group" type="socket-binding-groupType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includes" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A profile may include another profile. Overriding of included profiles is not supported.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Increment to apply to the base port values defined in the
+                    socket group to derive the values to use on this
+                    server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="host-socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Increment to apply to the base port values defined in the
+                    socket group to derive the values to use on this
+                    server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-bindingType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a socket.</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="client-mapping" type="socket-binding-client-mappingType"
+                        minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies zero or more client mappings for this socket binding.
+                        A client connecting to this socket should use the destination address
+                        specified in the mapping that matches its desired outbound interface.
+                        This allows for advanced network topologies that use either network
+                        address translation, or have bindings on multiple network interfaces
+                        to function.
+
+                        Each mapping should be evaluated in declared order, with the first successful
+                        match used to determine the destination.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the interface to which the socket should be bound, or, for multicast
+                    sockets, the interface on which it should listen. This should
+                    be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:unsignedShort" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Number of the port to which the socket should be bound.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the port value should remain fixed even if numerically offsets
+                    are applied to the other sockets in the socket group..
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-address" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Multicast address on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Port on which the socket should receive multicast
+                    traffic. Must be configured if 'multicast-address' is configured.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-client-mappingType">
+        <xs:annotation>
+            <xs:documentation>
+                Type definition for a client mapping on a socket binding. A client
+                mapping specifies how external clients should connect to this
+                socket's port, provided that the client's outbound interface
+                match the specified source network value.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="source-network" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Source network the client connection binds on. This value is in
+                    the form of ip/netmask. A client should match this value against
+                    the desired client host network interface, and if matched the
+                    client should connect to the corresponding destination values.
+
+                    If omitted this mapping should match any interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="destination-address" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The destination address that a client should connect to if the
+                    source-network matches. This value can either be a hostname or
+                    an IP address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="destination-port" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The destination port that a client should connect to if the
+                    source-network matches.
+
+                    If omitted this mapping will reuse the effective socket binding
+                    port.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-socket-bindingType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for an outbound socket.</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="remote-destination" type="remote-destinationType" maxOccurs="1"/>
+            <xs:element name="local-destination" type="local-destinationType" maxOccurs="1"/>
+        </xs:choice>
+
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the outbound socket binding
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="source-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the interface that should be used for setting up the source address of the
+                    outbound socket. This should be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+
+        </xs:attribute>
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The port number that will be used for setting the source address of the outbound socket. If the
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
+                    then the system uses an ephemeral port while binding the socket to a source address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-source-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the source-port value should remain fixed even if the socket binding group specifies
+                    a port offset
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remote-destinationType">
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote server address to which the outbound socket has to be connect.
+                    The address can be either an IP address of the host server of the hostname of the server
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:positiveInteger" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote port to which the outbound socket has to connect.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="remote-protocol-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="remote"/>
+            <xs:enumeration value="http-remoting"/>
+            <xs:enumeration value="https-remoting"/>
+            <xs:enumeration value="remote+http"/>
+            <xs:enumeration value="remote+https"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="local-destinationType">
+        <xs:attribute name="socket-binding-ref" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The reference to a socket binding that has to be used as the destination for the outbound
+                    socket binding. This socket binding name should belong to the same socket binding group
+                    to which this local destination client socket belongs.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-group-refType">
+        <xs:attribute name="ref" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The socket group to use for the server group or server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" default="0" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Increment to apply to the base port values defined in the
+                    referenced socket group to derive the values to use on this
+                    server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one, overiding the one defined
+                    in the socket-binding-group referenced.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="named-interfacesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named network interfaces. The interfaces may or may
+                not be fully specified (i.e. include criteria on how to determine
+                their IP address.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="named-interfaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- TODO make this and specified-interfaceType the same except for interface-criteriaGroup minOccurs -->
+    <xs:complexType name="named-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named network interface, but without any criteria
+                for determining the IP address to associate with that interface.
+                Acts as a placeholder in the model (e.g. at the domain level)
+                until a fully specified interface definition is applied at a
+                lower level (e.g. at the server level, where available addresses
+                are known.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="interface-criteriaGroup" minOccurs="0"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="specified-interfacesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of fully specified named network interfaces.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="specified-interfaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named network interface, along with required criteria
+                for determining the IP address to associate with that interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="interface-criteriaGroup" minOccurs="1"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:group name="interface-criteriaGroup">
+        <xs:annotation>
+            <xs:documentation>
+                A set of criteria that can be used at runtime to determine
+                what IP address to use for an interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="any-address" type="any-addressType"/>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="inet-address" type="inet-addressType"/>
+                <xs:element name="loopback" type="loopbackType"/>
+                <xs:element name="loopback-address" type="loopback-addressType"/>
+                <xs:element name="multicast" type="multicastType"/>
+                <xs:element name="point-to-point" type="point-to-pointType"/>
+                <xs:element name="virtual" type="interface-virtualType"/>
+                <xs:element name="up" type="interface-upType"/>
+                <xs:element name="public-address" type="public-addressType"/>
+                <xs:element name="link-local-address" type="link-local-addressType"/>
+                <xs:element name="site-local-address" type="site-local-addressType"/>
+                <xs:element name="nic" type="nicType"/>
+                <xs:element name="nic-match" type="nic-matchType"/>
+                <xs:element name="subnet-match" type="subnet-matchType"/>
+                <xs:element name="not" type="address-exclusionType"/>
+                <xs:element name="any" type="address-exclusionType"/>
+            </xs:choice>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="inet-addressType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Either an IP address in IPv6 or IPv4 dotted decimal notation,
+                    or a hostname that can be resolved to an IP address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="nicType">
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a network interface (e.g. eth0, eth1, lo).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="nic-matchType">
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A regular expression against which the names of the network
+                    interfaces available on the machine can be matched to find
+                    an acceptable interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="subnet-matchType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A network IP address and the number of bits in the
+                    address' network prefix, written in "slash notation";
+                    e.g. "192.168.0.0/16".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="address-exclusionType">
+        <xs:choice>
+            <xs:element name="inet-address" type="inet-addressType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="loopback" type="loopbackType"/>
+            <xs:element name="loopback-address" type="loopback-addressType"/>
+            <xs:element name="multicast" type="multicastType"/>
+            <xs:element name="point-to-point" type="point-to-pointType"/>
+            <xs:element name="virtual" type="interface-virtualType"/>
+            <xs:element name="up" type="interface-upType"/>
+            <xs:element name="public-address" type="public-addressType"/>
+            <xs:element name="link-local-address" type="link-local-addressType"/>
+            <xs:element name="site-local-address" type="site-local-addressType"/>
+            <xs:element name="nic" type="nicType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="nic-match" type="nic-matchType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="subnet-match" type="subnet-matchType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="loopbackType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a loopback
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="loopback-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                A loopback address that may not actually be configured on the machine's loopback interface.
+                Differs from inet-addressType in that the given value will be used even if no NIC can
+                be found that has the IP address associated with it.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An IP address in IPv6 or IPv4 dotted decimal notation.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="multicastType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it supports
+                multicast.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="point-to-pointType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a point-to-point
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="interface-upType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is currently up.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="interface-virtualType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a virtual
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="public-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it has a publicly
+                routable address.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="site-local-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not an address associated
+                with it is site-local.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="link-local-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not an address associated
+                with it is link-local.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to a wildcard address. The IPv6 wildcard
+                address (::) will be used unless the java.net.preferIpV4Stack
+                system property is set to true, in which case the IPv4
+                wildcard address (0.0.0.0) will be used. If a socket is
+                bound to an IPv6 anylocal address on a dual-stack machine,
+                it can accept both IPv6 and IPv4 traffic; if it is bound to
+                an IPv4 (IPv4-mapped) anylocal address, it can only accept
+                IPv4 traffic.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="socketType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a socket.</xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the interface to which the socket should be bound, or, for multicast
+                    sockets, the interface on which it should listen. This should
+                    be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:unsignedShort" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Number of the port to which the socket should be bound.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the port value should remain fixed even if numerically offsets
+                    are applied to the other sockets in the socket group..
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-address" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Multicast address on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Port on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Path configurations -->
+    <xs:complexType name="named-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named filesystem paths. The paths may or may
+                not be fully specified (i.e. include the actual paths.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="named-pathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="named-pathType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem path, but without a requirement to specify
+                the actual path. If no actual path is specified, acts as a
+                as a placeholder in the model (e.g. at the domain level)
+                until a fully specified path definition is applied at a
+                lower level (e.g. at the host level, where available addresses
+                are known.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="pathType">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the path. Cannot be one of the standard fixed paths
+                            provided by the system:
+
+                            jboss.home.dir - the root directory of the JBoss AS distribution
+                            user.home - user's home directory
+                            user.dir - user's current working directory
+                            java.home - java installation directory
+                            jboss.server.base.dir - root directory for an individual server
+                            instance
+
+                            Note that the system provides other standard paths that can be
+                            overridden by declaring them in the configuration file. See
+                            the 'relative-to' attribute documentation for a complete
+                            list of standard paths.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="path">
+            <xs:annotation>
+                <xs:documentation>
+                    The actual filesystem path. Treated as an absolute path, unless the
+                    'relative-to' attribute is specified, in which case the value
+                    is treated as relative to that path.
+
+                    If treated as an absolute path, the actual runtime pathname specified
+                    by the value of this attribute will be determined as follows:
+
+                    If this value is already absolute, then the value is directly
+                    used.  Otherwise the runtime pathname is resolved in a
+                    system-dependent way.  On UNIX systems, a relative pathname is
+                    made absolute by resolving it against the current user directory.
+                    On Microsoft Windows systems, a relative pathname is made absolute
+                    by resolving it against the current directory of the drive named by the
+                    pathname, if any; if not, it is resolved against the current user
+                    directory.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute. The standard
+                    paths provided by the system include:
+
+                    jboss.home.dir - the root directory of the JBoss AS distribution
+                    user.home - user's home directory
+                    user.dir - user's current working directory
+                    java.home - java installation directory
+                    jboss.server.base.dir - root directory for an individual server
+                    instance
+                    jboss.server.config.dir - directory in which server configuration
+                    files are stored.
+                    jboss.server.data.dir - directory the server will use for persistent
+                    data file storage
+                    jboss.server.log.dir - directory the server will use for
+                    log file storage
+                    jboss.server.temp.dir - directory the server will use for
+                    temporary file storage
+                    jboss.domain.servers.dir - directory under which a host controller
+                    will create the working area for
+                    individual server instances
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="specified-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named filesystem paths.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="specified-pathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-pathType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem path.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the path. Cannot be one of the standard fixed paths
+                    provided by the system:
+
+                    jboss.home.dir - the root directory of the JBoss AS distribution
+                    user.home - user's home directory
+                    user.dir - user's current working directory
+                    java.home - java installation directory
+                    jboss.server.base.dir - root directory for an individual server
+                    instance
+
+                    Note that the system provides other standard paths that can be
+                    overridden by declaring them in the configuration file. See
+                    the 'relative-to' attribute documentation for a complete
+                    list of standard paths.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The actual filesystem path. Treated as an absolute path, unless the
+                    'relative-to' attribute is specified, in which case the value
+                    is treated as relative to that path.
+
+                    If treated as an absolute path, the actual runtime pathname specified
+                    by the value of this attribute will be determined as follows:
+
+                    If this value is already absolute, then the value is directly
+                    used.  Otherwise the runtime pathname is resolved in a
+                    system-dependent way.  On UNIX systems, a relative pathname is
+                    made absolute by resolving it against the current user directory.
+                    On Microsoft Windows systems, a relative pathname is made absolute
+                    by resolving it against the current directory of the drive named by the
+                    pathname, if any; if not, it is resolved against the current user
+                    directory.
+
+                    Note relative path declarations have to use '/' as file separator.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute. The standard
+                    paths provided by the system include:
+
+                    jboss.home.dir - the root directory of the JBoss AS distribution
+                    user.home - user's home directory
+                    user.dir - user's current working directory
+                    java.home - java installation directory
+                    jboss.server.base.dir - root directory for an individual server
+                    instance
+                    jboss.server.config.dir - directory in which server configuration
+                    files are stored.
+                    jboss.server.data.dir - directory the server will use for persistent
+                    data file storage
+                    jboss.server.log.dir - directory the server will use for
+                    log file storage
+                    jboss.server.temp.dir - directory the server will use for
+                    temporary file storage
+                    jboss.domain.servers.dir - directory under which a host controller
+                    will create the working area for
+                    individual server instances
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--  JVM configurations -->
+    <xs:complexType name="jvmsType">
+        <xs:sequence>
+            <xs:element name="jvm" type="namedJvmType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jvmType">
+        <xs:all minOccurs="0" maxOccurs="1">
+            <xs:element name="heap" type="heapType" minOccurs="0"/>
+            <xs:element name="permgen" type="bounded-memory-sizeType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                    Deprecated. Has no effect on current version servers or on any servers controlled
+                    by previous version host controllers running on JDK 8 or later, as the JVM no
+                    longer provides a separate Permanent Generation space.
+
+                    For legacy version servers running on JDK 7 or earlier, this configures the size of the
+                    server VM's Permanent Generation space (i.e. -XX:PermSize, -XX:MaxPermSize.)
+                    ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <!-- Xss -->
+            <xs:element name="stack" type="memory-sizeType" minOccurs="0"/>
+            <xs:element name="agent-lib" type="jvm-agentLibType" minOccurs="0"/>
+            <xs:element name="agent-path" type="jvm-agentPathType" minOccurs="0"/>
+            <xs:element name="java-agent" type="jvm-javaagentType" minOccurs="0"/>
+            <xs:element name="jvm-options" type="jvm-optionsType" minOccurs="0"/>
+            <xs:element name="environment-variables" type="environmentVariablesType" minOccurs="0"/>
+            <xs:element name="launch-command" type="launch-commandType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="java-home" type="xs:string"/>
+        <xs:attribute name="type" default="SUN">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="SUN">
+                        <xs:annotation>
+                            <xs:documentation>Allows the full set of JVM options to be set via the jvm schema elements</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="IBM">
+                        <xs:annotation>
+                            <xs:documentation>Sets a subset of the JVM options via the jvm schema elements</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="env-classpath-ignored" default="true" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedJvmType">
+        <xs:complexContent>
+            <xs:extension base="jvmType">
+                <xs:attribute name="name" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serverJvmType">
+        <xs:complexContent>
+            <xs:extension base="namedJvmType">
+                <xs:attribute name="debug-enabled" type="xs:boolean" default="false"/>
+                <xs:attribute name="debug-options" type="xs:string" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="heapType">
+        <xs:attribute name="size" use="optional">
+            <xs:annotation>
+                <xs:documentation>Initial JVM heap size</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-size" use="optional">
+            <xs:annotation>
+                <xs:documentation>Maximum JVM heap size</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-optionsType">
+        <xs:sequence>
+            <xs:element name="option" type="jvm-optionType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-optionType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM option value</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-agentLibType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM agent lib value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-agentPathType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM agent path value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-javaagentType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM javaagent value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bounded-memory-sizeType">
+        <xs:attribute name="size" type="xs:string"/>
+        <xs:attribute name="max-size" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="memory-sizeType">
+        <xs:attribute name="size" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="properties-with-boottime">
+        <xs:sequence>
+            <xs:element name="property" type="boottimePropertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="properties">
+        <xs:sequence>
+            <xs:element name="property" type="propertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="environmentVariablesType">
+        <xs:sequence>
+            <xs:element name="variable" type="propertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="launch-commandType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Prepend commands to the JVM process launch.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="prefix" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    JVM launch command prefix
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:attribute name="name" use="required"/>
+        <xs:attribute name="value" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="boottimePropertyType">
+        <xs:complexContent>
+            <xs:extension base="propertyType">
+                <xs:attribute name="boot-time" type="xs:boolean" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="vaultType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Vault Configuration. If no 'code' and 'module' are supplied the default implementation will be used.
+                    If 'code' is specified but no 'module', it will look for the class named by 'specified' in the picketbox module.
+                    If 'module' is specified, it will look for the class specified by 'code' in the module specified by 'module'.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="vault-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="xs:string" use="optional"/>
+        <xs:attribute name="module" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="management-client-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Storage information about re-usable chunks of data useful to management clients that are stored
+                   in the domain content repository.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="rollout-plans" type="contentType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                           Storage information about a set of named management update rollout plans useful to management
+                           clients that are stored in the domain content repository. The management API exposed by the domain
+                           controller provides access to these plans to management clients, allowing clients to use the plans
+                           by referencing them by name, avoiding the need to recreate them for each use.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="standalone-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="deployment" type="deployment-overlay-deploymentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="domain-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
+    </xs:complexType>
+
+    <xs:complexType name="server-group-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="server-group-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-group-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="deployment" type="deployment-overlay-deploymentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-contentType">
+        <xs:attribute name="path" type="xs:token" use="required"/>
+        <xs:attribute name="content" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-deploymentType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="domain-access-controlType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Contains the central access control configuration for a domain.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-group-scoped-roles" type="server-group-scoped-rolesType" minOccurs="0"/>
+            <xs:element name="host-scoped-roles" type="host-scoped-rolesType" minOccurs="0"/>
+            <xs:element name="role-mapping" type="role-mappingType" minOccurs="0"/>
+            <xs:element name="constraints" type="constraintsType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="provider" type="access-control-providerType" use="optional" default="simple"/>
+        <xs:attribute name="use-identity-roles" type="xs:boolean" default="false" />
+        <xs:attribute name="permission-combination-policy" type="permission-combination-policyType" use="optional" default="permissive"/>
+    </xs:complexType>
+
+    <xs:simpleType name="access-control-providerType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="simple">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        Simple access control implementation that gives all permissions to any authenticated
+                        user.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rbac">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        WildFly's standard Role Based Access Control implementation.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="permission-combination-policyType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                  The policy for combining access control permissions when the configuration grants the user
+                  more than one type of permission for a given action. For example, in the standard WildFly role based
+                  access control system, a user may map to more than one role. This attribute would control how the permissions
+                   associated with those roles should be combined to make access control decisions.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="permissive">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        If multiple permissions for the same action exist, if any of them allow the action,
+                        the action is allowed.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rejecting">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                        If multiple permissions for the same action exist an exception should be thrown and the action
+                        should not be allowed. This value indicates that creating multiple permissions (e.g. by
+                        mapping a user to multiple roles) should be treated as a configuration error.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="server-access-controlType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Contains the access control configuration for a standalone server.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="role-mapping" type="role-mappingType" minOccurs="0"/>
+            <xs:element name="constraints" type="constraintsType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="provider" type="access-control-providerType" use="optional" default="simple"/>
+        <xs:attribute name="use-identity-roles" type="xs:boolean" default="false" />
+    </xs:complexType>
+
+    <xs:complexType name="identityType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of the security domain to use to obtain the current identity from.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="security-domain" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the security domain to use to obtain the current identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="role-mappingType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Contains the mapping of authenticated users to roles.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="role" type="roleType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="roleType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    An individual role definition.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="include" type="include-excludeType" minOccurs="0"/>
+            <xs:element name="exclude" type="include-excludeType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The name of the role, this should either be one of the standard roles or a scoped role.
+
+                        A user is added to a role if any of the following are true: -
+                          1 - The user is a member of a group listed in the includes element.
+                          2 - The user is explicitly listed in the includes element.
+                        AND neither of the following are true: -
+                          1 - The user is a member of a group listed in the excludes element.
+                          2 - The user is explicitly listed in the groups element.
+
+                        i.e. Any excludes definition takes priority over any includes definition.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="include-all" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        If set to true all authenticated users will be granted this role provided that they
+                        have not been matched to the exclude list.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="include-excludeType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    A list of users or groups to be included/excluded from the role containing this type.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="user" type="principalType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="group" type="principalType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="principalType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                  Representation of a single principal to indicate role assignment.
+
+                  If the realm attribute is specified then the realm used to authenticated the user
+                  will also be taken into account when performing the comparison.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="alias" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        If you are editing the XML configuration directly you do not need to be adding
+                        this attribute and in general you should not be adding this attribute.
+
+                        When the management tools are used to add include and exclude definitions for
+                        groups and users the name used in the address is an arbitrary String, this attribute
+                        is used when non-standard forms of the address are used so that it can be persisted
+                        and the model will be consistent when it is reloaded.
+
+                        But as in the first sentence, if you are questioning if you should use this attribute
+                        yourself - DON'T.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The name of the realm the user used to authenticate.
+
+                        This attribute is deprecated and should not be used once management security is migrated to WildFly Elytron.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The name of the principal.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-group-scoped-rolesType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Roles scoped to a given set of server groups
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="role" type="server-group-scoped-roleType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="host-scoped-rolesType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Roles scoped to a given set of hosts
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="role" type="host-scoped-roleType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="base-scoped-roleType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Basic attributes of a scoped-role.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="base-role" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                   The name of the standard role upon which the scoped role is based.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-group-scoped-roleType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   A role scoped to a given set of server groups
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-scoped-roleType">
+                <xs:choice>
+                    <xs:element name="server-group" type="namedType" minOccurs="1" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   One of the server groups to which the role is constrained.
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-scoped-roleType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   A role scoped to a given set of hosts
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-scoped-roleType">
+                <xs:choice>
+                    <xs:element name="host" type="namedType" minOccurs="1" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   One of the hosts to which the role is constrained.
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constraintsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about configured access constraints.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="vault-expression-sensitivity" type="vault-expression-sensitivityType" minOccurs="0"/>
+            <xs:element name="sensitive-classifications" type="sensitive-classificationsType" minOccurs="0"/>
+            <xs:element name="application-classifications" type="application-classificationsType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="base-sensitivityType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Common configuration of a sensitivity constraint
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="requires-read" type="xs:boolean">
+          <xs:annotation>
+             <xs:documentation>
+                Configuration of if a classification's read is sensitive
+             </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="requires-write" type="xs:boolean">
+          <xs:annotation>
+             <xs:documentation>
+                Configuration of if a classification's write is sensitive
+             </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="vault-expression-sensitivityType">
+        <xs:complexContent>
+            <xs:extension base="base-sensitivityType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sensitive-classificationsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about a configured sensitive classification
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="sensitive-classification" type="typed-sensitivityType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="typed-sensitivityType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about a configured sensitive classification
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-sensitivityType">
+                <xs:attribute name="requires-addressable" type="xs:boolean">
+                      <xs:annotation>
+                         <xs:documentation>
+                            Configuration of if a classification's addressability is sensitive
+                         </xs:documentation>
+                      </xs:annotation>
+                  </xs:attribute>
+                <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                     <xs:documentation>
+                        The name of the constraint, must be unique for each name
+                     </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="type" type="xs:string" use="required">
+                  <xs:annotation>
+                     <xs:documentation>
+                        'core' or the name of the subsystem defining the constraint
+                     </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="application-classificationsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about a configured application classifications
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="application-classification" type="application-classificationType"/>
+        </xs:choice>
+
+    </xs:complexType>
+    <xs:complexType name="application-classificationType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about a configured application classification
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+           <xs:attribute name="name" type="xs:string" use="required">
+             <xs:annotation>
+                <xs:documentation>
+                   The name of the constraint, must be unique for each name
+                </xs:documentation>
+             </xs:annotation>
+           </xs:attribute>
+           <xs:attribute name="type" type="xs:string" use="required">
+             <xs:annotation>
+                <xs:documentation>
+                   'core' or the name of the subsystem defining the constraint
+                </xs:documentation>
+             </xs:annotation>
+           </xs:attribute>
+           <xs:attribute name="application" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   A type with a 'name' attribute
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="host-excludesType">
+        <xs:sequence>
+            <xs:element name="host-exclude" type="host-excludeType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="host-excludeType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Specification of management resources that should be made invisible to Host Controllers
+                   (excluding the master Domain Controller) running a particular software version. This is
+                   used to shield Host Controllers running earlier software versions from resources whose
+                   management API the host cannot understand (e.g. profiles including subsystems unavailable on
+                   that host.)
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="host-release" type="host-releaseType"/>
+                <xs:element name="host-api-version" type="host-api-versionType"/>
+            </xs:choice>
+            <xs:element name="excluded-extensions" type="excluded-extensionsType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                       Unique identifier for this particular configuration.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="active-server-groups" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                   A space-delimited list of server-group names specifying all the server groups that have servers
+                   running on the target hosts. These are the groups used by the host's servers. For these groups,
+                   the server-group resource and related profile, socket-binding-group and deployment resources will
+                   not be hidden; all other server-group, profile, socket-binding-group and deployment resources
+                   will be hidden.
+
+                   NOTE: For any host, the Domain Controller only applies this setting if, when the host registers
+                   with the Domain Controller, it does not inform the Domain Controller that it is configured to
+                   "ignore-unused-configuration". The host.xml "ignore-unused-configuration" setting provides similar
+                   functionality and takes precedence over this domain-wide setting.
+
+                   The primary expecuted use case for this setting is for managing hosts running releases prior to the
+                   introduction of the host.xml "ignore-unused-configuration" setting.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="active-socket-binding-groups" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                   A space-delimited list of socket-binding-group names specifying all the socket binding groups that
+                   are used by servers running on the target hosts. Only used if 'active-server-groups' is set;
+                   otherwise ignored. Only needs to be set if the socket binding groups specified in the configuration
+                   of the server groups listed in 'active-server-groups' isn't the complete set of socket binding
+                   groups used on the servers (i.e. some other socket binding groups are specified in the target
+                   hosts' 'server-config' resources.)
+
+                   NOTE: For any host, the Domain Controller only applies this setting if, when the host registers
+                   with the Domain Controller, it does not inform the Domain Controller that it is configured to
+                   "ignore-unused-configuration". The host.xml "ignore-unused-configuration" setting provides similar
+                   functionality and takes precedence over this domain-wide setting.
+
+                   The primary expecuted use case for this setting is for managing hosts running releases prior to the
+                   introduction of the host.xml "ignore-unused-configuration" setting.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="host-releaseType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   A shorthand identifier for a well known EAP or WildFly Core based software distribution that the
+                   Host Controller is running. Used as a simpler alternative to specifying the kernel management API
+                   versions. When a Host Controller running the kernel major + minor management API associated with
+                   this release registers with the master Domain Controller, the settings associated with
+                   the enclosing host-ignore configuration will be used to determine what resources are visible
+                   to the host.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="id">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="EAP6.2">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 1.5.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="EAP6.3">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 1.6.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="EAP6.4">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 1.7.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly10.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 4.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="EAP7.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 4.1.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly10.1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 4.2.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly11.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 5.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="EAP7.1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 5.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly12.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 6.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly13.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 7.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly14.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 8.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly15.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 9.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="host-api-versionType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Specification of the kernel (i.e. non-subsystem) management API version that the
+                   Host Controller is running. When a Host Controller running this management API version
+                   registers with the master Domain Controller, the settings associated with
+                   the enclosing host-ignore configuration will be used to determine what resources are visible
+                   to the host.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="major-version" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                       The kernel management API major version used by the host.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="minor-version" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                       The kernel management API minor version used by the host.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="micro-version" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                       The kernel management API micro version. If unspecified, the enclosing host-ignore
+                       configuration applies to all releases of the given major + minor version, excluding any
+                       for which a different configuration with a micro version also specified is present.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="excluded-extensionsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   A list of extension names the resources for which (i.e those administered at the /extension=*
+                   addresses in the CLI) should be hidden from the target hosts.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="extension" type="extensionType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Credential Reference Types -->
+    <xs:attributeGroup name="credentialReferenceStoreBased">
+        <xs:annotation>
+            <xs:documentation>
+                Group of attributes used when referencing credential through credential store.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="store" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential store name used to fetch credential with given 'alias' from.
+                    Credential store name has to be defined elsewhere.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Alias of credential in the credential store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Type of credential to be fetched from credential store.
+                    It is usually fully qualified class name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:complexType name="credentialReferenceType">
+        <xs:attributeGroup ref="credentialReferenceStoreBased"/>
+        <xs:attribute name="clear-text" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential/password in clear text. Use just for testing purpose.
+                    Otherwise use credential store to mask the actual credential from your configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-auto-ignore.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-auto-ignore.xml
@@ -24,7 +24,7 @@
   ~  */
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
     <!--
       A trimmed down domain.xml for use with the auto-ignore resources on slave tests.
 

--- a/testsuite/domain/src/test/resources/domain-configs/domain-config-changes.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-config-changes.xml
@@ -22,7 +22,7 @@
   ~ */
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-default-interface.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-default-interface.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0"
+<domain xmlns="urn:jboss:domain:10.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0"
+<domain xmlns="urn:jboss:domain:10.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" domain-organization="wildfly-core">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -22,7 +22,7 @@
   ~ */
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn-http.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0"
+<domain xmlns="urn:jboss:domain:10.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0"
+<domain xmlns="urn:jboss:domain:10.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -22,7 +22,7 @@
   ~ */
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-synchronization.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-synchronization.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0"
+<domain xmlns="urn:jboss:domain:10.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain.cached-remote.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain.cached-remote.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:9.0"
+<domain xmlns="urn:jboss:domain:10.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
@@ -22,9 +22,9 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd">
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd">
 
     <management>
         <security-realms>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
@@ -22,9 +22,9 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd">
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd">
 
     <management>
         <security-realms>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
@@ -22,9 +22,9 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
@@ -22,9 +22,9 @@
   ~  */
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
@@ -20,9 +20,9 @@
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-cacheddc.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-cacheddc.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master" organization="core-master">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-config-changes.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-config-changes.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master" organization="core-master">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron-no-legacy-realms.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron-no-legacy-realms.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0" name="master">
+<host xmlns="urn:jboss:domain:10.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0" name="master">
+<host xmlns="urn:jboss:domain:10.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-kerberos.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-kerberos.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-ssl-1way-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-ssl-1way-elytron.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-ssl-2way-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-ssl-2way-elytron.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host name="master" xmlns="urn:jboss:domain:9.0">
+<host name="master" xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-ssl.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-ssl.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master" organization="core-master">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-minimal.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-minimal.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-nonexistent-group.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-nonexistent-group.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master" organization="core-master">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-outbound-ldap-connection.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-outbound-ldap-connection.xml
@@ -22,9 +22,9 @@
 ~
 -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets-elytron-subsystem.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets-elytron-subsystem.xml
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 -->
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 -->
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-cacheddc.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-cacheddc.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-config-changes.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-config-changes.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron-no-legacy-realms.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron-no-legacy-realms.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0" name="slave">
+<host xmlns="urn:jboss:domain:10.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:9.0" name="slave">
+<host xmlns="urn:jboss:domain:10.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
@@ -19,9 +19,9 @@
 ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-kerberos.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-kerberos.xml
@@ -13,8 +13,8 @@
 	Franklin St, Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site: 
 	http://www.fsf.org. -->
 
-<host xmlns="urn:jboss:domain:9.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd" name="slave">
+<host xmlns="urn:jboss:domain:10.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd" name="slave">
 
 	<extensions>
 		<extension module="org.jboss.as.jmx" />

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way-elytron.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0" name="slave">
+<host xmlns="urn:jboss:domain:10.0" name="slave">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way-elytron.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0" name="slave">
+<host xmlns="urn:jboss:domain:10.0" name="slave">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc1.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="hc1">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc2.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="hc2">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master-http.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/patching/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/patching/src/test/resources/domain-configs/domain-standard.xml
@@ -22,7 +22,7 @@
   ~ */
   -->
 
-<domain xmlns="urn:jboss:domain:9.0">
+<domain xmlns="urn:jboss:domain:10.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/patching/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/patching/src/test/resources/host-configs/host-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/patching/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/patching/src/test/resources/host-configs/host-slave.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:9.0"
+<host xmlns="urn:jboss:domain:10.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">
 
     <paths>


### PR DESCRIPTION
* add wildfly-config_10_0.xsd and bump the domain namespace to
  urn:jboss:domain:10.0
* remove custom write methods from StandaloneXml_9, HostXml_9 and
  DomainXml_9

Schema changes between wildfly-config_9_0.xsd and
wildfly-config_10_0.xsd:
* add WildFly15.0 to the enumeration for the id of the host-release
  type.

JIRA: https://issues.jboss.org/browse/WFCORE-4247