### PR TITLE
Fix for WFCORE-4389, CLI, deploy fails in batch when operation is validated

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1743,6 +1743,11 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
                         }
                     }
                 }
+                // Needed to have the command be fully parsed and retrieve the
+                // child command. This is caused by aesh 2.0 behavior.
+                if (isBatchMode()) {
+                    exec.populateCommand();
+                }
                 BatchCompliantCommand bc = exec.getBatchCompliant();
                 if (isBatchMode() && bc != null) {
                     try {

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractDeployContentCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractDeployContentCommand.java
@@ -128,9 +128,11 @@ public abstract class AbstractDeployContentCommand extends AbstractDeployCommand
         // replace
         final ModelNode request = new ModelNode();
         request.get(Util.OPERATION).set(op);
-        request.get(Util.NAME).set(name);
         if (op.equals(Util.ADD)) { // replace is on root, add is on deployed artifact.
             request.get(Util.ADDRESS, Util.DEPLOYMENT).set(name);
+        } else {
+            request.get(Util.NAME).set(name);
+            request.get(Util.ADDRESS).setEmptyList();
         }
         if (runtimeName != null) {
             request.get(Util.RUNTIME_NAME).set(runtimeName);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
@@ -709,4 +709,70 @@ public class DeployTestCase extends AbstractCliTestBase{
         assertThat("After disabling of already disabled application deployment something is change!",
                 after, is(before));
     }
+
+    @Test
+    public void testDeployInBatch() throws Exception {
+        ctx.handle("batch");
+        try {
+            ctx.handle("deploy " + cliTestApp1War.getAbsolutePath() + " --runtime-name=calendar.war --name=calendar.war --disabled --unmanaged");
+            ctx.handle("run-batch");
+        } catch (Exception ex) {
+            try {
+                ctx.handle("discard-batch");
+            } catch (Exception ex2) {
+                // XXX OK, the batch failed but terminated.
+            }
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testForceDeployInBatch() throws Exception {
+        ctx.handle("deploy " + cliTestApp1War.getAbsolutePath() +" --runtime-name=calendar.war --name=calendar.war --disabled --unmanaged");
+        ctx.handle("batch");
+        try {
+            ctx.handle("deploy " + cliTestApp1War.getAbsolutePath() + " --runtime-name=calendar.war --name=calendar.war --disabled --unmanaged --force");
+            ctx.handle("run-batch");
+        } catch (Exception ex) {
+            try {
+                ctx.handle("discard-batch");
+            } catch (Exception ex2) {
+                // XXX OK, the batch failed but terminated.
+            }
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testDeployFileInBatch() throws Exception {
+        ctx.handle("batch");
+        try {
+            ctx.handle("deployment deploy-file " + cliTestApp1War.getAbsolutePath() + " --runtime-name=calendar.war --name=calendar.war --disabled --unmanaged");
+            ctx.handle("run-batch");
+        } catch (Exception ex) {
+            try {
+                ctx.handle("discard-batch");
+            } catch (Exception ex2) {
+                // XXX OK, the batch failed but terminated.
+            }
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testForceDeployFileInBatch() throws Exception {
+        ctx.handle("deployment deploy-file " + cliTestApp1War.getAbsolutePath() +" --runtime-name=calendar.war --name=calendar.war --disabled --unmanaged");
+        ctx.handle("batch");
+        try {
+            ctx.handle("deployment deploy-file " + cliTestApp1War.getAbsolutePath() +" --runtime-name=calendar.war --name=calendar.war --disabled --unmanaged --replace");
+            ctx.handle("run-batch");
+        } catch(Exception ex) {
+            try {
+                ctx.handle("discard-batch");
+            } catch(Exception ex2) {
+                // XXX OK, the batch failed but terminated.
+            }
+            throw ex;
+        }
+    }
 }


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFCORE-4389

- Fixed DMR not compliant with operation-description and CLI validation rules (request must have an address).
- Added unit tests for adding and replacing deployments in batch.
- Fixed an issue discovered during testing with aesh2.0
