### PR TITLE
[WFCORE-4374] security-manager permissions are loaded using java.se m…

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
@@ -33,6 +33,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.se"/>
         <module name="java.xml"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>


### PR DESCRIPTION
…odule

Issue: https://issues.jboss.org/browse/WFCORE-4374

Adding dependency on java.se module to security-manager would allow most of standard permissions to be defined in security-manager permissions configuration without the need to specify module option