### PR TITLE
Fix for WFCORE-4402, Upgrade CLI to use aesh 2.3

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandContainer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandContainer.java
@@ -161,6 +161,16 @@ public class CLICommandContainer extends DefaultCommandContainer<CLICommandInvoc
         public void doPopulate(ProcessedCommand processedCommand, InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException {
             parser.doPopulate(processedCommand, invocationProviders, aeshContext, mode);
         }
+
+        @Override
+        public void updateAnsiMode(boolean mode) {
+            parser.updateAnsiMode(mode);
+        }
+
+        @Override
+        public String getFormattedCommand(int offset, int descriptionStart) {
+            return parser.getFormattedCommand(offset, descriptionStart);
+        }
     }
 
     public class CLICommandParser implements CommandLineParser<CLICommandInvocation> {
@@ -272,6 +282,16 @@ public class CLICommandContainer extends DefaultCommandContainer<CLICommandInvoc
         @Override
         public void doPopulate(ProcessedCommand processedCommand, InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException {
             container.getParser().doPopulate(processedCommand, invocationProviders, aeshContext, mode);
+        }
+
+        @Override
+        public void updateAnsiMode(boolean mode) {
+            container.getParser().updateAnsiMode(mode);
+        }
+
+        @Override
+        public String getFormattedCommand(int offset, int descriptionStart) {
+            return container.getParser().getFormattedCommand(offset, descriptionStart);
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/LegacyCommandContainer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/LegacyCommandContainer.java
@@ -192,6 +192,16 @@ public class LegacyCommandContainer extends DefaultCommandContainer<CLICommandIn
         @Override
         public void doPopulate(ProcessedCommand processedCommand, InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException {
         }
+
+        @Override
+        public void updateAnsiMode(boolean mode) {
+
+        }
+
+        @Override
+        public String getFormattedCommand(int offset, int descriptionStart) {
+            return null;
+        }
     }
 
     private final Command<CLICommandInvocation> command = new LegacyCommand();

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/OperationCommandContainer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/operation/OperationCommandContainer.java
@@ -186,6 +186,16 @@ public class OperationCommandContainer extends DefaultCommandContainer<CLIComman
         @Override
         public void doPopulate(ProcessedCommand processedCommand, InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException {
         }
+
+        @Override
+        public void updateAnsiMode(boolean mode) {
+
+        }
+
+        @Override
+        public String getFormattedCommand(int offset, int descriptionStart) {
+            return null;
+        }
     }
 
     private final Command<CLICommandInvocation> command = new OperationCommand();

--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,9 @@
         <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
-        <version.org.aesh>2.0</version.org.aesh>
+        <version.org.aesh>2.3</version.org.aesh>
         <version.org.aesh-extensions>1.7</version.org.aesh-extensions>
-        <version.org.aesh-readline>1.15</version.org.aesh-readline>
+        <version.org.aesh-readline>1.17</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <!-- TODO Elytron - Bump to M17 -->
         <version.org.apache.httpcomponents.httpclient>4.5.4</version.org.apache.httpcomponents.httpclient>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.eclipse.jgit>5.0.2.201807311906-r</version.org.eclipse.jgit>
-        <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
+        <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.4.Final</version.org.jboss.classfilewriter>


### PR DESCRIPTION
Fix for: https://issues.jboss.org/browse/WFCORE-4402 and https://issues.jboss.org/browse/WFCORE-4408

- Aesh release contains jansi upgrade needed to fix dll copy on Windows.
- jansi upgrade to the one expected by aesh.