### PR TITLE
[WFCORE-4430] Upgrade jboss-stdio from 1.0.2.GA to 1.1.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>1.0.2.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
-        <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
+        <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.7.1.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4430