### PR TITLE
[WFCORE-4343] / [WFCORE-4344] / [ WFCORE-4345] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.8.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.4.0.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.elytron.tool>1.6.0.CR1</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.6.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.8.0.CR2</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.8.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.4.0.CR1</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.6.0.CR1</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.8.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.4.0.CR1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.4.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.6.0.CR1</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4343
https://issues.jboss.org/browse/WFCORE-4344
https://issues.jboss.org/browse/WFCORE-4345

No changes were made to WildFly Elytron Tool other than component upgrades to bring dependencies in-line with WildFly Core versions, including the upgrade to WildFly Elytron 1.8.0.Final.


        Release Notes - WildFly Elytron - Version 1.8.0.Final
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1464'>ELY-1464</a>] -         Programatic authentication should be caching the SecurityIdentity not the name of the identity
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1677'>ELY-1677</a>] -         Elytron Bearer Token Authentication - Return a 401 on Invalid Token
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1690'>ELY-1690</a>] -         JDK11 unknown cipher suites 
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1691'>ELY-1691</a>] -         Add test if Mechansim Database cover cipher suites from JDK
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1703'>ELY-1703</a>] -         Intermittent failure of PrincipalMappingSuiteChild#testDnToDnVerify
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1758'>ELY-1758</a>] -         Release WildFly Elytron 1.8.0.Final
</li>
</ul>



        Release Notes - Elytron Web - Version 1.4.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-45'>ELYWEB-45</a>] -         Bring the dependency versions in-line with WildFly Core
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-46'>ELYWEB-46</a>] -         Elytron Bearer Token Authentication - Return a 401 on Invalid Token test fix
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-44'>ELYWEB-44</a>] -         Release Elytron Web 1.4.0.Final
</li>
</ul>
                                        