### PR TITLE
[WFCORE-4458] Do not re-wrap a LogContextSelector if it's already bee…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
@@ -50,8 +50,13 @@ class WildFlyLogContextSelectorImpl implements WildFlyLogContextSelector {
     }
 
     WildFlyLogContextSelectorImpl(final LogContextSelector defaultLogContextSelector) {
+        // There is not a way to reset the LogContextSelector after a reload. If the current selector is already a
+        // WildFlyLogContextSelectorImpl we should use the system default selector. This avoids possibly wrapping the
+        // same log context several times. It should also work with the embedded CLI selector as the commands handle
+        // setting and resetting the contexts.
+        final LogContextSelector dft = (defaultLogContextSelector instanceof WildFlyLogContextSelectorImpl ? LogContext.DEFAULT_LOG_CONTEXT_SELECTOR : defaultLogContextSelector);
         counter = new AtomicInteger(0);
-        contextSelector = new ClassLoaderLogContextSelector(defaultLogContextSelector, true);
+        contextSelector = new ClassLoaderLogContextSelector(dft, true);
         threadLocalContextSelector = new ThreadLocalLogContextSelector(contextSelector);
     }
 


### PR DESCRIPTION
…n wrapped once. This avoids issues with recursive searches.

https://issues.jboss.org/browse/WFCORE-4458