### PR TITLE
WFCORE-4376 Fix deprecation warnings resulting from the improper deprecation of AbstractCapability.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1499,7 +1499,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         registerCapability(capability, activeStep, null);
     }
 
-    void registerCapability(RuntimeCapability capability, Step step, String attribute) {
+    void registerCapability(RuntimeCapability<?> capability, Step step, String attribute) {
         assert isControllingThread();
         assertStageModel(currentStage);
         ensureLocalCapabilityRegistry();
@@ -1614,7 +1614,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         CapabilityScope context = createCapabilityContext(step.address);
         RuntimeCapabilityRegistration capReg = managementModel.getCapabilityRegistry().removeCapability(capabilityName, context, step.address);
         if (capReg != null) {
-            RuntimeCapability capability = capReg.getCapability();
+            RuntimeCapability<?> capability = capReg.getCapability();
             for (String required : capability.getRequirements()) {
                 removeRequirement(required, context, step);
             }
@@ -1994,7 +1994,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         return new RuntimeRequirementRegistration(required, dependent, context, rp, runtimeOnly);
     }
 
-    private RuntimeCapabilityRegistration createCapabilityRegistration(RuntimeCapability capability, Step step, String attribute) {
+    private RuntimeCapabilityRegistration createCapabilityRegistration(RuntimeCapability<?> capability, Step step, String attribute) {
         CapabilityScope context = createCapabilityContext(step.address);
         RegistrationPoint rp = new RegistrationPoint(step.address, attribute);
         return new RuntimeCapabilityRegistration(capability, context, rp);

--- a/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
@@ -300,6 +300,46 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         return additionalPackages;
     }
 
+    @Override
+    public String getName() {
+        return super.getName();
+    }
+
+    @Override
+    public Set<String> getRequirements() {
+        return super.getRequirements();
+    }
+
+    @Override
+    public boolean isDynamicallyNamed() {
+        return super.isDynamicallyNamed();
+    }
+
+    @Override
+    public String getDynamicName(String dynamicNameElement) {
+        return super.getDynamicName(dynamicNameElement);
+    }
+
+    @Override
+    public String getDynamicName(PathAddress address) {
+        return super.getDynamicName(address);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
     /**
      * Builder for a {@link RuntimeCapability}.
      *

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityRegistration.java
@@ -38,7 +38,7 @@ import org.jboss.as.controller.capability.Capability;
  *
  * @author Brian Stansberry (c) 2014 Red Hat Inc.
  */
-public class CapabilityRegistration<C extends Capability> implements Comparable<CapabilityRegistration> {
+public class CapabilityRegistration<C extends Capability> implements Comparable<CapabilityRegistration<C>> {
 
     private final Map<PathAddress, RegistrationPoint> registrationPoints = new LinkedHashMap<>();
     private final C capability;

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistration.java
@@ -31,9 +31,9 @@ import org.jboss.as.controller.capability.RuntimeCapability;
  *
  * @author Brian Stansberry (c) 2014 Red Hat Inc.
  */
-public class RuntimeCapabilityRegistration extends CapabilityRegistration<RuntimeCapability> {
+public class RuntimeCapabilityRegistration extends CapabilityRegistration<RuntimeCapability<?>> {
 
-    public RuntimeCapabilityRegistration(RuntimeCapability capability, CapabilityScope context, RegistrationPoint registrationPoint) {
+    public RuntimeCapabilityRegistration(RuntimeCapability<?> capability, CapabilityScope context, RegistrationPoint registrationPoint) {
         super(capability, context, registrationPoint);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
@@ -814,8 +814,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                     }
                 }
                 // WFLY-4164 record the fixed requirements of the registration's capabilities
-                Set<RuntimeCapability> regCaps = registration.getCapabilities();
-                for (RuntimeCapability regCap : regCaps) {
+                for (RuntimeCapability<?> regCap : registration.getCapabilities()) {
                     for (String capReq : regCap.getRequirements()) {
                         if (!required.containsKey(capReq)) {
                             ModelNode capability = new ModelNode();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4376

AbstractCapability was deprecated a little over a year ago. However, because RuntimeCapability inherits most of its Capability method implementations from it, users of RuntimeCapability encounter lots of inappropriate deprecation warnings when referencing many of the non-deprecated methods from the Capability interface. This PR fixes that and any compilation errors resulting from the invocation of these methods from a raw-typed RuntimeCapability.