### PR TITLE
[WFCORE-4317] Upgrade jboss-logmanager from 2.1.5.Final to 2.1.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.5.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.7.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.0.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4317

<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/LOGMGR-213'>LOGMGR-213</a>] -         Add a System.LoggerFinder for Java 9+
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/LOGMGR-218'>LOGMGR-218</a>] -         JBoss Logmanager is incompatibile with -Xbootclasspath and JDK 11
</li>
<li>[<a href='https://issues.jboss.org/browse/LOGMGR-236'>LOGMGR-236</a>] -         java.lang.ArrayIndexOutOfBoundsException: 76 	at org.jboss.logmanager.JDKSpecific.calculateCaller(JDKSpecific.java:112)
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/LOGMGR-210'>LOGMGR-210</a>] -         Use the StackTraceFormatter to render the stack trace for structured formatters
</li>
</ul>