### PR TITLE
[WFCORE-4359] Ensure the CLI embedded stdio and log contexts are used for CLI loggers.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/ThreadLocalContextSelector.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/ThreadLocalContextSelector.java
@@ -26,10 +26,14 @@ import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.LogContextSelector;
 import org.jboss.stdio.StdioContext;
 import org.jboss.stdio.StdioContextSelector;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * {@link org.jboss.stdio.StdioContextSelector} and {@link org.jboss.logmanager.LogContextSelector}
  * that uses an {@link java.lang.InheritableThreadLocal} as a source of the contexts.
+ * <p>
+ * Note that if the logger is a CLI logger the default contexts will be used regardless of the thread-local contexts.
+ * </p>
  *
  * @author Brian Stansberry (c) 2015 Red Hat Inc.
  */
@@ -39,6 +43,7 @@ class ThreadLocalContextSelector implements LogContextSelector, StdioContextSele
 
     private final Contexts localContexts;
     private final Contexts defaultContexts;
+    private final ClassLoader cliClassLoader;
 
     ThreadLocalContextSelector(Contexts local, Contexts defaults) {
         assert local != null;
@@ -48,6 +53,7 @@ class ThreadLocalContextSelector implements LogContextSelector, StdioContextSele
         assert defaults.getLogContext() != null;
         this.localContexts = local;
         this.defaultContexts = defaults;
+        cliClassLoader = ThreadLocalContextSelector.class.getClassLoader();
     }
 
     Contexts pushLocal() {
@@ -62,6 +68,10 @@ class ThreadLocalContextSelector implements LogContextSelector, StdioContextSele
 
     @Override
     public StdioContext getStdioContext() {
+        // CLI loggers should only use the default stdio context regardless if the thread-local context is set.
+        if (WildFlySecurityManager.getCurrentContextClassLoaderPrivileged().equals(cliClassLoader)) {
+            return defaultContexts.getStdioContext();
+        }
         Contexts threadContext = threadLocal.get();
         StdioContext local = threadContext != null ? threadContext.getStdioContext() : null;
         return local == null ? defaultContexts.getStdioContext() : local;
@@ -69,6 +79,11 @@ class ThreadLocalContextSelector implements LogContextSelector, StdioContextSele
 
     @Override
     public LogContext getLogContext() {
+        // CLI loggers should only use the default stdio context regardless if the thread-local context is set This
+        // allows the context configured for CLI, e.g. jboss-cli-logging.properties.
+        if (WildFlySecurityManager.getCurrentContextClassLoaderPrivileged().equals(cliClassLoader)) {
+            return defaultContexts.getLogContext();
+        }
         Contexts threadContext = threadLocal.get();
         LogContext local = threadContext != null ? threadContext.getLogContext() : null;
         return local == null ? defaultContexts.getLogContext() : local;

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelector.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelector.java
@@ -112,12 +112,22 @@ public interface WildFlyLogContextSelector extends LogContextSelector {
     class Factory {
         private static final LogContext EMBEDDED_LOG_CONTEXT = LogContext.create();
 
+        /**
+         * Creates a new selector which wraps the current {@linkplain LogContext#getLogContextSelector() selector}.
+         *
+         * @return a new selector that wraps the current selector
+         */
         public static WildFlyLogContextSelector create() {
-            // Use the current log context as the default, not LogContext.DEFAULT_LOG_CONTEXT_SELECTOR
-            // This allows embedding use cases to control the log context
-            return new WildFlyLogContextSelectorImpl(LogContext.getLogContext());
+            // Wrap the current LogContextSelector. This will be used as the default in the cases where this selector
+            // does not find a log context.
+            return new WildFlyLogContextSelectorImpl(LogContext.getLogContextSelector());
         }
 
+        /**
+         * Creates a new selector which by default returns a static embedded context which can be used.
+         *
+         * @return a new selector
+         */
         public static WildFlyLogContextSelector createEmbedded() {
             clearLogContext();
             return new WildFlyLogContextSelectorImpl(EMBEDDED_LOG_CONTEXT);

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
@@ -41,13 +41,17 @@ class WildFlyLogContextSelectorImpl implements WildFlyLogContextSelector {
     private final AtomicInteger counter;
 
     WildFlyLogContextSelectorImpl(final LogContext defaultLogContext) {
-        counter = new AtomicInteger(0);
-        contextSelector = new ClassLoaderLogContextSelector(new LogContextSelector() {
+        this(new ClassLoaderLogContextSelector(new LogContextSelector() {
             @Override
             public LogContext getLogContext() {
                 return defaultLogContext;
             }
-        }, true);
+        }));
+    }
+
+    WildFlyLogContextSelectorImpl(final LogContextSelector defaultLogContextSelector) {
+        counter = new AtomicInteger(0);
+        contextSelector = new ClassLoaderLogContextSelector(defaultLogContextSelector, true);
         threadLocalContextSelector = new ThreadLocalLogContextSelector(contextSelector);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.7.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.8.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.0.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
### [WFCORE-4358](https://issues.jboss.org/browse/WFCORE-4358l)

This commit just upgrades the log manager with a single commit to expose the [`LogContext.getLogContextSelector()`](https://issues.jboss.org/browse/LOGMGR-241) which is required for the second commit.

### [WFCORE-4358](https://issues.jboss.org/browse/WFCORE-4359)
This commit fixes the issue where the incorrect log context could be used when creating CLI loggers and the incorrect `StdioContext` being used when CLI writes log messages.

Instead of just wrapping the current `LogContext` this wraps the CLI `ThreadLocalContextSelector` instead to ensure the correct contexts are used. I tested both the `embed-server` and `embed-host-controller` with the `jboss-cli.sh` script and the `jboss-cli-client.jar`. Log messages from CLI will now use the `jboss-cli-logging.properties` configuration (assuming that's used) and log messages from the server us the correct contexts from the server itself.

@jfdenise Could you please have a look and approve this?