### PR TITLE
[WFCORE-4467] / [WFCORE-4468] WildFly Elytron Component Upgrades

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -325,6 +325,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-credential-source-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-credential-store</artifactId>
         </dependency>
         <dependency>

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -1352,6 +1352,17 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-credential-source-impl</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-credential-store</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -49,6 +49,7 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-client}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-credential}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-credential-source-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-credential-source-impl}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-credential-store}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-digest}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http}"/>

--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -657,6 +657,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-credential-source-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-credential-store</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.9.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.5.0.CR2</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.5.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.9.0.CR5</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.9.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.5.0.CR2</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
@@ -1555,6 +1555,11 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-credential-source-deprecated</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-credential-source-impl</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4467
https://issues.jboss.org/browse/WFCORE-4468


        Release Notes - WildFly Elytron - Version 1.9.0.Final
                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1805'>ELY-1805</a>] -         Remove wildfly-elytron-titan module from project
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1807'>ELY-1807</a>] -         Two ElytronMessage definitions in the same package
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1716'>ELY-1716</a>] -         Develop an alternative to &#39;wildfly-elytron-credential-source-deprecated&#39;
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1762'>ELY-1762</a>] -         Ensure JAPICMP Compatibility and enable plug-in for all builds.
</li>
</ul>
                                    


        Release Notes - Elytron Web - Version 1.5.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-56'>ELYWEB-56</a>] -         Upgrade JBoss Parent to version 35
</li>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-57'>ELYWEB-57</a>] -         Update WildFly Checkstyle Config to 1.0.8.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-58'>ELYWEB-58</a>] -         Upgrade WildFly Elytron to 1.9.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-59'>ELYWEB-59</a>] -         Upgrade WildFly Common to 1.5.1.Final
</li>
</ul>
                                                                                                    
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-60'>ELYWEB-60</a>] -         Release Elytron Web 1.5.0.Final
</li>
</ul>
                    