### PR TITLE
[WFCORE-4490] [WFCORE-4491] Upgrade  JBoss Remoting to 5.0.12.Final and Xnio to 3.7.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.7.1.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.7.2.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.7.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.5.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.9.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.12.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4491
and https://issues.jboss.org/browse/WFCORE-4490

Notice that WFCORE-4491 blocks WFCORE-4490, so this PR can be merged as an option to https://github.com/wildfly/wildfly-core/pull/3795 followed by https://github.com/wildfly/wildfly-core/pull/3786 if that saves some time for you, @jmesnil 

(the first PR, XNIO upgrade, will have tests passing only after the second PR, jboss remoting upgrade, is merged)