### PR TITLE
Fix for WFCORE-4281, upgrade threads to 2.3.3.Final

### DIFF
--- a/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTestCase.java
+++ b/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTestCase.java
@@ -143,7 +143,7 @@ public class IOSubsystemTestCase extends AbstractSubsystemBaseTest {
         kernelServices.executeOperation(keepAliveOp);
 
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        ObjectName threadPoolName = new ObjectName("jboss.threads:name=default,type=thread-pool");
+        ObjectName threadPoolName = new ObjectName("jboss.threads:name=\"default\",type=thread-pool");
         Assert.assertEquals(coreThreads, (int) mbs.getAttribute(threadPoolName, "CorePoolSize"));
         Assert.assertEquals(maxThreads, (int) mbs.getAttribute(threadPoolName, "MaximumPoolSize"));
         Assert.assertEquals(keepAliveMillis / 1000, (long) mbs.getAttribute(threadPoolName, "KeepAliveTimeSeconds"));

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
-        <version.org.jboss.threads>2.3.2.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.6.5.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFCORE-4281, upgrade threads to 2.3.3.Final in order to fix 
CLI issue with jconsole: https://issues.jboss.org/browse/WFCORE-4199 