### PR TITLE
[WFCORE-4401] Make the 'org.wildfly.security.password.util' package public.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -52,6 +52,7 @@
                     <path name="org/wildfly/security/password"/>
                     <path name="org/wildfly/security/password/interfaces"/>
                     <path name="org/wildfly/security/password/spec"/>
+                    <path name="org/wildfly/security/password/util"/>
                     <path name="org/wildfly/security/permission"/>
                     <path name="org/wildfly/security/sasl/util"/>
                     <path name="org/wildfly/security/ssl"/>


### PR DESCRIPTION
This is an existing API that should have been public to allow users to populate their security realms: -

https://issues.jboss.org/browse/WFCORE-4401
