### PR TITLE
[WFCORE-4276] eliminates overrides of SimpleResourceDefinition.registerCapabilities

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -362,6 +362,13 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         // no-op
     }
 
+    /**
+     * Register capabilities associated with this resource.
+     *
+     * <p>Classes that overrides this method <em>MUST</em> call {@code super.registerCapabilities(resourceRegistration)}.</p>
+     *
+     * @param resourceRegistration a {@link ManagementResourceRegistration} created from this definition
+     */
     @Override
     public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
         if (capabilities!=null) {

--- a/controller/src/main/java/org/jboss/as/controller/management/BaseNativeInterfaceResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/management/BaseNativeInterfaceResourceDefinition.java
@@ -115,11 +115,6 @@ public abstract class BaseNativeInterfaceResourceDefinition extends SimpleResour
         }
     }
 
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(NATIVE_MANAGEMENT_RUNTIME_CAPABILITY);
-    }
-
     protected abstract AttributeDefinition[] getAttributeDefinitions();
 
     protected static AttributeDefinition[] combine(AttributeDefinition[] commonAttributes, AttributeDefinition... additionalAttributes) {

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
@@ -111,12 +112,13 @@ public abstract class AbstractSocketBindingResourceDefinition extends SimpleReso
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
-    public AbstractSocketBindingResourceDefinition(final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
+    public AbstractSocketBindingResourceDefinition(final OperationStepHandler addHandler, final OperationStepHandler removeHandler, RuntimeCapability<Void>... capabilities) {
         super(new Parameters(PATH, ControllerResolver.getResolver(ModelDescriptionConstants.SOCKET_BINDING))
                 .setAddHandler(addHandler)
                 .setRemoveHandler(removeHandler)
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
-                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES));
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .addCapabilities(capabilities));
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
@@ -176,10 +177,11 @@ public class InterfaceDefinition extends SimpleResourceDefinition {
     private final boolean updateRuntime;
     private final boolean resolvable;
 
-    public InterfaceDefinition(InterfaceAddHandler addHandler, OperationStepHandler removeHandler, boolean updateRuntime, boolean resolvable) {
+    public InterfaceDefinition(InterfaceAddHandler addHandler, OperationStepHandler removeHandler, boolean updateRuntime, boolean resolvable, RuntimeCapability<Void>... capabilities) {
         super(new Parameters(PathElement.pathElement(INTERFACE), ControllerResolver.getResolver(INTERFACE))
                 .setAddHandler(addHandler)
                 .setRemoveHandler(removeHandler)
+                .addCapabilities(capabilities)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG));
         this.updateRuntime = updateRuntime;
         this.resolvable = resolvable;

--- a/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
@@ -153,7 +153,6 @@ public class ListAttributeDefinitionTestCase {
 
             @Override
             public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-
             }
         };
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
@@ -30,9 +30,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FEA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPTIONAL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_PARAMS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_PARAMS_MAPPING;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPTIONAL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PACKAGE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PACKAGES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PARAMS;
@@ -614,7 +614,9 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
                         .build();
 
         MainResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver) {
-            super(pathElement, descriptionResolver, new AddHandler(), null);
+            super(new SimpleResourceDefinition.Parameters(pathElement, descriptionResolver)
+                    .setAddHandler(new AddHandler())
+                    .addCapabilities(MAIN_RESOURCE_CAPABILITY));
         }
 
         @Override
@@ -626,12 +628,6 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
             resourceRegistration.registerReadWriteAttribute(OBJECT_ATTRIBUTE, null, WRITE_HANDLER);
             resourceRegistration.registerReadWriteAttribute(COMPLEX_OBJECT_ATTRIBUTE, null, WRITE_HANDLER);
             resourceRegistration.registerReadWriteAttribute(LIST_ATTRIBUTE, null, WRITE_HANDLER);
-        }
-
-        @Override
-        public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-            super.registerCapabilities(resourceRegistration);
-            resourceRegistration.registerCapability(MAIN_RESOURCE_CAPABILITY);
         }
     }
 
@@ -650,6 +646,7 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
 
         ReferencingResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver) {
             super(new Parameters(pathElement, descriptionResolver)
+                    .addCapabilities(REFERENCING_RESOURCE_CAPABILITY)
                     .addRequirement(REFERENCING_RESOURCE_CAPABILITY_NAME, null, ROOT_CAPABILITY_NAME, null)
             );
         }
@@ -658,12 +655,6 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
             super.registerAttributes(resourceRegistration);
             resourceRegistration.registerReadWriteAttribute(MAIN_RESOURCE_ATTR, null, WRITE_HANDLER);
-        }
-
-        @Override
-        public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-            super.registerCapabilities(resourceRegistration);
-            resourceRegistration.registerCapability(REFERENCING_RESOURCE_CAPABILITY);
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
@@ -91,7 +91,11 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
 
 
     public ProfileResourceDefinition(LocalHostControllerInfo hostInfo, IgnoredDomainResourceRegistry ignoredDomainResourceRegistry) {
-        super(PATH, DomainResolver.getResolver(PROFILE, false), ProfileAddHandler.INSTANCE, ProfileRemoveHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(PATH, DomainResolver.getResolver(PROFILE, false))
+                .setAddHandler(ProfileAddHandler.INSTANCE)
+                .setRemoveHandler(ProfileRemoveHandler.INSTANCE)
+                .addCapabilities(PROFILE_CAPABILITY)
+        );
         this.hostInfo = hostInfo;
         this.ignoredDomainResourceRegistry = ignoredDomainResourceRegistry;
     }
@@ -109,12 +113,6 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerReadOnlyAttribute(NAME, ReadResourceNameOperationStepHandler.INSTANCE);
         resourceRegistration.registerReadWriteAttribute(INCLUDES, null, createIncludesValidationHandler());
     }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(PROFILE_CAPABILITY);
-    }
-
 
     public static OperationStepHandler createIncludesValidationHandler() {
         return new DomainIncludesValidationWriteAttributeHandler(INCLUDES);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.domain.controller.resources;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FEATURE_REFERENCE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -36,7 +37,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FEATURE_REFERENCE;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.parsing.Attribute;
@@ -115,7 +115,11 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
 
     public ServerGroupResourceDefinition(final boolean master, final LocalHostControllerInfo hostInfo,
                                          final HostFileRepository fileRepository, final ContentRepository contentRepository) {
-        super(PATH, DomainResolver.getResolver(SERVER_GROUP, false), ServerGroupAddHandler.INSTANCE, new ServerGroupRemoveHandler(hostInfo));
+        super(new SimpleResourceDefinition.Parameters(PATH, DomainResolver.getResolver(SERVER_GROUP, false))
+                .setAddHandler(ServerGroupAddHandler.INSTANCE)
+                .setRemoveHandler(new ServerGroupRemoveHandler(hostInfo))
+                .addCapabilities(SERVER_GROUP_CAPABILITY));
+
         this.contentRepository = contentRepository;
         this.fileRepository = fileRepository;
     }
@@ -147,11 +151,6 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(DomainDeploymentResourceDefinition.createForServerGroup(fileRepository, contentRepository));
         resourceRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(Location.SERVER_GROUP));
         resourceRegistration.registerSubModel(new DomainDeploymentOverlayDefinition(false, null, null));
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(SERVER_GROUP_CAPABILITY);
     }
 
     public static OperationStepHandler createRestartRequiredHandler() {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/SocketBindingResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/SocketBindingResourceDefinition.java
@@ -24,10 +24,9 @@ package org.jboss.as.domain.controller.resources;
 
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.resource.AbstractSocketBindingResourceDefinition;
 import org.jboss.as.server.services.net.SocketBindingAddHandler;
 import org.jboss.as.server.services.net.SocketBindingRemoveHandler;
-import org.jboss.as.controller.resource.AbstractSocketBindingResourceDefinition;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for a domain-level socket binding resource.
@@ -48,12 +47,7 @@ public class SocketBindingResourceDefinition extends AbstractSocketBindingResour
     );
 
     private SocketBindingResourceDefinition() {
-        super(SocketBindingAddHandler.INSTANCE, SocketBindingRemoveHandler.INSTANCE);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY);
+        super(SocketBindingAddHandler.INSTANCE, SocketBindingRemoveHandler.INSTANCE, org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -274,7 +274,18 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
                                   final ManagedAuditLogger auditLogger,
                                   final BootErrorCollector bootErrorCollector) {
         super(new Parameters(PathElement.pathElement(HOST, hostName), HostModelUtil.getResourceDescriptionResolver())
-                .setCapabilities(HOST_RUNTIME_CAPABILITY));
+                .setCapabilities(HOST_RUNTIME_CAPABILITY,
+                        PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.HOME_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_CONFIG_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_DATA_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_LOG_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_TEMP_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.CONTROLLER_TEMP_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_BASE_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_CONFIG_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_DATA_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_LOG_DIR),
+                        PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_TEMP_DIR)));
         this.configurationPersister = configurationPersister;
         this.environment = environment;
         this.runningModeControl = runningModeControl;
@@ -389,24 +400,6 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
 
         ignoredRegistry.registerResources(hostRegistration);
 
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        super.registerCapabilities(resourceRegistration);
-
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.HOME_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_CONFIG_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_DATA_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_LOG_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.DOMAIN_TEMP_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(HostControllerEnvironment.CONTROLLER_TEMP_DIR));
-
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_BASE_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_CONFIG_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_DATA_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_LOG_DIR));
-        resourceRegistration.registerCapability(PATH_CAPABILITY.fromBaseCapability(ServerEnvironment.SERVER_TEMP_DIR));
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -165,8 +165,10 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
      * @param pathManager the {@link PathManagerService} to use for the child {@code path} resources. Cannot be {@code null}
      */
     public ServerConfigResourceDefinition(final LocalHostControllerInfo hostControllerInfo, final ServerInventory serverInventory, final PathManagerService pathManager, final ControlledProcessState processState, final File domainDataDir) {
-        super(PathElement.pathElement(SERVER_CONFIG), HostResolver.getResolver(SERVER_CONFIG, false),
-                ServerAddHandler.create(hostControllerInfo, serverInventory, processState, domainDataDir), ServerRemoveHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SERVER_CONFIG), HostResolver.getResolver(SERVER_CONFIG, false))
+                .setAddHandler(ServerAddHandler.create(hostControllerInfo, serverInventory, processState, domainDataDir))
+                .setRemoveHandler(ServerRemoveHandler.INSTANCE)
+                .addCapabilities(SERVER_CONFIG_CAPABILITY));
 
         assert pathManager != null : "pathManager is null";
 
@@ -223,11 +225,6 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(JvmResourceDefinition.SERVER);
         // ssl=loopback
         resourceRegistration.registerSubModel(new SslLoopbackResourceDefinition());
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(SERVER_CONFIG_CAPABILITY);
     }
 
     public static void registerServerLifecycleOperations(final ManagementResourceRegistration resourceRegistration, final ServerInventory serverInventory) {

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
@@ -45,7 +45,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.Service;
@@ -126,6 +125,8 @@ class BufferPoolResourceDefinition extends PersistentResourceDefinition {
                 IOExtension.getResolver(Constants.BUFFER_POOL))
                 .setAddHandler(new BufferPoolAdd())
                 .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
+                .addCapabilities(IO_POOL_RUNTIME_CAPABILITY,
+                        IO_BYTE_BUFFER_POOL_RUNTIME_CAPABILITY)
                 .setDeprecatedSince(ModelVersion.create(4))
         );
     }
@@ -134,12 +135,6 @@ class BufferPoolResourceDefinition extends PersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return (Collection) ATTRIBUTES;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(IO_POOL_RUNTIME_CAPABILITY);
-        resourceRegistration.registerCapability(IO_BYTE_BUFFER_POOL_RUNTIME_CAPABILITY);
     }
 
     private static class BufferPoolAdd extends AbstractAddStepHandler {

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IORootDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IORootDefinition.java
@@ -32,8 +32,8 @@ import java.util.List;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 
 /**
@@ -54,12 +54,12 @@ class IORootDefinition extends PersistentResourceDefinition {
         };
 
     private IORootDefinition() {
-        super(IOExtension.SUBSYSTEM_PATH,
-                IOExtension.getResolver(),
-                IOSubsystemAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE,
-                OperationEntry.Flag.RESTART_ALL_SERVICES);
+        super(new SimpleResourceDefinition.Parameters(IOExtension.SUBSYSTEM_PATH, IOExtension.getResolver())
+                .setAddHandler(IOSubsystemAdd.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .addCapabilities(IO_MAX_THREADS_RUNTIME_CAPABILITY));
     }
 
     @Override
@@ -70,10 +70,5 @@ class IORootDefinition extends PersistentResourceDefinition {
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
         return Arrays.asList(CHILDREN);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(IO_MAX_THREADS_RUNTIME_CAPABILITY);
     }
 }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
@@ -134,22 +135,16 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
 
 
     private WorkerResourceDefinition() {
-        super(IOExtension.WORKER_PATH,
-                IOExtension.getResolver(Constants.WORKER),
-                WorkerAdd.INSTANCE,
-                new ReloadRequiredRemoveStepHandler()
-        );
+        super(new SimpleResourceDefinition.Parameters(IOExtension.WORKER_PATH, IOExtension.getResolver(Constants.WORKER))
+                .setAddHandler(WorkerAdd.INSTANCE)
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(IO_WORKER_RUNTIME_CAPABILITY));
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return (Collection) ATTRIBUTES_BY_XMLNAME.values();
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(IO_WORKER_RUNTIME_CAPABILITY);
     }
 
     @Override

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
@@ -88,6 +88,7 @@ public class JMXSubsystemRootResource extends SimpleResourceDefinition {
         super(new Parameters(PATH_ELEMENT, JMXExtension.getResourceDescriptionResolver(JMXExtension.SUBSYSTEM_NAME))
                 .setAddHandler(new JMXSubsystemAdd(auditLogger, authorizer, securityIdentitySupplier, hostInfoAccessor))
                 .setRemoveHandler(new JMXSubsystemRemove(auditLogger, authorizer, securityIdentitySupplier, hostInfoAccessor))
+                .addCapabilities(JMX_CAPABILITY)
                 .setAccessConstraints(JMXExtension.JMX_SENSITIVITY_DEF));
         this.auditLogger = auditLogger;
         this.authorizer = authorizer;
@@ -117,11 +118,6 @@ public class JMXSubsystemRootResource extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new ExposeModelResourceExpression(auditLogger, authorizer, securityIdentitySupplier, hostInfoAccessor));
         resourceRegistration.registerSubModel(RemotingConnectorResource.INSTANCE);
         resourceRegistration.registerSubModel(new JmxAuditLoggerResourceDefinition(auditLogger));
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(JMX_CAPABILITY);
     }
 
     private static class ShowModelAliasWriteHandler implements OperationStepHandler {

--- a/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorResource.java
@@ -59,10 +59,10 @@ public class RemotingConnectorResource extends SimpleResourceDefinition {
     static final RemotingConnectorResource INSTANCE = new RemotingConnectorResource();
 
     private RemotingConnectorResource() {
-        super(REMOTE_CONNECTOR_CONFIG_PATH,
-                JMXExtension.getResourceDescriptionResolver(CommonAttributes.REMOTING_CONNECTOR),
-                RemotingConnectorAdd.INSTANCE,
-                RemotingConnectorRemove.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(REMOTE_CONNECTOR_CONFIG_PATH, JMXExtension.getResourceDescriptionResolver(CommonAttributes.REMOTING_CONNECTOR))
+                .setAddHandler(RemotingConnectorAdd.INSTANCE)
+                .setRemoveHandler(RemotingConnectorRemove.INSTANCE)
+                .setCapabilities(REMOTE_JMX_CAPABILITY));
     }
 
     @Override
@@ -103,10 +103,5 @@ public class RemotingConnectorResource extends SimpleResourceDefinition {
             }
         };
         resourceRegistration.registerReadWriteAttribute(USE_MANAGEMENT_ENDPOINT, null, writeHandler);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(REMOTE_JMX_CAPABILITY);
     }
 }

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerRootDefinition.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerRootDefinition.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
@@ -71,10 +72,10 @@ class RequestControllerRootDefinition extends PersistentResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     RequestControllerRootDefinition(boolean registerRuntimeOnly) {
-        super(RequestControllerExtension.SUBSYSTEM_PATH,
-                RequestControllerExtension.getResolver(),
-                new RequestControllerSubsystemAdd(getAttributeDefinitions(registerRuntimeOnly)),
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(RequestControllerExtension.SUBSYSTEM_PATH, RequestControllerExtension.getResolver())
+                .setAddHandler(new RequestControllerSubsystemAdd(getAttributeDefinitions(registerRuntimeOnly)))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(REQUEST_CONTROLLER_CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -104,10 +105,5 @@ class RequestControllerRootDefinition extends PersistentResourceDefinition {
         if(registerRuntimeOnly) {
             resourceRegistration.registerMetric(ACTIVE_REQUESTS, new ActiveRequestsReadHandler());
         }
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(REQUEST_CONTROLLER_CAPABILITY);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.server.services.net;
 
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.resource.InterfaceDefinition;
 import org.jboss.as.network.NetworkInterfaceBinding;
 
@@ -46,11 +45,6 @@ public class InterfaceResourceDefinition extends InterfaceDefinition {
 
     public InterfaceResourceDefinition(InterfaceAddHandler addHandler, OperationStepHandler removeHandler,
                                        boolean updateRuntime, boolean resolvable) {
-        super(addHandler, removeHandler, updateRuntime, resolvable);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(INTERFACE_CAPABILITY);
+        super(addHandler, removeHandler, updateRuntime, resolvable, INTERFACE_CAPABILITY);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
@@ -75,7 +75,10 @@ public abstract class OutboundSocketBindingResourceDefinition extends SimpleReso
 
     protected OutboundSocketBindingResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver,
                                                       final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler);
+        super(new SimpleResourceDefinition.Parameters(pathElement, descriptionResolver)
+                .setAddHandler(addHandler)
+                .setRemoveHandler(removeHandler)
+                .addCapabilities(OUTBOUND_SOCKET_BINDING_CAPABILITY));
     }
 
     @Override
@@ -84,10 +87,5 @@ public abstract class OutboundSocketBindingResourceDefinition extends SimpleReso
         for (SimpleAttributeDefinition ad:ATTRIBUTES){
             resourceRegistration.registerReadWriteAttribute(ad, null, new OutboundSocketBindingWriteHandler(ad, false));
         }
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(OUTBOUND_SOCKET_BINDING_CAPABILITY);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
@@ -50,7 +50,7 @@ public class SocketBindingResourceDefinition extends AbstractSocketBindingResour
     public static final SocketBindingResourceDefinition INSTANCE = new SocketBindingResourceDefinition();
 
     private SocketBindingResourceDefinition() {
-        super(BindingAddHandler.INSTANCE, BindingRemoveHandler.INSTANCE);
+        super(BindingAddHandler.INSTANCE, BindingRemoveHandler.INSTANCE, SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY);
     }
 
     @Override
@@ -61,11 +61,6 @@ public class SocketBindingResourceDefinition extends AbstractSocketBindingResour
         resourceRegistration.registerReadOnlyAttribute(BindingRuntimeHandlers.BoundHandler.ATTRIBUTE_DEFINITION, BindingRuntimeHandlers.BoundHandler.INSTANCE);
         resourceRegistration.registerReadOnlyAttribute(BindingRuntimeHandlers.BoundAddressHandler.ATTRIBUTE_DEFINITION, BindingRuntimeHandlers.BoundAddressHandler.INSTANCE);
         resourceRegistration.registerReadOnlyAttribute(BindingRuntimeHandlers.BoundPortHandler.ATTRIBUTE_DEFINITION, BindingRuntimeHandlers.BoundPortHandler.INSTANCE);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(SOCKET_BINDING_CAPABILITY);
     }
 
     @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
@@ -109,8 +109,10 @@ public class TestHostCapableExtension implements Extension {
         private static final OperationDefinition TEST_OP = new SimpleOperationDefinitionBuilder("test-op", new NonResolvingResourceDescriptionResolver()).build();
 
         public RootResourceDefinition(String name) {
-            super(PathElement.pathElement(SUBSYSTEM, name), new NonResolvingResourceDescriptionResolver(),
-                    new AddSubsystemHandler(), new RemoveSubsystemHandler());
+            super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SUBSYSTEM, name), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AddSubsystemHandler())
+                    .setRemoveHandler(new RemoveSubsystemHandler())
+                    .addCapabilities(TEST_CAPABILITY));
         }
 
         @Override
@@ -132,11 +134,6 @@ public class TestHostCapableExtension implements Extension {
                     context.getResult().set(sc != null);
                 }
             });
-        }
-
-        @Override
-        public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-            resourceRegistration.registerCapability(TEST_CAPABILITY);
         }
 
         private static ServiceName createServiceName(PathAddress address) {


### PR DESCRIPTION
Configure capabilities using
org.jboss.as.controller.SimpleResourceDefinition.Parameters#addCapabilities
instead of overriding SimpleResourceDefinition.registerCapabilities
(unless a specific treatment is required).

JIRA: https://issues.jboss.org/browse/WFCORE-4276