### PR TITLE
[WFCORE-4269] Fix socket parser

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_10.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_10.java
@@ -502,6 +502,9 @@ final class HostXml_10 extends CommonXml implements ManagementXmlDelegate {
         operationAddress.add(MANAGEMENT_INTERFACE, HTTP_INTERFACE);
         final ModelNode addOp = Util.getEmptyOperation(ADD, operationAddress);
 
+        int socketCount = 0;
+        int httpUpgradeCount = 0;
+
         // Handle attributes
         parseHttpManagementInterfaceAttributes(reader, addOp);
 
@@ -511,9 +514,15 @@ final class HostXml_10 extends CommonXml implements ManagementXmlDelegate {
             final Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case SOCKET:
+                    if (++socketCount > 1) {
+                        throw unexpectedElement(reader);
+                    }
                     parseHttpManagementSocket(reader, addOp);
                     break;
                 case HTTP_UPGRADE:
+                    if (++httpUpgradeCount > 1) {
+                        throw unexpectedElement(reader);
+                    }
                     parseHttpUpgrade(reader, addOp);
                     break;
                 default:


### PR DESCRIPTION
* Do not allow more than one <socket> child in the <http-interface>
  element.
* idem for <http-upgrade>

JIRA: https://issues.jboss.org/browse/WFCORE-4269