### PR TITLE
 [WFCORE-4475] jboss-deployment-structure.xml with fails to parse when annotations=true on a sub-deployment module

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/annotation/CompositeIndexProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/annotation/CompositeIndexProcessor.java
@@ -90,12 +90,17 @@ public class CompositeIndexProcessor implements DeploymentUnitProcessor {
         for (final ModuleIdentifier moduleIdentifier : additionalModuleIndexes) {
             AdditionalModuleSpecification additional = additionalModuleSpecificationMap.get(moduleIdentifier);
             if(additional != null) {
+                final List<Index> moduleIndexes = new ArrayList<>();
                 for(ResourceRoot resource : additional.getResourceRoots()) {
                     ResourceRootIndexer.indexResourceRoot(resource);
                     Index indexAttachment = resource.getAttachment(Attachments.ANNOTATION_INDEX);
                     if(indexAttachment != null) {
                         indexes.add(indexAttachment);
+                        moduleIndexes.add(indexAttachment);
                     }
+                }
+                if (!moduleIndexes.isEmpty()) {
+                    additionalAnnotationIndexes.put(moduleIdentifier, new CompositeIndex(moduleIndexes));
                 }
             } else if (subdeploymentDependencies.containsKey(moduleIdentifier)) {
                 List<ResourceRoot> resourceRoots = subdeploymentDependencies.get(moduleIdentifier).getAttachment(Attachments.RESOURCE_ROOTS);
@@ -107,11 +112,16 @@ public class CompositeIndexProcessor implements DeploymentUnitProcessor {
                 if (ModuleRootMarker.isModuleRoot(deploymentRoot)) {
                     allResourceRoots.add(deploymentRoot);
                 }
+                final List<Index> moduleIndexes = new ArrayList<>();
                 for (ResourceRoot resourceRoot : allResourceRoots) {
                     Index index = resourceRoot.getAttachment(Attachments.ANNOTATION_INDEX);
                     if (index != null) {
                         indexes.add(index);
+                        moduleIndexes.add(index);
                     }
+                }
+                if (!moduleIndexes.isEmpty()) {
+                    additionalAnnotationIndexes.put(moduleIdentifier, new CompositeIndex(moduleIndexes));
                 }
             } else {
                 try {

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
@@ -294,7 +294,8 @@ public class DeploymentStructureDescriptorParser implements DeploymentUnitProces
             }
             deploymentUnit.addToAttachmentList(Attachments.ADDITIONAL_ANNOTATION_INDEXES, identifier);
             // additional modules will not be created till much later, a dep on them would fail
-            if (identifier.getName().startsWith(ServiceModuleLoader.MODULE_PREFIX) && !additionalModules.keySet().contains(identifier)) {
+            if (identifier.getName().startsWith(ServiceModuleLoader.MODULE_PREFIX) &&
+                !(additionalModules.keySet().contains(identifier) || isSubdeployment(identifier, deploymentUnit))) {
                 phaseContext.addToAttachmentList(Attachments.NEXT_PHASE_DEPS, ServiceModuleLoader.moduleServiceName(identifier));
             }
         }
@@ -303,6 +304,11 @@ public class DeploymentStructureDescriptorParser implements DeploymentUnitProces
         if(rootDeploymentSpecification.getExcludedSubsystems() != null) {
             deploymentUnit.putAttachment(Attachments.EXCLUDED_SUBSYSTEMS, rootDeploymentSpecification.getExcludedSubsystems());
         }
+    }
+
+    private boolean isSubdeployment(ModuleIdentifier dependency, DeploymentUnit deploymentUnit) {
+        DeploymentUnit top = deploymentUnit.getParent()==null?deploymentUnit:deploymentUnit.getParent();
+        return dependency.getName().startsWith(ServiceModuleLoader.MODULE_PREFIX.concat(top.getName()));
     }
 
     private Map<VirtualFile, ResourceRoot> resourceRoots(final DeploymentUnit deploymentUnit) {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFCORE-4475

@jmesnil could you review this please? I based this on fix for https://issues.jboss.org/browse/WFCORE-3268, but I'm not sure I check the right resource roots on subdeployments.
I've got a WiP test case for the issue in https://github.com/wildfly/wildfly/compare/master...spyrkob:WFCORE-4475