### PR TITLE
[WFCORE-4206] Remove javax.annotation.api un-used optional dependency from Elytron extension

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -42,7 +42,6 @@
         <module name="java.security.sasl"/>
         <module name="java.sql"/>
         <module name="java.xml"/>
-        <module name="javax.annotation.api" optional="true"/>
         <module name="javax.security.jacc.api"/>
         <module name="javax.security.auth.message.api"/>
         <module name="org.jboss.staxmapper"/>


### PR DESCRIPTION
Remove from `org.wildfly.extension.elytron` an optional dependency `javax.annotation.api`. It helps out Galleon to ensure the provisioning is correct.

Jira issue: https://issues.jboss.org/browse/WFCORE-4206

CC: @darranl 