### PR TITLE
WFCORE-4450 java.rmi package not visible to application

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -41,6 +41,8 @@
         <!-- This is a workaround for WFLY-10394 -->
         <module name="java.naming"/>
         <module name="java.management"/>
+        <!-- This is a workaround for WFCORE-4450 -->
+        <module name="java.rmi"/>
         <module name="jdk.security.auth"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-4450
WFLY issue: https://issues.jboss.org/browse/WFLY-12026
Downstream issue: https://issues.jboss.org/browse/JBEAP-16725