### PR TITLE
[WFCORE-4307] / [WFCORE-4308] / [WFCORE-4058] WildFly Elytron Component Upgrades and related RFE

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -83,7 +83,10 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
 
     private static void from6(ChainedTransformationDescriptionBuilder chainedBuilder) {
         ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(ELYTRON_6_0_0, ELYTRON_5_0_0);
-
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.KEY_STORE))
+            .getAttributeBuilder()
+            .addRejectCheck(RejectAttributeChecker.UNDEFINED, ElytronDescriptionConstants.TYPE)
+            .end();
     }
 
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
@@ -82,7 +82,7 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
 
     static final ServiceUtil<KeyStore> KEY_STORE_UTIL = ServiceUtil.newInstance(KEY_STORE_RUNTIME_CAPABILITY, ElytronDescriptionConstants.KEY_STORE, KeyStore.class);
 
-    static final SimpleAttributeDefinition TYPE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.TYPE, ModelType.STRING, false)
+    static final SimpleAttributeDefinition TYPE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.TYPE, ModelType.STRING, true)
         .setAttributeGroup(ElytronDescriptionConstants.IMPLEMENTATION)
         .setAllowExpression(true)
         .setMinSize(1)
@@ -241,7 +241,7 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
             ModelNode model = resource.getModel();
             String providers = PROVIDERS.resolveModelAttribute(context, model).asStringOrNull();
             String providerName = PROVIDER_NAME.resolveModelAttribute(context, model).asStringOrNull();
-            String type = TYPE.resolveModelAttribute(context, model).asString();
+            String type = TYPE.resolveModelAttribute(context, model).asStringOrNull();
             String path = PATH.resolveModelAttribute(context, model).asStringOrNull();
             String relativeTo = null;
             boolean required;
@@ -251,9 +251,11 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
             if (path != null) {
                 relativeTo = RELATIVE_TO.resolveModelAttribute(context, model).asStringOrNull();
                 required = REQUIRED.resolveModelAttribute(context, model).asBoolean();
-
                 keyStoreService = KeyStoreService.createFileBasedKeyStoreService(providerName, type, relativeTo, path, required, aliasFilter);
             } else {
+                if (type == null) {
+                    throw ROOT_LOGGER.filelessKeyStoreMissingType();
+                }
                 keyStoreService = KeyStoreService.createFileLessKeyStoreService(providerName, type, aliasFilter);
             }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
@@ -54,6 +54,7 @@ import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.keystore.AliasFilter;
 import org.wildfly.security.keystore.AtomicLoadKeyStore;
 import org.wildfly.security.keystore.FilteringKeyStore;
+import org.wildfly.security.keystore.KeyStoreUtil;
 import org.wildfly.security.keystore.ModifyTrackingKeyStore;
 import org.wildfly.security.keystore.UnmodifiableKeyStore;
 import org.wildfly.security.password.interfaces.ClearPassword;
@@ -108,8 +109,13 @@ class KeyStoreService implements ModifiableKeyStoreService {
     @Override
     public void start(StartContext startContext) throws StartException {
         try {
-            Provider provider = resolveProvider();
-            AtomicLoadKeyStore keyStore = AtomicLoadKeyStore.newInstance(type, provider);
+            AtomicLoadKeyStore keyStore = null;
+
+            if (type != null) {
+                Provider provider = resolveProvider();
+                keyStore = AtomicLoadKeyStore.newInstance(type, provider);
+            }
+
             if (path != null) {
                 pathResolver = pathResolver();
                 resolvedPath = getResolvedPath(pathResolver, path, relativeTo);
@@ -117,13 +123,14 @@ class KeyStoreService implements ModifiableKeyStoreService {
 
             synched = System.currentTimeMillis();
             if (resolvedPath != null && ! resolvedPath.exists()) {
-                if (required) {
+                if (required || type == null) {
                     throw ROOT_LOGGER.keyStoreFileNotExists(resolvedPath.getAbsolutePath());
                 } else {
                     ROOT_LOGGER.keyStoreFileNotExistsButIgnored(resolvedPath.getAbsolutePath());
                 }
             }
-            try (InputStream is = (resolvedPath != null && resolvedPath.exists()) ? new FileInputStream(resolvedPath) : null) {
+
+            try (FileInputStream is = (resolvedPath != null && resolvedPath.exists()) ? new FileInputStream(resolvedPath) : null) {
                 char[] password = resolvePassword();
 
                 ROOT_LOGGER.tracef(
@@ -132,7 +139,22 @@ class KeyStoreService implements ModifiableKeyStoreService {
                 );
 
                 if (is != null) {
-                    keyStore.load(is, password);
+                    if (type != null) {
+                        keyStore.load(is, password);
+                    } else {
+                        Provider[] resolvedProviders = providers.getOptionalValue();
+                        if (resolvedProviders == null) {
+                            resolvedProviders = Security.getProviders();
+                        }
+                        final Provider[] finalProviders = resolvedProviders;
+                        KeyStore detected = KeyStoreUtil.loadKeyStore(() -> finalProviders, this.provider, is, resolvedPath.getPath(), password);
+
+                        if (detected == null) {
+                            throw ROOT_LOGGER.unableToDetectKeyStore(resolvedPath.getPath());
+                        }
+
+                        keyStore = AtomicLoadKeyStore.atomize(detected);
+                    }
                 } else {
                     synchronized (EmptyProvider.getInstance()) {
                         keyStore.load(null, password);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -551,4 +551,10 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1058, value = "Failed to parse PEM public key with kid: %s")
     OperationFailedException failedToParsePEMPublicKey(String kid);
 
+    @Message(id = 1059, value = "Unable to detect KeyStore '%s'")
+    StartException unableToDetectKeyStore(String path);
+
+    @Message(id = 1060, value = "Fileless KeyStore needs to have a defined type.")
+    OperationFailedException filelessKeyStoreMissingType();
+
 }

--- a/elytron/src/main/resources/schema/wildfly-elytron_6_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_6_0.xsd
@@ -4610,7 +4610,7 @@
                 keystore implementation details
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="type" type="xs:string" use="required">
+        <xs:attribute name="type" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The KeyStore type, e.g. jks, pkcs#12.

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -115,6 +115,8 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM, "KeyMapTokenRealm")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE
+                ).addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.KEY_STORE, "automatic.keystore")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE
                 ));
     }
 

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -32,6 +32,11 @@
                 <implementation type="JKS"/>
                 <file path="accounts.keystore.jks" relative-to="jboss.server.config.dir"/>
             </key-store>
+            <key-store name="automatic.keystore">
+                <credential-reference clear-text="elytron"/>
+                <implementation/>
+                <file path="accounts.keystore.jks" relative-to="jboss.server.config.dir"/>
+            </key-store>
         </key-stores>
         <key-managers>
             <key-manager name="key1" key-store="accounts.keystore">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -43,6 +43,11 @@
                 <implementation type="JKS" />
                 <file path="target/not-existing.keystore" required="false"/>
             </key-store>
+            <key-store name="AutomaticKeystore" >
+                <credential-reference clear-text="Elytron"/>
+                <implementation/>
+                <file path="firefly.keystore" relative-to="jboss.server.config.dir"/>
+            </key-store>
             <filtering-key-store name="FilteringKeyStore" key-store="FireflyKeystore" alias-filter="NONE:+firefly"/>
         </key-stores>
         <key-managers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -43,6 +43,11 @@
                 <implementation type="JKS" />
                 <file path="target/not-existing.keystore" required="false"/>
             </key-store>
+            <key-store name="AutomaticKeystore" >
+                <credential-reference clear-text="Elytron"/>
+                <implementation/>
+                <file path="firefly.keystore" relative-to="jboss.server.config.dir"/>
+            </key-store>
             <filtering-key-store name="FilteringKeyStore" key-store="FireflyKeystore" alias-filter="NONE:+firefly"/>
         </key-stores>
         <key-managers>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.8.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.8.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.4.0.CR1</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.5.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.8.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.4.0.CR1</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.elytron.tool>1.5.0.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.6.0.CR1</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4307
https://issues.jboss.org/browse/WFCORE-4308

This PR also incorporates the changes from https://github.com/wildfly/wildfly-core/pull/3626 for a related RFE:
https://issues.jboss.org/browse/WFCORE-4058


        Release Notes - WildFly Elytron - Version 1.8.0.CR2
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1650'>ELY-1650</a>] -         Automatic detection of file based KeyStore types.
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1686'>ELY-1686</a>] -         Utility to port legacy properties files into a FileSystemRealm
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1696'>ELY-1696</a>] -         Dead code in ElytronXmlParser - PrivateKeyKeyStoreEntryCredentialFactory
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1747'>ELY-1747</a>] -         Programmatic web authentication does not save the password as a credential
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1746'>ELY-1746</a>] -         The getInputStream and getOutputStream methods can return &#39;null&#39;
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1751'>ELY-1751</a>] -         Release WildFly Elytron 1.8.0.CR2
</li>
</ul>

The WildFly Elytron Tool upgrade includes the upgrade to WildFly Elytron 1.8.0.CR2 as well as the implementation for feature [ELY-1686](https://issues.jboss.org/browse/ELY-1686).
                    