### PR TITLE
Fix for WFCORE-4305, CLI, new option to enable properties resolution

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -193,7 +193,7 @@ class CliConfigImpl implements CliConfig {
         cliConfig.validateOperationRequests = configuration.isValidateOperationRequests() != null ? configuration.isValidateOperationRequests() : cliConfig.validateOperationRequests;
         cliConfig.outputJSON                = configuration.isOutputJSON()                        ? configuration.isOutputJSON()                : cliConfig.isOutputJSON();
         cliConfig.outputPaging              = !configuration.isOutputPaging()                     ? configuration.isOutputPaging()              : cliConfig.isOutputPaging();
-
+        cliConfig.resolveParameterValues    = configuration.isResolveParameterValues()            ? configuration.isResolveParameterValues()    : cliConfig.resolveParameterValues;
         if (!configuration.isColorOutput()) {
             cliConfig.colorOutput = false;
         } else if (configuration.isColorOutput() && cliConfig.colorConfig == null) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -170,6 +170,8 @@ public class CliLauncher {
                     ctxBuilder.setColorOutput(false);
                 } else if (arg.equals("--no-output-paging")) {
                     ctxBuilder.setOutputPaging(false);
+                } else if (arg.equals("--resolve-parameter-values")) {
+                    ctxBuilder.setResolveParameterValues(true);
                 } else if (arg.startsWith("--command-timeout=")) {
                     ctxBuilder.
                             setCommandTimeout(Integer.parseInt(arg.substring(18)));

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
@@ -45,10 +45,12 @@ public class CommandContextConfiguration {
     private final boolean outputJSON;
     private final boolean colorOutput;
     private final boolean outputPaging;
+    private final boolean resolveParameters;
 
     private CommandContextConfiguration(String controller, String username, char[] password, String clientBindAddress,
             boolean disableLocalAuth, boolean initConsole, int connectionTimeout, InputStream consoleInput, OutputStream consoleOutput,
-            boolean echoCommand, Integer commandTimeout, boolean outputJSON, boolean colorOutput, boolean outputPaging) {
+            boolean echoCommand, Integer commandTimeout, boolean outputJSON, boolean colorOutput,
+            boolean outputPaging, boolean resolveParameters) {
         this.controller = controller;
         this.username = username;
         this.password = password;
@@ -63,6 +65,7 @@ public class CommandContextConfiguration {
         this.outputJSON = outputJSON;
         this.colorOutput = colorOutput;
         this.outputPaging = outputPaging;
+        this.resolveParameters = resolveParameters;
     }
 
     public Integer getCommandTimeout() {
@@ -133,6 +136,10 @@ public class CommandContextConfiguration {
         return colorOutput;
     }
 
+    public boolean isResolveParameterValues() {
+        return resolveParameters;
+    }
+
     public static class Builder {
         private String controller;
         private String username;
@@ -152,6 +159,7 @@ public class CommandContextConfiguration {
         private boolean outputJSON;
         private boolean colorOutput;
         private boolean outputPaging = true;
+        private boolean resolveParameters;
 
         public Builder() {
         }
@@ -162,7 +170,7 @@ public class CommandContextConfiguration {
             }
             final CommandContextConfiguration config = new CommandContextConfiguration(controller, username, password,
                     clientBindAddress, disableLocalAuth, initConsole, connectionTimeout, consoleInput, consoleOutput,
-                    echoCommand, commandTimeout, outputJSON, colorOutput, outputPaging);
+                    echoCommand, commandTimeout, outputJSON, colorOutput, outputPaging, resolveParameters);
             config.silent = silent;
             config.errorOnInteract = errorOnInteract;
             config.validateOperationRequests = validateOperationRequests;
@@ -256,6 +264,11 @@ public class CommandContextConfiguration {
 
         public Builder setOutputPaging(boolean outputPaging) {
             this.outputPaging = outputPaging;
+            return this;
+        }
+
+        public Builder setResolveParameterValues(boolean resolveParameters) {
+            this.resolveParameters = resolveParameters;
             return this;
         }
     }

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -17,6 +17,7 @@ Usage:
                      [--output-json]
                      [--no-color-output]
                      [--no-output-paging]
+                     [--resolve-parameter-values]
 
  --help (-h)     - prints (this) basic description of the command line utility.
 
@@ -108,7 +109,11 @@ Usage:
 
  --no-color-output  - disable CLI output and prompt colors.
 
- --no-output-paging - disable output paging (the possibility to browse and search in output of commands) and print the output of commands at once.
+ --no-output-paging - disable output paging (the possibility to browse 
+                      and search in output of commands) and print the output of commands at once.
+
+ --resolve-parameter-values  - resolve system properties before sending 
+                               the operation requests to the controller.
 
 For a list of available commands, once the CLI is started, execute:
 


### PR DESCRIPTION
Fix for CLI, new option to enable properties resolution, EAP7-1190
Analysis: https://github.com/wildfly/wildfly-proposals/pull/173/
No community doc,  help contains documentation of new option.
Added new option --resolve-parameter-values and test.

https://issues.jboss.org/browse/WFCORE-4305