### PR TITLE
[WFCORE-4438] Disable console error context handler for ConsoleMode.NO_CONSOLE

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -379,7 +379,7 @@ public class ManagementHttpServer {
             ROOT_LOGGER.consoleModuleNotFound(builder.consoleSlot == null ? "main" : builder.consoleSlot);
         }
 
-        if (builder.consoleMode.hasConsole()) {
+        if (builder.consoleMode != ConsoleMode.NO_CONSOLE) {
             try {
                 addErrorContextHandler(pathHandler, builder);
             } catch (ModuleLoadException e) {


### PR DESCRIPTION
This fix follows up https://github.com/wildfly/wildfly-core/pull/3699, it disables the console error context handler only for ConsoleMode.NO_CONSOLE. For any other console modes ADMIN_ONLY, SLAVE_HC or CONSOLE, the error context handler is added.

Jira issue: https://issues.jboss.org/browse/WFCORE-4438

FYI @soul2zimate since it is related to the changes in this PR: https://github.com/jbossas/wildfly-core-eap/pull/662