### PR TITLE
[WFCORE-4238] Add flags to categorize numerical metrics

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -151,7 +151,23 @@ public final class AttributeAccess {
          * Support for use of an expression for the value of this attribute is deprecated
          * and may be removed in a future release.
          */
-        EXPRESSIONS_DEPRECATED;
+        EXPRESSIONS_DEPRECATED,
+        /**
+         * The attribute represents a Gauge metric, a single numerical value that can arbitrarily go up and down.
+         *
+         * If the attribute is registered as a metric without specifying the {@link #GAUGE_METRIC} or {@link #COUNTER_METRIC} flag,
+         * it is considered as a gauge.
+         *
+         * {@link #GAUGE_METRIC} and {@link #COUNTER_METRIC} are mutually exclusive.
+         */
+        GAUGE_METRIC,
+        /**
+         * The attribute represents a Counter metric, a cumulative metric that represents a single monotonically
+         * increasing counter whose value can only increase or be reset to zero on restart.
+         *
+         * {@link #GAUGE_METRIC} and {@link #COUNTER_METRIC} are mutually exclusive.
+         */
+        COUNTER_METRIC;
 
         private static final Map<EnumSet<AttributeAccess.Flag>, Set<AttributeAccess.Flag>> flagSets = new ConcurrentHashMap<>(16);
         public static Set<AttributeAccess.Flag> immutableSetOf(AttributeAccess.Flag... flags) {

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
@@ -1,5 +1,8 @@
 package org.jboss.as.platform.mbean;
 
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.GAUGE_METRIC;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -19,16 +22,19 @@ class ClassLoadingResourceDefinition extends SimpleResourceDefinition {
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(COUNTER_METRIC)
             .build();
     private static SimpleAttributeDefinition LOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.LOADED_CLASS_COUNT, ModelType.INT, false)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(GAUGE_METRIC)
             .build();
     private static SimpleAttributeDefinition UNLOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.UNLOADED_CLASS_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(COUNTER_METRIC)
             .build();
     //r+w attributes
     private static SimpleAttributeDefinition VERBOSE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VERBOSE, ModelType.BOOLEAN, false)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
@@ -24,6 +24,8 @@
 
 package org.jboss.as.platform.mbean;
 
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.GAUGE_METRIC;
 import static org.jboss.as.platform.mbean.PlatformMBeanConstants.NAME;
 
 import java.util.Arrays;
@@ -48,11 +50,13 @@ class GarbageCollectorResourceDefinition extends SimpleResourceDefinition {
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(COUNTER_METRIC)
             .build();
     private static SimpleAttributeDefinition COLLECTION_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_TIME, ModelType.LONG, false)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
+            .setFlags(GAUGE_METRIC)
             .build();
     private static AttributeDefinition MEMORY_POOL_NAMES = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.MEMORY_POOL_NAMES)
             .setStorageRuntime()

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
@@ -25,6 +25,7 @@
 package org.jboss.as.platform.mbean;
 
 
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 import static org.jboss.as.platform.mbean.PlatformMBeanConstants.NAME;
 import static org.jboss.as.platform.mbean.PlatformMBeanConstants.VALID;
 
@@ -83,12 +84,14 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(COUNTER_METRIC)
             .build();
 
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD_COUNT, ModelType.LONG, true)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(COUNTER_METRIC)
             .build();
 
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD, ModelType.LONG, true)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
@@ -24,6 +24,7 @@
 
 package org.jboss.as.platform.mbean;
 
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 import static org.jboss.as.platform.mbean.PlatformMBeanConstants.RUNTIME_PATH;
 
 import java.util.Arrays;
@@ -50,6 +51,7 @@ class RuntimeResourceDefinition extends SimpleResourceDefinition {
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
+            .setFlags(COUNTER_METRIC)
             .build();
 
     private static AttributeDefinition START_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.START_TIME, ModelType.LONG, false)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
@@ -24,6 +24,7 @@
 
 package org.jboss.as.platform.mbean;
 
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 import static org.jboss.as.platform.mbean.PlatformMBeanConstants.THREADING_PATH;
 
 import java.util.Arrays;
@@ -80,6 +81,7 @@ class ThreadResourceDefinition extends SimpleResourceDefinition {
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
+            .setFlags(COUNTER_METRIC)
             .build();
 
     static AttributeDefinition DAEMON_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.DAEMON_THREAD_COUNT, ModelType.INT, false)


### PR DESCRIPTION
Add the COUNTER_METRIC and GAUGE_METRIC flags to AttributeAccess.Flag
enum to further specify the type of metrics when an AttributeDefinition
is registered as a Metric.

Specify the COUNTER_METRIC flag for attributes representing counters (if
the flag is absent, the metric is considered as a gauge).

JIRA: https://issues.jboss.org/browse/WFCORE-4238