### PR TITLE
[WFCORE-4517] Add back the --add-modules=java.se argument for modular…

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -60,6 +60,9 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         modularJavaOpts.add("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED");
+        // As of jboss-modules 1.9.1.Final the java.se module is no longer required to be added. However as this API is
+        // designed to work with older versions of the server we still need to add this argument of modular JVM's.
+        modularJavaOpts.add("--add-modules=java.se");
         DEFAULT_MODULAR_VM_ARGUMENTS = Collections.unmodifiableList(modularJavaOpts);
     }
 

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -203,6 +203,7 @@ public class CommandBuilderTest {
             assertArgumentExists(command, "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED", expectedCount);
+            assertArgumentExists(command, "--add-modules=java.se", expectedCount);
         } else {
             Assert.assertFalse("Did not expect \"--add-exports=java.base/sun.nio.ch=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"));
@@ -210,6 +211,7 @@ public class CommandBuilderTest {
                     command.contains("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED"));
+            Assert.assertFalse("Did not expect \"--add-modules=java.se\" to be in the command list", command.contains("--add-modules=java.se"));
         }
     }
 


### PR DESCRIPTION
… environments.

https://issues.jboss.org/browse/WFCORE-4517

This also fixes https://issues.jboss.org/browse/WFLY-12182 allowing mixed domain tests to pass again on JDK 12.