### PR TITLE
[WFCORE-4521] PropertyFileFinder should not validate perms for non-ex…

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
@@ -220,7 +220,7 @@ public class PropertyFileFinder implements State {
                     SERVER_CONFIG_DIR, SERVER_BASE_DIR, "standalone", fileName);
             if (standaloneProps.exists()) {
                 foundFiles.add(standaloneProps);
-            }
+            } // TODO should this invalid --sc be an error regardless of whether domainConfigOpt points to a valid dir?
         }
 
         if (domainConfigOpt != null) {
@@ -228,7 +228,7 @@ public class PropertyFileFinder implements State {
                     DOMAIN_CONFIG_DIR, DOMAIN_BASE_DIR, "domain", fileName);
             if (domainProps.exists()) {
                 foundFiles.add(domainProps);
-            }
+            } // TODO should this invalid --dc be an error regardless of whether serverConfigOpt points to a valid dir?
         }
 
         return !foundFiles.isEmpty();
@@ -242,8 +242,9 @@ public class PropertyFileFinder implements State {
                 serverBaseDirPropertyName, defaultBaseDir);
 
         File file = new File(dirPath, fileName);
-        validatePermissions(dirPath, file);
-
+        if (file.exists()) {
+            validatePermissions(dirPath, file);
+        } // else caller deals with non-existent files
         return file;
 
     }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.domain.management.security.adduser;
 
 import org.jboss.as.domain.management.security.adduser.AddUser.FileMode;
 import org.jboss.msc.service.StartException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import static java.lang.System.getProperty;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -50,6 +52,14 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
     public void setup() throws IOException {
         values.setFileMode(FileMode.MANAGEMENT);
         values.getOptions().setJBossHome(getProperty("java.io.tmpdir"));
+        cleanFiles("domain");
+        cleanFiles("standalone");
+    }
+
+    @After
+    public void teardown() throws IOException {
+        cleanFiles("domain");
+        cleanFiles("standalone");
     }
 
     private File createPropertyFile(String filename, String mode) throws IOException {
@@ -69,6 +79,23 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
            bw.close();
         }
         return propertyUserFile;
+    }
+
+    private void cleanFiles(String mode) {
+        File dir = new File(getProperty("java.io.tmpdir")+File.separator+mode);
+        cleanFiles(dir);
+    }
+
+    private void cleanFiles(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    cleanFiles(child);
+                }
+            }
+        }
+        file.delete();
     }
 
     @Test
@@ -123,6 +150,38 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
 
         assertUserPropertyFile(newUserName);
         consoleBuilder.validate();
+    }
+
+    @Test
+    public void noDomainDir() throws IOException {
+        File standaloneMgmtUserFile = createPropertyFile("mgmt-users.properties", "standalone");
+        File standaloneMgmtGroupFile = createPropertyFile("mgmt-groups.properties", "standalone");
+        File domainDir = standaloneMgmtGroupFile.getParentFile().getParentFile().toPath().resolve("domain").toFile();
+        assertFalse(domainDir.exists());
+
+        System.setProperty("jboss.server.config.dir", standaloneMgmtGroupFile.getParent());
+        System.setProperty("jboss.domain.config.dir", domainDir.getAbsolutePath());
+        State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
+        State nextState = propertyFileFinder.execute();
+        assertTrue(nextState.toString(), nextState instanceof PromptRealmState);
+        assertTrue("Expected to find the "+USER_NAME+" in the list of known enabled users",values.getEnabledKnownUsers().contains(USER_NAME));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile,values.getUserFiles().contains(standaloneMgmtUserFile));
+    }
+
+    @Test
+    public void noStandaloneDir() throws IOException {
+        File domainMgmtUserFile = createPropertyFile("mgmt-users.properties", "domain");
+        File domainMgmtGroupFile = createPropertyFile("mgmt-groups.properties", "domain");
+        File standaloneDir = domainMgmtGroupFile.getParentFile().getParentFile().toPath().resolve("standalone").toFile();
+        assertFalse(standaloneDir.exists());
+
+        System.setProperty("jboss.server.config.dir", standaloneDir.getAbsolutePath());
+        System.setProperty("jboss.domain.config.dir", domainMgmtGroupFile.getParent());
+        State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
+        State nextState = propertyFileFinder.execute();
+        assertTrue(nextState.toString(), nextState instanceof PromptRealmState);
+        assertTrue("Expected to find the "+USER_NAME+" in the list of known enabled users",values.getEnabledKnownUsers().contains(USER_NAME));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile,values.getUserFiles().contains(domainMgmtUserFile));
     }
 
 


### PR DESCRIPTION
…istent files as they are ignored

https://issues.jboss.org/browse/WFCORE-4521