### PR TITLE
[WFCORE-4328] Add EAP 7.2 host exclusion enum type in Wildfly config xsd

### DIFF
--- a/server/src/main/resources/schema/wildfly-config_10_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_10_0.xsd
@@ -4914,6 +4914,15 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="EAP7.2">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 8.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                     <xs:enumeration value="WildFly15.0">
                         <xs:annotation>
                             <xs:documentation>


### PR DESCRIPTION
It will allow adding EAP7.2 host exclusion in the product branches

Jira issue: https://issues.jboss.org/browse/WFCORE-4328