### PR TITLE
[WFCORE-4348] Ignore Windows tests until the cause of the CI failures…

### DIFF
--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -49,6 +49,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -108,6 +109,7 @@ public abstract class ScriptTestCase {
     }
 
     @Test
+    @Ignore("WFCORE-4348 - tests are currently failing on Windows CI runs")
     public void testBatchScript() throws Exception {
         Assume.assumeTrue(Environment.isWindows());
         try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".bat"), check)) {
@@ -116,6 +118,7 @@ public abstract class ScriptTestCase {
     }
 
     @Test
+    @Ignore("WFCORE-4348 - tests are currently failing on Windows CI runs")
     public void testPowerShellScript() throws Exception {
         Assume.assumeTrue(Environment.isWindows() && isShellSupported("powershell", "-Help"));
         try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".ps1"), check, POWER_SHELL_PREFIX)) {


### PR DESCRIPTION
… can be determined.

https://issues.jboss.org/browse/WFCORE-4348

This is not a fix for the issues. It just disables the tests to get clean CI runs while investigating the issue.