### PR TITLE
[WFCORE-4385] DomainTestSupport and DomainLifecycleUtil implement AutoCloseable

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AbstractConfigurationChangesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AbstractConfigurationChangesTestCase.java
@@ -89,7 +89,7 @@ public abstract class AbstractConfigurationChangesTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;
         testSupport = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
@@ -91,7 +91,7 @@ public class AdminOnlyModeTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
 
         testSupport = null;
         domainMasterLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -77,7 +77,7 @@ public class AdminOnlyPolicyTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
 
         testSupport = null;
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HTTPSManagementInterfaceTestCase.java
@@ -115,7 +115,7 @@ public class HTTPSManagementInterfaceTestCase {
     @AfterClass
     public static void tearDownDomain() throws Exception {
         httpManagementRealmSetup.tearDown(domainMasterLifecycleUtil.getDomainClient());
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         FileUtils.deleteDirectory(WORK_DIR);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/KerberosServerIdentityTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/KerberosServerIdentityTestCase.java
@@ -52,7 +52,7 @@ public class KerberosServerIdentityTestCase {
             Assert.fail("Server did not start properly.");
         } finally {
             if (testSupport != null) {
-                testSupport.stop();
+                testSupport.close();
                 testSupport = null;
             }
             if (keytabFileCreated){

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/NonExistentServerGroupTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/NonExistentServerGroupTestCase.java
@@ -42,7 +42,7 @@ public class NonExistentServerGroupTestCase {
     @After
     public void cleanUp() {
         if (testSupport != null) {
-            testSupport.stop();
+            testSupport.close();
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
@@ -200,7 +200,7 @@ public class OperationTimeoutTestCase {
         ModelNode removeExtension = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(PathElement.pathElement(EXTENSION, BlockerExtension.MODULE_NAME)));
         executeForResult(safeTimeout(removeExtension), masterClient);
 
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         masterClient = null;
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ProductInfoUnitTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ProductInfoUnitTestCase.java
@@ -80,7 +80,7 @@ public class ProductInfoUnitTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ReadOnlyModeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ReadOnlyModeTestCase.java
@@ -56,7 +56,7 @@ public class ReadOnlyModeTestCase {
 
     @After
     public void tearDownDomain() throws Exception {
-        domainManager.stop();
+        domainManager.close();
         domainManager = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SSLMasterSlaveOneWayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SSLMasterSlaveOneWayTestCase.java
@@ -81,7 +81,7 @@ public class SSLMasterSlaveOneWayTestCase extends AbstractSSLMasterSlaveTestCase
     public static void tearDownDomain() throws Exception {
         masterManagementRealmSetup.tearDown(domainMasterLifecycleUtil.getDomainClient());
 
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SSLMasterSlaveTwoWayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SSLMasterSlaveTwoWayTestCase.java
@@ -76,7 +76,7 @@ public class SSLMasterSlaveTwoWayTestCase extends AbstractSSLMasterSlaveTestCase
     public static void tearDownDomain() throws Exception {
         masterManagementRealmSetup.tearDown(domainMasterLifecycleUtil.getDomainClient());
 
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ServerManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ServerManagementTestCase.java
@@ -157,7 +157,7 @@ public class ServerManagementTestCase {
                     PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.profile-includes-test")), domainMasterLifecycleUtil.getDomainClient());
         }
 
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveHostControllerAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveHostControllerAuthenticationTestCase.java
@@ -98,7 +98,7 @@ public class SlaveHostControllerAuthenticationTestCase extends AbstractSlaveHCAu
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterClient = null;
         domainSlaveClient = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/autoignore/AutoIgnoredResourcesDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/autoignore/AutoIgnoredResourcesDomainTestCase.java
@@ -143,7 +143,7 @@ public class AutoIgnoredResourcesDomainTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;
         testSupport = null;
@@ -762,7 +762,7 @@ public class AutoIgnoredResourcesDomainTestCase {
 
     private void restartDomainAndReloadReadOnlyConfig(boolean slaveIsBackupDC, boolean slaveIsCachedDC) throws Exception {
         DomainTestSupport.stopHosts(TimeoutUtil.adjust(30000), domainSlaveLifecycleUtil, domainMasterLifecycleUtil);
-        testSupport.stop();
+        testSupport.close();
 
         //Totally reinitialize the domain client
         setupDomain(slaveIsBackupDC, slaveIsCachedDC);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/cacheddc/CachedDcDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/cacheddc/CachedDcDomainTestCase.java
@@ -92,7 +92,7 @@ public class CachedDcDomainTestCase {
     @After
     public void stopDomain() {
         if(domainManager != null) {
-            domainManager.stop();
+            domainManager.close();
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/DomainServerNoLegacyAuthRealmsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/DomainServerNoLegacyAuthRealmsTestCase.java
@@ -59,7 +59,7 @@ public class DomainServerNoLegacyAuthRealmsTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         master = null;
         slave = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SSLElytronMasterSlaveOneWayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SSLElytronMasterSlaveOneWayTestCase.java
@@ -53,7 +53,7 @@ public class SSLElytronMasterSlaveOneWayTestCase extends AbstractSSLMasterSlaveT
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
 
         FileUtils.deleteDirectory(WORK_DIR);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SSLElytronMasterSlaveTwoWayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SSLElytronMasterSlaveTwoWayTestCase.java
@@ -53,7 +53,7 @@ public class SSLElytronMasterSlaveTwoWayTestCase extends AbstractSSLMasterSlaveT
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
 
         FileUtils.deleteDirectory(WORK_DIR);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SlaveHostControllerElytronAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SlaveHostControllerElytronAuthenticationTestCase.java
@@ -82,7 +82,7 @@ public class SlaveHostControllerElytronAuthenticationTestCase extends AbstractSl
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterClient = null;
         domainSlaveClient = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
@@ -89,7 +89,7 @@ public class JmxControlledStateNotificationsTestCase {
     @AfterClass
     public static void cleanClass() throws Exception {
         task.tearDown(domainMasterLifecycleUtil.getDomainClient(), "main-server-group");
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         DomainTestSuite.stopSupport();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/ProcessStateListenerTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/ProcessStateListenerTestCase.java
@@ -111,7 +111,7 @@ public class ProcessStateListenerTestCase {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         PathUtil.deleteSilentlyRecursively(data);
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/LegacySecurityRealmPropagationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/LegacySecurityRealmPropagationTestCase.java
@@ -57,7 +57,7 @@ public class LegacySecurityRealmPropagationTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ReadConfigAsFeaturesDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ReadConfigAsFeaturesDomainTestCase.java
@@ -65,7 +65,7 @@ public class ReadConfigAsFeaturesDomainTestCase extends ReadConfigAsFeaturesTest
 
     @AfterClass
     public static void tearDownDomain() {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerAutoStartTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerAutoStartTestCase.java
@@ -125,7 +125,7 @@ public class ServerAutoStartTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerStartFailureTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerStartFailureTestCase.java
@@ -108,7 +108,7 @@ public class ServerStartFailureTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/slavereconnect/SlaveReconnectTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/slavereconnect/SlaveReconnectTestCase.java
@@ -100,7 +100,7 @@ public class SlaveReconnectTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         testSupport = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
@@ -99,7 +99,7 @@ public class CLITestSuite {
 
     private static synchronized void stop() {
         if(support != null) {
-            support.stop();
+            support.close();
             support = null;
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -100,7 +100,7 @@ public class DomainTestSuite {
 
     private static synchronized void stop() {
         if(support != null) {
-            support.stop();
+            support.close();
             support = null;
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderPropertiesRoleMappingTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderPropertiesRoleMappingTestSuite.java
@@ -77,7 +77,7 @@ public class FullRbacProviderPropertiesRoleMappingTestSuite {
 
     private static synchronized void stop() {
         if(support != null) {
-            support.stop();
+            support.close();
             support = null;
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderRunAsTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderRunAsTestSuite.java
@@ -79,7 +79,7 @@ public class FullRbacProviderRunAsTestSuite {
 
     private static synchronized void stop() {
         if(support != null) {
-            support.stop();
+            support.close();
             support = null;
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderTestSuite.java
@@ -92,7 +92,7 @@ public class FullRbacProviderTestSuite {
 
     private static synchronized void stop() {
         if(support != null) {
-            support.stop();
+            support.close();
             support = null;
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OutboundLdapConnectionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OutboundLdapConnectionTestCase.java
@@ -221,7 +221,7 @@ public class OutboundLdapConnectionTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
         domainMasterLifecycleUtil = null;
         testSupport = null;
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/SimpleRbacProviderTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/SimpleRbacProviderTestSuite.java
@@ -77,7 +77,7 @@ public class SimpleRbacProviderTestSuite {
 
     private static synchronized void stop() {
         if(support != null) {
-            support.stop();
+            support.close();
             support = null;
         }
     }

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchRemoteHostUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchRemoteHostUnitTestCase.java
@@ -76,7 +76,7 @@ public class PatchRemoteHostUnitTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport.close();
 
         if (IoUtils.recursiveDelete(tempDir)) {
             tempDir.deleteOnExit();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,18 +51,26 @@ import org.junit.Assert;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class DomainTestSupport {
+public class DomainTestSupport implements AutoCloseable {
 
 
     private static final Logger log = Logger.getLogger("org.jboss.as.test.integration.domain");
 
     public static final String masterAddress = System.getProperty("jboss.test.host.master.address", "127.0.0.1");
     public static final String slaveAddress = System.getProperty("jboss.test.host.slave.address", "127.0.0.1");
+    /** @deprecated unused */
+    @Deprecated()
     public static final long domainBootTimeout = Long.valueOf(System.getProperty("jboss.test.domain.boot.timeout", "60000"));
+    /** @deprecated unused */
+    @Deprecated
     public static final long domainShutdownTimeout = Long.valueOf(System.getProperty("jboss.test.domain.shutdown.timeout", "20000"));
+    @SuppressWarnings("WeakerAccess")
     public static final String masterJvmHome = System.getProperty("jboss.test.host.master.jvmhome");
+    @SuppressWarnings("WeakerAccess")
     public static final String slaveJvmHome = System.getProperty("jboss.test.host.slave.jvmhome");
+    @SuppressWarnings("WeakerAccess")
     public static final String masterControllerJvmHome = System.getProperty("jboss.test.host.master.controller.jvmhome");
+    @SuppressWarnings("WeakerAccess")
     public static final String slaveControllerJvmHome = System.getProperty("jboss.test.host.slave.controller.jvmhome");
 
     /**
@@ -163,6 +170,7 @@ public class DomainTestSupport {
         }
     }
 
+    @SuppressWarnings("unused")
     public static void startHosts(long timeout, DomainLifecycleUtil... hosts) {
         Future<?>[] futures = new Future<?>[hosts.length];
         for (int i = 0; i < hosts.length; i++) {
@@ -181,23 +189,52 @@ public class DomainTestSupport {
         processFutures(futures, timeout);
     }
 
+    /**
+     * Gets the base dir in which content specific to {@code testname} should be written.
+     *
+     * @param testName name identifying a test or test suite whose written output so be segregated from other output
+     * @return the file representing the base dir
+     */
+    @SuppressWarnings("WeakerAccess")
     public static File getBaseDir(String testName) {
         return new File("target" + File.separator + "domains" + File.separator + testName);
     }
 
+    /**
+     * Gets the dir under {@link #getBaseDir(String)} in which content specific to a particular host should be written.
+     *
+     * @param testName name identifying a test or test suite whose written output so be segregated from other output
+     * @param hostName the name of the host
+     * @return the file representing the host's dir
+     */
     public static File getHostDir(String testName, String hostName) {
         return new File(getBaseDir(testName), hostName);
     }
 
+    /**
+     * Gets the dir under {@link #getBaseDir(String)} in which additional JBoss Modules modules used by
+     * the test should be written.
+     *
+     * @param testName name identifying a test or test suite whose written output so be segregated from other output
+     * @return the file representing the host's dir
+     */
     public static File getAddedModulesDir(String testName) {
         File f = new File(getBaseDir(testName), "added-modules");
-        f.mkdirs();
+        checkedMkDirs(f);
         return f;
     }
 
+    /**
+     * Gets the dir under {@link #getHostDir(String, String)} )} in which additional JBoss Modules modules used by
+     * the test but targetted to a particular host should be written.
+     *
+     * @param testName name identifying a test or test suite whose written output so be segregated from other output
+     * @return the file representing the host's dir
+     */
+    @SuppressWarnings("WeakerAccess")
     public static File getHostOverrideModulesDir(String testName, String hostName) {
         final File f = new File(getHostDir(testName, hostName), "added-modules");
-        f.mkdirs();
+        checkedMkDirs(f);
         return f;
     }
 
@@ -248,11 +285,15 @@ public class DomainTestSupport {
         return response.get(FAILURE_DESCRIPTION);
     }
 
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public static void cleanFile(File file) {
         if (file != null && file.exists()) {
             if (file.isDirectory()) {
-                for (File child : file.listFiles()) {
-                    cleanFile(child);
+                File[] children = file.listFiles();
+                if (children != null) {
+                    for (File child : children) {
+                        cleanFile(child);
+                    }
                 }
             }
             if (!file.delete()) {
@@ -261,7 +302,7 @@ public class DomainTestSupport {
         }
     }
 
-    public static void safeClose(final Closeable closeable) {
+    public static void safeClose(final AutoCloseable closeable) {
         if (closeable != null) try {
             closeable.close();
         } catch (Throwable t) {
@@ -303,12 +344,19 @@ public class DomainTestSupport {
         config.setModulePath(path.toString());
     }
 
+    private static void checkedMkDirs(File f) {
+        if (!f.mkdirs() && !f.exists()) {
+            throw new RuntimeException("Cannot create dir " + f);
+        }
+    }
+
     private final WildFlyManagedConfiguration masterConfiguration;
     private final WildFlyManagedConfiguration slaveConfiguration;
     private final DomainLifecycleUtil domainMasterLifecycleUtil;
     private final DomainLifecycleUtil domainSlaveLifecycleUtil;
     private final DomainControllerClientConfig sharedClientConfig;
     private final String testClass;
+    private volatile boolean closed;
 
 
 
@@ -357,7 +405,14 @@ public class DomainTestSupport {
         return masterConfiguration;
     }
 
+    /**
+     * Gets the {@link DomainLifecycleUtil} object for interacting with the master @{code HostController}.
+     * @return the util object. Will not return {@code null}
+     *
+     * @throws IllegalStateException if {@link #close()} has previously been called
+     */
     public DomainLifecycleUtil getDomainMasterLifecycleUtil() {
+        checkClosed();
         return domainMasterLifecycleUtil;
     }
 
@@ -365,7 +420,15 @@ public class DomainTestSupport {
         return slaveConfiguration;
     }
 
+    /**
+     * Gets the {@link DomainLifecycleUtil} object for interacting with the non-master @{code HostController}, if there
+     * is one.
+     * @return the util object. May return {@code null} if this object was not configured to provide a non-master.
+     *
+     * @throws IllegalStateException if {@link #close()} has previously been called
+     */
     public DomainLifecycleUtil getDomainSlaveLifecycleUtil() {
+        checkClosed();
         return domainSlaveLifecycleUtil;
     }
 
@@ -373,7 +436,13 @@ public class DomainTestSupport {
         return sharedClientConfig;
     }
 
+    /**
+     * Starts the {@link DomainLifecycleUtil} objects managed by this object.
+     *
+     * @throws IllegalStateException if {@link #close()} has previously been called
+     */
     public void start() {
+        checkClosed();
         domainMasterLifecycleUtil.start();
         if (domainSlaveLifecycleUtil != null) {
             try {
@@ -389,20 +458,42 @@ public class DomainTestSupport {
         }
     }
 
+    /**
+     * Adds a new module to the {@link #getAddedModulesDir(String) added module dir} associated with the
+     * test suite or class for which this object is providing support.
+     *
+     * @param moduleName the name of the module
+     * @param moduleXml  stream providing the contents of the module's {@code moudle.xml} file
+     * @param contents   map of module contents, keyed by the name of the content
+     *
+     * @throws IllegalStateException if {@link #close()} has previously been called
+     */
     public void addTestModule(String moduleName, InputStream moduleXml, Map<String, StreamExporter> contents) throws IOException {
+        checkClosed();
         File modulesDir = getAddedModulesDir(testClass);
         addModule(modulesDir, moduleName, moduleXml, contents);
     }
 
+    /**
+     * Adds a new module to the {@link #getHostOverrideModulesDir(String, String) host overrides module dir} associated with the
+     * test suite or class for which this object is providing support.
+     *
+     * @param moduleName the name of the module
+     * @param moduleXml  stream providing the contents of the module's {@code moudle.xml} file
+     * @param contents   map of module contents, keyed by the name of the content
+     *
+     * @throws IllegalStateException if {@link #close()} has previously been called
+     */
     public void addOverrideModule(String hostName, String moduleName, InputStream moduleXml, Map<String, StreamExporter> contents) throws IOException {
+        checkClosed();
         File modulesDir = getHostOverrideModulesDir(testClass, hostName);
         addModule(modulesDir, moduleName, moduleXml, contents);
     }
 
-    static void addModule(final File modulesDir, String moduleName, InputStream moduleXml, Map<String, StreamExporter> resources) throws IOException {
+    private static void addModule(final File modulesDir, String moduleName, InputStream moduleXml, Map<String, StreamExporter> resources) throws IOException {
         String modulePath = moduleName.replace('.', File.separatorChar) + File.separatorChar + "main";
         File moduleDir = new File(modulesDir, modulePath);
-        moduleDir.mkdirs();
+        checkedMkDirs(moduleDir);
         FileUtils.copyFile(moduleXml, new File(moduleDir, "module.xml"));
         for (Map.Entry<String, StreamExporter> entry : resources.entrySet()) {
             entry.getValue().exportTo(new File(moduleDir, entry.getKey()), true);
@@ -412,21 +503,31 @@ public class DomainTestSupport {
     /**
      * Stops the {@link #getDomainMasterLifecycleUtil() master host} and, if there is one, the
      * {@link #getDomainSlaveLifecycleUtil() slave host}, and also closes any
-     * {@link #getSharedClientConfiguration() shared client configuration}. This object should not be used
-     * for controlling or interacting with hosts after this is called, even if {@link #start()} is called again.
+     * {@link #getSharedClientConfiguration() shared client configuration}. This object and any
+     * {@link DomainLifecycleUtil} objects obtained from it cannot be used
+     * for controlling or interacting with hosts after this is called.
      */
-    public void stop() {
+    public void close() {
+        closed = true;
         try {
             try {
                 if (domainSlaveLifecycleUtil != null) {
-                    domainSlaveLifecycleUtil.stop();
+                    domainSlaveLifecycleUtil.close();
                 }
             } finally {
-                domainMasterLifecycleUtil.stop();
+                domainMasterLifecycleUtil.close();
             }
         } finally {
             StreamUtils.safeClose(sharedClientConfig);
         }
+    }
+
+    /**
+     * Calls {@link #close()}. This object cannot be used for controlling or interacting with hosts after
+     * this is called.
+     */
+    public void stop() {
+        close();
     }
 
     /**
@@ -435,10 +536,17 @@ public class DomainTestSupport {
      * timeout for a host to stop.
      */
     public void stopHosts() {
+        //checkClosed(); -- don't fail if already closed, as this is harmless
         if (domainSlaveLifecycleUtil != null) {
             stopHosts(120000, domainSlaveLifecycleUtil, domainMasterLifecycleUtil);
         } else {
             stopHosts(120000, domainMasterLifecycleUtil);
+        }
+    }
+
+    private void checkClosed() {
+        if (closed) {
+            throw new IllegalStateException(getClass().getSimpleName() + " is closed");
         }
     }
 
@@ -472,10 +580,12 @@ public class DomainTestSupport {
             return create(testName, domainConfig, masterConfig, slaveConfig, false, false, false);
         }
 
+        @SuppressWarnings("WeakerAccess")
         public static Configuration createDebugMaster(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
             return create(testName, domainConfig, masterConfig, slaveConfig, false, false, true, false, false);
         }
 
+        @SuppressWarnings("WeakerAccess")
         public static Configuration createDebugSlave(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
             return create(testName, domainConfig, masterConfig, slaveConfig, false, false, false, false, true);
         }
@@ -521,7 +631,8 @@ public class DomainTestSupport {
             masterConfig.setHostConfigFile(new File(toURI(url)).getAbsolutePath());
             File masterDir = new File(domains, hostName);
             // TODO this should not be necessary
-            new File(masterDir, "configuration").mkdirs();
+            File cfgDir = new File(masterDir, "configuration");
+            checkedMkDirs(cfgDir);
             masterConfig.setDomainDirectory(masterDir.getAbsolutePath());
             if (masterJvmHome != null) masterConfig.setJavaHome(masterJvmHome);
             if (masterControllerJvmHome != null) masterConfig.setControllerJavaHome(masterControllerJvmHome);
@@ -548,10 +659,12 @@ public class DomainTestSupport {
             }
             slaveConfig.setReadOnlyHost(readOnlyHost);
             URL url = tccl.getResource(hostConfigPath);
+            assert url != null;
             slaveConfig.setHostConfigFile(new File(toURI(url)).getAbsolutePath());
             File slaveDir = new File(domains, hostName);
             // TODO this should not be necessary
-            new File(slaveDir, "configuration").mkdirs();
+            File cfgDir = new File(slaveDir, "configuration");
+            checkedMkDirs(cfgDir);
             slaveConfig.setDomainDirectory(slaveDir.getAbsolutePath());
             if (slaveJvmHome != null) slaveConfig.setJavaHome(slaveJvmHome);
             if (slaveControllerJvmHome != null) slaveConfig.setControllerJavaHome(slaveControllerJvmHome);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -525,7 +525,10 @@ public class DomainTestSupport implements AutoCloseable {
     /**
      * Calls {@link #close()}. This object cannot be used for controlling or interacting with hosts after
      * this is called.
+     *
+     * @deprecated Use {@link #close()}
      */
+    @Deprecated
     public void stop() {
         close();
     }


### PR DESCRIPTION
Stopping DomainTestSupport causes it to close its controlled DomainLifecycleUtil objects
Stopping DomainLifecyleUtil closes its shared DomainTestClient.
Deprecate DomainTestSupport.stop() in favor of close() as close has a clearer semantic
Also a lot of cleanup to get rid of IDE warns for these classes.

https://issues.jboss.org/browse/WFCORE-4385

Needs #3709 and #3711 first as those correct invalid uses of DomainTestSupport that the main commits in this PR disallow.  The commits in those PRs are in this one.