### PR TITLE
[WFCORE-4407] Configure Elytron domain services with LAZY initial mode

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -371,7 +371,7 @@ class AuthenticationFactoryDefinitions {
         AttributeDefinition mechanismConfigurationAttribute = getMechanismConfiguration(HTTP_AUTHENTICATION_FACTORY_CAPABILITY);
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { securityDomainAttribute, HTTP_SERVER_MECHANISM_FACTORY, mechanismConfigurationAttribute };
-        AbstractAddStepHandler add = new TrivialAddHandler<HttpAuthenticationFactory>(HttpAuthenticationFactory.class, attributes, HTTP_AUTHENTICATION_FACTORY_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<HttpAuthenticationFactory>(HttpAuthenticationFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, HTTP_AUTHENTICATION_FACTORY_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<HttpAuthenticationFactory> getValueSupplier(
@@ -456,7 +456,7 @@ class AuthenticationFactoryDefinitions {
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { securityDomainAttribute, SASL_SERVER_FACTORY, mechanismConfigurationAttribute };
 
-        AbstractAddStepHandler add = new TrivialAddHandler<SaslAuthenticationFactory>(SaslAuthenticationFactory.class, attributes, SASL_AUTHENTICATION_FACTORY_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<SaslAuthenticationFactory>(SaslAuthenticationFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, SASL_AUTHENTICATION_FACTORY_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<SaslAuthenticationFactory> getValueSupplier(

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -249,7 +249,7 @@ class DomainDefinition extends SimpleResourceDefinition {
         DomainService domain = new DomainService(defaultRealm, trustedSecurityDomain, identityOperator);
 
         ServiceBuilder<SecurityDomain> domainBuilder = serviceTarget.addService(initialName, domain)
-                .setInitialMode(Mode.ACTIVE);
+                .setInitialMode(Mode.LAZY);
 
         if (preRealmPrincipalTransformer != null) {
             injectPrincipalTransformer(preRealmPrincipalTransformer, context, domainBuilder, domain.createPreRealmPrincipalTransformerInjector(preRealmPrincipalTransformer));
@@ -354,7 +354,7 @@ class DomainDefinition extends SimpleResourceDefinition {
 
         ServiceTarget serviceTarget = context.getServiceTarget();
         ServiceBuilder<SecurityDomain> domainBuilder = serviceTarget.addService(domainName, finalDomainService)
-                .setInitialMode(Mode.ACTIVE);
+                .setInitialMode(Mode.LAZY);
         domainBuilder.addDependency(initialName, SecurityDomain.class, securityDomain);
         for (String trustedDomainName : trustedSecurityDomainNames) {
             InjectedValue<SecurityDomain> trustedDomainInjector = new InjectedValue<>();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -215,7 +215,7 @@ class HttpServerDefinitions {
 
     static ResourceDefinition getServiceLoaderServerMechanismFactoryDefinition() {
         AttributeDefinition[] attributes = new AttributeDefinition[] { MODULE };
-        AbstractAddStepHandler add = new TrivialAddHandler<HttpServerAuthenticationMechanismFactory>(HttpServerAuthenticationMechanismFactory.class, attributes, HTTP_SERVER_MECHANISM_FACTORY_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<HttpServerAuthenticationMechanismFactory>(HttpServerAuthenticationMechanismFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, HTTP_SERVER_MECHANISM_FACTORY_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<HttpServerAuthenticationMechanismFactory> getValueSupplier(

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -942,7 +942,7 @@ class SSLDefinitions {
                 PRE_REALM_PRINCIPAL_TRANSFORMER, POST_REALM_PRINCIPAL_TRANSFORMER, FINAL_PRINCIPAL_TRANSFORMER, REALM_MAPPER,
                 providersDefinition, PROVIDER_NAME};
 
-        AbstractAddStepHandler add = new TrivialAddHandler<SSLContext>(SSLContext.class, ServiceController.Mode.ACTIVE, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<SSLContext>(SSLContext.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<SSLContext> getValueSupplier(ServiceBuilder<SSLContext> serviceBuilder,

--- a/elytron/src/test/java/org/wildfly/extension/elytron/DomainTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/DomainTestCase.java
@@ -84,6 +84,12 @@ public class DomainTestCase extends AbstractSubsystemTest {
         if (!services.isSuccessfulBoot()) {
             Assert.fail(services.getBootError().toString());
         }
+
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "MyDomain");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "X500Domain");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "X500DomainTwo");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "X500DomainThree");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "AnotherDomain");
     }
 
     @Test

--- a/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
@@ -110,6 +110,9 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         KernelServices services = createKernelServicesBuilder(null)
                 .setSubsystemXmlResource("identity-management.xml")
                 .build();
+
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "FileSystemDomain");
+
         PathAddress securityDomainAddress = getSecurityDomainAddress("FileSystemDomain");
         String principalName = "plainUser";
         ModelNode operation = createAddIdentityOperation(getSecurityRealmAddress("FileSystemRealm"), principalName);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
@@ -48,6 +48,7 @@ public class MappersTestCase extends AbstractSubsystemBaseTest {
             Assert.fail(services.getBootError().toString());
         }
 
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomain");
         ServiceName serviceName = Capabilities.PRINCIPAL_TRANSFORMER_RUNTIME_CAPABILITY.getCapabilityServiceName("tree");
         PrincipalTransformer transformer = (PrincipalTransformer) services.getContainer().getService(serviceName).getValue();
         Assert.assertNotNull(transformer);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/RoleMappersTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/RoleMappersTestCase.java
@@ -34,6 +34,8 @@ import java.io.IOException;
  * @author <a href="mailto:mmazanek@redhat.com">Martin Mazanek</a>
  */
 public class RoleMappersTestCase extends AbstractSubsystemBaseTest {
+    private KernelServices services = null;
+
     public RoleMappersTestCase() {
         super(ElytronExtension.SUBSYSTEM_NAME, new ElytronExtension());
     }
@@ -43,12 +45,21 @@ public class RoleMappersTestCase extends AbstractSubsystemBaseTest {
         return readResource("role-mappers-test.xml");
     }
 
-    @Test
-    public void testMappedRoleMapper() throws Exception {
-        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("role-mappers-test.xml").build();
+    private void init(String... domainsToActivate) throws Exception {
+        services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("role-mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
             Assert.fail(services.getBootError().toString());
         }
+
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestDomain1");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestDomain2");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestDomain3");
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestDomain4");
+    }
+
+    @Test
+    public void testMappedRoleMapper() throws Exception {
+        init("TestDomain1");
 
         ServiceName serviceName = Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY.getCapabilityServiceName("TestDomain1");
         Assert.assertNotNull(services.getContainer());
@@ -73,10 +84,7 @@ public class RoleMappersTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testKeepMappedRoleMapper() throws Exception {
-        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("role-mappers-test.xml").build();
-        if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
-        }
+        init("TestDomain2");
 
         ServiceName serviceName = Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY.getCapabilityServiceName("TestDomain2");
         Assert.assertNotNull(services.getContainer());
@@ -101,10 +109,7 @@ public class RoleMappersTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testKeepNonMappedRoleMapper() throws Exception {
-        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("role-mappers-test.xml").build();
-        if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
-        }
+        init("TestDomain3");
 
         ServiceName serviceName = Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY.getCapabilityServiceName("TestDomain3");
         Assert.assertNotNull(services.getContainer());
@@ -129,10 +134,7 @@ public class RoleMappersTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testKeepBothMappedRoleMapper() throws Exception {
-        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("role-mappers-test.xml").build();
-        if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
-        }
+        init("TestDomain4");
 
         ServiceName serviceName = Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY.getCapabilityServiceName("TestDomain4");
         Assert.assertNotNull(services.getContainer());

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -19,8 +19,13 @@ package org.wildfly.extension.elytron;
 
 import mockit.Mock;
 import mockit.MockUp;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.wildfly.security.x500.cert.BasicConstraintsExtension;
 import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
 import org.wildfly.security.x500.cert.X509CertificateBuilder;
@@ -198,4 +203,10 @@ class TestEnvironment extends AdditionalInitialization {
         new ClassLoadingAttributeDefinitionsMock();
     }
 
+    static void activateService(KernelServices services, RuntimeCapability capability, String... dynamicNameElements) throws InterruptedException {
+        ServiceName serviceName = capability.getCapabilityServiceName(dynamicNameElements);
+        ServiceController<?> serviceController = services.getContainer().getService(serviceName);
+        serviceController.setMode(ServiceController.Mode.ACTIVE);
+        serviceController.awaitValue();
+    }
 }


### PR DESCRIPTION
Change the initial mode of some of the Security Domain service graph as LAZY to allow configuring them in an embedded server running in admin-mode.

Jira issue: https://issues.jboss.org/browse/WFCORE-4407

CC: @darranl 