### PR TITLE
use default charset for cli --properties file

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -28,6 +28,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -67,6 +68,7 @@ public class CliLauncher {
             boolean connect = false;
             boolean version = false;
             int connectionTimeout = -1;
+            Charset propertiesEncoding = StandardCharsets.UTF_8;
 
             final CommandContextConfiguration.Builder ctxBuilder = new CommandContextConfiguration.Builder();
             ctxBuilder.setErrorOnInteract(errorOnInteract);
@@ -205,6 +207,14 @@ public class CliLauncher {
                 } else if (arg.equals("--help") || arg.equals("-h")) {
                     help = true;
                     break;
+                } else if(arg.startsWith("--properties-encoding=")) {
+                    final String value  = arg.substring(22);
+                    try {
+                        propertiesEncoding = Charset.forName(value);
+                    } catch (Exception ex) {
+                        argError = "Could not create charset by value: " + value;
+                        break;
+                    }
                 } else if (arg.startsWith("--properties=")) {
                     final String value  = arg.substring(13);
                     final File propertiesFile = new File(FilenameTabCompleter.expand(value));
@@ -215,7 +225,7 @@ public class CliLauncher {
                     final Properties props = new Properties();
                     InputStreamReader inputStreamReader = null;
                     try {
-                        inputStreamReader = new InputStreamReader(new FileInputStream(propertiesFile), Charset.defaultCharset());
+                        inputStreamReader = new InputStreamReader(new FileInputStream(propertiesFile), propertiesEncoding);
                         props.load(inputStreamReader);
                     } catch(FileNotFoundException e) {
                         argError = e.getLocalizedMessage();

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,7 +67,6 @@ public class CliLauncher {
             boolean connect = false;
             boolean version = false;
             int connectionTimeout = -1;
-            Charset propertiesEncoding = StandardCharsets.UTF_8;
 
             final CommandContextConfiguration.Builder ctxBuilder = new CommandContextConfiguration.Builder();
             ctxBuilder.setErrorOnInteract(errorOnInteract);
@@ -207,14 +205,6 @@ public class CliLauncher {
                 } else if (arg.equals("--help") || arg.equals("-h")) {
                     help = true;
                     break;
-                } else if(arg.startsWith("--properties-encoding=")) {
-                    final String value  = arg.substring(22);
-                    try {
-                        propertiesEncoding = Charset.forName(value);
-                    } catch (Exception ex) {
-                        argError = "Could not create charset by value: " + value;
-                        break;
-                    }
                 } else if (arg.startsWith("--properties=")) {
                     final String value  = arg.substring(13);
                     final File propertiesFile = new File(FilenameTabCompleter.expand(value));
@@ -225,7 +215,7 @@ public class CliLauncher {
                     final Properties props = new Properties();
                     InputStreamReader inputStreamReader = null;
                     try {
-                        inputStreamReader = new InputStreamReader(new FileInputStream(propertiesFile), propertiesEncoding);
+                        inputStreamReader = new InputStreamReader(new FileInputStream(propertiesFile), StandardCharsets.UTF_8);
                         props.load(inputStreamReader);
                     } catch(FileNotFoundException e) {
                         argError = e.getLocalizedMessage();

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -21,7 +21,12 @@
  */
 package org.jboss.as.cli.impl;
 
-import java.io.*;
+import java.io.InputStreamReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -21,11 +21,8 @@
  */
 package org.jboss.as.cli.impl;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.*;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -211,10 +208,10 @@ public class CliLauncher {
                         break;
                     }
                     final Properties props = new Properties();
-                    FileInputStream fis = null;
+                    InputStreamReader inputStreamReader = null;
                     try {
-                        fis = new FileInputStream(propertiesFile);
-                        props.load(fis);
+                        inputStreamReader = new InputStreamReader(new FileInputStream(propertiesFile), Charset.defaultCharset());
+                        props.load(inputStreamReader);
                     } catch(FileNotFoundException e) {
                         argError = e.getLocalizedMessage();
                         break;
@@ -222,9 +219,9 @@ public class CliLauncher {
                         argError = "Failed to load properties from " + propertiesFile.getAbsolutePath() + ": " + e.getLocalizedMessage();
                         break;
                     } finally {
-                        if(fis != null) {
+                        if(inputStreamReader != null) {
                             try {
-                                fis.close();
+                                inputStreamReader.close();
                             } catch(java.io.IOException e) {
                             }
                         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -21,11 +21,11 @@
  */
 package org.jboss.as.cli.impl;
 
+import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.BufferedReader;
 import java.io.FileReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;


### PR DESCRIPTION
jboss-cli can read only ISO 8859-1 properties files via --properties arg
this patch fix it