### PR TITLE
[WFCORE-4274] SuspendResumeTestCase fails sometimes

### DIFF
--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
@@ -113,7 +113,17 @@ public class SuspendResumeTestCase {
 
             HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(30), TimeUnit.SECONDS);
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
-            Assert.assertEquals("SUSPENDED", serverController.getClient().executeForResult(op).asString());
+            String suspendState;
+            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+            do {
+                suspendState = serverController.getClient().executeForResult(op).asString();
+                if ("SUSPENDING".equals(suspendState)) {
+                    Thread.sleep(50);
+                } else {
+                    break;
+                }
+            } while (System.currentTimeMillis() < timeout);
+            Assert.assertEquals("SUSPENDED", suspendState);
 
             final HttpURLConnection conn = (HttpURLConnection) new URL(address).openConnection();
             try {


### PR DESCRIPTION
We could get the server in SUSPENDING state just after unlocking the web application, which in turns makes the test fails. This patch gives the oportunity to wait a bit longer in that case to get the SUSPENDED state.

Jira issue: https://issues.jboss.org/browse/WFCORE-4274

It supersedes https://github.com/wildfly/wildfly-core/pull/3641