### PR TITLE
[WFCORE-4351] Replace fixed value in message with variable effectivel…

### DIFF
--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -163,7 +163,7 @@ public abstract class ScriptTestCase {
                 Assert.fail(script.getErrorMessage(String.format("Expected an exit value 0f 0 got %d", exitValue)));
             }
         } else {
-            Assert.fail(script.getErrorMessage("The script process did not exit within 10 seconds."));
+            Assert.fail(script.getErrorMessage("The script process did not exit within " + Environment.getTimeout() + " seconds."));
         }
     }
 

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -230,7 +230,7 @@ public class Server {
             }
             if (!serverAvailable) {
                 destroyProcess();
-                throw new RuntimeException("Managed server was not started within 30s");
+                throw new RuntimeException("Managed server was not started within " + startupTimeout + " seconds.");
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
…y used

The messages uses a fixed value of 10, but this is only the default value and no longer correct.
Use the dynamic value.

Jira https://issues.jboss.org/browse/WFCORE-4351.
Related to WFCORE-4348.