### PR TITLE
WFCORE-4347: upgrade WildFly Maven Plugins to 2.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.plugins>2.0.0.Beta2</version.org.wildfly.plugins>
+        <version.org.wildfly.plugins>2.0.0.Final</version.org.wildfly.plugins>
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>
         <version.versions.plugin>2.5</version.versions.plugin>
         <version.xml.plugin>1.0.1</version.xml.plugin>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFCORE-4347