### PR TITLE
[WFCORE-4297] added constant for jaxrs use in deployment process

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -573,6 +573,7 @@ public enum Phase {
     public static final int POST_MODULE_JAXRS_SCANNING                  = 0x1A00;
     public static final int POST_MODULE_JAXRS_COMPONENT                 = 0x1B00;
     public static final int POST_MODULE_JAXRS_CDI_INTEGRATION           = 0x1C00;
+    public static final int POST_MODULE_JAXRS_METHOD_PARAMETER          = 0x1C20;
     public static final int POST_MODULE_RTS_PROVIDERS                   = 0x1D00;
     public static final int POST_MODULE_LOCAL_HOME                      = 0x1E00;
     public static final int POST_MODULE_APPLICATION_CLIENT_MANIFEST     = 0x1F00;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4297 
          https://issues.jboss.org/browse/WFLY-11651 depends on this PR being
          merged first.  [WFLY-11651] will not compile successfully without 
          the constant added in Phase.java.  JaxrsSubsystemAdd in wfly uses 
          this constant.