### PR TITLE
[WFCORE-4469] Upgrade Remoting JMX to 3.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.5.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.9.Final</version.org.jboss.remoting>
-        <version.org.jboss.remotingjmx.remoting-jmx>3.0.1.Final</version.org.jboss.remotingjmx.remoting-jmx>
+        <version.org.jboss.remotingjmx.remoting-jmx>3.0.2.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4469


        Release Notes - Remoting JMX - Version 3.0.2.Final
                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/REMJMX-160'>REMJMX-160</a>] -         Every JMXConnectorFactory#connect() creates a new ThreadGroup which is never reclaimed
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/REMJMX-162'>REMJMX-162</a>] -         Release Remoting JMX 3.0.2.Final
</li>
</ul>
                    