### PR TITLE
Fix for WFCORE-4372, Upgrade CLI to use aesh 2.0

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/AeshCommands.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/AeshCommands.java
@@ -147,11 +147,18 @@ public class AeshCommands {
             return execution.getCommand() instanceof OperationCommand;
         }
 
-        public String getLine() {
+        public String getLine() throws CommandLineParserException, OptionValidatorException {
             if (execution.getCommand() instanceof SpecialCommand) {
+                // SpecialCommand must be ppopulated for Parsing to occur and
+                // command part to be extracted from chained operators.
+                execution.populateCommand();
                 return ((SpecialCommand) execution.getCommand()).getLine();
             }
             return null;
+        }
+
+        public void populateCommand() throws CommandLineParserException, OptionValidatorException {
+            execution.populateCommand();
         }
 
         public CommandHandler getLegacyHandler() {
@@ -164,7 +171,7 @@ public class AeshCommands {
     }
 
     private final CLICommandInvocationBuilder invocationBuilder;
-    private final CommandRuntime<Command<CLICommandInvocation>, CLICommandInvocation> processor;
+    private final CommandRuntime<CLICommandInvocation> processor;
     private final CLICommandRegistry registry;
     private final CLICompletionHandler completionHandler;
 
@@ -265,6 +272,8 @@ public class AeshCommands {
                         exe.execution.execute();
                     } catch (CommandException | CommandValidatorException ex) {
                         throw new CommandLineException(ex.getLocalizedMessage());
+                    } catch (OptionValidatorException | CommandLineParserException ex) {
+                        throw new CommandFormatException(ex.getLocalizedMessage());
                     } catch (InterruptedException ex) {
                         Thread.interrupted();
                         throw new CommandLineException(ex);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandContainer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandContainer.java
@@ -45,18 +45,18 @@ import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
  *
  * @author jfdenise
  */
-public class CLICommandContainer extends DefaultCommandContainer<Command<CLICommandInvocation>, CLICommandInvocation> {
+public class CLICommandContainer extends DefaultCommandContainer<CLICommandInvocation> {
 
-    private class WrappedParser implements CommandLineParser<Command<CLICommandInvocation>> {
+    private class WrappedParser implements CommandLineParser<CLICommandInvocation> {
 
-        private final CommandLineParser<Command<CLICommandInvocation>> parser;
+        private final CommandLineParser<CLICommandInvocation> parser;
 
-        private WrappedParser(CommandLineParser<Command<CLICommandInvocation>> parser) {
+        private WrappedParser(CommandLineParser<CLICommandInvocation> parser) {
             this.parser = parser;
         }
 
         @Override
-        public ProcessedCommand<Command<CLICommandInvocation>> getProcessedCommand() {
+        public ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> getProcessedCommand() {
             return parser.getProcessedCommand();
         }
 
@@ -76,17 +76,17 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> getChildParser(String name) {
+        public CommandLineParser<CLICommandInvocation> getChildParser(String name) {
             return parser.getChildParser(name);
         }
 
         @Override
-        public void addChildParser(CommandLineParser<Command<CLICommandInvocation>> childParser) throws CommandLineParserException {
+        public void addChildParser(CommandLineParser<CLICommandInvocation> childParser) throws CommandLineParserException {
             parser.addChildParser(childParser);
         }
 
         @Override
-        public List<CommandLineParser<Command<CLICommandInvocation>>> getAllChildParsers() {
+        public List<CommandLineParser<CLICommandInvocation>> getAllChildParsers() {
             return parser.getAllChildParsers();
         }
 
@@ -143,7 +143,7 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> parsedCommand() {
+        public CommandLineParser<CLICommandInvocation> parsedCommand() {
             return parser.parsedCommand();
         }
 
@@ -163,14 +163,14 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         }
     }
 
-    public class CLICommandParser implements CommandLineParser<Command<CLICommandInvocation>> {
+    public class CLICommandParser implements CommandLineParser<CLICommandInvocation> {
 
-        public CommandLineParser<Command<CLICommandInvocation>> getWrappedParser() {
+        public CommandLineParser<CLICommandInvocation> getWrappedParser() {
             return container.getParser();
         }
 
         @Override
-        public ProcessedCommand<Command<CLICommandInvocation>> getProcessedCommand() {
+        public ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> getProcessedCommand() {
             return container.getParser().getProcessedCommand();
         }
 
@@ -190,17 +190,17 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> getChildParser(String name) {
+        public CommandLineParser<CLICommandInvocation> getChildParser(String name) {
             return container.getParser().getChildParser(name);
         }
 
         @Override
-        public void addChildParser(CommandLineParser<Command<CLICommandInvocation>> childParser) throws CommandLineParserException {
+        public void addChildParser(CommandLineParser<CLICommandInvocation> childParser) throws CommandLineParserException {
             container.getParser().addChildParser(childParser);
         }
 
         @Override
-        public List<CommandLineParser<Command<CLICommandInvocation>>> getAllChildParsers() {
+        public List<CommandLineParser<CLICommandInvocation>> getAllChildParsers() {
             return container.getParser().getAllChildParsers();
         }
 
@@ -255,7 +255,7 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> parsedCommand() {
+        public CommandLineParser<CLICommandInvocation> parsedCommand() {
             return container.getParser().parsedCommand();
         }
 
@@ -275,18 +275,18 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         }
     }
 
-    private final CommandContainer<Command<CLICommandInvocation>, CLICommandInvocation> container;
-    private final CommandLineParser<Command<CLICommandInvocation>> parser;
+    private final CommandContainer<CLICommandInvocation> container;
+    private final CommandLineParser<CLICommandInvocation> parser;
     private final CommandContext ctx;
 
-    CLICommandContainer(CommandContainer<Command<CLICommandInvocation>, CLICommandInvocation> container, CommandContext ctx) throws OptionParserException {
+    CLICommandContainer(CommandContainer<CLICommandInvocation> container, CommandContext ctx) throws OptionParserException {
         this.container = container;
         this.ctx = ctx;
         this.parser = new CLICommandParser();
     }
 
     @Override
-    public CommandLineParser<Command<CLICommandInvocation>> getParser() {
+    public CommandLineParser<CLICommandInvocation> getParser() {
         return parser;
     }
 
@@ -324,7 +324,7 @@ public class CLICommandContainer extends DefaultCommandContainer<Command<CLIComm
         return container;
     }
 
-    public CommandLineParser<Command<CLICommandInvocation>> wrapParser(CommandLineParser<Command<CLICommandInvocation>> p) {
+    public CommandLineParser<CLICommandInvocation> wrapParser(CommandLineParser<CLICommandInvocation> p) {
         return new WrappedParser(p);
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandInvocationBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandInvocationBuilder.java
@@ -16,8 +16,8 @@ limitations under the License.
 package org.jboss.as.cli.impl.aesh;
 
 import java.io.IOException;
-import org.aesh.command.Command;
 import org.aesh.command.CommandRuntime;
+import org.aesh.command.container.CommandContainer;
 import org.aesh.command.shell.Shell;
 import org.aesh.command.invocation.CommandInvocationBuilder;
 import org.aesh.command.invocation.CommandInvocationConfiguration;
@@ -39,7 +39,7 @@ import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
  * @author jdenise@redhat.com
  */
 public class CLICommandInvocationBuilder implements
-        CommandInvocationBuilder<Command<CLICommandInvocation>, CLICommandInvocation> {
+        CommandInvocationBuilder<CLICommandInvocation> {
 
     public class ShellImpl implements Shell {
 
@@ -141,15 +141,15 @@ public class CLICommandInvocationBuilder implements
     }
 
     @Override
-    public CLICommandInvocation build(CommandRuntime<Command<CLICommandInvocation>, CLICommandInvocation> runtime,
-            CommandInvocationConfiguration configuration) {
+    public CLICommandInvocation build(CommandRuntime<CLICommandInvocation> runtime,
+            CommandInvocationConfiguration configuration, CommandContainer<CLICommandInvocation> commandContainer) {
         // We must set a CommandContext that can deal with timeout.
         // Another approach would have been to set the ctx CommandContext instance
         // and have the CommandExecutor to set the timeoutContext onto the CLICommandInvocation
         // but this would require a public setter on the CLICommandInvocationImpl class
         // something that we don't want.
         return new CLICommandInvocationImpl(ctx.newTimeoutCommandContext(),
-                registry, console, shell, runtime, configuration);
+                registry, console, shell, runtime, configuration, commandContainer);
     }
 
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandInvocationImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandInvocationImpl.java
@@ -24,11 +24,11 @@ import org.aesh.readline.action.KeyAction;
 import org.aesh.command.impl.parser.CommandLineParser;
 import org.aesh.command.validator.CommandValidatorException;
 import org.aesh.command.validator.OptionValidatorException;
-import org.aesh.readline.AeshContext;
 import org.aesh.command.shell.Shell;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandNotFoundException;
 import org.aesh.command.CommandRuntime;
+import org.aesh.command.container.CommandContainer;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.invocation.CommandInvocationConfiguration;
 import org.aesh.command.parser.CommandLineParserException;
@@ -50,15 +50,17 @@ class CLICommandInvocationImpl implements CLICommandInvocation {
     private final ReadlineConsole console;
     private final CommandInvocationConfiguration config;
     private final CommandRuntime runtime;
+    private final CommandContainer<CLICommandInvocation> commandContainer;
     CLICommandInvocationImpl(CommandContext ctx, CLICommandRegistry registry,
             ReadlineConsole console, Shell shell, CommandRuntime runtime,
-            CommandInvocationConfiguration config) {
+            CommandInvocationConfiguration config, CommandContainer<CLICommandInvocation> commandContainer) {
         this.ctx = ctx;
         this.registry = registry;
         this.console = console;
         this.shell = shell;
         this.runtime = runtime;
         this.config = config;
+        this.commandContainer = commandContainer;
     }
 
     @Override
@@ -103,11 +105,6 @@ class CLICommandInvocationImpl implements CLICommandInvocation {
     @Override
     public void stop() {
         ctx.terminateSession();
-    }
-
-    @Override
-    public AeshContext getAeshContext() {
-        return config.getAeshContext();
     }
 
     @Override
@@ -167,4 +164,8 @@ class CLICommandInvocationImpl implements CLICommandInvocation {
         return null;
     }
 
+    @Override
+    public String getHelpInfo() {
+        return commandContainer.getParser().parsedCommand().printHelp();
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/HelpSupport.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/HelpSupport.java
@@ -307,7 +307,7 @@ public class HelpSupport {
                     + buildAddress(address) + ":"
                     + Util.READ_OPERATION_DESCRIPTION + "(name=" + commandName + ")";
             ModelNode props = mn.get(Util.REQUEST_PROPERTIES);
-            ProcessedCommand<?> pcommand = new ProcessedCommandBuilder().
+            ProcessedCommand pcommand = ProcessedCommandBuilder.builder().
                     name(commandName).description(desc).create();
             for (String prop : props.keys()) {
                 ModelNode p = props.get(prop);
@@ -446,18 +446,18 @@ public class HelpSupport {
     }
 
     public static String getSubCommandHelp(String parentCommand,
-            CommandLineParser<Command<CLICommandInvocation>> parser) {
+            CommandLineParser<CLICommandInvocation> parser) {
         String commandName = parser.getProcessedCommand().name();
         return getCommandHelp(parentCommand, commandName, parser);
     }
 
-    public static String getCommandHelp(CommandLineParser<Command<CLICommandInvocation>> parser) {
+    public static String getCommandHelp(CommandLineParser<CLICommandInvocation> parser) {
         String commandName = parser.getProcessedCommand().name();
         return getCommandHelp(null, commandName, parser);
     }
 
     private static String getCommandHelp(String parentName, String commandName,
-            CommandLineParser<Command<CLICommandInvocation>> parser) {
+            CommandLineParser<CLICommandInvocation> parser) {
 
         // First retrieve deprecated options.
         Set<String> deprecated = new HashSet<>();
@@ -466,11 +466,11 @@ public class HelpSupport {
         retrieveDeprecated(deprecated, parser.getCommand().getClass(), superNames);
         retrieveHidden(deprecated, parser.getProcessedCommand());
 
-        List<CommandLineParser<Command<CLICommandInvocation>>> parsers = parser.getAllChildParsers();
+        List<CommandLineParser<CLICommandInvocation>> parsers = parser.getAllChildParsers();
 
         ResourceBundle bundle = getBundle(parser.getCommand());
 
-        ProcessedCommand<?> pcommand = retrieveDescriptions(bundle, parentName,
+        ProcessedCommand<?, ?> pcommand = retrieveDescriptions(bundle, parentName,
                 parser.getProcessedCommand(), superNames, deprecated);
 
         List<ProcessedOption> opts = new ArrayList<>();
@@ -491,12 +491,12 @@ public class HelpSupport {
 
     private static String getCommandHelp(ResourceBundle bundle, List<String> superNames,
             ProcessedOption arg,
-            List<CommandLineParser<Command<CLICommandInvocation>>> parsers,
+            List<CommandLineParser<CLICommandInvocation>> parsers,
             List<ProcessedOption> opts,
-            ProcessedCommand<?> pcommand,
+            ProcessedCommand<?, ?> pcommand,
             String parentName,
             String commandName,
-            ProcessedCommand<?> origCommand, boolean isOperation) {
+            ProcessedCommand<?, ?> origCommand, boolean isOperation) {
         StringBuilder builder = new StringBuilder();
         builder.append(Config.getLineSeparator());
 
@@ -572,7 +572,7 @@ public class HelpSupport {
     private static String printActions(ResourceBundle bundle,
             String parentName,
             String commandName,
-            List<CommandLineParser<Command<CLICommandInvocation>>> parsers,
+            List<CommandLineParser<CLICommandInvocation>> parsers,
             List<String> superNames) {
         StringBuilder builder = new StringBuilder();
         if (parsers != null && parsers.size() > 0) {
@@ -628,7 +628,7 @@ public class HelpSupport {
         return builder.toString();
     }
 
-    private static void retrieveHidden(Set<String> deprecated, ProcessedCommand<Command<CLICommandInvocation>> cmd) {
+    private static void retrieveHidden(Set<String> deprecated, ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> cmd) {
         if ((cmd.getArgument() != null && cmd.getArgument().activator() instanceof HideOptionActivator)
                 || (cmd.getArguments() != null && cmd.getArguments().activator() instanceof HideOptionActivator)) {
             deprecated.add("");
@@ -816,7 +816,7 @@ public class HelpSupport {
 
     private static ProcessedCommandBuilder retrieveDescriptionBuilder(ResourceBundle bundle,
             String parentName,
-            ProcessedCommand<?> pc, List<String> superNames) {
+            ProcessedCommand<?, ?> pc, List<String> superNames) {
         if (bundle == null) {
             if (testMode) {
                 throw new RuntimeException("Invalid help for command, no bundle");
@@ -828,13 +828,13 @@ public class HelpSupport {
         if (bdesc != null) {
             desc = bdesc;
         }
-        ProcessedCommandBuilder builder = new ProcessedCommandBuilder().name(pc.name()).description(desc);
+        ProcessedCommandBuilder builder = ProcessedCommandBuilder.builder().name(pc.name()).description(desc);
         return builder;
     }
 
     private static ProcessedCommand retrieveDescriptions(ResourceBundle bundle,
             String parentName,
-            ProcessedCommand<?> pc, List<String> superNames, Set<String> deprecated) {
+            ProcessedCommand<?, ?> pc, List<String> superNames, Set<String> deprecated) {
         try {
             ProcessedCommandBuilder builder = retrieveDescriptionBuilder(bundle, parentName, pc, superNames);
             if (builder == null) {
@@ -1044,8 +1044,8 @@ public class HelpSupport {
         testMode = mode;
     }
 
-    public static void checkCommand(CommandLineParser<Command<CLICommandInvocation>> parent,
-            CommandLineParser<Command<CLICommandInvocation>> child) throws Exception {
+    public static void checkCommand(CommandLineParser<CLICommandInvocation> parent,
+            CommandLineParser<CLICommandInvocation> child) throws Exception {
         boolean currentMode = testMode;
         testMode(true);
         try {

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/DeploymentCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/DeploymentCommand.java
@@ -44,7 +44,7 @@ import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
  */
 @GroupCommandDefinition(name = "deployment", description = "", activator = ControlledCommandActivator.class)
 public class DeploymentCommand extends CommandWithPermissions
-        implements GroupCommand<CLICommandInvocation, Command> {
+        implements GroupCommand<CLICommandInvocation> {
 
     public DeploymentCommand(CommandContext ctx, Permissions permissions) {
         super(ctx, AccessRequirements.deploymentAccess(permissions), permissions);
@@ -65,8 +65,8 @@ public class DeploymentCommand extends CommandWithPermissions
     }
 
     @Override
-    public List<Command> getCommands() {
-        List<Command> commands = new ArrayList<>();
+    public List<Command<CLICommandInvocation>> getCommands() {
+        List<Command<CLICommandInvocation>> commands = new ArrayList<>();
         commands.add(new EnableCommand(getCommandContext(), getPermissions()));
         commands.add(new EnableAllCommand(getCommandContext(), getPermissions()));
         commands.add(new DeployArchiveCommand(getCommandContext(), getPermissions()));

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/LegacyCommandContainer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/LegacyCommandContainer.java
@@ -49,7 +49,7 @@ import org.wildfly.core.cli.command.aesh.activator.AbstractCommandActivator;
  *
  * @author jdenise@redhat.com
  */
-public class LegacyCommandContainer extends DefaultCommandContainer<Command<CLICommandInvocation>, CLICommandInvocation> {
+public class LegacyCommandContainer extends DefaultCommandContainer<CLICommandInvocation> {
 
     public class LegacyCommand implements Command<CLICommandInvocation>, SpecialCommand {
 
@@ -76,10 +76,10 @@ public class LegacyCommandContainer extends DefaultCommandContainer<Command<CLIC
         }
     }
 
-    public class CommandParser implements CommandLineParser<Command<CLICommandInvocation>> {
+    public class CommandParser implements CommandLineParser<CLICommandInvocation> {
 
         @Override
-        public ProcessedCommand<Command<CLICommandInvocation>> getProcessedCommand() {
+        public ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> getProcessedCommand() {
             return processedCommand;
         }
 
@@ -99,25 +99,25 @@ public class LegacyCommandContainer extends DefaultCommandContainer<Command<CLIC
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> getChildParser(String name) {
+        public CommandLineParser<CLICommandInvocation> getChildParser(String name) {
             return null;
         }
 
         @Override
-        public void addChildParser(CommandLineParser<Command<CLICommandInvocation>> childParser) {
+        public void addChildParser(CommandLineParser<CLICommandInvocation> childParser) {
 
         }
 
         @Override
-        public List<CommandLineParser<Command<CLICommandInvocation>>> getAllChildParsers() {
+        public List<CommandLineParser<CLICommandInvocation>> getAllChildParsers() {
             return Collections.emptyList();
         }
 
         @Override
-        public CommandPopulator<Object, Command<CLICommandInvocation>> getCommandPopulator() {
-            return new CommandPopulator<Object, Command<CLICommandInvocation>>() {
+        public CommandPopulator<Object, CLICommandInvocation> getCommandPopulator() {
+            return new CommandPopulator<Object, CLICommandInvocation>() {
                 @Override
-                public void populateObject(ProcessedCommand<Command<CLICommandInvocation>> processedCommand,
+                public void populateObject(ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> processedCommand,
                         InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException {
                 }
 
@@ -175,7 +175,7 @@ public class LegacyCommandContainer extends DefaultCommandContainer<Command<CLIC
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> parsedCommand() {
+        public CommandLineParser<CLICommandInvocation> parsedCommand() {
             return this;
         }
 
@@ -198,7 +198,7 @@ public class LegacyCommandContainer extends DefaultCommandContainer<Command<CLIC
 
     private String line;
 
-    private final CommandLineParser<Command<CLICommandInvocation>> parser = new CommandParser();
+    private final CommandLineParser<CLICommandInvocation> parser = new CommandParser();
     private final CommandContextImpl ctx;
     private final String name;
     private final CommandHandler handler;
@@ -210,12 +210,12 @@ public class LegacyCommandContainer extends DefaultCommandContainer<Command<CLIC
         this.name = names[0];
         this.aliases = names.length > 1 ? Arrays.asList(Arrays.copyOfRange(names, 1, names.length)) : Collections.emptyList();
         this.handler = handler;
-        processedCommand = new ProcessedCommandBuilder().command(command).name(name).
+        processedCommand = ProcessedCommandBuilder.<Command<CLICommandInvocation>, CLICommandInvocation>builder().command(command).name(name).
                 aliases(aliases).activator(new Activator()).create();
     }
 
     @Override
-    public CommandLineParser<Command<CLICommandInvocation>> getParser() {
+    public CommandLineParser<CLICommandInvocation> getParser() {
         return parser;
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/OperationCommandContainer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/OperationCommandContainer.java
@@ -47,7 +47,7 @@ import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
  *
  * @author jdenise@redhat.com
  */
-public class OperationCommandContainer extends DefaultCommandContainer<Command<CLICommandInvocation>, CLICommandInvocation> {
+public class OperationCommandContainer extends DefaultCommandContainer<CLICommandInvocation> {
 
     public static boolean isOperation(String mainCommand) {
         mainCommand = mainCommand.trim();
@@ -67,12 +67,12 @@ public class OperationCommandContainer extends DefaultCommandContainer<Command<C
         }
     }
 
-    public class OperationParser implements CommandLineParser<Command<CLICommandInvocation>> {
+    public class OperationParser implements CommandLineParser<CLICommandInvocation> {
 
         @Override
-        public ProcessedCommand<Command<CLICommandInvocation>> getProcessedCommand() {
+        public ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> getProcessedCommand() {
             try {
-                return new ProcessedCommandBuilder().command(command).name("/").create();
+                return ProcessedCommandBuilder.<Command<CLICommandInvocation>, CLICommandInvocation>builder().command(command).name("/").create();
             } catch (CommandLineParserException ex) {
                 throw new RuntimeException(ex);
             }
@@ -94,25 +94,25 @@ public class OperationCommandContainer extends DefaultCommandContainer<Command<C
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> getChildParser(String name) {
+        public CommandLineParser<CLICommandInvocation> getChildParser(String name) {
             return null;
         }
 
         @Override
-        public void addChildParser(CommandLineParser<Command<CLICommandInvocation>> childParser) {
+        public void addChildParser(CommandLineParser<CLICommandInvocation> childParser) {
 
         }
 
         @Override
-        public List<CommandLineParser<Command<CLICommandInvocation>>> getAllChildParsers() {
+        public List<CommandLineParser<CLICommandInvocation>> getAllChildParsers() {
             return Collections.emptyList();
         }
 
         @Override
-        public CommandPopulator<Object, Command<CLICommandInvocation>> getCommandPopulator() {
-            return new CommandPopulator<Object, Command<CLICommandInvocation>>() {
+        public CommandPopulator<Object, CLICommandInvocation> getCommandPopulator() {
+            return new CommandPopulator<Object, CLICommandInvocation>() {
                 @Override
-                public void populateObject(ProcessedCommand<Command<CLICommandInvocation>> processedCommand,
+                public void populateObject(ProcessedCommand<Command<CLICommandInvocation>, CLICommandInvocation> processedCommand,
                         InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException {
                 }
 
@@ -169,7 +169,7 @@ public class OperationCommandContainer extends DefaultCommandContainer<Command<C
         }
 
         @Override
-        public CommandLineParser<Command<CLICommandInvocation>> parsedCommand() {
+        public CommandLineParser<CLICommandInvocation> parsedCommand() {
             return this;
         }
 
@@ -192,14 +192,14 @@ public class OperationCommandContainer extends DefaultCommandContainer<Command<C
 
     private String line;
 
-    private final CommandLineParser<Command<CLICommandInvocation>> parser = new OperationParser();
+    private final CommandLineParser<CLICommandInvocation> parser = new OperationParser();
     private final CommandContextImpl ctx;
     public OperationCommandContainer(CommandContextImpl ctx) {
         this.ctx = ctx;
     }
 
     @Override
-    public CommandLineParser<Command<CLICommandInvocation>> getParser() {
+    public CommandLineParser<CLICommandInvocation> getParser() {
         return parser;
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
@@ -60,7 +60,7 @@ import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
  * @author jdenise@redhat.com
  */
 @GroupCommandDefinition(name = "security", description = "")
-public class SecurityCommand implements GroupCommand<CLICommandInvocation, Command> {
+public class SecurityCommand implements GroupCommand<CLICommandInvocation> {
 
     public static final FailureConsumer DEFAULT_FAILURE_CONSUMER = new FailureConsumer() {
 
@@ -131,8 +131,8 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
     }
 
     @Override
-    public List<Command> getCommands() {
-        List<Command> commands = new ArrayList<>();
+    public List<Command<CLICommandInvocation>> getCommands() {
+        List<Command<CLICommandInvocation>> commands = new ArrayList<>();
         commands.add(new ManagementEnableSSLCommand(ctx));
         commands.add(new ManagementDisableSSLCommand(embeddedServerRef));
         commands.add(new HTTPServerEnableSSLCommand(ctx));

--- a/cli/src/test/java/org/jboss/as/cli/impl/aesh/HelpSupportTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/impl/aesh/HelpSupportTestCase.java
@@ -66,7 +66,7 @@ public class HelpSupportTestCase {
             if (!(container.getWrappedContainer() instanceof LegacyCommandContainer)
                     && !isAeshExtension(container.getParser().getCommand())) {
                 HelpSupport.checkCommand(null, container.getParser());
-                for (CommandLineParser<Command<CLICommandInvocation>> child : container.getParser().getAllChildParsers()) {
+                for (CommandLineParser<CLICommandInvocation> child : container.getParser().getAllChildParsers()) {
                     HelpSupport.checkCommand(container.getParser(), child);
                 }
             }

--- a/patching/src/test/java/org/jboss/as/patching/cli/PatchHelpTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/PatchHelpTestCase.java
@@ -15,7 +15,6 @@ limitations under the License.
  */
 package org.jboss.as.patching.cli;
 
-import org.aesh.command.Command;
 import org.aesh.command.container.CommandContainer;
 import org.aesh.command.impl.parser.CommandLineParser;
 import org.jboss.as.cli.CommandContextFactory;
@@ -35,9 +34,9 @@ public class PatchHelpTestCase {
     public void testCLICommands() throws Exception {
         CommandContextImpl ctx = (CommandContextImpl) CommandContextFactory.getInstance().newCommandContext();
         AeshCommands commands = ctx.getAeshCommands();
-        CommandContainer<Command<CLICommandInvocation>, CLICommandInvocation> container = commands.getRegistry().getCommand("patch", "patch");
+        CommandContainer<CLICommandInvocation> container = commands.getRegistry().getCommand("patch", "patch");
         HelpSupport.checkCommand(null, container.getParser());
-        for (CommandLineParser<Command<CLICommandInvocation>> child : container.getParser().getAllChildParsers()) {
+        for (CommandLineParser<CLICommandInvocation> child : container.getParser().getAllChildParsers()) {
             HelpSupport.checkCommand(container.getParser(), child);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,9 @@
         <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
-        <version.org.aesh>1.11</version.org.aesh>
-        <version.org.aesh-extensions>1.6</version.org.aesh-extensions>
-        <version.org.aesh-readline>1.14</version.org.aesh-readline>
+        <version.org.aesh>2.0</version.org.aesh>
+        <version.org.aesh-extensions>1.7</version.org.aesh-extensions>
+        <version.org.aesh-readline>1.15</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <!-- TODO Elytron - Bump to M17 -->
         <version.org.apache.httpcomponents.httpclient>4.5.4</version.org.apache.httpcomponents.httpclient>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GrepTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GrepTestCase.java
@@ -106,7 +106,7 @@ public class GrepTestCase {
 
     @Test(expected = CommandFormatException.class)
     public void testGrepWithNonExistingParameter() throws Exception {
-        testCommand("grep --mo", "'mo' is not a valid parameter name", false);
+        testCommand("grep --mo", "The option --mo is unknown.", false);
     }
 
     @Test


### PR DESCRIPTION
- Changes in CommandBuilder API.
- Commands are populated at execution time, impact legacy commands, raw operations and Command to DMR translation (for aesh based commands).
- Updated test due to change of exception message.