### PR TITLE
WFCORE-4314 - improve elytron keystore commands

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
@@ -513,14 +513,14 @@ class AdvancedModifiableKeyStoreDecorator extends ModifiableKeyStoreDecorator {
                                     throw ROOT_LOGGER.trustedCertificateAlreadyInCacertsKeyStore(trustedCertificateAlias);
                                 }
                             }
-                            writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate);
+                            writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate, true);
                             throw ROOT_LOGGER.unableToDetermineIfCertificateIsTrusted();
                         } else {
                             try {
                                 final HashMap<Principal, HashSet<X509Certificate>> certificatesMap = getKeyStoreCertificates(keyStore, cacertsKeyStore);
                                 X500.createX509CertificateChain(trustedCertificate, certificatesMap);
                             } catch (IllegalArgumentException e) {
-                                writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate);
+                                writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate, true);
                                 throw ROOT_LOGGER.unableToDetermineIfCertificateIsTrusted();
                             }
                         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
@@ -115,18 +115,28 @@ class CertificateChainAttributeDefinitions {
     }
 
     static void writeCertificate(final ModelNode certificateModel, final Certificate certificate) throws CertificateEncodingException, NoSuchAlgorithmException {
+        writeCertificate(certificateModel, certificate, false);
+    }
+
+    static void writeCertificate(final ModelNode certificateModel, final Certificate certificate, final boolean verbose) throws CertificateEncodingException, NoSuchAlgorithmException {
         certificateModel.get(ElytronDescriptionConstants.TYPE).set(certificate.getType());
 
         PublicKey publicKey = certificate.getPublicKey();
         certificateModel.get(ElytronDescriptionConstants.ALGORITHM).set(publicKey.getAlgorithm());
         certificateModel.get(ElytronDescriptionConstants.FORMAT).set(publicKey.getFormat());
-        certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY).set(encodedHexString(publicKey.getEncoded()));
-
+        if(verbose) {
+            certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY).set(encodedHexString(publicKey.getEncoded()));
+        } else {
+            certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY);
+        }
         byte[] encodedCertificate = certificate.getEncoded();
         certificateModel.get(ElytronDescriptionConstants.SHA_1_DIGEST).set(encodedHexString(digest(SHA_1, encodedCertificate)));
         certificateModel.get(ElytronDescriptionConstants.SHA_256_DIGEST).set(encodedHexString(digest(SHA_256, encodedCertificate)));
-        certificateModel.get(ElytronDescriptionConstants.ENCODED).set(encodedHexString(encodedCertificate));
-
+        if(verbose) {
+            certificateModel.get(ElytronDescriptionConstants.ENCODED).set(encodedHexString(encodedCertificate));
+        } else {
+            certificateModel.get(ElytronDescriptionConstants.ENCODED);
+        }
         if (certificate instanceof X509Certificate) {
             writeX509Certificate(certificateModel, (X509Certificate) certificate);
         }
@@ -154,10 +164,14 @@ class CertificateChainAttributeDefinitions {
      * @throws NoSuchAlgorithmException
      */
     static void writeCertificates(final ModelNode result, final Certificate[] certificates) throws CertificateEncodingException, NoSuchAlgorithmException {
+        writeCertificates(result, certificates, false);
+    }
+
+    static void writeCertificates(final ModelNode result, final Certificate[] certificates, final boolean verbose) throws CertificateEncodingException, NoSuchAlgorithmException {
         if (certificates != null) {
             for (Certificate current : certificates) {
                 ModelNode certificate = new ModelNode();
-                writeCertificate(certificate, current);
+                writeCertificate(certificate, current, verbose);
                 result.add(certificate);
             }
         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -396,6 +396,7 @@ interface ElytronDescriptionConstants {
     String PROVIDERS = "providers";
     String PUBLIC_KEY = "public-key";
 
+    String RECURSIVE = "recursive";
     String RDN_IDENTIFIER = "rdn-identifier";
     String READ_ALIAS = "read-alias";
     String READ_ALIASES = "read-aliases";
@@ -539,6 +540,7 @@ interface ElytronDescriptionConstants {
     String VALIDATE = "validate";
     String VALIDITY = "validity";
     String VALUE = "value";
+    String VERBOSE = "verbose";
     String VERIFIABLE = "verifiable";
     String VERSION = "version";
     String VERSION_COMPARISON = "version-comparison";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/FileAttributeDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/FileAttributeDefinitions.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathManager.Callback.Handle;
 import org.jboss.as.controller.services.path.PathManager.Event;
 import org.jboss.as.controller.services.path.PathManager.PathEventContext;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceName;
 
@@ -50,6 +51,7 @@ class FileAttributeDefinitions {
         .setMinSize(1)
         .setAttributeGroup(ElytronDescriptionConstants.FILE)
         .setRequires(ElytronDescriptionConstants.PATH)
+        .setDefaultValue(new ModelNode("jboss.server.config.dir"))
         .setRestartAllServices()
         .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
@@ -111,13 +111,18 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
 
     static class ReadAliasHandler extends ElytronRuntimeOnlyHandler {
 
-        static final SimpleAttributeDefinition ALIAS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALIAS, ModelType.STRING, false)
+        static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, false)
                 .setAllowExpression(false)
+                .build();
+
+        static final SimpleAttributeDefinition VERBOSE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.VERBOSE, ModelType.BOOLEAN, false)
+                .setAllowExpression(false)
+                .setDefaultValue(new ModelNode(false))
                 .build();
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
             SimpleOperationDefinition READ_ALIAS = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIAS, descriptionResolver)
-                    .setParameters(ALIAS)
+                    .setParameters(NAME,VERBOSE)
                     .setReadOnly()
                     .setRuntimeOnly()
                     .build();
@@ -126,8 +131,9 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
 
         @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
-            String alias = ALIAS.resolveModelAttribute(context, operation).asString();
-            KeyStore keyStore = getKeyStore(context);
+            final String alias = NAME.resolveModelAttribute(context, operation).asString();
+            final boolean verbose = VERBOSE.resolveModelAttribute(context, operation).asBoolean();
+            final KeyStore keyStore = getKeyStore(context);
 
             try {
                 ModelNode result = context.getResult();
@@ -136,7 +142,7 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
                     return;
                 }
 
-                result.get(ElytronDescriptionConstants.ALIAS).set(alias);
+                result.get(ElytronDescriptionConstants.NAME).set(alias);
                 result.get(ElytronDescriptionConstants.ENTRY_TYPE).set(getEntryType(keyStore, alias));
 
                 Date creationDate = keyStore.getCreationDate(alias);
@@ -149,10 +155,10 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
                 if (chain == null) {
                     Certificate cert = keyStore.getCertificate(alias);
                     if (cert != null) {
-                        writeCertificate(result.get(ElytronDescriptionConstants.CERTIFICATE), cert);
+                        writeCertificate(result.get(ElytronDescriptionConstants.CERTIFICATE), cert, verbose);
                     }
                 } else {
-                    writeCertificates(result.get(ElytronDescriptionConstants.CERTIFICATE_CHAIN), chain);
+                    writeCertificates(result.get(ElytronDescriptionConstants.CERTIFICATE_CHAIN), chain, verbose);
                 }
             } catch (KeyStoreException | NoSuchAlgorithmException | CertificateEncodingException e) {
                 throw new OperationFailedException(e);
@@ -176,13 +182,13 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
 
     static class RemoveAliasHandler extends ElytronRuntimeOnlyHandler {
 
-        static final SimpleAttributeDefinition ALIAS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALIAS, ModelType.STRING, false)
+        static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.NAME, ModelType.STRING, false)
                 .setAllowExpression(false)
                 .build();
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
             resourceRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.REMOVE_ALIAS, descriptionResolver)
-                        .setParameters(ALIAS)
+                        .setParameters(NAME)
                         .setRuntimeOnly()
                         .build()
                     , new RemoveAliasHandler());
@@ -190,7 +196,7 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
 
         @Override
         protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            String alias = ALIAS.resolveModelAttribute(context, operation).asString();
+            String alias = NAME.resolveModelAttribute(context, operation).asString();
             KeyStore keyStore = getModifiableKeyStore(context);
 
             try {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
@@ -85,8 +85,19 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
 
     static class ReadAliasesHandler extends ElytronRuntimeOnlyHandler {
 
+        static final SimpleAttributeDefinition RECURSIVE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.RECURSIVE, ModelType.BOOLEAN, false)
+                .setAllowExpression(false)
+                .setDefaultValue(new ModelNode(false))
+                .build();
+
+        static final SimpleAttributeDefinition VERBOSE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.VERBOSE, ModelType.BOOLEAN, false)
+                .setAllowExpression(false)
+                .setDefaultValue(new ModelNode(false))
+                .build();
+
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
             SimpleOperationDefinition READ_ALIASES = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIASES, descriptionResolver)
+                    .setParameters(RECURSIVE,VERBOSE)
                     .setReadOnly()
                     .setRuntimeOnly()
                     .build();
@@ -101,9 +112,17 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
                 ModelNode result = context.getResult();
                 Enumeration<String> aliases = keyStore.aliases();
                 while (aliases.hasMoreElements()) {
-                    result.add(aliases.nextElement());
+                    final String name = aliases.nextElement();
+                    final boolean recursive = RECURSIVE.resolveModelAttribute(context, operation).asBoolean();
+                    if(recursive) {
+                        final ModelNode aliasNode = result.get(name);
+                        final boolean verbose = VERBOSE.resolveModelAttribute(context, operation).asBoolean();
+                        ReadAliasHandler.readAlias(keyStore, name, verbose, aliasNode);
+                    } else {
+                        result.add(name);
+                    }
                 }
-            } catch (KeyStoreException e) {
+            } catch (KeyStoreException | NoSuchAlgorithmException | CertificateEncodingException e) {
                 throw new OperationFailedException(e);
             }
         }
@@ -137,35 +156,13 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
 
             try {
                 ModelNode result = context.getResult();
-                if ( ! keyStore.containsAlias(alias)) {
-                    ROOT_LOGGER.tracef("Alias [%s] does not exists in KeyStore");
-                    return;
-                }
-
-                result.get(ElytronDescriptionConstants.NAME).set(alias);
-                result.get(ElytronDescriptionConstants.ENTRY_TYPE).set(getEntryType(keyStore, alias));
-
-                Date creationDate = keyStore.getCreationDate(alias);
-                if (creationDate != null) {
-                    SimpleDateFormat sdf = new SimpleDateFormat(ISO_8601_FORMAT);
-                    result.get(ElytronDescriptionConstants.CREATION_DATE).set(sdf.format(creationDate));
-                }
-
-                Certificate[] chain = keyStore.getCertificateChain(alias);
-                if (chain == null) {
-                    Certificate cert = keyStore.getCertificate(alias);
-                    if (cert != null) {
-                        writeCertificate(result.get(ElytronDescriptionConstants.CERTIFICATE), cert, verbose);
-                    }
-                } else {
-                    writeCertificates(result.get(ElytronDescriptionConstants.CERTIFICATE_CHAIN), chain, verbose);
-                }
+                readAlias(keyStore,alias,verbose,result);
             } catch (KeyStoreException | NoSuchAlgorithmException | CertificateEncodingException e) {
                 throw new OperationFailedException(e);
             }
         }
 
-        private String getEntryType(KeyStore keyStore, String alias) throws KeyStoreException {
+        private static String getEntryType(KeyStore keyStore, String alias) throws KeyStoreException {
             if (keyStore.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
                 return KeyStore.PrivateKeyEntry.class.getSimpleName();
             } else if (keyStore.entryInstanceOf(alias, KeyStore.SecretKeyEntry.class)) {
@@ -176,6 +173,32 @@ class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
                 return PasswordEntry.class.getSimpleName();
             } else {
                 return "Other";
+            }
+        }
+
+        static void readAlias(final KeyStore keyStore, final String name, final boolean verbose, final ModelNode result) throws KeyStoreException,  NoSuchAlgorithmException, CertificateEncodingException {
+            if ( ! keyStore.containsAlias(name)) {
+                ROOT_LOGGER.tracef("Alias [%s] does not exists in KeyStore");
+                return;
+            }
+
+            result.get(ElytronDescriptionConstants.NAME).set(name);
+            result.get(ElytronDescriptionConstants.ENTRY_TYPE).set(ReadAliasHandler.getEntryType(keyStore, name));
+
+            Date creationDate = keyStore.getCreationDate(name);
+            if (creationDate != null) {
+                SimpleDateFormat sdf = new SimpleDateFormat(ISO_8601_FORMAT);
+                result.get(ElytronDescriptionConstants.CREATION_DATE).set(sdf.format(creationDate));
+            }
+
+            Certificate[] chain = keyStore.getCertificateChain(name);
+            if (chain == null) {
+                Certificate cert = keyStore.getCertificate(name);
+                if (cert != null) {
+                    writeCertificate(result.get(ElytronDescriptionConstants.CERTIFICATE), cert, verbose);
+                }
+            } else {
+                writeCertificates(result.get(ElytronDescriptionConstants.CERTIFICATE_CHAIN), chain, verbose);
             }
         }
     }

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1009,6 +1009,8 @@ elytron.modifiable-key-store.read-alias=Read an alias from a KeyStore.
 elytron.modifiable-key-store.read-alias.name=The name of alias of the KeyStore item to read.
 elytron.modifiable-key-store.read-alias.verbose=Instruct read to show HEX format fields content.
 elytron.modifiable-key-store.read-aliases=Read aliases from a KeyStore.
+elytron.modifiable-key-store.read-aliases.recursive=Read more than name of aliases in keystore.
+elytron.modifiable-key-store.read-aliases.verbose=Include HEX form fields in case of recursive read.
 elytron.modifiable-key-store.remove-alias=Remove an alias from a KeyStore.
 elytron.modifiable-key-store.remove-alias.name=The name of alias of the KeyStore item to remove.
 

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1006,10 +1006,11 @@ elytron.key-store.alias.certificate-chain.signature=The signature of the certifi
 elytron.key-store.alias.certificate-chain.version=The certificate version.
 
 elytron.modifiable-key-store.read-alias=Read an alias from a KeyStore.
-elytron.modifiable-key-store.read-alias.alias=The alias of the KeyStore item to read.
+elytron.modifiable-key-store.read-alias.name=The name of alias of the KeyStore item to read.
+elytron.modifiable-key-store.read-alias.verbose=Instruct read to show HEX format fields content.
 elytron.modifiable-key-store.read-aliases=Read aliases from a KeyStore.
 elytron.modifiable-key-store.remove-alias=Remove an alias from a KeyStore.
-elytron.modifiable-key-store.remove-alias.alias=The alias of the KeyStore item to remove.
+elytron.modifiable-key-store.remove-alias.name=The name of alias of the KeyStore item to remove.
 
 elytron.modifiable-key-store.generate-key-pair=Generate a key pair and wrap the resulting public key in a self-signed X.509 certificate. The generated private key and self-signed certificate will be added to the KeyStore.
 elytron.modifiable-key-store.generate-key-pair.alias=The alias of the new KeyStore entry.

--- a/elytron/src/test/java/org/wildfly/extension/elytron/CertificateAuthoritiesTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CertificateAuthoritiesTestCase.java
@@ -395,7 +395,7 @@ public class CertificateAuthoritiesTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(Boolean.TRUE);
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store", keyStoreName);
         operation.get(ClientConstants.OP).set(ClientConstants.ADD);
-        operation.get(ElytronDescriptionConstants.PATH).set(resources + "/test-copy.keystore");
+        operation.get(ElytronDescriptionConstants.PATH).set("test-copy.keystore");
         operation.get(ElytronDescriptionConstants.TYPE).set("JKS");
         operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set(KEYSTORE_PASSWORD);
         assertSuccess(services.executeOperation(operation));

--- a/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
@@ -433,7 +433,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(Boolean.TRUE);
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store", "ModifiedKeyStore");
         operation.get(ClientConstants.OP).set(ClientConstants.ADD);
-        operation.get(ElytronDescriptionConstants.PATH).set(resources + "/firefly-copy.keystore");
+        operation.get(ElytronDescriptionConstants.PATH).set("firefly-copy.keystore");
         operation.get(ElytronDescriptionConstants.TYPE).set("JKS");
         operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set("Elytron");
         assertSuccess(services.executeOperation(operation));
@@ -448,7 +448,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(Boolean.TRUE);
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store","ModifiedKeyStore");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.REMOVE_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set("ca");
+        operation.get(ElytronDescriptionConstants.NAME).set("ca");
         assertSuccess(services.executeOperation(operation));
 
         operation = new ModelNode();
@@ -493,9 +493,9 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add(ElytronDescriptionConstants.FILTERING_KEY_STORE,"FilteringKeyStore");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set("firefly");
+        operation.get(ElytronDescriptionConstants.NAME).set("firefly");
         ModelNode firefly = assertSuccess(services.executeOperation(operation)).get(ClientConstants.RESULT);
-        assertEquals("firefly", firefly.get(ElytronDescriptionConstants.ALIAS).asString());
+        assertEquals("firefly", firefly.get(ElytronDescriptionConstants.NAME).asString());
         assertEquals(KeyStore.PrivateKeyEntry.class.getSimpleName(), firefly.get(ElytronDescriptionConstants.ENTRY_TYPE).asString());
         assertTrue(firefly.get(ElytronDescriptionConstants.CERTIFICATE_CHAIN).isDefined());
     }
@@ -538,18 +538,18 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add(ElytronDescriptionConstants.KEY_STORE,"AutomaticKeystore");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set("firefly");
+        operation.get(ElytronDescriptionConstants.NAME).set("firefly");
         ModelNode firefly = assertSuccess(services.executeOperation(operation)).get(ClientConstants.RESULT);
-        assertEquals("firefly", firefly.get(ElytronDescriptionConstants.ALIAS).asString());
+        assertEquals("firefly", firefly.get(ElytronDescriptionConstants.NAME).asString());
         assertEquals(KeyStore.PrivateKeyEntry.class.getSimpleName(), firefly.get(ElytronDescriptionConstants.ENTRY_TYPE).asString());
         assertTrue(firefly.get(ElytronDescriptionConstants.CERTIFICATE_CHAIN).isDefined());
 
         operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add(ElytronDescriptionConstants.KEY_STORE,"AutomaticKeystore");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set("ca");
+        operation.get(ElytronDescriptionConstants.NAME).set("ca");
         ModelNode ca = assertSuccess(services.executeOperation(operation)).get(ClientConstants.RESULT);
-        assertEquals("ca", ca.get(ElytronDescriptionConstants.ALIAS).asString());
+        assertEquals("ca", ca.get(ElytronDescriptionConstants.NAME).asString());
         assertEquals(KeyStore.TrustedCertificateEntry.class.getSimpleName(), ca.get(ElytronDescriptionConstants.ENTRY_TYPE).asString());
     }
 
@@ -643,7 +643,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             extensions.add(getExtension(true, "KeyUsage", "digitalSignature"));
             operation.get(ElytronDescriptionConstants.EXTENSIONS).set(extensions);
             operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set(KEY_PASSWORD);
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + csrFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(csrFileName);
             assertSuccess(services.executeOperation(operation));
 
             assertTrue(csrFile.exists());
@@ -695,8 +695,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.IMPORT_CERTIFICATE);
             operation.get(ElytronDescriptionConstants.ALIAS).set("ssmith");
             operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set(KEY_PASSWORD);
-            Path resources = Paths.get(KeyStoresTestCase.class.getResource(".").toURI());
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + replyFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(replyFileName);
             assertSuccess(services.executeOperation(operation));
 
             alias = readAlias("ssmith");
@@ -747,8 +746,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.IMPORT_CERTIFICATE);
             operation.get(ElytronDescriptionConstants.ALIAS).set("ssmith");
             operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set(KEY_PASSWORD);
-            Path resources = Paths.get(KeyStoresTestCase.class.getResource(".").toURI());
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + replyFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(replyFileName);
             operation.get(ElytronDescriptionConstants.VALIDATE).set(validate);
             operation.get(ElytronDescriptionConstants.TRUST_CACERTS).set(true);
 
@@ -794,8 +792,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add("key-store", KEYSTORE_NAME);
             operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.IMPORT_CERTIFICATE);
             operation.get(ElytronDescriptionConstants.ALIAS).set("intermediateCA");
-            Path resources = Paths.get(KeyStoresTestCase.class.getResource(".").toURI());
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + replyFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(replyFileName);
             operation.get(ElytronDescriptionConstants.TRUST_CACERTS).set(true);
             assertSuccess(services.executeOperation(operation));
             assertEquals(numAliasesBefore + 1, readAliases().size());
@@ -838,8 +835,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add("key-store", KEYSTORE_NAME);
             operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.IMPORT_CERTIFICATE);
             operation.get(ElytronDescriptionConstants.ALIAS).set("anotherCA");
-            Path resources = Paths.get(KeyStoresTestCase.class.getResource(".").toURI());
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + replyFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(replyFileName);
             operation.get(ElytronDescriptionConstants.VALIDATE).set(validate);
             operation.get(ElytronDescriptionConstants.TRUST_CACERTS).set(true);
 
@@ -880,7 +876,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add("key-store", KEYSTORE_NAME);
             operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.EXPORT_CERTIFICATE);
             operation.get(ElytronDescriptionConstants.ALIAS).set("ssmith");
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + certificateFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(certificateFileName);
             assertSuccess(services.executeOperation(operation));
 
             assertTrue(certificateFile.exists());
@@ -909,7 +905,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
             operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add("key-store", KEYSTORE_NAME);
             operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.EXPORT_CERTIFICATE);
             operation.get(ElytronDescriptionConstants.ALIAS).set("ssmith");
-            operation.get(ElytronDescriptionConstants.PATH).set(resources + certificateFileName);
+            operation.get(ElytronDescriptionConstants.PATH).set(certificateFileName);
             operation.get(ElytronDescriptionConstants.PEM).set(true);
             assertSuccess(services.executeOperation(operation));
 
@@ -1233,7 +1229,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(Boolean.TRUE);
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store", keyStoreName);
         operation.get(ClientConstants.OP).set(ClientConstants.ADD);
-        operation.get(ElytronDescriptionConstants.PATH).set(resources + "/test-copy.keystore");
+        operation.get(ElytronDescriptionConstants.PATH).set("test-copy.keystore");
         operation.get(ElytronDescriptionConstants.TYPE).set("JKS");
         operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set(keyStorePassword);
         assertSuccess(services.executeOperation(operation));
@@ -1251,7 +1247,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(Boolean.TRUE);
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store", KEYSTORE_NAME);
         operation.get(ClientConstants.OP).set(ClientConstants.ADD);
-        operation.get(ElytronDescriptionConstants.PATH).set(resources + "/test-copy.keystore");
+        operation.get(ElytronDescriptionConstants.PATH).set("test-copy.keystore");
         operation.get(ElytronDescriptionConstants.TYPE).set("JKS");
         operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set("Elytron");
         assertSuccess(services.executeOperation(operation));
@@ -1268,9 +1264,9 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store", KEYSTORE_NAME);
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set(aliasName);
+        operation.get(ElytronDescriptionConstants.NAME).set(aliasName);
         ModelNode alias = assertSuccess(services.executeOperation(operation)).get(ClientConstants.RESULT);
-        assertEquals(aliasName, alias.get(ElytronDescriptionConstants.ALIAS).asString());
+        assertEquals(aliasName, alias.get(ElytronDescriptionConstants.NAME).asString());
         return alias;
     }
 
@@ -1303,7 +1299,7 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(Boolean.TRUE);
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add("key-store", KEYSTORE_NAME);
         operation.get(ClientConstants.OP).set(ClientConstants.ADD);
-        operation.get(ElytronDescriptionConstants.PATH).set(resources + nonExistentFileName);
+        operation.get(ElytronDescriptionConstants.PATH).set(nonExistentFileName);
         operation.get(ElytronDescriptionConstants.TYPE).set("JKS");
         operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set("Elytron");
         if (required) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
@@ -341,7 +341,7 @@ public class LdapTestCase extends AbstractSubsystemTest {
         operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add("ldap-key-store", keystoreName);
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set(alias);
+        operation.get(ElytronDescriptionConstants.NAME).set(alias);
 
         ModelNode aliasNode = assertSuccess(services.executeOperation(operation)).get(ClientConstants.RESULT);
         Assert.assertNotNull(aliasNode.get(ElytronDescriptionConstants.CREATION_DATE).asString());
@@ -386,7 +386,7 @@ public class LdapTestCase extends AbstractSubsystemTest {
         operation = new ModelNode(); // remove through subsystem operation
         operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add("ldap-key-store", "LdapKeyStoreMaximal");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.REMOVE_ALIAS);
-        operation.get(ElytronDescriptionConstants.ALIAS).set("serenity2");
+        operation.get(ElytronDescriptionConstants.NAME).set("serenity2");
         assertSuccess(services.executeOperation(operation)).get(ClientConstants.RESULT);
         Assert.assertNull(keyStore.getKey("serenity2", "password2".toCharArray()));
         Assert.assertEquals(1, keyStore.size());

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -369,7 +369,7 @@ public class TlsTestCase extends AbstractSubsystemTest {
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add(ElytronDescriptionConstants.KEY_STORE, INIT_TEST_TRUSTSTORE);
         operation.get(ClientConstants.OP).set(ClientConstants.ADD);
-        operation.get(ElytronDescriptionConstants.PATH).set(resources + INIT_TEST_FILE);
+        operation.get(ElytronDescriptionConstants.PATH).set(INIT_TEST_FILE);
         operation.get(ElytronDescriptionConstants.TYPE).set("JKS");
         operation.get(CredentialReference.CREDENTIAL_REFERENCE).get(CredentialReference.CLEAR_TEXT).set("Elytron");
         Assert.assertEquals(services.executeOperation(operation).get(OUTCOME).asString(), SUCCESS);

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -6,7 +6,7 @@
     <security-realms>
 
         <properties-realm name="HashedPropertyRealm">
-            <users-properties path="target/test-classes/org/wildfly/extension/elytron/users-hashed.properties" digest-realm-name="Hashed" />
+            <users-properties path="users-hashed.properties" digest-realm-name="Hashed" />
         </properties-realm>
 
         <properties-realm name="ClearPropertyRealm" groups-attribute="groupAttr">
@@ -40,7 +40,7 @@
             <key-store name="ElytronCaTruststore" >
                 <credential-reference clear-text="Elytron"/>
                 <implementation type="JKS" />
-                <file path="target/test-classes/org/wildfly/extension/elytron/ca.truststore"/>
+                <file path="ca.truststore"/>
             </key-store>
         </key-stores>
         <trust-managers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -36,12 +36,12 @@
             <key-store name="ElytronCaTruststore" >
                 <credential-reference clear-text="Elytron"/>
                 <implementation type="JKS" />
-                <file path="target/test-classes/org/wildfly/extension/elytron/ca.truststore"/>
+                <file path="ca.truststore"/>
             </key-store>
             <key-store name="NewKeyStore" >
                 <credential-reference clear-text="Elytron"/>
                 <implementation type="JKS" />
-                <file path="target/not-existing.keystore" required="false"/>
+                <file path="not-existing.keystore" required="false"/>
             </key-store>
             <key-store name="AutomaticKeystore" >
                 <credential-reference clear-text="Elytron"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -36,12 +36,12 @@
             <key-store name="ElytronCaTruststore" >
                 <credential-reference clear-text="Elytron"/>
                 <implementation type="JKS" />
-                <file path="target/test-classes/org/wildfly/extension/elytron/ca.truststore"/>
+                <file path="ca.truststore"/>
             </key-store>
             <key-store name="NewKeyStore" >
                 <credential-reference clear-text="Elytron"/>
                 <implementation type="JKS" />
-                <file path="target/not-existing.keystore" required="false"/>
+                <file path="not-existing.keystore" required="false"/>
             </key-store>
             <key-store name="AutomaticKeystore" >
                 <credential-reference clear-text="Elytron"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4314

* read-alias
  -- dumps HEXed key, signature etc. Usually its not required? Add 'verbose' parameter
  -- requires 'alias' parameter, maybe should be 'name' to align with other server resources?
* read-aliases - add 'recursive' and 'verbose'(check above) to allow read of more than names?
* add default 'relative-to' to avoid punching "jboss.server.config.dir"