### PR TITLE
[WFCORE-4315] Upgrade the wildfly-maven-plugin to 1.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.galleon-plugins>3.0.1.CR3</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
-        <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
+        <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.0.0.Beta2</version.org.wildfly.plugins>


### PR DESCRIPTION
The sole intention of this upgrade is to include WFMP-88 fix in wildfly core. We have some Jenkins jobs for eap-ization commits running on uppercase folder names, and we have to do some workarounds to make the job running. This upgrade will facilitate this issue.

notice the following; wildfly-full is already using 1.2.1.Final

Jira issue: https://issues.jboss.org/browse/WFCORE-4315

cc: @jamezp 