### PR TITLE
Fix for WFCORE-4311, Testing of layer execution

### DIFF
--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -39,7 +39,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                             <feature-packs>
@@ -69,7 +68,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -104,7 +102,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -139,7 +136,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -174,7 +170,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -209,7 +204,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -244,7 +238,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -279,7 +272,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -314,7 +306,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -349,7 +340,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -384,7 +374,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -419,7 +408,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -454,7 +442,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -489,7 +476,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -524,7 +510,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -559,7 +544,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -594,7 +578,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
@@ -629,7 +612,6 @@
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
-                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>


### PR DESCRIPTION
Fix for : https://issues.jboss.org/browse/WFCORE-4311
- Layers execution testing.
- Check for WFLYSRV0025 ==> success, WFLYSRV0026 ==> failure
- Other errors that could occur during startup (eg: UT005041: Cannot send advertise message on un-configured macOSX) are not checked.
- Maximum server start timeout is 1 minute (should be enough to protect us against slow test env).
- Introduce LayersTest.testExecution that will be used by Wildfly full layers test.
- Disabled maven resolution of module artefacts at runtime. Servers are now provisioned with module resources.