### PR TITLE
[WFCORE-4304] Upgrade Galleon to 3.0.1.CR2 and WFGP to 3.0.1.CR3

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -60,6 +60,8 @@
                         </goals>
                         <configuration>
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -71,6 +71,8 @@
                                 </goals>
                                 <configuration>
                                     <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
                                     <plugin-options>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 
         <!-- Galleon -->
         <galleon.fork.embedded>true</galleon.fork.embedded>
+        <galleon.log.time>true</galleon.log.time>
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
@@ -104,10 +105,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>3.0.1.CR1</version.org.jboss.galleon>
+        <version.org.jboss.galleon>3.0.1.CR2</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>3.0.1.CR2</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>3.0.1.CR3</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -98,7 +98,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                             <feature-packs>
@@ -106,6 +109,11 @@
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
                                     <version>${project.version}</version>
+                                    <excluded-configs>
+                                        <config>
+                                            <model>standalone</model>
+                                        </config>
+                                    </excluded-configs>
                                     <excluded-packages>
                                         <name>product.conf</name>
                                     </excluded-packages>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -115,7 +115,10 @@
                             <phase>process-test-resources</phase>
                             <configuration>
                                 <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
+                                <record-state>false</record-state>
+                                <log-time>${galleon.log.time}</log-time>
                                 <plugin-options>
+                                    <jboss-maven-dist/>
                                     <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 </plugin-options>
                                 <resolve-locals>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -36,7 +36,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/test-standalone-reference</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                             <feature-packs>
@@ -63,7 +66,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/base-server</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -95,7 +101,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/core-management</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -127,7 +136,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/core-server</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -159,7 +171,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/deployment-scanner</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -191,7 +206,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/discovery</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -223,7 +241,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/elytron</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -255,7 +276,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/io</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -287,7 +311,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/jmx</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -319,7 +346,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/jmx-remoting</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -351,7 +381,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/secure-management-realms-security</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -383,7 +416,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/logging</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -415,7 +451,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/management</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -447,7 +486,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/remoting</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -479,7 +521,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/request-controller</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -511,7 +556,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/security-manager</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -543,7 +591,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/core-tools</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -575,7 +626,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/layers-results/test-all-layers</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -150,7 +150,10 @@
                                 <phase>process-test-resources</phase>
                                 <configuration>
                                     <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
                                     <plugin-options>
+                                        <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>
                                     <resolve-locals>

--- a/testsuite/patching/pom.xml
+++ b/testsuite/patching/pom.xml
@@ -76,7 +76,10 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                             <feature-packs>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -75,7 +75,10 @@
                         <phase>generate-test-resources</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                             <resolve-locals>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -121,7 +121,10 @@
                         <phase>process-test-resources</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                             <feature-packs>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4304

In addition to upgrading the versions, in this PR I am taking the opportunity to optimize provisioning in various modules according to what is required.
In most of the provisioning configurations I am adding:
- `<record-state>false</record-state>` which indicates to galleon that the provisioning state should not be persisted in .galleon dir (simply to save a bit of time);
- `<log-time>${galleon.log.time}</log-time>` to log provisioning time which is controlled by the property and set to true. It's not a lot of noise but helps tracking how provisioning time changes over the course of development and galleon upgrades (as discussed with @bstansberry);
- `<jboss-maven-dist/>` simply to avoid unnecessary file copying while provisioning distributions to run tests.