### PR TITLE
[WFCORE-4334] Upgrade to Galleon and WFGP 3.0.1.Final

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -62,6 +62,7 @@
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -73,6 +73,7 @@
                                     <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
                                     <record-state>false</record-state>
                                     <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
                                     <plugin-options>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>

--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>3.0.1.CR2</version.org.jboss.galleon>
+        <version.org.jboss.galleon>3.0.1.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>3.0.1.CR3</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>3.0.1.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -100,6 +100,7 @@
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -117,6 +117,7 @@
                                 <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
                                 <record-state>false</record-state>
                                 <log-time>${galleon.log.time}</log-time>
+                                <offline>true</offline>
                                 <plugin-options>
                                     <jboss-maven-dist/>
                                     <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -38,6 +38,7 @@
                             <install-dir>${project.build.directory}/layers-results/test-standalone-reference</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
@@ -67,6 +68,7 @@
                             <install-dir>${project.build.directory}/layers-results/base-server</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -101,6 +103,7 @@
                             <install-dir>${project.build.directory}/layers-results/core-management</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -135,6 +138,7 @@
                             <install-dir>${project.build.directory}/layers-results/core-server</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -169,6 +173,7 @@
                             <install-dir>${project.build.directory}/layers-results/deployment-scanner</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -203,6 +208,7 @@
                             <install-dir>${project.build.directory}/layers-results/discovery</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -237,6 +243,7 @@
                             <install-dir>${project.build.directory}/layers-results/elytron</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -271,6 +278,7 @@
                             <install-dir>${project.build.directory}/layers-results/io</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -305,6 +313,7 @@
                             <install-dir>${project.build.directory}/layers-results/jmx</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -339,6 +348,7 @@
                             <install-dir>${project.build.directory}/layers-results/jmx-remoting</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -373,6 +383,7 @@
                             <install-dir>${project.build.directory}/layers-results/secure-management-realms-security</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -407,6 +418,7 @@
                             <install-dir>${project.build.directory}/layers-results/logging</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -441,6 +453,7 @@
                             <install-dir>${project.build.directory}/layers-results/management</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -475,6 +488,7 @@
                             <install-dir>${project.build.directory}/layers-results/remoting</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -509,6 +523,7 @@
                             <install-dir>${project.build.directory}/layers-results/request-controller</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -543,6 +558,7 @@
                             <install-dir>${project.build.directory}/layers-results/security-manager</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -577,6 +593,7 @@
                             <install-dir>${project.build.directory}/layers-results/core-tools</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
@@ -611,6 +628,7 @@
                             <install-dir>${project.build.directory}/layers-results/test-all-layers</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -152,6 +152,7 @@
                                     <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
                                     <record-state>false</record-state>
                                     <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
                                     <plugin-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/testsuite/patching/pom.xml
+++ b/testsuite/patching/pom.xml
@@ -78,6 +78,7 @@
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -77,6 +77,7 @@
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -123,6 +123,7 @@
                             <install-dir>${project.build.directory}/${server.output.dir.prefix}</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4334

The `offline=true` added to `provision` goal is not changing anything for our builds, since all the artifacts needed to produce the dist have already been built and/or installed in the local repo by the Maven build process. This option simply makes sure that if one day Galleon needs to resolve something from a remote repo, it will fail.