### PR TITLE
[WFCORE-4361] Add evidence decoders in the Elytron subsystem

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
@@ -37,6 +37,7 @@ import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
 import org.wildfly.extension.elytron.capabilities._private.SecurityEventListener;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.server.EvidenceDecoder;
 import org.wildfly.security.auth.server.HttpAuthenticationFactory;
 import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.PrincipalDecoder;
@@ -182,6 +183,12 @@ class Capabilities {
 
     static final RuntimeCapability<Void> ROLE_MAPPER_RUNTIME_CAPABILITY =  RuntimeCapability
             .Builder.of(ROLE_MAPPER_CAPABILITY, true, RoleMapper.class)
+            .build();
+
+    static final String EVIDENCE_DECODER_CAPABILITY = CAPABILITY_BASE + "evidence-decoder";
+
+    static final RuntimeCapability<Void> EVIDENCE_DECODER_RUNTIME_CAPABILITY =  RuntimeCapability
+            .Builder.of(EVIDENCE_DECODER_CAPABILITY, true, EvidenceDecoder.class)
             .build();
 
     static final String SECURITY_EVENT_LISTENER_CAPABILITY = CAPABILITY_BASE + "security-event-listener";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -19,6 +19,7 @@
 package org.wildfly.extension.elytron;
 
 import static java.security.AccessController.doPrivileged;
+import static org.wildfly.extension.elytron.Capabilities.EVIDENCE_DECODER_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.PERMISSION_MAPPER_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.PRINCIPAL_DECODER_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.PRINCIPAL_TRANSFORMER_CAPABILITY;
@@ -84,6 +85,7 @@ import org.wildfly.extension.elytron.DomainService.RealmDependency;
 import org.wildfly.extension.elytron.TrivialService.ValueSupplier;
 import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
 import org.wildfly.extension.elytron.capabilities._private.SecurityEventListener;
+import org.wildfly.security.auth.server.EvidenceDecoder;
 import org.wildfly.security.auth.server.PrincipalDecoder;
 import org.wildfly.security.auth.server.RealmMapper;
 import org.wildfly.security.auth.server.RealmUnavailableException;
@@ -147,6 +149,11 @@ class DomainDefinition extends SimpleResourceDefinition {
         .setCapabilityReference(ROLE_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
+    static final SimpleAttributeDefinition EVIDENCE_DECODER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.EVIDENCE_DECODER, ModelType.STRING, true)
+            .setMinSize(1)
+            .setCapabilityReference(EVIDENCE_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
+            .build();
+
     static final SimpleAttributeDefinition REALM_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM, ModelType.STRING, false)
         .setXmlName(ElytronDescriptionConstants.NAME)
         .setMinSize(1)
@@ -203,7 +210,8 @@ class DomainDefinition extends SimpleResourceDefinition {
             .build();
 
     private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PRE_REALM_PRINCIPAL_TRANSFORMER, POST_REALM_PRINCIPAL_TRANSFORMER, PRINCIPAL_DECODER,
-            REALM_MAPPER, ROLE_MAPPER, PERMISSION_MAPPER, DEFAULT_REALM, REALMS, TRUSTED_SECURITY_DOMAINS, OUTFLOW_ANONYMOUS, OUTFLOW_SECURITY_DOMAINS, SECURITY_EVENT_LISTENER };
+            REALM_MAPPER, ROLE_MAPPER, PERMISSION_MAPPER, DEFAULT_REALM, REALMS, TRUSTED_SECURITY_DOMAINS, OUTFLOW_ANONYMOUS, OUTFLOW_SECURITY_DOMAINS, SECURITY_EVENT_LISTENER,
+            EVIDENCE_DECODER};
 
     private static final DomainAddHandler ADD = new DomainAddHandler();
     private static final OperationStepHandler REMOVE = new DomainRemoveHandler(ADD);
@@ -244,6 +252,7 @@ class DomainDefinition extends SimpleResourceDefinition {
         String permissionMapper = PERMISSION_MAPPER.resolveModelAttribute(context, model).asStringOrNull();
         String realmMapper = REALM_MAPPER.resolveModelAttribute(context, model).asStringOrNull();
         String roleMapper = ROLE_MAPPER.resolveModelAttribute(context, model).asStringOrNull();
+        String evidenceDecoder = EVIDENCE_DECODER.resolveModelAttribute(context, model).asStringOrNull();
         String securityEventListener = SECURITY_EVENT_LISTENER.resolveModelAttribute(context, model).asStringOrNull();
 
         DomainService domain = new DomainService(defaultRealm, trustedSecurityDomain, identityOperator);
@@ -277,6 +286,12 @@ class DomainDefinition extends SimpleResourceDefinition {
         }
         if (roleMapper != null) {
             injectRoleMapper(roleMapper, context, domainBuilder, domain.createDomainRoleMapperInjector(roleMapper));
+        }
+
+        if (evidenceDecoder != null) {
+            String runtimeCapability = RuntimeCapability.buildDynamicCapabilityName(EVIDENCE_DECODER_CAPABILITY, evidenceDecoder);
+            ServiceName evidenceDecoderServiceName = context.getCapabilityServiceName(runtimeCapability, EvidenceDecoder.class);
+            domainBuilder.addDependency(evidenceDecoderServiceName, EvidenceDecoder.class, domain.getEvidenceDecoderInjector());
         }
 
         if (securityEventListener != null) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainService.java
@@ -35,6 +35,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
 import org.wildfly.extension.elytron.capabilities._private.SecurityEventListener;
+import org.wildfly.security.auth.server.EvidenceDecoder;
 import org.wildfly.security.auth.server.PrincipalDecoder;
 import org.wildfly.security.auth.server.RealmMapper;
 import org.wildfly.security.auth.server.SecurityDomain;
@@ -69,6 +70,7 @@ class DomainService implements Service<SecurityDomain> {
     private final InjectedValue<PrincipalDecoder> principalDecoderInjector = new InjectedValue<>();
     private final InjectedValue<RealmMapper> realmMapperInjector = new InjectedValue<>();
     private final InjectedValue<PermissionMapper> permissionMapperInjector = new InjectedValue<>();
+    private final InjectedValue<EvidenceDecoder> evidenceDecoderInjector = new InjectedValue<>();
     private final InjectedValue<SecurityEventListener> securityEventListenerInjector = new InjectedValue<>();
 
     DomainService(final String defaultRealm, final Predicate<SecurityDomain> trustedSecurityDomain, final UnaryOperator<SecurityIdentity> identityOperator) {
@@ -147,6 +149,10 @@ class DomainService implements Service<SecurityDomain> {
         return createRoleMapperInjector(name);
     }
 
+    Injector<EvidenceDecoder> getEvidenceDecoderInjector() {
+        return evidenceDecoderInjector;
+    }
+
     Injector<SecurityEventListener> getSecurityEventListenerInjector() {
         return securityEventListenerInjector;
     }
@@ -175,6 +181,10 @@ class DomainService implements Service<SecurityDomain> {
         }
         if (roleMapper != null) {
             builder.setRoleMapper(roleMappers.get(roleMapper).getValue());
+        }
+        EvidenceDecoder evidenceDecoder = evidenceDecoderInjector.getOptionalValue();
+        if (evidenceDecoder != null) {
+            builder.setEvidenceDecoder(evidenceDecoder);
         }
         if (defaultRealm != null) {
             builder.setDefaultRealmName(defaultRealm);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -21,6 +21,7 @@ package org.wildfly.extension.elytron;
 
 import static org.wildfly.extension.elytron.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.ELYTRON_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.PERMISSION_MAPPER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.PRINCIPAL_DECODER_RUNTIME_CAPABILITY;
@@ -90,6 +91,7 @@ import org.wildfly.extension.elytron.capabilities._private.SecurityEventListener
 import org.wildfly.security.Version;
 import org.wildfly.security.auth.jaspi.DelegatingAuthConfigFactory;
 import org.wildfly.security.auth.jaspi.ElytronAuthConfigFactory;
+import org.wildfly.security.auth.server.EvidenceDecoder;
 import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.PrincipalDecoder;
 import org.wildfly.security.auth.server.RealmMapper;
@@ -257,6 +259,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         // Evidence Decoders
         resourceRegistration.registerSubModel(EvidenceDecoderDefinitions.getX500SubjectEvidenceDecoderDefinition());
         resourceRegistration.registerSubModel(EvidenceDecoderDefinitions.getX509SubjectAltNameEvidenceDecoderDefinition());
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(EvidenceDecoder.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_EVIDENCE_DECODER, EVIDENCE_DECODER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(EvidenceDecoderDefinitions.getAggregateEvidenceDecoderDefinition());
 
         // HTTP Mechanisms

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -254,6 +254,11 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getLogicalRoleMapperDefinition());
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getMappedRoleMapperDefinition());
 
+        // Evidence Decoders
+        resourceRegistration.registerSubModel(EvidenceDecoderDefinitions.getX500SubjectEvidenceDecoderDefinition());
+        resourceRegistration.registerSubModel(EvidenceDecoderDefinitions.getX509SubjectAltNameEvidenceDecoderDefinition());
+        resourceRegistration.registerSubModel(EvidenceDecoderDefinitions.getAggregateEvidenceDecoderDefinition());
+
         // HTTP Mechanisms
         resourceRegistration.registerSubModel(HttpServerDefinitions.getAggregateHttpServerFactoryDefinition());
         resourceRegistration.registerSubModel(HttpServerDefinitions.getConfigurableHttpServerMechanismFactoryDefinition());

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -35,6 +35,7 @@ interface ElytronDescriptionConstants {
     String ADD_PREFIX_ROLE_MAPPER = "add-prefix-role-mapper";
     String ADD_SUFFIX_ROLE_MAPPER = "add-suffix-role-mapper";
     String AGREE_TO_TERMS_OF_SERVICE = "agree-to-terms-of-service";
+    String AGGREGATE_EVIDENCE_DECODER = "aggregate-evidence-decoder";
     String AGGREGATE_HTTP_SERVER_MECHANISM_FACTORY = "aggregate-http-server-mechanism-factory";
     String AGGREGATE_PRINCIPAL_DECODER = "aggregate-principal-decoder";
     String AGGREGATE_PRINCIPAL_TRANSFORMER = "aggregate-principal-transformer";
@@ -49,6 +50,7 @@ interface ElytronDescriptionConstants {
     String ALGORITHM = "algorithm";
     String ALGORITHM_FROM = "algorithm-from";
     String ALLOW_BLANK_PASSWORD = "allow-blank-password";
+    String ALT_NAME_TYPE = "alt-name-type";
     String AND = "and";
     String ANONYMOUS = "anonymous";
     String APPLICATION_BUFFER_SIZE = "application-buffer-size";
@@ -174,6 +176,8 @@ interface ElytronDescriptionConstants {
     String ENABLING = "enabling";
     String ENCODED = "encoded";
     String ENTRY_TYPE = "entry-type";
+    String EVIDENCE_DECODER = "evidence-decoder";
+    String EVIDENCE_DECODERS = "evidence-decoders";
     String EXPIRATION = "expiration";
     String EXPORT_CERTIFICATE = "export-certificate";
     String EXTERNAL_ACCOUNT_REQUIRED = "external-account-required";
@@ -471,6 +475,7 @@ interface ElytronDescriptionConstants {
     String SELECTION_CRITERIA = "selection-criteria";
     String SEED = "seed";
     String SEED_FROM = "seed-from";
+    String SEGMENT = "segment";
     String SERVER_NAME = "server-name";
     String SERIAL_NUMBER = "serial-number";
     String SERIAL_NUMBER_FROM = "serial-number-from";
@@ -557,7 +562,9 @@ interface ElytronDescriptionConstants {
     String WRITABLE = "writable";
 
     String X500_ATTRIBUTE_PRINCIPAL_DECODER = "x500-attribute-principal-decoder";
+    String X500_SUBJECT_EVIDENCE_DECODER = "x500-subject-evidence-decoder";
     String X509_CREDENTIAL_MAPPER = "x509-credential-mapper";
+    String X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER = "x509-subject-alt-name-evidence-decoder";
     String XOR = "xor";
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -139,6 +139,7 @@ interface ElytronDescriptionConstants {
     String CRITICAL = "critical";
 
     String CUSTOM_CREDENTIAL_SECURITY_FACTORY = "custom-credential-security-factory";
+    String CUSTOM_EVIDENCE_DECODER = "custom-evidence-decoder";
     String CUSTOM_PERMISSION_MAPPER = "custom-permission-mapper";
     String CUSTOM_POLICY = "custom-policy";
     String CUSTOM_PRINCIPAL_DECODER = "custom-principal-decoder";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser4_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser4_0.java
@@ -40,7 +40,7 @@ public class ElytronSubsystemParser4_0 extends ElytronSubsystemParser3_0 {
 
     @Override
     protected PersistentResourceXMLDescription getMapperParser() {
-        return new MapperParser().getParser();
+        return new MapperParser(MapperParser.Version.VERSION_4_0).getParser();
     }
 
     @Override

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser8_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser8_0.java
@@ -18,6 +18,10 @@
 
 package org.wildfly.extension.elytron;
 
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SECURITY_DOMAIN;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SECURITY_DOMAINS;
+
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 
 /**
@@ -28,6 +32,23 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
  */
 public class ElytronSubsystemParser8_0 extends ElytronSubsystemParser7_0 {
 
+    final PersistentResourceXMLDescription domainParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(SECURITY_DOMAIN))
+            .setXmlWrapperElement(SECURITY_DOMAINS)
+            .addAttribute(DomainDefinition.DEFAULT_REALM)
+            .addAttribute(DomainDefinition.PERMISSION_MAPPER)
+            .addAttribute(DomainDefinition.PRE_REALM_PRINCIPAL_TRANSFORMER)
+            .addAttribute(DomainDefinition.POST_REALM_PRINCIPAL_TRANSFORMER)
+            .addAttribute(DomainDefinition.PRINCIPAL_DECODER)
+            .addAttribute(DomainDefinition.REALM_MAPPER)
+            .addAttribute(DomainDefinition.ROLE_MAPPER)
+            .addAttribute(DomainDefinition.TRUSTED_SECURITY_DOMAINS)
+            .addAttribute(DomainDefinition.OUTFLOW_ANONYMOUS)
+            .addAttribute(DomainDefinition.OUTFLOW_SECURITY_DOMAINS)
+            .addAttribute(DomainDefinition.SECURITY_EVENT_LISTENER)
+            .addAttribute(DomainDefinition.REALMS)
+            .addAttribute(DomainDefinition.EVIDENCE_DECODER) // new
+            .build();
+
     @Override
     String getNameSpace() {
         return ElytronExtension.NAMESPACE_8_0;
@@ -35,5 +56,15 @@ public class ElytronSubsystemParser8_0 extends ElytronSubsystemParser7_0 {
 
     PersistentResourceXMLDescription getTlsParser() {
         return new TlsParser().tlsParser_8_0;
+    }
+
+    @Override
+    protected PersistentResourceXMLDescription getMapperParser() {
+        return new MapperParser().getParser();
+    }
+
+    @Override
+    PersistentResourceXMLDescription getDomainParser() {
+        return domainParser;
     }
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -100,6 +100,14 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
 
     private static void from8(ChainedTransformationDescriptionBuilder chainedBuilder) {
         ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(ELYTRON_8_0_0, ELYTRON_7_0_0);
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN))
+                .getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ElytronDescriptionConstants.EVIDENCE_DECODER)
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, DomainDefinition.EVIDENCE_DECODER)
+                .end();
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.X500_SUBJECT_EVIDENCE_DECODER));
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER));
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_EVIDENCE_DECODER));
 
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY));
         builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNT))

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -107,6 +107,7 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
                 .end();
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.X500_SUBJECT_EVIDENCE_DECODER));
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER));
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.CUSTOM_EVIDENCE_DECODER));
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_EVIDENCE_DECODER));
 
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY));

--- a/elytron/src/main/java/org/wildfly/extension/elytron/EvidenceDecoderDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/EvidenceDecoderDefinitions.java
@@ -1,0 +1,149 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.elytron;
+
+import static org.wildfly.extension.elytron.Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.X500_SUBJECT_EVIDENCE_DECODER;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.StringAllowedValuesValidator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceBuilder;
+import org.wildfly.extension.elytron.TrivialService.ValueSupplier;
+import org.wildfly.security.auth.server.EvidenceDecoder;
+import org.wildfly.security.x500.GeneralName;
+import org.wildfly.security.x500.principal.X500SubjectEvidenceDecoder;
+import org.wildfly.security.x500.principal.X509SubjectAltNameEvidenceDecoder;
+
+/**
+ * Holder for {@link ResourceDefinition} instances for services that return an {@link EvidenceDecoder}.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+class EvidenceDecoderDefinitions {
+
+    private static final String RFC_822_NAME = "rfc822Name";
+    private static final String DNS_NAME = "dNSName";
+    private static final String DIRECTORY_NAME = "directoryName";
+    private static final String URI_NAME = "uniformResourceIdentifier";
+    private static final String IP_ADDRESS = "iPAddress";
+    private static final String REGISTERED_ID = "registeredID";
+
+    private enum SubjectAltNameType {
+
+        RFC_822_NAME_TYPE(RFC_822_NAME, GeneralName.RFC_822_NAME),
+        DNS_NAME_TYPE(DNS_NAME, GeneralName.DNS_NAME),
+        DIRECTORY_NAME_TYPE(DIRECTORY_NAME, GeneralName.DIRECTORY_NAME),
+        URI_NAME_TYPE(URI_NAME, GeneralName.URI_NAME),
+        IP_ADDRESS_TYPE(IP_ADDRESS, GeneralName.IP_ADDRESS),
+        REGISTERED_ID_TYPE(REGISTERED_ID, GeneralName.REGISTERED_ID);
+
+        private final String name;
+        private final int type;
+
+        SubjectAltNameType(final String name, final int type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public static SubjectAltNameType fromName(final String name) {
+            switch (name) {
+                case RFC_822_NAME:
+                    return RFC_822_NAME_TYPE;
+                case DNS_NAME:
+                    return DNS_NAME_TYPE;
+                case DIRECTORY_NAME:
+                    return DIRECTORY_NAME_TYPE;
+                case URI_NAME:
+                    return URI_NAME_TYPE;
+                case IP_ADDRESS:
+                    return IP_ADDRESS_TYPE;
+                case REGISTERED_ID:
+                    return REGISTERED_ID_TYPE;
+                default:
+                    throw new IllegalArgumentException(name);
+            }
+        }
+    }
+
+    static final SimpleAttributeDefinition ALT_NAME_TYPE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALT_NAME_TYPE, ModelType.STRING, false)
+            .setValidator(new StringAllowedValuesValidator(RFC_822_NAME, DNS_NAME, DIRECTORY_NAME, URI_NAME, IP_ADDRESS, REGISTERED_ID))
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
+
+    static final SimpleAttributeDefinition SEGMENT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SEGMENT, ModelType.INT, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(0))
+            .setValidator(new IntRangeValidator(0, true, true))
+            .setRestartAllServices()
+            .build();
+
+    private static final AggregateComponentDefinition<EvidenceDecoder> AGGREGATE_EVIDENCE_DECODER = AggregateComponentDefinition.create(EvidenceDecoder.class,
+            ElytronDescriptionConstants.AGGREGATE_EVIDENCE_DECODER, ElytronDescriptionConstants.EVIDENCE_DECODERS, EVIDENCE_DECODER_RUNTIME_CAPABILITY, EvidenceDecoder::aggregate);
+
+    static ResourceDefinition getX500SubjectEvidenceDecoderDefinition() {
+        final AttributeDefinition[] attributes = new AttributeDefinition[] {};
+        AbstractAddStepHandler add = new TrivialAddHandler<EvidenceDecoder>(EvidenceDecoder.class, attributes, EVIDENCE_DECODER_RUNTIME_CAPABILITY) {
+
+            @Override
+            protected ValueSupplier<EvidenceDecoder> getValueSupplier(ServiceBuilder<EvidenceDecoder> serviceBuilder,
+                                                                           OperationContext context, ModelNode model) throws OperationFailedException {
+                return () -> new X500SubjectEvidenceDecoder();
+            }
+        };
+        return new TrivialResourceDefinition(X500_SUBJECT_EVIDENCE_DECODER, add, attributes, EVIDENCE_DECODER_RUNTIME_CAPABILITY);
+    }
+
+    static ResourceDefinition getX509SubjectAltNameEvidenceDecoderDefinition() {
+        final AttributeDefinition[] attributes = new AttributeDefinition[] { ALT_NAME_TYPE, SEGMENT };
+        AbstractAddStepHandler add = new TrivialAddHandler<EvidenceDecoder>(EvidenceDecoder.class, attributes, EVIDENCE_DECODER_RUNTIME_CAPABILITY) {
+
+            @Override
+            protected ValueSupplier<EvidenceDecoder> getValueSupplier(ServiceBuilder<EvidenceDecoder> serviceBuilder,
+                                                                           OperationContext context, ModelNode model) throws OperationFailedException {
+                final String  altNameType = ALT_NAME_TYPE.resolveModelAttribute(context, model).asString();
+                final int segment  = SEGMENT.resolveModelAttribute(context, model).asInt();
+                return () -> new X509SubjectAltNameEvidenceDecoder(SubjectAltNameType.fromName(altNameType).getType(), segment);
+            }
+        };
+        return new TrivialResourceDefinition(X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER, add, attributes, EVIDENCE_DECODER_RUNTIME_CAPABILITY);
+    }
+
+    static AggregateComponentDefinition<EvidenceDecoder> getAggregateEvidenceDecoderDefinition() {
+        return AGGREGATE_EVIDENCE_DECODER;
+    }
+
+}

--- a/elytron/src/main/java/org/wildfly/extension/elytron/MapperParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/MapperParser.java
@@ -19,6 +19,7 @@ package org.wildfly.extension.elytron;
 
 import static org.jboss.as.controller.PersistentResourceXMLDescription.decorator;
 import static org.jboss.as.controller.parsing.ParseUtils.requireAttributes;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_EVIDENCE_DECODER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_PERMISSION_MAPPER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_PRINCIPAL_DECODER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_PRINCIPAL_TRANSFORMER;
@@ -61,7 +62,7 @@ class MapperParser {
         VERSION_1_1,
         VERSION_3_0, // permission-sets in permission-mappings and constant-permission-mappers
         VERSION_4_0, // mapped-role-mappers
-        CURRENT // x500-subject-evidence-decoder, x509-subject-alt-name-evidence-decoder, aggregate-evidence-decoder
+        CURRENT // x500-subject-evidence-decoder, x509-subject-alt-name-evidence-decoder, custom-evidence-decoder, aggregate-evidence-decoder
     }
 
     private final Version version;
@@ -377,6 +378,7 @@ class MapperParser {
                 .addChild(mappedRoleMapperParser)
                 .addChild(x500SubjectEvidenceDecoderParser) // new
                 .addChild(x509SubjectAltNameEvidenceDecoder) // new
+                .addChild(getCustomComponentParser(CUSTOM_EVIDENCE_DECODER)) // new
                 .addChild(aggregateEvidenceDecoderParser) // new
                 .build();
     }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/MapperParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/MapperParser.java
@@ -25,6 +25,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_P
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_REALM_MAPPER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_ROLE_DECODER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_ROLE_MAPPER;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.EVIDENCE_DECODER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FROM;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.PRINCIPAL_DECODER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.PRINCIPAL_TRANSFORMER;
@@ -59,7 +60,8 @@ class MapperParser {
         VERSION_1_0,
         VERSION_1_1,
         VERSION_3_0, // permission-sets in permission-mappings and constant-permission-mappers
-        CURRENT // mapped-role-mappers
+        VERSION_4_0, // mapped-role-mappers
+        CURRENT // x500-subject-evidence-decoder, x509-subject-alt-name-evidence-decoder, aggregate-evidence-decoder
     }
 
     private final Version version;
@@ -222,6 +224,18 @@ class MapperParser {
             .addAttribute(RoleMapperDefinitions.RIGHT)
             .build();
 
+    private PersistentResourceXMLDescription x500SubjectEvidenceDecoderParser = PersistentResourceXMLDescription.builder(EvidenceDecoderDefinitions.getX500SubjectEvidenceDecoderDefinition().getPathElement())
+            .build();
+
+    private PersistentResourceXMLDescription x509SubjectAltNameEvidenceDecoder = PersistentResourceXMLDescription.builder(EvidenceDecoderDefinitions.getX509SubjectAltNameEvidenceDecoderDefinition().getPathElement())
+            .addAttribute(EvidenceDecoderDefinitions.ALT_NAME_TYPE)
+            .addAttribute(EvidenceDecoderDefinitions.SEGMENT)
+            .build();
+
+    private PersistentResourceXMLDescription aggregateEvidenceDecoderParser = PersistentResourceXMLDescription.builder(EvidenceDecoderDefinitions.getAggregateEvidenceDecoderDefinition().getPathElement())
+            .addAttribute(EvidenceDecoderDefinitions.getAggregateEvidenceDecoderDefinition().getReferencesAttribute(), new AttributeParsers.NamedStringListParser(EVIDENCE_DECODER), new AttributeMarshallers.NamedStringListMarshaller(EVIDENCE_DECODER))
+            .build();
+
     MapperParser(Version version) {
         this.version = version;
     }
@@ -292,10 +306,7 @@ class MapperParser {
                 .build();
     }
 
-    public PersistentResourceXMLDescription getParser() {
-        if (version.equals(Version.VERSION_1_0) || version.equals(Version.VERSION_1_1) || version.equals(Version.VERSION_3_0)) {
-            return getParser_1_0_to_3_0();
-        }
+    private PersistentResourceXMLDescription getParser_4_0() {
         return decorator(ElytronDescriptionConstants.MAPPERS)
                 .addChild(getCustomComponentParser(CUSTOM_PERMISSION_MAPPER))
                 .addChild(logicalPermissionMapper)
@@ -325,6 +336,48 @@ class MapperParser {
                 .addChild(getCustomComponentParser(CUSTOM_ROLE_MAPPER))
                 .addChild(logicalRoleMapperParser)
                 .addChild(mappedRoleMapperParser) // new
+                .build();
+    }
+
+    public PersistentResourceXMLDescription getParser() {
+        if (version.equals(Version.VERSION_1_0) || version.equals(Version.VERSION_1_1) || version.equals(Version.VERSION_3_0)) {
+            return getParser_1_0_to_3_0();
+        }
+        if (version.equals(Version.VERSION_4_0)) {
+            return getParser_4_0();
+        }
+        return decorator(ElytronDescriptionConstants.MAPPERS)
+                .addChild(getCustomComponentParser(CUSTOM_PERMISSION_MAPPER))
+                .addChild(logicalPermissionMapper)
+                .addChild(getSimpleMapperParser())
+                .addChild(getConstantPermissionMapperParser())
+                .addChild(aggregatePrincipalDecoderParser)
+                .addChild(concatenatingPrincipalDecoderParser)
+                .addChild(constantPrincipalDecoderParser)
+                .addChild(getCustomComponentParser(CUSTOM_PRINCIPAL_DECODER))
+                .addChild(x500AttributePrincipalDecoderParser)
+                .addChild(aggregatePrincipalTransformerParser)
+                .addChild(chainedPrincipalTransformersParser)
+                .addChild(constantPrincipalTransformersParser)
+                .addChild(getCustomComponentParser(CUSTOM_PRINCIPAL_TRANSFORMER))
+                .addChild(regexPrincipalTransformerParser)
+                .addChild(regexValidatingTransformerParser)
+                .addChild(constantRealmMapperParser)
+                .addChild(getCustomComponentParser(CUSTOM_REALM_MAPPER))
+                .addChild(simpleRegexRealmMapperParser)
+                .addChild(mappedRegexRealmMapperParser)
+                .addChild(getCustomComponentParser(CUSTOM_ROLE_DECODER))
+                .addChild(simpleRoleDecoderParser)
+                .addChild(addPrefixRoleMapperParser)
+                .addChild(addSuffixRoleMapperParser)
+                .addChild(aggregateRoleMapperParser)
+                .addChild(constantRoleMapperParser)
+                .addChild(getCustomComponentParser(CUSTOM_ROLE_MAPPER))
+                .addChild(logicalRoleMapperParser)
+                .addChild(mappedRoleMapperParser)
+                .addChild(x500SubjectEvidenceDecoderParser) // new
+                .addChild(x509SubjectAltNameEvidenceDecoder) // new
+                .addChild(aggregateEvidenceDecoderParser) // new
                 .build();
     }
 }

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -249,6 +249,7 @@ elytron.security-domain.permission-mapper=A reference to a PermissionMapper to b
 elytron.security-domain.principal-decoder=A reference to a PrincipalDecoder to be used by this domain.
 elytron.security-domain.realm-mapper=Reference to the RealmMapper to be used by this domain.
 elytron.security-domain.role-mapper=Reference to the RoleMapper to be used by this domain.
+elytron.security-domain.evidence-decoder=A reference to an EvidenceDecoder to be used by this domain.
 elytron.security-domain.security-event-listener=Reference to a listener for security events.
 elytron.security-domain.default-realm=The default realm contained by this security domain.
 elytron.security-domain.realms=The list of realms contained by this security domain.
@@ -507,6 +508,30 @@ elytron.regex-validating-principal-transformer.remove=The remove operation for t
 # Attributes
 elytron.regex-validating-principal-transformer.pattern=The regular expression to use for the principal transformer.
 elytron.regex-validating-principal-transformer.match=If set to true, the name must match the given pattern to make validation successful. If set to false, the name must not match the given pattern to make validation successful.
+
+######################
+# Evidence Decoders #
+######################
+
+elytron.aggregate-evidence-decoder=An evidence decoder that is an aggregation of other evidence decoders. Given evidence, these evidence decoders will be attempted in order until one returns a non-null principal or until there are no more evidence decoders left to try.
+# Operations
+elytron.aggregate-evidence-decoder.add=The add operation for the evidence decoder.
+elytron.aggregate-evidence-decoder.remove=The remove operation for the evidence decoder.
+# Attributes
+elytron.aggregate-evidence-decoder.evidence-decoders=The referenced evidence decoders to aggregate.
+
+elytron.x509-subject-alt-name-evidence-decoder=An evidence decoder that derives the principal associated with the given evidence from an X.509 subject alternative name from the first certificate in the given evidence.
+# Operations
+elytron.x509-subject-alt-name-evidence-decoder.add=The add operation for the evidence decoder.
+elytron.x509-subject-alt-name-evidence-decoder.remove=The remove operation for the evidence decoder.
+# Attributes
+elytron.x509-subject-alt-name-evidence-decoder.alt-name-type=The subject alternative name type to decode from the given evidence. Allowed values: 'rfc822Name', 'dNSName', 'directoryName', 'uniformResourceIdentifier', 'iPAddress', 'registeredID'
+elytron.x509-subject-alt-name-evidence-decoder.segment=The 0-based occurrence of the subject alternative name to map. This attribute is optional and only used when there is more than one subject alternative name of the given alt-name-type. The default value is 0.
+
+elytron.x500-subject-evidence-decoder=An evidence decoder that derives the principal associated with the given evidence from the subject from the first certificate in the given evidence.
+# Operations
+elytron.x500-subject-evidence-decoder.add=The add operation for the evidence decoder.
+elytron.x500-subject-evidence-decoder.remove=The remove operation for the evidence decoder.
 
 #################
 # Realm Mappers #

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -533,6 +533,15 @@ elytron.x500-subject-evidence-decoder=An evidence decoder that derives the princ
 elytron.x500-subject-evidence-decoder.add=The add operation for the evidence decoder.
 elytron.x500-subject-evidence-decoder.remove=The remove operation for the evidence decoder.
 
+elytron.custom-evidence-decoder=Definition of a custom evidence decoder.
+# Operations
+elytron.custom-evidence-decoder.add=Add operation for the evidence decoder.
+elytron.custom-evidence-decoder.remove=Remove operation for the evidence decoder.
+#Attributes
+elytron.custom-evidence-decoder.module=Name of the module to use to load the evidence decoder.
+elytron.custom-evidence-decoder.class-name=Fully qualified class name of the evidence decoder.
+elytron.custom-evidence-decoder.configuration=The optional key/value configuration for the evidence decoder.
+
 #################
 # Realm Mappers #
 #################

--- a/elytron/src/main/resources/schema/wildfly-elytron_8_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_8_0.xsd
@@ -830,6 +830,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="evidence-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to an EvidenceDecoder to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="realm-mapper" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
@@ -2443,6 +2450,9 @@
             <xs:element name="custom-role-mapper" type="customRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="logical-role-mapper" type="logicalRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="mapped-role-mapper" type="mappedRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="x500-subject-evidence-decoder" type="x500SubjectEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="x509-subject-alt-name-evidence-decoder" type="x509SubjectAltNameEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-evidence-decoder" type="aggregateEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
         </xs:choice>
     </xs:complexType>
 
@@ -3473,6 +3483,96 @@
             <xs:annotation>
                 <xs:documentation>
                     The name of the referenced RoleMapper.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="x500SubjectEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                An EvidenceDecoder that derives the principal associated with the given evidence from the subject from
+                the first certificate in the certificate chain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="x509SubjectAltNameEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                An EvidenceDecoder that derives the principal associated with the given evidence from an X.509 subject
+                alternative name from the first certificate in the given evidence.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType">
+                <xs:attribute name="alt-name-type" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The subject alternative name type to decode from the given evidence.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="rfc822Name" />
+                            <xs:enumeration value="dNSName" />
+                            <xs:enumeration value="directoryName" />
+                            <xs:enumeration value="uniformResourceIdentifier" />
+                            <xs:enumeration value="iPAddress" />
+                            <xs:enumeration value="registeredID" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="segment" type="xs:int" default="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The 0-based occurrence of the subject alternative name to map. This attribute is optional and only
+                            used when there is more than one subject alternative name of the given alt-name-type
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                An EvidenceDecoder definition that is an aggregation of other EvidenceDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType">
+                <xs:sequence>
+                    <xs:element name="evidence-decoder" type="evidenceDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="evidenceDecoderRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to an EvidenceDecoder
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="evidenceDecoderType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all EvidenceDecoder definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the EvidenceDecoder, note names used for EvidenceDecoder must be unique
+                    across the whole context.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/elytron/src/main/resources/schema/wildfly-elytron_8_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_8_0.xsd
@@ -2452,6 +2452,7 @@
             <xs:element name="mapped-role-mapper" type="mappedRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="x500-subject-evidence-decoder" type="x500SubjectEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="x509-subject-alt-name-evidence-decoder" type="x509SubjectAltNameEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-evidence-decoder" type="customEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="aggregate-evidence-decoder" type="aggregateEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
         </xs:choice>
     </xs:complexType>
@@ -3549,6 +3550,31 @@
                 <xs:sequence>
                     <xs:element name="evidence-decoder" type="evidenceDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
                 </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom EvidenceDecoder implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the EvidenceDecoder implementation.
+
+                                Note: If configuration is supplied the EvidenceDecoder MUST implement the initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/CustomEvidenceDecoder.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CustomEvidenceDecoder.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.elytron;
+
+import java.util.Locale;
+
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.server.EvidenceDecoder;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.X509PeerCertificateChainEvidence;
+
+/**
+ * A custom evidence decoder used in MappersTestCase.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class CustomEvidenceDecoder implements EvidenceDecoder {
+
+    public NamePrincipal getPrincipal(final Evidence evidence) {
+        if (! (evidence instanceof X509PeerCertificateChainEvidence)) {
+            return null;
+        }
+        // just returns subject name as a NamePrincipal in upper case
+        return new NamePrincipal(((X509PeerCertificateChainEvidence) evidence).getFirstCertificate().getSubjectX500Principal().getName().toUpperCase(Locale.ROOT));
+    }
+}

--- a/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
@@ -112,6 +112,24 @@ public class MappersTestCase extends AbstractSubsystemBaseTest {
 
     }
 
+    @Test
+    public void testCustomEvidenceDecoder() throws Exception {
+        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
+        if (!services.isSuccessfulBoot()) {
+            Assert.fail(services.getBootError().toString());
+        }
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "CustomTestingDomain");
+
+        X509Certificate[] certificateChain = populateCertificateChain(true);
+        X509PeerCertificateChainEvidence evidence = new X509PeerCertificateChainEvidence(certificateChain);
+
+        ServiceName serviceName = Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY.getCapabilityServiceName("customEvidenceDecoder");
+        EvidenceDecoder evidenceDecoder = (EvidenceDecoder) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(evidenceDecoder);
+        // custom evidence decoder just converts the subject name to upper case
+        Assert.assertEquals("CN=BOB0", evidenceDecoder.getPrincipal(evidence).getName());
+    }
+
     private static X509Certificate[] populateCertificateChain(boolean includeSubjectAltNames) throws Exception {
         KeyPairGenerator keyPairGenerator;
         try {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
@@ -23,9 +23,25 @@ import org.jboss.msc.service.ServiceName;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import org.wildfly.security.asn1.ASN1Encodable;
 import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.server.EvidenceDecoder;
+import org.wildfly.security.evidence.X509PeerCertificateChainEvidence;
+import org.wildfly.security.x500.GeneralName;
+import org.wildfly.security.x500.X500;
+import org.wildfly.security.x500.X500AttributeTypeAndValue;
+import org.wildfly.security.x500.X500PrincipalBuilder;
+import org.wildfly.security.x500.cert.SubjectAlternativeNamesExtension;
+import org.wildfly.security.x500.cert.X509CertificateBuilder;
 
 import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+import javax.security.auth.x500.X500Principal;
 
 /**
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
@@ -58,5 +74,86 @@ public class MappersTestCase extends AbstractSubsystemBaseTest {
         Assert.assertEquals("gamma@example.com", transformer.apply(new NamePrincipal("gamma@example.com")).getName()); // keep
         Assert.assertEquals(null, transformer.apply(new NamePrincipal("invalid"))); // not an e-mail address
         Assert.assertEquals(null, transformer.apply(null));
+    }
+
+    @Test
+    public void testEvidenceDecoder() throws Exception {
+        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
+        if (!services.isSuccessfulBoot()) {
+            Assert.fail(services.getBootError().toString());
+        }
+        TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomain");
+
+        X509Certificate[] certificateChain = populateCertificateChain(true);
+        X509PeerCertificateChainEvidence evidence = new X509PeerCertificateChainEvidence(certificateChain);
+
+        ServiceName serviceName = Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY.getCapabilityServiceName("subjectDecoder");
+        EvidenceDecoder evidenceDecoder = (EvidenceDecoder) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(evidenceDecoder);
+        Assert.assertEquals("CN=bob0", evidenceDecoder.getPrincipal(evidence).getName());
+
+        serviceName = Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY.getCapabilityServiceName("rfc822Decoder");
+        evidenceDecoder = (EvidenceDecoder) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(evidenceDecoder);
+        Assert.assertEquals("bob0@anotherexample.com", evidenceDecoder.getPrincipal(evidence).getName());
+
+        serviceName = Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY.getCapabilityServiceName("aggregateEvidenceDecoder");
+        evidenceDecoder = (EvidenceDecoder) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(evidenceDecoder);
+        Assert.assertEquals("bob0@anotherexample.com", evidenceDecoder.getPrincipal(evidence).getName());
+
+        certificateChain = populateCertificateChain(false);
+        evidence = new X509PeerCertificateChainEvidence(certificateChain);
+
+        serviceName = Capabilities.EVIDENCE_DECODER_RUNTIME_CAPABILITY.getCapabilityServiceName("aggregateEvidenceDecoder");
+        evidenceDecoder = (EvidenceDecoder) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(evidenceDecoder);
+        Assert.assertEquals("CN=bob0", evidenceDecoder.getPrincipal(evidence).getName());
+
+    }
+
+    private static X509Certificate[] populateCertificateChain(boolean includeSubjectAltNames) throws Exception {
+        KeyPairGenerator keyPairGenerator;
+        try {
+            keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new Error(e);
+        }
+        final KeyPair[] keyPairs = new KeyPair[5];
+        for (int i = 0; i < keyPairs.length; i++) {
+            keyPairs[i] = keyPairGenerator.generateKeyPair();
+        }
+        final X509Certificate[] orderedCertificates = new X509Certificate[5];
+        for (int i = 0; i < orderedCertificates.length; i++) {
+            X509CertificateBuilder builder = new X509CertificateBuilder();
+            X500PrincipalBuilder principalBuilder = new X500PrincipalBuilder();
+            principalBuilder.addItem(X500AttributeTypeAndValue.create(X500.OID_AT_COMMON_NAME,
+                    ASN1Encodable.ofUtf8String("bob" + i)));
+            X500Principal dn = principalBuilder.build();
+            builder.setSubjectDn(dn);
+            if (i == orderedCertificates.length - 1) {
+                // self-signed
+                builder.setIssuerDn(dn);
+                builder.setSigningKey(keyPairs[i].getPrivate());
+            } else {
+                principalBuilder = new X500PrincipalBuilder();
+                principalBuilder.addItem(X500AttributeTypeAndValue.create(X500.OID_AT_COMMON_NAME,
+                        ASN1Encodable.ofUtf8String("bob" + (i + 1))));
+                X500Principal issuerDn = principalBuilder.build();
+                builder.setIssuerDn(issuerDn);
+                builder.setSigningKey(keyPairs[i + 1].getPrivate());
+                if (includeSubjectAltNames) {
+                    builder.addExtension(new SubjectAlternativeNamesExtension(
+                            true,
+                            Arrays.asList(new GeneralName.RFC822Name("bob" + i + "@example.com"),
+                                    new GeneralName.DNSName("bob" + i + ".example.com"),
+                                    new GeneralName.RFC822Name("bob" + i + "@anotherexample.com"))));
+                }
+            }
+            builder.setSignatureAlgorithmName("SHA256withRSA");
+            builder.setPublicKey(keyPairs[i].getPublic());
+            orderedCertificates[i] = builder.build();
+        }
+        return orderedCertificates;
     }
 }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -90,6 +90,14 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testRejectingTransformersEAP720() throws Exception {
         testRejectingTransformers(EAP_7_2_0, "elytron-transformers-4.0-reject.xml", new FailedOperationTransformationConfig()
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.X500_SUBJECT_EVIDENCE_DECODER, "subjectDecoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER, "rfc822Decoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_EVIDENCE_DECODER, "aggregateEvidenceDecoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN)),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(DomainDefinition.EVIDENCE_DECODER))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS, new FailedOperationTransformationConfig.NewAttributesConfig(ElytronDefinition.DEFAULT_SSL_CONTEXT))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.JASPI_CONFIGURATION, "minimal")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -94,6 +94,8 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER, "rfc822Decoder")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.CUSTOM_EVIDENCE_DECODER, "customEvidenceDecoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_EVIDENCE_DECODER, "aggregateEvidenceDecoder")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN)),

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
@@ -111,6 +111,7 @@
         </mapped-role-mapper>
         <x500-subject-evidence-decoder name="subjectDecoder" />
         <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
@@ -109,6 +109,12 @@
             <role-mapping from="From" to="To1 to2"/>
             <role-mapping from="From2" to="To1 to3"/>
         </mapped-role-mapper>
+        <x500-subject-evidence-decoder name="subjectDecoder" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
+            <evidence-decoder name="rfc822Decoder"/>
+            <evidence-decoder name="subjectDecoder"/>
+        </aggregate-evidence-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
@@ -18,6 +18,18 @@
         <security-domain name="AnotherDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" trusted-security-domains="MyDomain">
             <realm name="PropRealm"/>
         </security-domain>
+        <security-domain name="AggregateEvidenceDecoderDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" principal-decoder="MyCn0Decoder"
+                         pre-realm-principal-transformer="MyChainedTransformer" evidence-decoder="aggregateEvidenceDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
+        <security-domain name="SubjectAltNameEvidenceDecoderDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" principal-decoder="MyCn0Decoder"
+                         pre-realm-principal-transformer="MyChainedTransformer" evidence-decoder="rfc822Decoder">
+            <realm name="PropRealm"/>
+        </security-domain>
+        <security-domain name="SubjectEvidenceDecoderDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" principal-decoder="MyCn0Decoder"
+                         pre-realm-principal-transformer="MyChainedTransformer" evidence-decoder="subjectDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
     </security-domains>
     <security-realms>
         <properties-realm name="PropRealm">
@@ -71,10 +83,17 @@
         <x500-attribute-principal-decoder joiner="," maximum-segments="1" name="MyX500PrincipalDecoderTwo" oid="2.5.4.3" required-oids="2.5.4.3 2.5.4.11" required-attributes="cN" reverse="true"
                                           start-segment="2"/>
         <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="Cn" start-segment="1"/>
+        <x500-attribute-principal-decoder maximum-segments="1" name="MyCn0Decoder" attribute-name="Cn"/>
         <x500-attribute-principal-decoder name="MyDcDecoder" oid="0.9.2342.19200300.100.1.25"/>
+        <chained-principal-transformer name="MyChainedTransformer">
+            <principal-transformer name="CnRegex"/>
+            <principal-transformer name="DnsRegex"/>
+        </chained-principal-transformer>
         <regex-principal-transformer name="NameRewriterXY" pattern="x(.*)" replacement="y$1"/>
         <regex-principal-transformer name="NameRewriterYU" pattern="y(.*)" replacement="u$1"/>
         <regex-principal-transformer name="NameRewriterRealmRemover" pattern="(.*)@.*" replacement="$1"/>
+        <regex-principal-transformer name="CnRegex" pattern=".*([0-9]+)$" replacement="$1"/>
+        <regex-principal-transformer name="DnsRegex" pattern="(.*)@.*.com" replacement="$1"/>
         <simple-regex-realm-mapper name="MyRealmMapper" pattern=".*@(.*)"/>
         <simple-role-decoder attribute="roles" name="MyRoleDecoder"/>
         <add-prefix-role-mapper name="RolePrefixer" prefix="prefix"/>
@@ -83,6 +102,12 @@
             <role-mapper name="RolePrefixer"/>
             <role-mapper name="RoleSuffixer"/>
         </aggregate-role-mapper>
+        <x500-subject-evidence-decoder name="subjectDecoder" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
+            <evidence-decoder name="rfc822Decoder"/>
+            <evidence-decoder name="subjectDecoder"/>
+        </aggregate-evidence-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="login-permission">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
@@ -104,6 +104,7 @@
         </aggregate-role-mapper>
         <x500-subject-evidence-decoder name="subjectDecoder" />
         <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-8.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-8.0.xml
@@ -184,6 +184,7 @@
         </mapped-role-mapper>
         <x500-subject-evidence-decoder name="subjectDecoder" />
         <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-8.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-8.0.xml
@@ -33,6 +33,9 @@
         <security-domain name="X500DomainThree" default-realm="FileRealm" principal-decoder="MyX500PrincipalDecoderThree">
             <realm name="FileRealm"/>
         </security-domain>
+        <security-domain name="X500DomainFour" default-realm="FileRealm" principal-decoder="MyX500PrincipalDecoderThree" evidence-decoder="aggregateEvidenceDecoder">
+            <realm name="FileRealm"/>
+        </security-domain>
         <security-domain name="AnotherDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" trusted-security-domains="MyDomain">
             <realm name="PropRealm"/>
         </security-domain>
@@ -179,6 +182,12 @@
             <role-mapping from="Admin" to="Administrator"/>
             <role-mapping from="foo" to="bar baz"/>
         </mapped-role-mapper>
+        <x500-subject-evidence-decoder name="subjectDecoder" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
+            <evidence-decoder name="rfc822Decoder"/>
+            <evidence-decoder name="subjectDecoder"/>
+        </aggregate-evidence-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -76,6 +76,7 @@
     <mappers>
         <x500-subject-evidence-decoder name="subjectDecoder" />
         <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -15,6 +15,11 @@
         <size-rotating-file-audit-log name="audit5" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="true" autoflush="false" />
         <size-rotating-file-audit-log name="audit6" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="false" autoflush="true" />
     </audit-logging>
+    <security-domains>
+        <security-domain name="X500Domain" default-realm="FileRealm" evidence-decoder="aggregateEvidenceDecoder">
+            <realm name="FileRealm"/>
+        </security-domain>
+    </security-domains>
     <security-realms>
         <jdbc-realm name="JdbcBcryptHashHex">
             <principal-query sql="SELECT role, password, salt, ic FROM User WHERE username = ?" data-source="ExampleDS">
@@ -64,7 +69,18 @@
                 <key kid="1" public-key="-----BEGIN PUBLIC KEY-----MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgF1mQenACcf3tWRJ8nugSIXXdlgaAh3xf6K1ak8r4fI7vigfzYa/+OfvJeKgWL/fO1PTkYAqyDfxi+k3AORQRE3I0zqQoZBhtm99ZPluZGRU9+COLlbIK3Uac0K/t1dEjo9Cb2EMHyHBaaX3mwmS296zHyDFVDEm7Sw1G98TLnz9AgMBAAE=-----END PUBLIC KEY-----"/>
             </jwt>
         </token-realm>
+        <filesystem-realm name="FileRealm" levels="2" encoded="false">
+            <file path="filesystem-realm" relative-to="jboss.server.config.dir"/>
+        </filesystem-realm>
     </security-realms>
+    <mappers>
+        <x500-subject-evidence-decoder name="subjectDecoder" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
+            <evidence-decoder name="rfc822Decoder"/>
+            <evidence-decoder name="subjectDecoder"/>
+        </aggregate-evidence-decoder>
+    </mappers>
     <tls>
         <key-stores>
             <key-store name="accounts.keystore">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
@@ -1,6 +1,6 @@
 <subsystem xmlns="urn:wildfly:elytron:8.0">
     <security-domains>
-        <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree">
+        <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder">
             <realm name="PropRealm"/>
         </security-domain>
     </security-domains>
@@ -32,6 +32,13 @@
         <regex-validating-principal-transformer name="isJbossEmail" pattern="(.*)@jboss.com"/>
         <regex-validating-principal-transformer name="isWildflyEmail" pattern="(.*)@wildfly.org"/>
         <regex-validating-principal-transformer name="genericEmail" pattern="(.*)@(.*)"/>
+
+        <x500-subject-evidence-decoder name="subjectDecoder" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
+            <evidence-decoder name="rfc822Decoder"/>
+            <evidence-decoder name="subjectDecoder"/>
+        </aggregate-evidence-decoder>
 
     </mappers>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
@@ -3,6 +3,9 @@
         <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder">
             <realm name="PropRealm"/>
         </security-domain>
+        <security-domain name="CustomTestingDomain" default-realm="PropRealm" evidence-decoder="customEvidenceDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
     </security-domains>
     <security-realms>
         <properties-realm name="PropRealm">
@@ -35,6 +38,7 @@
 
         <x500-subject-evidence-decoder name="subjectDecoder" />
         <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.extension.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -111,6 +111,7 @@
         </mapped-role-mapper>
         <x500-subject-evidence-decoder name="subjectDecoder" />
         <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -109,6 +109,12 @@
             <role-mapping from="From" to="To1 to2"/>
             <role-mapping from="From2" to="To1 to3"/>
         </mapped-role-mapper>
+        <x500-subject-evidence-decoder name="subjectDecoder" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
+        <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
+            <evidence-decoder name="rfc822Decoder"/>
+            <evidence-decoder name="subjectDecoder"/>
+        </aggregate-evidence-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4361
https://issues.jboss.org/browse/EAP7-1173

This also contains the Elytron subsystem version bump included in #3777

To pass CI, this will require an Elytron upgrade but this is ready for the subsystem changes to be reviewed.

Analysis document: https://github.com/wildfly/wildfly-proposals/pull/203
Capabilities PR: https://github.com/wildfly/wildfly-capabilities/pull/34
WildFly PR: https://github.com/wildfly/wildfly/pull/12352
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/1294
