### PR TITLE
[WFCORE-4271] Exclude transitive jboss-servlet-api_3.1 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -999,6 +999,12 @@
                 <groupId>org.jboss.spec.javax.security.jacc</groupId>
                 <artifactId>jboss-jacc-api_1.5_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.servlet</groupId>
+                        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.stdio</groupId>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
@@ -337,8 +337,8 @@ public class CoreUtils {
 
     /**
      * Returns response body for the given URL request as a String. It also checks if the returned HTTP status code is the
-     * expected one. If the server returns {@link HttpServletResponse#SC_UNAUTHORIZED} and username is provided, then a new
-     * request is created with the provided credentials (basic authentication).
+     * expected one. If the server returns {@link org.apache.http.HttpStatus#SC_UNAUTHORIZED} and username is provided,
+     * then a new request is created with the provided credentials (basic authentication).
      *
      * @param url URL to which the request should be made
      * @param user Username (may be null)


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4271

Added exclusion of jboss-servlet-api_3.1 which seems not needed in wildfly-core; also this aligns it with other places in wildfly-core project (details in jira).

related wildfly PR: https://github.com/wildfly/wildfly/pull/11986