### PR TITLE
[WFCORE-4410] Upgrade Elytron Web to 1.5.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.9.0.CR2</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.4.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.5.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>


### PR DESCRIPTION
This component upgrade is just switching to the minor version of Elytron Web also updated to use the modularised version of WildFly Elytron - this specific release does not contain further fixes / enhancements.