### PR TITLE
[WFCORE-4373] org.jboss.log4j.logmanager module requires java.sql module

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
@@ -36,6 +36,7 @@
         <module name="java.desktop"/>
         <module name="java.logging"/>
         <module name="java.xml"/>
+        <module name="java.sql"/>
         <module name="javax.mail.api" optional="true"/>
         <module name="javax.jms.api" optional="true"/>
         <module name="org.jboss.logmanager"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4373

Adding java.sql module dependency to logmanager.