### PR TITLE
[WFCORE-4528] / [WFCORE-4529] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.10.0.CR1</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.5.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.6.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.9.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.5.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4528
https://issues.jboss.org/browse/WFCORE-4529

        Release Notes - WildFly Elytron - Version 1.10.0.CR1
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1823'>ELY-1823</a>] -         Update SecurityProviderServerMechanismFactory to cache Provider interaction.
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1824'>ELY-1824</a>] -         Provider should cache instances of stateless factories it creates
</li>
</ul>
                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1617'>ELY-1617</a>] -         Support SSL Certificate revocation using OCSP
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1797'>ELY-1797</a>] -         Make the certificate authority used by a certificate-authority-account configurable
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-613'>ELY-613</a>] -         Some nested classes should be considered to be static nested in Elytron
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1792'>ELY-1792</a>] -         IBM, error VaultCommandTest
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1818'>ELY-1818</a>] -         Don&#39;t use a lambda for the disposal of mechanisms in forEach
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1820'>ELY-1820</a>] -         SecurityProviderServerMechanismFactory should support Provider instances
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1821'>ELY-1821</a>] -         ProviderUtil should contain overloaded methods which accept arrays of Providers
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1777'>ELY-1777</a>] -         Add version 1.4 of the Elytron client schema
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1816'>ELY-1816</a>] -         Ensure a source jar is created for the common test module
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1828'>ELY-1828</a>] -         Release WildFly Elytron 1.10.0.CR1
</li>
</ul>

        Release Notes - Elytron Web - Version 1.6.0.CR1

<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-61'>ELYWEB-61</a>] -         Upgrade WildFly Elytron to 1.10.0.CR1
</li>
</ul>                                                                                                            
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-62'>ELYWEB-62</a>] -         Release Elytron Web 1.6.0.CR1
</li>
</ul>