### PR TITLE
[WFCORE-4476] Upgrade Wildfly Elytron to 1.9.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.9.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.9.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.5.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4476


        Release Notes - WildFly Elytron - Version 1.9.1.Final
                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1810'>ELY-1810</a>] -         (Intermittent) stuck start with secmgr after enabling Elytron JACC for undertow/application-security-domain
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1811'>ELY-1811</a>] -         Release WildFly Elytron 1.9.1.Final
</li>
</ul>
                    