### PR TITLE
[WFCORE-4284] Upgrade Elytron Web to 1.4.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.8.0.CR1</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.3.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.4.0.CR1</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.5.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4284

        Release Notes - Elytron Web - Version 1.4.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-38'>ELYWEB-38</a>] -         Upgrade WildFly Elytron to 1.8.0.CR1
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-36'>ELYWEB-36</a>] -         ElytronHttpExchange.getRequestParameters() is prematurely readying the request.
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-37'>ELYWEB-37</a>] -         Release Elytron Web 1.4.0.CR1
</li>
</ul>