### PR TITLE
[WFCORE-4415] Upgrading JBoss Modules from 1.9.0.Final to 1.9.1.Final

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/src/main/resources/content/bin/common.bat
@@ -15,7 +15,6 @@ goto :eof
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.base/sun.nio.ch=ALL-UNNAMED"
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED"
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED"
-      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-modules=java.se"
     ) else (
       set "DEFAULT_MODULAR_JVM_OPTIONS="
     )

--- a/core-feature-pack/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/common.ps1
@@ -132,7 +132,6 @@ Param(
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED"
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED"
-        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-modules=java.se"
     }
     return $DEFAULT_MODULAR_JVM_OPTIONS
 }

--- a/core-feature-pack/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/src/main/resources/content/bin/common.sh
@@ -13,7 +13,6 @@ setDefaultModularJvmOptions() {
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.base/sun.nio.ch=ALL-UNNAMED"
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED"
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED"
-      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-modules=java.se"
     else
       DEFAULT_MODULAR_JVM_OPTIONS=""
     fi

--- a/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
@@ -59,7 +59,6 @@ public final class JvmType {
         modularJavaOpts.add("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED");
-        modularJavaOpts.add("--add-modules=java.se");
         DEFAULT_MODULAR_JVM_ARGUMENTS = Collections.unmodifiableList(modularJavaOpts);
     }
 

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -124,7 +124,7 @@ public class ManagedServerBootCmdFactoryTestCase {
         List<String> result = instance.getServerLaunchCommand();
         Assert.assertThat(result.size(), is(notNullValue()));
         if (result.size() > 16) {
-            Assert.assertThat(result.size(), is(20));
+            Assert.assertThat(result.size(), is(19));
         } else {
             Assert.assertThat(result.size(), is(16));
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -60,7 +60,6 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         modularJavaOpts.add("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED");
-        modularJavaOpts.add("--add-modules=java.se");
         DEFAULT_MODULAR_VM_ARGUMENTS = Collections.unmodifiableList(modularJavaOpts);
     }
 

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -203,7 +203,6 @@ public class CommandBuilderTest {
             assertArgumentExists(command, "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED", expectedCount);
-            assertArgumentExists(command, "--add-modules=java.se", expectedCount);
         } else {
             Assert.assertFalse("Did not expect \"--add-exports=java.base/sun.nio.ch=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"));
@@ -211,7 +210,6 @@ public class CommandBuilderTest {
                     command.contains("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED"));
-            Assert.assertFalse("Did not expect \"--add-modules=java.se\" to be in the command list", command.contains("--add-modules=java.se"));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>2.1.8.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.modules.jboss-modules>1.9.0.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.5.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.8.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.1.Final</version.org.jboss.remotingjmx.remoting-jmx>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4415

This update brings in the following fixes:
 * [MODULES-387] Add JMX operation to get a class location
 * [MODULES-386] Fixing Javadoc build issues on JDK11
 * [MODULES-375] Check if the artifact was successfully resolved before attempting to create the loader
 * [MODULES-372] provide our own "java.se" module on JDK 9+

