### PR TITLE
[WFCORE-4251] Provide ability to list module dependencies for a deployment and subdeployment

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -280,6 +280,7 @@ public class ModelDescriptionConstants {
     public static final String LDAP = "ldap";
     public static final String LDAP_CONNECTION = "ldap-connection";
     public static final String LIST_SNAPSHOTS_OPERATION = "list-snapshots";
+    public static final String LIST_MODULES = "list-modules";
     public static final String LOCAL = "local";
     public static final String LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING = "local-destination-outbound-socket-binding";
     public static final String LOCAL_HOST_NAME = "local-host-name";
@@ -604,7 +605,8 @@ public class ModelDescriptionConstants {
     public static final String VAULT_EXPRESSION = "vault-expression";
     public static final String VAULT_OPTION = "vault-option";
     public static final String VAULT_OPTIONS = "vault-options";
-      public static final String WARNING = "warning";
+    public static final String VERBOSE = "verbose";
+    public static final String WARNING = "warning";
     public static final String WARNINGS = "warnings";
     public static final String WARNING_LEVEL = "warning-level";
     public static final String WEB_URL = "web-url";

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -361,6 +361,15 @@ public class DeploymentAttributes {
     @SuppressWarnings("unchecked")
     public static final Map<String, AttributeDefinition> ALL_CONTENT_ATTRIBUTES = createAttributeMap(MANAGED_CONTENT_ATTRIBUTES, UNMANAGED_CONTENT_ATTRIBUTES);
 
+    public static SimpleAttributeDefinition VERBOSE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.VERBOSE, ModelType.BOOLEAN, true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
+    public static final OperationDefinition LIST_MODULES = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.LIST_MODULES, DEPLOYMENT_RESOLVER)
+            .addParameter(VERBOSE)
+            .withFlags(Flag.READ_ONLY)
+            .build();
+
     public static final OperationDefinition DEPLOY_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.DEPLOY, DEPLOYMENT_RESOLVER).build();
     public static final OperationDefinition UNDEPLOY_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.UNDEPLOY, DEPLOYMENT_RESOLVER).build();
     public static final OperationDefinition REDEPLOY_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.REDEPLOY, DEPLOYMENT_RESOLVER).build();

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerDeploymentResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerDeploymentResourceDefinition.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.deployment.DeploymentListModulesHandler;
 import org.jboss.as.server.deployment.ExplodedDeploymentAddContentHandler;
 import org.jboss.as.server.deployment.DeploymentAddHandler;
 import org.jboss.as.server.deployment.DeploymentDeployHandler;
@@ -74,6 +75,7 @@ public class ServerDeploymentResourceDefinition extends DeploymentResourceDefini
         resourceRegistration.registerOperationHandler(DeploymentAttributes.DEPLOYMENT_REMOVE_CONTENT_DEFINITION, new ExplodedDeploymentRemoveContentHandler(contentRepository, serverEnvironment));
         resourceRegistration.registerOperationHandler(DeploymentAttributes.DEPLOYMENT_READ_CONTENT_DEFINITION, new ManagedDeploymentReadContentHandler(contentRepository));
         resourceRegistration.registerOperationHandler(DeploymentAttributes.DEPLOYMENT_BROWSE_CONTENT_DEFINITION, new ManagedDeploymentBrowseContentHandler(contentRepository));
+        resourceRegistration.registerOperationHandler(DeploymentAttributes.LIST_MODULES, new DeploymentListModulesHandler());
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -29,7 +29,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND;
 import static org.jboss.as.controller.services.path.PathResourceDefinition.PATH_CAPABILITY;
 
@@ -42,7 +41,6 @@ import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.NoopOperationStepHandler;
 import org.jboss.as.controller.OperationDefinition;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.ResourceDefinition;
@@ -551,7 +549,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new DeploymentOverlayDefinition(false, contentRepository, null));
 
         // The sub-deployments registry
-        deployments.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement(SUBDEPLOYMENT), DeploymentAttributes.DEPLOYMENT_RESOLVER));
+        deployments.registerSubModel(ServerSubDeploymentResourceDefinition.create());
 
         // Extensions
         resourceRegistration.registerSubModel(new ExtensionResourceDefinition(extensionRegistry, parallelBoot, ExtensionRegistryType.SERVER, rootResourceRegistrationProvider));

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerSubDeploymentResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerSubDeploymentResourceDefinition.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server.controller.resources;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.server.deployment.DeploymentListModulesHandler;
+
+/**
+ * The sub-deployment resource definition.
+ *
+ * @author Yeray Borges
+ */
+public class ServerSubDeploymentResourceDefinition extends SimpleResourceDefinition {
+
+    private ServerSubDeploymentResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver) {
+        super(pathElement, descriptionResolver);
+    }
+
+    static ServerSubDeploymentResourceDefinition create(){
+        return new ServerSubDeploymentResourceDefinition(PathElement.pathElement(SUBDEPLOYMENT), DeploymentAttributes.DEPLOYMENT_RESOLVER);
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(DeploymentAttributes.LIST_MODULES, new DeploymentListModulesHandler());
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentListModulesHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentListModulesHandler.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server.deployment;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LIST_MODULES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.VERBOSE;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.moduleservice.ModuleLoadService;
+import org.jboss.as.server.moduleservice.ServiceModuleLoader;
+import org.jboss.dmr.ModelNode;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * Handles listing module dependencies of a deployment and sub-deployment.
+ *
+ * @author Yeray Borges
+ */
+public class DeploymentListModulesHandler implements OperationStepHandler {
+    public static final String OPERATION_NAME = LIST_MODULES;
+
+    public DeploymentListModulesHandler() {
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final PathAddress currentAddress = context.getCurrentAddress();
+        final boolean subDeploymentFlag = currentAddress.getLastElement().getKey().equals(SUBDEPLOYMENT);
+        final PathAddress address = subDeploymentFlag ? currentAddress.getParent() : currentAddress;
+
+        final ModelNode model = context.readResourceFromRoot(address, false).getModel();
+        final boolean verbose = VERBOSE.resolveModelAttribute(context, operation).asBoolean();
+        final boolean enabled = ENABLED.resolveModelAttribute(context, model).asBoolean();
+        final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
+        final String item = context.getCurrentAddressValue();
+
+        if (enabled && context.isNormalServer()) {
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext context, ModelNode operation) {
+                    final ServiceRegistry sr = context.getServiceRegistry(false);
+                    final ServiceController<?> deploymentUnitSc = sr.getService(Services.deploymentUnitName(runtimeName));
+                    final DeploymentUnit deploymentUnit = (DeploymentUnit) deploymentUnitSc.getValue();
+
+                    ModuleIdentifier moduleIdentifier = null;
+                    if (subDeploymentFlag) {
+                        for (DeploymentUnit subDeployment : deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS)) {
+                            if (subDeployment.getName().equals(item)) {
+                                moduleIdentifier = subDeployment.getAttachment(Attachments.MODULE_IDENTIFIER);
+                                break;
+                            }
+                        }
+                        if (moduleIdentifier == null) {
+                            throw ControllerLogger.ROOT_LOGGER.managementResourceNotFound(currentAddress);
+                        }
+                    } else {
+                        moduleIdentifier = deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER);
+                    }
+
+                    final ServiceController<?> moduleLoadServiceController = sr.getService(ServiceModuleLoader.moduleServiceName(moduleIdentifier));
+                    final ModuleLoadService moduleLoadService = (ModuleLoadService) moduleLoadServiceController.getService();
+
+                    final ModelNode result = new ModelNode();
+                    List<ModuleDependency> dependencies = moduleLoadService.getSystemDependencies();
+                    Collections.sort(dependencies, Comparator.comparing(p -> p.getIdentifier().toString()));
+                    result.get("system-dependencies").set(buildDependenciesInfo(dependencies, verbose));
+
+                    dependencies = moduleLoadService.getLocalDependencies();
+                    Collections.sort(dependencies, Comparator.comparing(p -> p.getIdentifier().toString()));
+                    result.get("local-dependencies").set(buildDependenciesInfo(dependencies, verbose));
+
+                    dependencies = moduleLoadService.getUserDependencies();
+                    Collections.sort(dependencies, Comparator.comparing(p -> p.getIdentifier().toString()));
+                    result.get("user-dependencies").set(buildDependenciesInfo(dependencies, verbose));
+
+                    context.getResult().set(result);
+                }
+            }, OperationContext.Stage.RUNTIME);
+        }
+    }
+
+    private ModelNode buildDependenciesInfo(List<ModuleDependency> dependencies, boolean verbose) {
+        ModelNode deps = new ModelNode().setEmptyList();
+        for (ModuleDependency dependency : dependencies) {
+            ModelNode depData = new ModelNode();
+            ModuleIdentifier identifier = dependency.getIdentifier();
+            depData.get("name").set(identifier.toString());
+            if (verbose) {
+                depData.get("optional").set(dependency.isOptional());
+                depData.get("export").set(dependency.isExport());
+                depData.get("import-services").set(dependency.isImportServices());
+            }
+            deps.add(depData);
+        }
+        return deps;
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -27,18 +27,18 @@ import java.security.Permission;
 import java.security.Permissions;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.PropertyPermission;
 
-import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.SubDeploymentMarker;
+import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.server.moduleservice.ModuleDefinition;
 import org.jboss.as.server.moduleservice.ModuleLoadService;
 import org.jboss.as.server.moduleservice.ModuleResolvePhaseService;
@@ -282,14 +282,9 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
         sb.setInitialMode(Mode.ON_DEMAND);
         sb.install();
 
-        final List<ModuleDependency> allDependencies = new ArrayList<ModuleDependency>();
-        allDependencies.addAll(dependencies);
-        allDependencies.addAll(localDependencies);
-        allDependencies.addAll(userDependencies);
-
         ModuleResolvePhaseService.installService(phaseContext.getServiceTarget(), moduleDefinition);
 
-        return ModuleLoadService.install(phaseContext.getServiceTarget(), moduleIdentifier, allDependencies);
+        return ModuleLoadService.install(phaseContext.getServiceTarget(), moduleIdentifier, dependencies, localDependencies, userDependencies);
     }
 
     private void installAliases(final ModuleSpecification moduleSpecification, final ModuleIdentifier moduleIdentifier, final DeploymentUnit deploymentUnit, final DeploymentPhaseContext phaseContext) {
@@ -310,7 +305,8 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
             sb.requires(phaseContext.getPhaseServiceName());
             sb.setInitialMode(Mode.ON_DEMAND);
             sb.install();
-            ModuleLoadService.installService(phaseContext.getServiceTarget(), alias, Collections.singletonList(moduleIdentifier));
+
+            ModuleLoadService.installAliases(phaseContext.getServiceTarget(), alias, Collections.singletonList(moduleIdentifier));
 
             ModuleResolvePhaseService.installService(phaseContext.getServiceTarget(), moduleDefinition);
         }

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ExtensionIndexService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ExtensionIndexService.java
@@ -25,7 +25,6 @@ package org.jboss.as.server.moduleservice;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -37,7 +36,6 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
 import org.jboss.as.server.deployment.module.ExtensionInfo;
-import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.logging.Logger;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleSpec;
@@ -123,8 +121,7 @@ public final class ExtensionIndexService implements Service<ExtensionIndex>, Ext
                             sb.setInitialMode(Mode.ON_DEMAND);
                             sb.install();
 
-                            ModuleLoadService.install(context.getChildTarget(), moduleIdentifier, Collections
-                                    .<ModuleDependency> emptyList());
+                            ModuleLoadService.install(context.getChildTarget(), moduleIdentifier);
 
                             extensionJarSet.add(extensionJar);
 

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -314,4 +314,6 @@ deployment.disabled-time=Last time the application was disabled
 deployment.disabled-timestamp=Last timestamp the application was disabled. Format is yyyy-MM-dd HH:mm:ss,SSS zzz.
 deployment.deployment-deployed=Notification sent when a deployment is deployed.
 deployment.deployment-undeployed=Notification sent when a deployment is undeployed.
+deployment.list-modules=List all module dependencies of the current deployment.
+deployment.list-modules.verbose=Optional, default is false and results in brief info about the module dependencies, true to include detailed information about the module dependencies added to the current deployment.
 deployment.managed=Indicates if the deployment is managed (aka uses the ContentRepository).

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentModulesListTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentModulesListTestCase.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.core.test.standalone.mgmt.api.core;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.PropertyPermission;
+import java.util.stream.Collectors;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LIST_MODULES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VERBOSE;
+import static org.wildfly.common.Assert.assertFalse;
+import static org.wildfly.common.Assert.assertTrue;
+
+/**
+ * List modules which are on deployment’s classpath
+ * /deployment=application_war_ear_name:list-modules(verbose=false|true)
+ * @author <a href="mailto:szhantem@redhat.com">Sultan Zhantemirov</a> (c) 2019 Red Hat, inc.
+ */
+@RunWith(WildflyTestRunner.class)
+public class DeploymentModulesListTestCase {
+
+    private JavaArchive archive;
+    private static final String NODE_TYPE = "deployment";
+    private static final String EXAMPLE_MODULE_TO_EXCLUDE = "ibm.jdk";
+    private static final String EXAMPLE_USER_MODULE = "jdk.net";
+    private static final String JAR_DEPLOYMENT_NAME_SUFFIX = "-module-test.jar";
+    private static final String JAR_DEPLOYMENT_NAME = EXAMPLE_USER_MODULE + JAR_DEPLOYMENT_NAME_SUFFIX;
+
+    @Inject
+    private static ManagementClient managementClient;
+    private ModelControllerClient client;
+
+    @Before
+    public void deploy() throws Exception {
+        client = managementClient.getControllerClient();
+        archive = createJarArchive();
+
+        ModelNode response = deployArchive(client, archive);
+
+        // check deployment
+        if (!Operations.isSuccessfulOutcome(response)) {
+            Assert.fail(String.format("Failed to deploy %s: %s", archive, Operations.getFailureDescription(response).asString()));
+        }
+    }
+
+    @After
+    public void undeploy() throws Exception {
+        undeployArchive(client);
+    }
+
+    @Test
+    public void listModulesNonVerbose() throws Exception {
+        this.listModules(false);
+    }
+
+    @Test
+    public void listModulesVerbose() throws Exception {
+        this.listModules(true);
+    }
+
+    private void listModules(boolean verbose) throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(LIST_MODULES);
+        operation.get(OP_ADDR).set(PathAddress.parseCLIStyleAddress("/" + NODE_TYPE + "=" + archive.getName()).toModelNode());
+
+        if (verbose) {
+            operation.get(VERBOSE).set(Boolean.TRUE.toString());
+        }
+
+        final ModelNode operationResult = client.execute(operation);
+
+        // check whether the operation was successful
+        assertTrue(Operations.isSuccessfulOutcome(operationResult));
+
+        // check standard/detailed output
+        if (!verbose) {
+            // check whether modules are ordered alphabetically
+            assertTrue(isOrderedAlphabetically(operationResult));
+            // check module presence
+            assertTrue(checkModulesListPresence(operationResult, EXAMPLE_USER_MODULE));
+            // check module absence
+            assertFalse(checkModulesListPresence(operationResult, EXAMPLE_MODULE_TO_EXCLUDE));
+            // check system and user dependencies presence
+            assertTrue(checkModulesListNonEmptiness(operationResult));
+        } else {
+            // check other attributes presence only
+            assertTrue(checkDetailedOutput(operationResult));
+        }
+    }
+
+    /**
+     * Checks given module presence in the "list-modules" command output.
+     * @param operationResult - operation object to extract result from
+     * @param moduleName - name of the module expected to be present
+     * @return true if given module is present in any (system, local, user) list of module dependencies
+     */
+    private boolean checkModulesListPresence(ModelNode operationResult, String moduleName) {
+        boolean isModulePresent = false;
+
+        for (Property dependenciesGroup : operationResult.get(RESULT).asPropertyList()) {
+            List<Property> list = dependenciesGroup
+                    .getValue()
+                    .asPropertyList()
+                    .stream()
+                    .filter(dependency -> dependency.getValue().asString().equalsIgnoreCase(moduleName))
+                    .collect(Collectors.toList());
+            if (list.size() > 0) isModulePresent = true;
+        }
+
+        return isModulePresent;
+    }
+
+    /**
+     * Checks whether both system and user dependencies lists are not empty.
+     * @param operationResult - operation object to extract result from
+     * @return true if both system and user dependencies lists are not empty
+     */
+    private boolean checkModulesListNonEmptiness(ModelNode operationResult) {
+        boolean isSystemDependenciesPresent = false;
+        boolean isUserDependenciesPresent = false;
+        for (Property dependenciesGroup : operationResult.get(RESULT).asPropertyList()) {
+            if (dependenciesGroup.getName().equalsIgnoreCase("system-dependencies")) {
+                // check system dependencies list non-emptiness
+                isSystemDependenciesPresent = !dependenciesGroup.getValue().asPropertyList().isEmpty();
+            }
+            if (dependenciesGroup.getName().equalsIgnoreCase("user-dependencies")) {
+                // check system dependencies list non-emptiness
+                isUserDependenciesPresent = !dependenciesGroup.getValue().asPropertyList().isEmpty();
+            }
+        }
+
+        return isSystemDependenciesPresent && isUserDependenciesPresent;
+    }
+
+    /**
+     * Checks whether the module output information contains at least one of the "optional", "export" and "import-services" attributes.
+     * @param operationResult - operation object to extract result from
+     * @return true if detailed output is present
+     */
+    private boolean checkDetailedOutput(ModelNode operationResult) {
+        boolean isDetailedOutput = false;
+
+        for (Property dependenciesGroup : operationResult.get(RESULT).asPropertyList()) {
+            for (ModelNode dependency : dependenciesGroup.getValue().asList()) {
+                isDetailedOutput = dependency
+                        .asPropertyList()
+                        .stream()
+                        .map(Property::getName)
+                        .anyMatch(attributeName ->
+                                attributeName.equalsIgnoreCase("optional") ||
+                                attributeName.equalsIgnoreCase("import-services") ||
+                                attributeName.equalsIgnoreCase("export")
+                        );
+            }
+        }
+
+        return isDetailedOutput;
+    }
+
+    private ModelNode deployArchive(ModelControllerClient client, Archive<?> archive) throws IOException {
+        final List<InputStream> streams = new ArrayList<>();
+        streams.add(archive.as(ZipExporter.class).exportAsInputStream());
+
+        final ModelNode addOperation = Util.createAddOperation(PathAddress.pathAddress(NODE_TYPE, JAR_DEPLOYMENT_NAME));
+        addOperation.get(ENABLED).set(true);
+        addOperation.get(CONTENT).add().get(ClientConstants.INPUT_STREAM_INDEX).set(0);
+        return client.execute(Operation.Factory.create(addOperation, streams, true));
+    }
+
+    private void undeployArchive(ModelControllerClient client) throws IOException {
+        final ModelNode removeOperation = Util.createRemoveOperation(PathAddress.pathAddress(NODE_TYPE, JAR_DEPLOYMENT_NAME));
+        client.execute(Operation.Factory.create(removeOperation));
+    }
+
+    private JavaArchive createJarArchive() throws Exception {
+        final Properties properties = new Properties();
+        final JavaArchive archive = ServiceActivatorDeploymentUtil
+                .createServiceActivatorDeploymentArchive(JAR_DEPLOYMENT_NAME, properties);
+
+        archive.delete("META-INF/permissions.xml");
+        archive.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                new PropertyPermission("test.deployment.trivial.prop", "write"),
+                new PropertyPermission(JAR_DEPLOYMENT_NAME + "Service", "write"),
+                new PropertyPermission("service", "write")
+        ), "permissions.xml");
+        archive.addAsResource(new StringAsset(prepareJBossDeploymentStructure()),
+                "META-INF/jboss-deployment-structure.xml");
+
+        return archive;
+    }
+
+    private String prepareJBossDeploymentStructure() {
+        return "<jboss-deployment-structure>\n" +
+                "  <deployment>\n" +
+                "   <exclusions>\n" +
+                "       <module name=\"" + EXAMPLE_MODULE_TO_EXCLUDE + "\"/>\n" +
+                "   </exclusions>\n" +
+                "    <dependencies>\n" +
+                "       <module name=\"" + EXAMPLE_USER_MODULE + "\"/>\n" +
+                "    </dependencies>\n" +
+                "  </deployment>\n" +
+                "</jboss-deployment-structure>\n";
+    }
+
+    private boolean isOrderedAlphabetically(ModelNode operationResult) {
+        List<String> dependenciesList;
+        List<Property> list;
+        boolean isSorted = true;
+
+        for (Property dependenciesGroup : operationResult.get(RESULT).asPropertyList()) {
+            dependenciesList =  new ArrayList<>();
+            list = dependenciesGroup.getValue().asPropertyList();
+            for (Property dependency : list) {
+                dependenciesList.add(dependency.getValue().asString());
+            }
+            isSorted = isSorted(dependenciesList);
+        }
+
+        return isSorted;
+    }
+
+    private boolean isSorted(List<String> list) {
+        boolean sorted = true;
+
+        for (int i = 1; i < list.size(); i++) {
+            if (list.get(i - 1).compareTo(list.get(i)) > 0) {
+                sorted = false;
+            }
+        }
+
+        return sorted;
+    }
+
+}


### PR DESCRIPTION
A feature that enables a command to list the module dependencies of a specific deployment and subdeployments. 

It is included only a test case for non ear deployments. Ear deployment processors are in wildfly-full, so a new PR will be added by @zhantemirov to cover this section of the test plan.

Jira issue: https://issues.jboss.org/browse/WFCORE-4251
Analysis doc: https://github.com/wildfly/wildfly-proposals/pull/159
Community doc: https://github.com/wildfly/wildfly/pull/12041