### PR TITLE
[WFCORE-4518] Disable the testEndpointConfigurationViaDeprecatedChild…

### DIFF
--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -63,6 +63,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.extension.io.IOServices;
 import org.wildfly.extension.io.WorkerService;
@@ -166,6 +167,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
      * WFCORE-3327. Use the management API to add the subsystem, with the endpoint configuration done via
      * the deprecated /subsystem=remoting/configuration=endpoint resource.
      */
+    @Ignore("WFCORE-4518")
     @Test
     public void testEndpointConfigurationViaDeprecatedChild() throws Exception {
         KernelServices services = createKernelServicesBuilder(createRuntimeAdditionalInitialization())


### PR DESCRIPTION
… as it seems to be unstable on CI.

This PR just ignores the failing test.

https://issues.jboss.org/browse/WFCORE-4518