### PR TITLE
[WFCORE-4387] Fix typo in remoting descriptions

### DIFF
--- a/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -13,7 +13,7 @@ remoting.worker-task-max-threads=The maximum number of threads for the remoting 
 remoting.worker-task-max-threads.deprecated=Use IO subsystem worker configuration
 remoting.worker-write-threads=The number of write threads to create for the remoting worker.
 remoting.worker-write-threads.deprecated=Use IO subsystem worker configuration
-remoting.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified\
+remoting.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified \
   and the selected SASL mechanism demands a user name.
 remoting.auth-realm=The authentication realm to use if no authentication CallbackHandler is specified.
 remoting.sasl-protocol=Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
@@ -26,7 +26,7 @@ remoting.max-outbound-messages=The maximum number of concurrent outbound message
 remoting.send-buffer-size=The size of the largest buffer that this endpoint will transmit over a connection.
 remoting.max-inbound-messages=The maximum number of concurrent inbound messages on a channel.
 remoting.receive-window-size=The maximum window size of the receive direction for connection channels, in bytes.
-remoting.heartbeat-interval=The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction\
+remoting.heartbeat-interval=The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction \
   for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
 remoting.max-inbound-message-size=The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
 remoting.max-outbound-channels=The maximum number of outbound channels to support for a connection.
@@ -40,7 +40,7 @@ endpoint=Endpoint configuration
 endpoint.add=Adds endpoint
 endpoint.remove=Removes endpoint configuration
 endpoint.deprecated=The child resource for configuring the remoting endpoint is deprecated. Use the attributes on the parent resource to configure the remoting endpoint.
-endpoint.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified\
+endpoint.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified \
   and the selected SASL mechanism demands a user name.
 endpoint.auth-realm=The authentication realm to use if no authentication CallbackHandler is specified.
 endpoint.sasl-protocol=Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
@@ -53,7 +53,7 @@ endpoint.max-outbound-messages=The maximum number of concurrent outbound message
 endpoint.send-buffer-size=The size of the largest buffer that this endpoint will transmit over a connection.
 endpoint.max-inbound-messages=The maximum number of concurrent inbound messages on a channel.
 endpoint.receive-window-size=The maximum window size of the receive direction for connection channels, in bytes.
-endpoint.heartbeat-interval=The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction\
+endpoint.heartbeat-interval=The interval to use for connection heartbeat, in milliseconds. If the connection is idle in the outbound direction \
   for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
 endpoint.max-inbound-message-size=The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
 endpoint.max-outbound-channels=The maximum number of outbound channels to support for a connection.


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-4387

