### PR TITLE
[WFCORE-4443] / [WFCORE-4444] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.9.0.CR4</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.5.0.CR1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.5.0.CR2</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.9.0.CR3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.9.0.CR4</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.5.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4443
https://issues.jboss.org/browse/WFCORE-4444

Bug fix / minor maintenance releases.


        **Release Notes - WildFly Elytron - Version 1.9.0.CR4**
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1786'>ELY-1786</a>] -         JBoss Logging Component Upgrades
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1787'>ELY-1787</a>] -         Upgrade WildFly Common to 1.5.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1793'>ELY-1793</a>] -         Cache JsonProvider in JsonSecurityEventFormatter
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1794'>ELY-1794</a>] -         FORM Authentication should detect FORM submission BEFORE attempting to restore from cache.
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1788'>ELY-1788</a>] -         Update the minimum JDK build version to 11
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1789'>ELY-1789</a>] -         Add a global property for the Maven XML plugin in the tests module
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1795'>ELY-1795</a>] -         Release WildFly Elytron 1.9.0.CR4
</li>
</ul>
                    



        **Release Notes - Elytron Web - Version 1.5.0.CR2**
                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-50'>ELYWEB-50</a>] -         Add test case testing use of AuthenticationManager
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-51'>ELYWEB-51</a>] -         Update ElytronHttpExchange.getSSLSession() to use Undertows SSLSessionInfo
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-55'>ELYWEB-55</a>] -         Release Elytron Web 1.5.0.CR2
</li>
</ul>
                    