### PR TITLE
[WFCORE-4506] Upgrade JBoss MSC to 1.4.6.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.7.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.4.5.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.4.6.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.12.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4506
Incorporates:
 * [MSC-242] Ensuring ReadableValueImpl and WritableValueImpl fields visibility
 * [MSC-243] Fixing wrong Java SE 8 API docs link
 * [MSC-244] Deprecating ServiceBuilder.addAliases(ServiceName...) method