### PR TITLE
 [WFLY-4322][WFCORE-3997] Bump domain management version to 10.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -63,6 +63,7 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         EAP64("EAP6.4", KernelAPIVersion.VERSION_1_7),
         EAP70("EAP7.0", KernelAPIVersion.VERSION_4_1),
         EAP71("EAP7.1", KernelAPIVersion.VERSION_5_0),
+        EAP72("EAP7.2", KernelAPIVersion.VERSION_8_0),
         WILDFLY10("WildFly10.0", KernelAPIVersion.VERSION_4_0),
         WILDFLY10_1("WildFly10.1", KernelAPIVersion.VERSION_4_2),
         WILDFLY11("WildFly11.0", KernelAPIVersion.VERSION_5_0),

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -68,7 +68,8 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY11("WildFly11.0", KernelAPIVersion.VERSION_5_0),
         WILDFLY12("WildFly12.0", KernelAPIVersion.VERSION_6_0),
         WILDFLY13("WildFly13.0", KernelAPIVersion.VERSION_7_0),
-        WILDFLY14("WildFly14.0", KernelAPIVersion.VERSION_8_0);
+        WILDFLY14("WildFly14.0", KernelAPIVersion.VERSION_8_0),
+        WILDFLY15("WildFly15.0", KernelAPIVersion.VERSION_9_0);
 
 
         private static final Map<String, KnownRelease> map = new HashMap<>();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -58,6 +58,8 @@ public enum KernelAPIVersion {
     VERSION_7_0(7, 0, 0),
     // WF 14.0.0
     VERSION_8_0(8, 0, 0),
+    // WF 15.0.0
+    VERSION_9_0(9, 0, 0),
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);
 

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -35,7 +35,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 9;
+    public static final int MANAGEMENT_MAJOR_VERSION = 10;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
[WFLY-4322] Bump domain management version to 10.0.0  …
* Set Version to 10.0.0 to prepare WildFly 16 release
* add KnownRelease.WILDFLY15 based on Kernel API version 9.0.0

JIRA: https://issues.jboss.org/browse/WFCORE-4322

---

[WFCORE-3997] Add HostExcludeResourceDefinition.KnownRelease items for EAP 7.2

JIRA: https://issues.jboss.org/browse/WFCORE-3997