### PR TITLE
[WFCORE-4348] Re-enable and fix Windows script tests

### DIFF
--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <!-- By default the scripts and configurations expect an IPv4 address so we should use one by default -->
         <jboss.test.script.address>127.0.0.1</jboss.test.script.address>
-        <jboss.test.start.timeout>20</jboss.test.start.timeout>
+        <jboss.test.start.timeout>120</jboss.test.start.timeout>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
         <test.log.level>INFO</test.log.level>
         <test.log.file>${project.build.directory}${file.separator}test.log</test.log.file>

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Environment.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Environment.java
@@ -59,7 +59,7 @@ public class Environment {
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to create the log directory", e);
         }
-        final String timeoutString = System.getProperty("jboss.test.start.timeout", "20");
+        final String timeoutString = System.getProperty("jboss.test.start.timeout", "120");
         TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
     }
 

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -68,6 +68,8 @@ public abstract class ScriptTestCase {
 
     private static final String[] POWER_SHELL_PREFIX = {
             "powershell",
+            "-ExecutionPolicy",
+            "Unrestricted",
             "-NonInteractive",
             "-File"
     };

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -42,14 +42,12 @@ import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -111,7 +109,6 @@ public abstract class ScriptTestCase {
     }
 
     @Test
-    @Ignore("WFCORE-4348 - tests are currently failing on Windows CI runs")
     public void testBatchScript() throws Exception {
         Assume.assumeTrue(Environment.isWindows());
         try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".bat"), check)) {
@@ -120,7 +117,6 @@ public abstract class ScriptTestCase {
     }
 
     @Test
-    @Ignore("WFCORE-4348 - tests are currently failing on Windows CI runs")
     public void testPowerShellScript() throws Exception {
         Assume.assumeTrue(Environment.isWindows() && isShellSupported("powershell", "-Help"));
         try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".ps1"), check, POWER_SHELL_PREFIX)) {
@@ -160,7 +156,7 @@ public abstract class ScriptTestCase {
     }
 
     void validateProcess(final ScriptProcess script) throws InterruptedException, IOException {
-        if (script.waitFor(TimeoutUtil.adjust(10), TimeUnit.SECONDS)) {
+        if (script.waitFor(Environment.getTimeout(), TimeUnit.SECONDS)) {
             // The script has exited, validate the exit code is valid
             final int exitValue = script.exitValue();
             if (exitValue != 0) {


### PR DESCRIPTION
### [WFCORE-4349](https://issues.jboss.org/browse/WFCORE-4349) 
The first commit just adds a command to make the Windows PowerShell scripts more generally work. I had a case where I had an update on my local VM that broke the tests because of the execution policy.

### [WFCORE-4348](https://issues.jboss.org/browse/WFCORE-4348)
This commit increases the timeout to 2 minutes. There was also a change to hopefully help the destroy wait to move on until the process is destroyed.