### PR TITLE
[WFCORE-4265] Latest DB2 11.1 JDBC driver requires additional IBM JDK system dependency

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
@@ -35,6 +35,7 @@
                 <path name="com/ibm"/>
                 <path name="com/ibm/crypto"/>
                 <path name="com/ibm/crypto/provider"/>
+                <path name="com/ibm/dataaccess"/>
                 <path name="com/ibm/jvm"/>
                 <path name="com/ibm/jvm/io"/>
                 <path name="com/ibm/jvm/util"/>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4265

`<path name="com/ibm/dataaccess"/>` needs to be exported from `ibm.jdk` module, so that deployed DB2 JDBC driver can access needed classes.

In case the DB2 JDBV driver is a separate JBoss module, I think the only way to do is to add dependency to `ibm.jdk` in the module definition.