### PR TITLE
[WFCORE-4381] Don't stop the DomainTestSupport before relaunching the…

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ReadOnlyModeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ReadOnlyModeTestCase.java
@@ -18,19 +18,12 @@ package org.jboss.as.test.integration.domain;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import java.util.concurrent.Future;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
-import org.jboss.as.controller.client.helpers.domain.impl.DomainClientImpl;
 import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
-import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,16 +36,13 @@ import org.junit.Test;
  */
 public class ReadOnlyModeTestCase {
 
-    private DomainTestSupport.Configuration domainConfig;
     private DomainTestSupport domainManager;
     private DomainLifecycleUtil domainMasterLifecycleUtil;
     private DomainLifecycleUtil domainSlaveLifecycleUtil;
-    private static final long TIMEOUT_S = TimeoutUtil.adjust(30);
-    private static final int TIMEOUT_SLEEP_MILLIS = 50;
 
     @Before
     public void setupDomain() throws Exception {
-       domainConfig = DomainTestSupport.Configuration.create(ReadOnlyModeTestCase.class.getSimpleName(),
+        DomainTestSupport.Configuration domainConfig = DomainTestSupport.Configuration.create(ReadOnlyModeTestCase.class.getSimpleName(),
                 "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
         domainConfig.getMasterConfiguration().setReadOnlyHost(true);
         domainConfig.getMasterConfiguration().setReadOnlyDomain(true);
@@ -77,97 +67,62 @@ public class ReadOnlyModeTestCase {
         ModelNode domainAddress = PathAddress.pathAddress("system-property", "domain-read-only").toModelNode();
         ModelNode masterAddress = PathAddress.pathAddress("host", "master").append("system-property", "master-read-only").toModelNode();
         ModelNode slaveAddress = PathAddress.pathAddress("host", "slave").append("system-property", "slave-read-only").toModelNode();
-        try (final DomainClient masterClient = domainMasterLifecycleUtil.getDomainClient()) {
-            ModelNode op = Operations.createAddOperation(domainAddress);
-            op.get("value").set(true);
-            Operations.isSuccessfulOutcome(masterClient.execute(op));
-            op = Operations.createAddOperation(masterAddress);
-            op.get("value").set(true);
-            Operations.isSuccessfulOutcome(masterClient.execute(op));
-            op = Operations.createAddOperation(slaveAddress);
-            op.get("value").set(true);
-            Operations.isSuccessfulOutcome(masterClient.execute(op));
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asBoolean());
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asBoolean());
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
+        DomainClient masterClient = domainMasterLifecycleUtil.getDomainClient();
 
-            // reload master HC
-            op = new ModelNode();
-            op.get(OP_ADDR).add(HOST, "master");
-            op.get(OP).set("reload");
-            domainMasterLifecycleUtil.executeAwaitConnectionClosed(op);
-            // Try to reconnect to the hc
-            domainMasterLifecycleUtil.connect();
-            domainMasterLifecycleUtil.awaitHostController(System.currentTimeMillis());
+        ModelNode op = Operations.createAddOperation(domainAddress);
+        op.get("value").set(true);
+        Operations.isSuccessfulOutcome(masterClient.execute(op));
+        op = Operations.createAddOperation(masterAddress);
+        op.get("value").set(true);
+        Operations.isSuccessfulOutcome(masterClient.execute(op));
+        op = Operations.createAddOperation(slaveAddress);
+        op.get("value").set(true);
+        Operations.isSuccessfulOutcome(masterClient.execute(op));
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asBoolean());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asBoolean());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
 
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asBoolean());
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asBoolean());
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
+        // reload master HC
+        op = new ModelNode();
+        op.get(OP_ADDR).add(HOST, "master");
+        op.get(OP).set("reload");
+        domainMasterLifecycleUtil.executeAwaitConnectionClosed(op);
+        // Try to reconnect to the hc
+        domainMasterLifecycleUtil.connect();
+        domainMasterLifecycleUtil.awaitHostController(System.currentTimeMillis());
 
-            // reload slave HC
-            op = new ModelNode();
-            op.get(OP_ADDR).add(HOST, "slave");
-            op.get(OP).set("reload");
-            domainSlaveLifecycleUtil.executeAwaitConnectionClosed(op);
-            // Try to reconnect to the hc
-            domainSlaveLifecycleUtil.connect();
-            domainSlaveLifecycleUtil.awaitHostController(System.currentTimeMillis());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asBoolean());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asBoolean());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
 
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asBoolean());
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asBoolean());
-            Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
-        }
-        domainManager.stop();
-        domainConfig.getMasterConfiguration().setRewriteConfigFiles(false);
-        domainConfig.getSlaveConfiguration().setRewriteConfigFiles(false);
-        domainMasterLifecycleUtil = domainManager.getDomainMasterLifecycleUtil();
-        domainSlaveLifecycleUtil = domainManager.getDomainSlaveLifecycleUtil();
-        domainMasterLifecycleUtil.startAsync();
-        domainSlaveLifecycleUtil.startAsync();
-        try (final DomainClient clientMaster = getDomainClient(domainConfig.getMasterConfiguration())) {
-            waitForHostControllerBeingStarted(TIMEOUT_S, clientMaster);
-            Assert.assertTrue(Operations.getFailureDescription(clientMaster.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asString().contains("WFLYCTL0216"));
-            Assert.assertTrue(Operations.getFailureDescription(clientMaster.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asString().contains("WFLYCTL0216"));
-            Assert.assertTrue(Operations.readResult(clientMaster.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
-        }
-    }
+        // reload slave HC
+        op = new ModelNode();
+        op.get(OP_ADDR).add(HOST, "slave");
+        op.get(OP).set("reload");
+        domainSlaveLifecycleUtil.executeAwaitConnectionClosed(op);
+        // Try to reconnect to the hc
+        domainSlaveLifecycleUtil.connect();
+        domainSlaveLifecycleUtil.awaitHostController(System.currentTimeMillis());
 
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asBoolean());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asBoolean());
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
 
-    private void waitForHostControllerBeingStarted(long timeoutSeconds, DomainClient client) {
-        runWithTimeout(timeoutSeconds, () -> client.getServerStatuses());
-    }
+        domainSlaveLifecycleUtil.stop();
+        domainMasterLifecycleUtil.stop();
 
-    private void runWithTimeout(long timeoutSeconds, Runnable voidFunctionInterface) {
-        runWithTimeout(timeoutSeconds, () -> {
-            voidFunctionInterface.run();
-            return null;
-        });
-    }
+        domainMasterLifecycleUtil.getConfiguration().setRewriteConfigFiles(false);
+        domainSlaveLifecycleUtil.getConfiguration().setRewriteConfigFiles(false);
+        Future<Void> masterFuture = domainMasterLifecycleUtil.startAsync();
+        Future<Void> slaveFuture = domainSlaveLifecycleUtil.startAsync();
+        masterFuture.get();
+        slaveFuture.get();
 
-    private <T> T runWithTimeout(long timeoutSeconds, Supplier<T> function) {
-        final long timeoutTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(timeoutSeconds);
-        while(true) {
-            try {
-                return function.get();
-            } catch (Throwable t) {
-                if(timeoutTime < System.currentTimeMillis()) {
-                    throw new IllegalStateException("Function '" + function
-                        + "' failed to process in " + timeoutSeconds + " s, caused: " + t.getMessage() , t);
-                }
-                try {
-                    Thread.sleep(TIMEOUT_SLEEP_MILLIS);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        }
-    }
+        masterClient = domainMasterLifecycleUtil.getDomainClient();
+        Assert.assertTrue(Operations.getFailureDescription(masterClient.execute(Operations.createReadAttributeOperation(domainAddress, "value"))).asString().contains("WFLYCTL0216"));
+        Assert.assertTrue(Operations.getFailureDescription(masterClient.execute(Operations.createReadAttributeOperation(masterAddress, "value"))).asString().contains("WFLYCTL0216"));
+        Assert.assertTrue(Operations.readResult(masterClient.execute(Operations.createReadAttributeOperation(slaveAddress, "value"))).asBoolean());
 
-    private DomainClient getDomainClient(WildFlyManagedConfiguration config) throws UnknownHostException {
-        final InetAddress address = InetAddress.getByName(config.getHostControllerManagementAddress());
-        final int port = config.getHostControllerManagementPort();
-        final String protocol = config.getHostControllerManagementProtocol();
-        return new DomainClientImpl(protocol, address, port);
     }
 
 }


### PR DESCRIPTION
… HCs. Just stop the HCs.

Stopping the DomainTestSupport also closes down the shared client side Endpoint, and the DomainLifecycleUtil objects use those. Closing it down is what led to the need for unusual start handling after the DomainTestSupport.stop() call.

I also clean out the try with resources handling with the client. The client from DomainLifecycleUtil can now be used and doesn't have to be closed by the test method.

https://issues.jboss.org/browse/WFCORE-4381

https://github.com/wildfly/wildfly-core/pull/3709/files?w=1 is a good way to look at this as there's a big whitespace diff due to removing try blocks.