### PR TITLE
WFLY-12126 Fix issue with Java installations containing a space character

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/src/main/resources/content/bin/common.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 setModularJdk() {
-  $JAVA --add-modules=java.se -version > /dev/null 2>&1 && MODULAR_JDK=true || MODULAR_JDK=false
+  "$JAVA" --add-modules=java.se -version > /dev/null 2>&1 && MODULAR_JDK=true || MODULAR_JDK=false
 }
 
 setDefaultModularJvmOptions() {


### PR DESCRIPTION
The commit here is a patch borrowed from the JIRA https://issues.jboss.org/browse/WFLY-12126 where the user reports an issue with the server startup when the Java installation contains a space character in its path.