### PR TITLE
Fix for WFCORE-4354, secure-management layer doesn't secure direct http access

### DIFF
--- a/core-galleon-pack/src/main/resources/layers/standalone/secure-management/layer-spec.xml
+++ b/core-galleon-pack/src/main/resources/layers/standalone/secure-management/layer-spec.xml
@@ -7,6 +7,7 @@
     
     <feature spec="core-service.management.management-interface.http-interface">
         <param name="socket-binding" value="management-http"/>
+        <param name="http-authentication-factory" value="management-http-authentication"/>
         <feature spec="core-service.management.management-interface.http-interface.http-upgrade">
             <param name="sasl-authentication-factory" value="management-sasl-authentication"/>
         </feature>


### PR DESCRIPTION
- Set elytron http-authentication factory.
- Tested with private branch org.wildfly.test.integration.microprofile.metrics.secured.MicroProfileMetricsSecuredEndpointTestCase and org.wildfly.test.integration.microprofile.health.MicroProfileHealthSecuredHTTPEndpointTestCase