### PR TITLE
[WFCORE-4519] Fix content references management when a deployment is replaced

### DIFF
--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepositoryImpl.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepositoryImpl.java
@@ -344,6 +344,7 @@ public class ContentRepositoryImpl implements ContentRepository {
         cleanedContents.put(MARKED_CONTENT, new HashSet<>());
         cleanedContents.put(DELETED_CONTENT, new HashSet<>());
         synchronized (contentHashReferences) {
+            DeploymentRepositoryLogger.ROOT_LOGGER.debug("Current content hash references are "+contentHashReferences);
             for (ContentReference fsContent : listLocalContents()) {
                 if (!readWrite) {
                     return Collections.emptyMap();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentReplaceHandler.java
@@ -79,7 +79,7 @@ public class ServerGroupDeploymentReplaceHandler implements OperationStepHandler
 
         final PathElement deploymentPath = PathElement.pathElement(DEPLOYMENT, name);
         final PathElement replacePath = PathElement.pathElement(DEPLOYMENT, toReplace);
-        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+        final PathAddress referenceAddress = PathAddress.pathAddress(operation.get(OP_ADDR)).append(deploymentPath);
         Resource domainDeployment;
         try {
             // check if the domain deployment exists
@@ -92,7 +92,7 @@ public class ServerGroupDeploymentReplaceHandler implements OperationStepHandler
         final List<ContentReference> locallyAddedReferences = new LinkedList<ContentReference>();
         for (ModelNode content : deployment.require(CONTENT).asList()) {
             if ((content.hasDefined(HASH))) {
-                ContentReference reference = ModelContentReference.fromModelAddress(address, content.require(HASH).asBytes());
+                ContentReference reference = ModelContentReference.fromModelAddress(referenceAddress, content.require(HASH).asBytes());
                 // Ensure the local repo has the files
                 fileRepository.getDeploymentFiles(reference);
                 locallyAddedReferences.add(reference);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -301,7 +301,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerOperationHandler(ApplyExtensionsHandler.DEFINITION, aexh);
 
         }
-        resourceRegistration.registerOperationHandler(DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_DEFINITION, isMaster ? new DeploymentFullReplaceHandler(contentRepo) : new DeploymentFullReplaceHandler(fileRepository));
+        resourceRegistration.registerOperationHandler(DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_DEFINITION, new DeploymentFullReplaceHandler(contentRepo, fileRepository, isMaster, environment.isBackupDomainFiles()));
 
         resourceRegistration.registerOperationHandler(ValidateAddressOperationHandler.DEFINITION, ValidateAddressOperationHandler.INSTANCE);
 


### PR DESCRIPTION
Specifically, it addresses two incorrect behavior 

1. When a deployment is replaced using --force, which translates into `:full-replace-deployment` operation, we were not tracking correctly the references to the replaced content. The problem here is the content could be deleted by the cleanup task.
2. Server group replacement operation was using an incorrect path creating the content reference, instead of /server-group=server-group-name it should be /server-group=server-group-name/deployment=deployment-name. The use of that address is incorrect; if a server group deployment is later removed, then the HC content repository won't be deleted until the HC is reloaded. 
 
Additionally, added debug trace to follow up the current references of the local content repository, that could help debugging issues related. 

Jira issue: https://issues.jboss.org/browse/WFCORE-4519