### PR TITLE
WFCORE-4363 No need to handle error page request if console is disabled

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -379,10 +379,12 @@ public class ManagementHttpServer {
             ROOT_LOGGER.consoleModuleNotFound(builder.consoleSlot == null ? "main" : builder.consoleSlot);
         }
 
-        try {
-            addErrorContextHandler(pathHandler, builder);
-        } catch (ModuleLoadException e) {
-            ROOT_LOGGER.errorContextModuleNotFound(builder.consoleSlot == null ? "main" : builder.consoleSlot);
+        if (builder.consoleMode.hasConsole()) {
+            try {
+                addErrorContextHandler(pathHandler, builder);
+            } catch (ModuleLoadException e) {
+                ROOT_LOGGER.errorContextModuleNotFound(builder.consoleSlot == null ? "main" : builder.consoleSlot);
+            }
         }
 
         ManagementRootConsoleRedirectHandler rootConsoleRedirectHandler = new ManagementRootConsoleRedirectHandler(consoleHandler);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4363
It's unnecessary to add ErrorContextHandler for http://localhost:9990/error/ if the console is disabled.