### PR TITLE
[WFCORE-4457] Ensure that any tests that set the JVM wide default SSLContext restore it to the default default.

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -238,7 +238,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${org.jmockit:jmockit:jar} ${surefire.jacoco.args}</argLine>
+                    <argLine>-javaagent:${org.jmockit:jmockit:jar} ${surefire.jacoco.args} -Dorg.wildfly.extension.elytron.restore-default-ssl-context=true</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -108,6 +108,13 @@ import org.wildfly.security.manager.action.ReadPropertyAction;
  */
 class ElytronDefinition extends SimpleResourceDefinition {
 
+    /**
+     * System property which if set to {@code true} will cause the JVM wide default {@link SSLContext} to be restored when the subsystem shuts down.
+     *
+     * This property is only for use by test cases.
+     */
+    static final String RESTORE_DEFAULT_SSL_CONTEXT = ElytronDefinition.class.getPackage().getName() + ".restore-default-ssl-context";
+
     private static final AttachmentKey<SecurityPropertyService> SECURITY_PROPERTY_SERVICE_KEY = AttachmentKey.create(SecurityPropertyService.class);
 
     private static final AuthenticationContextDependencyProcessor AUTHENITCATION_CONTEXT_PROCESSOR = new AuthenticationContextDependencyProcessor();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4457