### PR TITLE
 [WFCORE-4172] Add support for TLS 1.3

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -116,6 +116,7 @@ public class Util {
     public static final String CORE_SERVICE = "core-service";
     public static final String CREDENTIAL_REFERENCE = "credential-reference";
     public static final String CIPHER_SUITE_FILTER = "cipher-suite-filter";
+    public static final String CIPHER_SUITE_NAMES = "cipher-suite-names";
     public static final String DATASOURCES = "datasources";
     public static final String DEFAULT = "default";
     public static final String DEFAULT_PERMISSION_MAPPER = "default-permission-mapper";

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ServerSSLContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ServerSSLContext.java
@@ -18,6 +18,7 @@ package org.jboss.as.cli.impl.aesh.cmd.security.model;
 import java.util.List;
 import org.jboss.as.cli.Util;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.security.ssl.CipherSuiteSelector;
 
 /**
  * Server SSLContext model class.
@@ -34,6 +35,7 @@ public class ServerSSLContext {
     private List<String> protocols;
     private boolean authenticationOptional;
     private String cipherSuiteFilter = "DEFAULT";
+    private String cipherSuiteNames = CipherSuiteSelector.OPENSSL_DEFAULT_CIPHER_SUITE_NAMES;
     private String finalPrincipalTransformer;
     private String postRealmPrincipalTransformer;
     private String preRealmPrincipalTransformer;
@@ -110,6 +112,25 @@ public class ServerSSLContext {
     public void setCipherSuiteFilter(String cipherSuiteFilter) {
         this.cipherSuiteFilter = cipherSuiteFilter;
     }
+
+    /**
+     * Get the cipher suite names.
+     *
+     * @return the cipher suite names
+     */
+    public String getCipherSuiteNames() {
+        return cipherSuiteNames;
+    }
+
+    /**
+     * Set the cipher suite names.
+     *
+     * @param cipherSuiteNames the cipher suite names
+     */
+    public void setCipherSuiteNames(String cipherSuiteNames) {
+        this.cipherSuiteNames = cipherSuiteNames;
+    }
+
 
     /**
      * @return the finalPrincipalTransformer
@@ -276,6 +297,11 @@ public class ServerSSLContext {
             sslCtx.get(Util.CIPHER_SUITE_FILTER).set(cipherSuiteFilter);
         } else {
             sslCtx.get(Util.CIPHER_SUITE_FILTER);
+        }
+        if (cipherSuiteNames != null) {
+            sslCtx.get(Util.CIPHER_SUITE_NAMES).set(cipherSuiteNames);
+        } else {
+            sslCtx.get(Util.CIPHER_SUITE_NAMES);
         }
         if (finalPrincipalTransformer != null) {
             sslCtx.get(Util.FINAL_PRINCIPAL_TRANSFORMER).set(finalPrincipalTransformer);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ServerSSLContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ServerSSLContext.java
@@ -18,7 +18,6 @@ package org.jboss.as.cli.impl.aesh.cmd.security.model;
 import java.util.List;
 import org.jboss.as.cli.Util;
 import org.jboss.dmr.ModelNode;
-import org.wildfly.security.ssl.CipherSuiteSelector;
 
 /**
  * Server SSLContext model class.
@@ -35,7 +34,9 @@ public class ServerSSLContext {
     private List<String> protocols;
     private boolean authenticationOptional;
     private String cipherSuiteFilter = "DEFAULT";
-    private String cipherSuiteNames = CipherSuiteSelector.OPENSSL_DEFAULT_CIPHER_SUITE_NAMES;
+    // WFCORE-4789: Set cipherSuiteNames to CipherSuiteSelector.OPENSSL_DEFAULT_CIPHER_SUITE_NAMES once we are ready to enable
+    // TLS 1.3 by default
+    private String cipherSuiteNames;
     private String finalPrincipalTransformer;
     private String postRealmPrincipalTransformer;
     private String preRealmPrincipalTransformer;

--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-all</artifactId>
-            <version>2.0.0-M17</version>  <!--TODO Elytron Remove once parent on M17 -->
+            <version>2.0.0-M24</version>  <!--TODO Elytron Remove once parent on AM26+ -->
             <scope>test</scope>
         </dependency>
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -102,6 +102,7 @@ interface ElytronDescriptionConstants {
     String CHANGE_ALIAS = "change-alias";
     String CIPHER_SUITE = "cipher-suite";
     String CIPHER_SUITE_FILTER = "cipher-suite-filter";
+    String CIPHER_SUITE_NAMES = "cipher-suite-names";
     String CLASS_LOADING = "class-loading";
     String CLASS_NAME = "class-name";
     String CLASS_NAMES = "class-names";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser9_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser9_0.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.extension.elytron;
 
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+
 /**
  * The subsystem parser, which uses stax to read and write to and from xml.
  *
@@ -29,6 +31,10 @@ public class ElytronSubsystemParser9_0 extends ElytronSubsystemParser8_0 {
     @Override
     String getNameSpace() {
         return ElytronExtension.NAMESPACE_9_0;
+    }
+
+    PersistentResourceXMLDescription getTlsParser() {
+        return new TlsParser().tlsParser_9_0;
     }
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -111,6 +111,16 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
         builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.AUTHENTICATION_CONFIGURATION))
                 .getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.ALWAYS, AuthenticationClientDefinitions.WEBSERVICES);
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.SERVER_SSL_CONTEXT))
+                .getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ElytronDescriptionConstants.CIPHER_SUITE_NAMES)
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, SSLDefinitions.CIPHER_SUITE_NAMES)
+                .end();
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT))
+                .getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ElytronDescriptionConstants.CIPHER_SUITE_NAMES)
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, SSLDefinitions.CIPHER_SUITE_NAMES)
+                .end();
     }
 
     private static void from8(ChainedTransformationDescriptionBuilder chainedBuilder) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -213,6 +213,14 @@ class SSLDefinitions {
             .setDefaultValue(new ModelNode("DEFAULT"))
             .build();
 
+    static final SimpleAttributeDefinition CIPHER_SUITE_NAMES = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CIPHER_SUITE_NAMES, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setMinSize(1)
+            .setRestartAllServices()
+            .setValidator(new CipherSuiteNamesValidator())
+            .setDefaultValue(new ModelNode(CipherSuiteSelector.OPENSSL_DEFAULT_CIPHER_SUITE_NAMES))
+            .build();
+
     private static final String[] ALLOWED_PROTOCOLS = { "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" };
 
     static final StringListAttributeDefinition PROTOCOLS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.PROTOCOLS)
@@ -443,6 +451,25 @@ class SSLDefinitions {
                     } catch (PatternSyntaxException exception) {
                         throw ROOT_LOGGER.invalidHostContextMapValue(hostname);
                     }
+                }
+            }
+        }
+    }
+
+    static class CipherSuiteNamesValidator extends ModelTypeValidator {
+
+        CipherSuiteNamesValidator() {
+            super(ModelType.STRING, true, true, false);
+        }
+
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+            if (value.isDefined()) {
+                try {
+                    CipherSuiteSelector.fromNamesString(value.asString());
+                } catch (IllegalArgumentException e) {
+                    throw ROOT_LOGGER.invalidCipherSuiteNames(e, e.getLocalizedMessage());
                 }
             }
         }
@@ -1077,7 +1104,7 @@ class SSLDefinitions {
                 .setRestartAllServices()
                 .build();
 
-        AttributeDefinition[] attributes = new AttributeDefinition[]{CIPHER_SUITE_FILTER, PROTOCOLS,
+        AttributeDefinition[] attributes = new AttributeDefinition[]{CIPHER_SUITE_FILTER, CIPHER_SUITE_NAMES, PROTOCOLS,
                 SECURITY_DOMAIN, WANT_CLIENT_AUTH, NEED_CLIENT_AUTH, AUTHENTICATION_OPTIONAL,
                 USE_CIPHER_SUITES_ORDER, MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, WRAP, keyManagerDefinition, TRUST_MANAGER,
                 PRE_REALM_PRINCIPAL_TRANSFORMER, POST_REALM_PRINCIPAL_TRANSFORMER, FINAL_PRINCIPAL_TRANSFORMER, REALM_MAPPER,
@@ -1100,7 +1127,8 @@ class SSLDefinitions {
 
                 final String providerName = PROVIDER_NAME.resolveModelAttribute(context, model).asStringOrNull();
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
-                final String cipherSuiteFilter = CIPHER_SUITE_FILTER.resolveModelAttribute(context, model).asStringOrNull();
+                final String cipherSuiteFilter = CIPHER_SUITE_FILTER.resolveModelAttribute(context, model).asString(); // has default value, can't be null
+                final String cipherSuiteNames = CIPHER_SUITE_NAMES.resolveModelAttribute(context, model).asString();
                 final boolean wantClientAuth = WANT_CLIENT_AUTH.resolveModelAttribute(context, model).asBoolean();
                 final boolean needClientAuth = NEED_CLIENT_AUTH.resolveModelAttribute(context, model).asBoolean();
                 final boolean authenticationOptional = AUTHENTICATION_OPTIONAL.resolveModelAttribute(context, model).asBoolean();
@@ -1128,8 +1156,7 @@ class SSLDefinitions {
                         builder.setTrustManager(trustManager);
                     if (providers != null)
                         builder.setProviderSupplier(() -> providers);
-                    if (cipherSuiteFilter != null)
-                        builder.setCipherSuiteSelector(CipherSuiteSelector.fromString(cipherSuiteFilter));
+                    builder.setCipherSuiteSelector(CipherSuiteSelector.aggregate(CipherSuiteSelector.fromNamesString(cipherSuiteNames), CipherSuiteSelector.fromString(cipherSuiteFilter)));
                     if (!protocols.isEmpty()) {
                         List<Protocol> list = new ArrayList<>();
                         for (String protocol : protocols) {
@@ -1162,9 +1189,9 @@ class SSLDefinitions {
                     if (ROOT_LOGGER.isTraceEnabled()) {
                         ROOT_LOGGER.tracef(
                                 "ServerSSLContext supplying:  securityDomain = %s  keyManager = %s  trustManager = %s  "
-                                        + "providers = %s  cipherSuiteFilter = %s  protocols = %s  wantClientAuth = %s  needClientAuth = %s  "
+                                        + "providers = %s  cipherSuiteFilter = %s  cipherSuiteNames = %s protocols = %s  wantClientAuth = %s  needClientAuth = %s  "
                                         + "authenticationOptional = %s  maximumSessionCacheSize = %s  sessionTimeout = %s wrap = %s",
-                                securityDomain, keyManager, trustManager, Arrays.toString(providers), cipherSuiteFilter,
+                                securityDomain, keyManager, trustManager, Arrays.toString(providers), cipherSuiteFilter, cipherSuiteNames,
                                 Arrays.toString(protocols.toArray()), wantClientAuth, needClientAuth, authenticationOptional,
                                 maximumSessionCacheSize, sessionTimeout, wrap);
                     }
@@ -1253,7 +1280,7 @@ class SSLDefinitions {
                 .setRestartAllServices()
                 .build();
 
-        AttributeDefinition[] attributes = new AttributeDefinition[]{CIPHER_SUITE_FILTER, PROTOCOLS,
+        AttributeDefinition[] attributes = new AttributeDefinition[]{CIPHER_SUITE_FILTER, CIPHER_SUITE_NAMES, PROTOCOLS,
                 KEY_MANAGER, TRUST_MANAGER, providersDefinition, PROVIDER_NAME};
 
         AbstractAddStepHandler add = new TrivialAddHandler<SSLContext>(SSLContext.class, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
@@ -1266,8 +1293,8 @@ class SSLDefinitions {
 
                 final String providerName = PROVIDER_NAME.resolveModelAttribute(context, model).asStringOrNull();
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
-                final String cipherSuiteFilter = CIPHER_SUITE_FILTER.resolveModelAttribute(context, model).asStringOrNull();
-
+                final String cipherSuiteFilter = CIPHER_SUITE_FILTER.resolveModelAttribute(context, model).asString(); // has default value, can't be null
+                final String cipherSuiteNames = CIPHER_SUITE_NAMES.resolveModelAttribute(context, model).asString(); // has default value, can't be null
                 return () -> {
                     X509ExtendedKeyManager keyManager = getX509KeyManager(keyManagerInjector.getOptionalValue());
                     X509ExtendedTrustManager trustManager = getX509TrustManager(trustManagerInjector.getOptionalValue());
@@ -1277,8 +1304,7 @@ class SSLDefinitions {
                     if (keyManager != null) builder.setKeyManager(keyManager);
                     if (trustManager != null) builder.setTrustManager(trustManager);
                     if (providers != null) builder.setProviderSupplier(() -> providers);
-                    if (cipherSuiteFilter != null)
-                        builder.setCipherSuiteSelector(CipherSuiteSelector.fromString(cipherSuiteFilter));
+                    builder.setCipherSuiteSelector(CipherSuiteSelector.aggregate(CipherSuiteSelector.fromNamesString(cipherSuiteNames), CipherSuiteSelector.fromString(cipherSuiteFilter)));
                     if (!protocols.isEmpty()) {
                         List<Protocol> list = new ArrayList<>();
                         for (String protocol : protocols) {
@@ -1295,8 +1321,8 @@ class SSLDefinitions {
                     if (ROOT_LOGGER.isTraceEnabled()) {
                         ROOT_LOGGER.tracef(
                                 "ClientSSLContext supplying:  keyManager = %s  trustManager = %s  providers = %s  " +
-                                        "cipherSuiteFilter = %s  protocols = %s",
-                                keyManager, trustManager, Arrays.toString(providers), cipherSuiteFilter,
+                                        "cipherSuiteFilter = %s cipherSuiteNames = %s protocols = %s",
+                                keyManager, trustManager, Arrays.toString(providers), cipherSuiteFilter, cipherSuiteNames,
                                 Arrays.toString(protocols.toArray())
                         );
                     }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -218,7 +218,8 @@ class SSLDefinitions {
             .setMinSize(1)
             .setRestartAllServices()
             .setValidator(new CipherSuiteNamesValidator())
-            .setDefaultValue(new ModelNode(CipherSuiteSelector.OPENSSL_DEFAULT_CIPHER_SUITE_NAMES))
+            // WFCORE-4789: Add the following line back when we are ready to enable TLS 1.3 by default
+            //.setDefaultValue(new ModelNode(CipherSuiteSelector.OPENSSL_DEFAULT_CIPHER_SUITE_NAMES))
             .build();
 
     private static final String[] ALLOWED_PROTOCOLS = { "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" };
@@ -1128,7 +1129,7 @@ class SSLDefinitions {
                 final String providerName = PROVIDER_NAME.resolveModelAttribute(context, model).asStringOrNull();
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
                 final String cipherSuiteFilter = CIPHER_SUITE_FILTER.resolveModelAttribute(context, model).asString(); // has default value, can't be null
-                final String cipherSuiteNames = CIPHER_SUITE_NAMES.resolveModelAttribute(context, model).asString();
+                final String cipherSuiteNames = CIPHER_SUITE_NAMES.resolveModelAttribute(context, model).asStringOrNull(); // doesn't have a default value yet since we are disabling TLS 1.3 by default
                 final boolean wantClientAuth = WANT_CLIENT_AUTH.resolveModelAttribute(context, model).asBoolean();
                 final boolean needClientAuth = NEED_CLIENT_AUTH.resolveModelAttribute(context, model).asBoolean();
                 final boolean authenticationOptional = AUTHENTICATION_OPTIONAL.resolveModelAttribute(context, model).asBoolean();
@@ -1156,7 +1157,7 @@ class SSLDefinitions {
                         builder.setTrustManager(trustManager);
                     if (providers != null)
                         builder.setProviderSupplier(() -> providers);
-                    builder.setCipherSuiteSelector(CipherSuiteSelector.aggregate(CipherSuiteSelector.fromNamesString(cipherSuiteNames), CipherSuiteSelector.fromString(cipherSuiteFilter)));
+                    builder.setCipherSuiteSelector(CipherSuiteSelector.aggregate(cipherSuiteNames != null ? CipherSuiteSelector.fromNamesString(cipherSuiteNames) : null, CipherSuiteSelector.fromString(cipherSuiteFilter)));
                     if (!protocols.isEmpty()) {
                         List<Protocol> list = new ArrayList<>();
                         for (String protocol : protocols) {
@@ -1294,7 +1295,7 @@ class SSLDefinitions {
                 final String providerName = PROVIDER_NAME.resolveModelAttribute(context, model).asStringOrNull();
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
                 final String cipherSuiteFilter = CIPHER_SUITE_FILTER.resolveModelAttribute(context, model).asString(); // has default value, can't be null
-                final String cipherSuiteNames = CIPHER_SUITE_NAMES.resolveModelAttribute(context, model).asString(); // has default value, can't be null
+                final String cipherSuiteNames = CIPHER_SUITE_NAMES.resolveModelAttribute(context, model).asStringOrNull(); // doesn't have a default value yet since we are disabling TLS 1.3 by default
                 return () -> {
                     X509ExtendedKeyManager keyManager = getX509KeyManager(keyManagerInjector.getOptionalValue());
                     X509ExtendedTrustManager trustManager = getX509TrustManager(trustManagerInjector.getOptionalValue());
@@ -1304,7 +1305,7 @@ class SSLDefinitions {
                     if (keyManager != null) builder.setKeyManager(keyManager);
                     if (trustManager != null) builder.setTrustManager(trustManager);
                     if (providers != null) builder.setProviderSupplier(() -> providers);
-                    builder.setCipherSuiteSelector(CipherSuiteSelector.aggregate(CipherSuiteSelector.fromNamesString(cipherSuiteNames), CipherSuiteSelector.fromString(cipherSuiteFilter)));
+                    builder.setCipherSuiteSelector(CipherSuiteSelector.aggregate(cipherSuiteNames != null ? CipherSuiteSelector.fromNamesString(cipherSuiteNames) : null, CipherSuiteSelector.fromString(cipherSuiteFilter)));
                     if (!protocols.isEmpty()) {
                         List<Protocol> list = new ArrayList<>();
                         for (String protocol : protocols) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -144,6 +144,29 @@ class TlsParser {
             .addAttribute(SSLDefinitions.FINAL_PRINCIPAL_TRANSFORMER)
             .addAttribute(SSLDefinitions.REALM_MAPPER);
 
+    private PersistentResourceXMLBuilder serverSslContextParser_9_0 = PersistentResourceXMLDescription.builder(PathElement.pathElement(SERVER_SSL_CONTEXT))
+            .setXmlWrapperElement(SERVER_SSL_CONTEXTS)
+            .setMarshallDefaultValues(true)
+            .addAttribute(SSLDefinitions.SECURITY_DOMAIN)
+            .addAttribute(SSLDefinitions.CIPHER_SUITE_FILTER)
+            .addAttribute(SSLDefinitions.CIPHER_SUITE_NAMES) // new
+            .addAttribute(SSLDefinitions.PROTOCOLS)
+            .addAttribute(SSLDefinitions.WANT_CLIENT_AUTH)
+            .addAttribute(SSLDefinitions.NEED_CLIENT_AUTH)
+            .addAttribute(SSLDefinitions.AUTHENTICATION_OPTIONAL)
+            .addAttribute(SSLDefinitions.USE_CIPHER_SUITES_ORDER)
+            .addAttribute(SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE)
+            .addAttribute(SSLDefinitions.SESSION_TIMEOUT)
+            .addAttribute(SSLDefinitions.WRAP)
+            .addAttribute(SSLDefinitions.KEY_MANAGER)
+            .addAttribute(SSLDefinitions.TRUST_MANAGER)
+            .addAttribute(SSLDefinitions.PROVIDERS)
+            .addAttribute(SSLDefinitions.PROVIDER_NAME)
+            .addAttribute(SSLDefinitions.PRE_REALM_PRINCIPAL_TRANSFORMER)
+            .addAttribute(SSLDefinitions.POST_REALM_PRINCIPAL_TRANSFORMER)
+            .addAttribute(SSLDefinitions.FINAL_PRINCIPAL_TRANSFORMER)
+            .addAttribute(SSLDefinitions.REALM_MAPPER);
+
     private PersistentResourceXMLBuilder clientSslContextParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(CLIENT_SSL_CONTEXT))
             .setXmlWrapperElement(CLIENT_SSL_CONTEXTS)
             .addAttribute(SSLDefinitions.SECURITY_DOMAIN)
@@ -165,6 +188,24 @@ class TlsParser {
             .setXmlWrapperElement(CERTIFICATE_AUTHORITIES)
             .addAttribute(CertificateAuthorityDefinition.URL)
             .addAttribute(CertificateAuthorityDefinition.STAGING_URL);
+
+    private PersistentResourceXMLBuilder clientSslContextParser_9_0 = PersistentResourceXMLDescription.builder(PathElement.pathElement(CLIENT_SSL_CONTEXT))
+            .setXmlWrapperElement(CLIENT_SSL_CONTEXTS)
+            .addAttribute(SSLDefinitions.SECURITY_DOMAIN)
+            .addAttribute(SSLDefinitions.CIPHER_SUITE_FILTER)
+            .addAttribute(SSLDefinitions.CIPHER_SUITE_NAMES) // new
+            .addAttribute(SSLDefinitions.PROTOCOLS)
+            .addAttribute(SSLDefinitions.WANT_CLIENT_AUTH)
+            .addAttribute(SSLDefinitions.NEED_CLIENT_AUTH)
+            .addAttribute(SSLDefinitions.AUTHENTICATION_OPTIONAL)
+            .addAttribute(SSLDefinitions.USE_CIPHER_SUITES_ORDER)
+            .addAttribute(SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE)
+            .addAttribute(SSLDefinitions.SESSION_TIMEOUT)
+            .addAttribute(SSLDefinitions.WRAP)
+            .addAttribute(SSLDefinitions.KEY_MANAGER)
+            .addAttribute(SSLDefinitions.TRUST_MANAGER)
+            .addAttribute(SSLDefinitions.PROVIDERS)
+            .addAttribute(SSLDefinitions.PROVIDER_NAME);
 
     private PersistentResourceXMLBuilder certificateAuthorityAccountParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(CERTIFICATE_AUTHORITY_ACCOUNT))
             .setXmlWrapperElement(CERTIFICATE_AUTHORITY_ACCOUNTS)
@@ -249,6 +290,21 @@ class TlsParser {
             .addChild(serverSslContextParser)
             .addChild(clientSslContextParser)
             .addChild(certificateAuthorityParser) // new
+            .addChild(certificateAuthorityAccountParser)
+            .addChild(serverSslSniContextParser)
+            .build();
+
+    final PersistentResourceXMLDescription tlsParser_9_0 = decorator(TLS)
+            .addChild(decorator(KEY_STORES)
+                    .addChild(keyStoreParser)
+                    .addChild(ldapKeyStoreParser)
+                    .addChild(filteringKeyStoreParser)
+            )
+            .addChild(keyManagerParser)
+            .addChild(trustManagerParser)
+            .addChild(serverSslContextParser_9_0) // new cipher-suite-names attribute
+            .addChild(clientSslContextParser_9_0) // new cipher-suite-names attribute
+            .addChild(certificateAuthorityParser)
             .addChild(certificateAuthorityAccountParser)
             .addChild(serverSslSniContextParser)
             .build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -575,4 +575,7 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1065, value = "Multiple maximum-cert-path definitions found.")
     OperationFailedException multipleMaximumCertPathDefinitions();
 
+    @Message(id = 1066, value = "Invalid value for cipher-suite-names. %s")
+    OperationFailedException invalidCipherSuiteNames(@Cause Throwable cause, String causeMessage);
+
 }

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1248,7 +1248,8 @@ elytron.client-ssl-context=An SSLContext for use on the client side of a connect
 elytron.client-ssl-context.add=Add the SSLContext definition.
 elytron.client-ssl-context.remove=Remove the SSLContext definition.
 #Attributes
-elytron.client-ssl-context.cipher-suite-filter=The filter to apply to specify the enabled cipher suites.
+elytron.client-ssl-context.cipher-suite-filter=The filter to apply to specify the enabled cipher suites for TLSv1.2 and below.
+elytron.client-ssl-context.cipher-suite-names=The filter to apply to specify the enabled cipher suites for TLSv1.3.
 elytron.client-ssl-context.protocols=The enabled protocols.
 elytron.client-ssl-context.use-cipher-suites-order=To honor local cipher suites preference.
 elytron.client-ssl-context.maximum-session-cache-size=The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
@@ -1317,7 +1318,8 @@ elytron.server-ssl-context.add=Add the SSLContext definition.
 elytron.server-ssl-context.remove=Remove the SSLContext definition.
 #Attributes
 elytron.server-ssl-context.security-domain=The security domain to use for authentication during SSL session establishment.
-elytron.server-ssl-context.cipher-suite-filter=The filter to apply to specify the enabled cipher suites.
+elytron.server-ssl-context.cipher-suite-filter=The filter to apply to specify the enabled cipher suites for TLSv1.2 and below.
+elytron.server-ssl-context.cipher-suite-names=The filter to apply to specify the enabled cipher suites for TLSv1.3.
 elytron.server-ssl-context.protocols=The enabled protocols.
 elytron.server-ssl-context.want-client-auth=To request (but not to require) a client certificate on SSL handshake. If a security domain is referenced and supports X509 evidence, this will be set to true automatically. Ignored when need-client-auth is set.
 elytron.server-ssl-context.need-client-auth=To require a client certificate on SSL handshake. Connection without trusted client certificate (see trust-manager) will be rejected.

--- a/elytron/src/main/resources/schema/wildfly-elytron_9_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_9_0.xsd
@@ -4760,6 +4760,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional" default="TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the TLSv1.3 cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="protocols" type="stringListType" use="optional">
             <xs:annotation>
                 <xs:documentation>
@@ -4913,6 +4920,13 @@
             <xs:annotation>
                 <xs:documentation>
                     The filter to be applied to the cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional" default="TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the TLSv1.3 cipher suites made available by this SSLContext.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/elytron/src/main/resources/schema/wildfly-elytron_9_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_9_0.xsd
@@ -4760,7 +4760,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional" default="TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256">
+        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The filter to be applied to the TLSv1.3 cipher suites made available by this SSLContext.
@@ -4923,7 +4923,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional" default="TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256">
+        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The filter to be applied to the TLSv1.3 cipher suites made available by this SSLContext.

--- a/elytron/src/test/java/org/wildfly/extension/elytron/LdapService.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/LdapService.java
@@ -143,6 +143,7 @@ public class LdapService implements Closeable {
             for (String current : indexes) {
                 partitionFactory.addIndex(partition, current, indexSize);
             }
+            partition.setCacheService(directoryService.getCacheService());
             partition.initialize();
             directoryService.addPartition(partition);
 
@@ -196,7 +197,7 @@ public class LdapService implements Closeable {
             Transport ldaps = new TcpTransport( hostName, port, 3, 5 );
             ldaps.enableSSL(true);
             server.addTransports(ldaps);
-            server.setKeystoreFile(getClass().getResource(keyStore).getFile());
+            server.setKeystoreFile(new File(getClass().getResource(keyStore).getFile()).getAbsolutePath());
             server.setCertificatePassword(keyStorePassword);
             server.setDirectoryService(directoryService);
             servers.add(server);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -91,6 +91,10 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testRejectingTransformersEAP720() throws Exception {
         testRejectingTransformers(EAP_7_2_0, "elytron-transformers-4.0-reject.xml", new FailedOperationTransformationConfig()
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SERVER_SSL_CONTEXT)),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(SSLDefinitions.CIPHER_SUITE_NAMES))
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT)),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(SSLDefinitions.CIPHER_SUITE_NAMES))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.X500_SUBJECT_EVIDENCE_DECODER, "subjectDecoder")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.X509_SUBJECT_ALT_NAME_EVIDENCE_DECODER, "rfc822Decoder")),

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-9.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-9.0.xml
@@ -312,10 +312,16 @@
                                 use-cipher-suites-order="false" maximum-session-cache-size="10"
                                 session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
                                 post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
+            <server-ssl-context name="serverTLS13" protocols="TLSv1.3" want-client-auth="true" need-client-auth="true" authentication-optional="true"
+                                cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_128_CCM_SHA256" use-cipher-suites-order="false" maximum-session-cache-size="10"
+                                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
+                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
                                 provider-name="first"/>
+            <client-ssl-context name="clientTLS13" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
+                                provider-name="first" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"/>
         </client-ssl-contexts>
         <certificate-authorities>
             <certificate-authority name="testCA" url="https://www.test.com"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -107,12 +107,14 @@
         </key-managers>
         <server-ssl-contexts>
             <server-ssl-context name="ctx" key-manager="key1"/>
+            <server-ssl-context name="ctxTLS13" key-manager="key1" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"/>
         </server-ssl-contexts>
         <server-ssl-sni-contexts>
             <server-ssl-sni-context name="test" default-ssl-context="ctx"></server-ssl-sni-context>
         </server-ssl-sni-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="ClientContext"/>
+            <client-ssl-context name="ClientContextTLS13" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"/>
         </client-ssl-contexts>
         <certificate-authorities>
             <certificate-authority name="testCA" url="http://www.test.com"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/legacy-elytron-subsystem-8.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/legacy-elytron-subsystem-8.0.xml
@@ -312,9 +312,15 @@
                                 use-cipher-suites-order="false" maximum-session-cache-size="10"
                                 session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
                                 post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
+            <server-ssl-context name="serverTLS13" protocols="TLSv1.3" want-client-auth="true" need-client-auth="true" authentication-optional="true"
+                                use-cipher-suites-order="false" maximum-session-cache-size="10"
+                                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
+                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
+                                provider-name="first"/>
+            <client-ssl-context name="clientTLS13" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
                                 provider-name="first"/>
         </client-ssl-contexts>
         <certificate-authorities>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -84,10 +84,25 @@
             <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1.3 TLSv1.2 TLSv1.1" key-manager="ServerKeyManager" trust-manager="CaTrustManager"
                                 want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false"
                                 providers="ManagerProviderLoader" provider-name="IBMJSSE2" session-timeout="321" maximum-session-cache-size="123"/>
+            <server-ssl-context name="ServerSslContextTLS13" protocols="TLSv1.3 TLSv1.2 TLSv1.1" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                key-manager="ServerKeyManager" trust-manager="CaTrustManager" want-client-auth="true" need-client-auth="true"
+                                authentication-optional="false" use-cipher-suites-order="false" providers="ManagerProviderLoader" provider-name="IBMJSSE2"
+                                session-timeout="321" maximum-session-cache-size="123"/>
+            <server-ssl-context name="ServerSslContextTLS13Only" protocols="TLSv1.3" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                key-manager="ServerKeyManager" trust-manager="CaTrustManager" want-client-auth="true" need-client-auth="true"
+                                authentication-optional="false" use-cipher-suites-order="false" providers="ManagerProviderLoader" provider-name="IBMJSSE2"
+                                session-timeout="321" maximum-session-cache-size="123"/>
+            <server-ssl-context name="ServerSslContextTLS12Only" protocols="TLSv1.2" key-manager="ServerKeyManager" trust-manager="CaTrustManager"
+                                want-client-auth="true" need-client-auth="true" authentication-optional="false" providers="ManagerProviderLoader"
+                                provider-name="IBMJSSE2" session-timeout="321" maximum-session-cache-size="123"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="ClientSslContextNoAuth" trust-manager="CaTrustManager" />
             <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextTLS13" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextTLS13Only" protocols="TLSv1.3" cipher-suite-names="TLS_AES_128_GCM_SHA256"
+                                key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -84,10 +84,25 @@
             <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1.3 TLSv1.2 TLSv1.1" key-manager="ServerKeyManager" trust-manager="CaTrustManager"
                                 want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false"
                                 providers="ManagerProviderLoader" provider-name="SunJSSE" session-timeout="321" maximum-session-cache-size="123"/>
+            <server-ssl-context name="ServerSslContextTLS13" protocols="TLSv1.3 TLSv1.2 TLSv1.1" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                key-manager="ServerKeyManager" trust-manager="CaTrustManager" want-client-auth="true" need-client-auth="true"
+                                authentication-optional="false" use-cipher-suites-order="false" providers="ManagerProviderLoader" provider-name="SunJSSE"
+                                session-timeout="321" maximum-session-cache-size="123"/>
+            <server-ssl-context name="ServerSslContextTLS13Only" protocols="TLSv1.3" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                key-manager="ServerKeyManager" trust-manager="CaTrustManager" want-client-auth="true" need-client-auth="true"
+                                authentication-optional="false" use-cipher-suites-order="false" providers="ManagerProviderLoader" provider-name="SunJSSE"
+                                session-timeout="321" maximum-session-cache-size="123"/>
+            <server-ssl-context name="ServerSslContextTLS12Only" protocols="TLSv1.2" key-manager="ServerKeyManager" trust-manager="CaTrustManager"
+                                want-client-auth="true" need-client-auth="true" authentication-optional="false" providers="ManagerProviderLoader"
+                                provider-name="SunJSSE" session-timeout="321" maximum-session-cache-size="123"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="ClientSslContextNoAuth" trust-manager="CaTrustManager" />
             <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextTLS13" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextTLS13Only" protocols="TLSv1.3" cipher-suite-names="TLS_AES_128_GCM_SHA256"
+                                key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -55,9 +55,16 @@
         <server-ssl-contexts>
             <server-ssl-context name="server" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true" use-cipher-suites-order="false" maximum-session-cache-size="10"
                 session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a" post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first" />
+            <server-ssl-context name="serverTLS13" protocols="TLSv1.3" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"
+                                want-client-auth="true" need-client-auth="true" authentication-optional="true" use-cipher-suites-order="false"
+                                maximum-session-cache-size="10" session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust"
+                                pre-realm-principal-transformer="a" post-realm-principal-transformer="b" final-principal-transformer="c"
+                                realm-mapper="d" providers="custom-loader" provider-name="first" />
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader" provider-name="first" />
+            <client-ssl-context name="clientTLS13" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
+                                provider-name="first" cipher-suite-names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"/>
         </client-ssl-contexts>
     </tls>
     <credential-stores>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,11 @@
         <version.org.aesh-extensions>1.8</version.org.aesh-extensions>
         <version.org.aesh-readline>2.0</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
-        <!-- TODO Elytron - Bump to M17 -->
+        <!-- TODO Elytron - Bump to AM26+ after AM26 is released.
+             Cannot bump to M24 due to https://issues.apache.org/jira/browse/DIRSERVER-2231
+             (the current workaround causes test failures in domain-management tests).
+             Cannot bump to AM25 due to https://issues.apache.org/jira/browse/DIRSERVER-2247.
+        -->
         <version.org.apache.httpcomponents.httpclient>4.5.4</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.5</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4172
https://issues.jboss.org/browse/WFCORE-4391
https://issues.jboss.org/browse/EAP7-1022

This also contains the Elytron subsystem version bump included in #3777

To pass CI, this will require an Elytron upgrade but this is ready for the subsystem changes to be reviewed.

Analysis document: https://github.com/wildfly/wildfly-proposals/pull/148
WildFly PR with documentation and test updates: https://github.com/wildfly/wildfly/pull/12361
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/1295
Also depends on https://issues.jboss.org/browse/WFWIP-160