### PR TITLE
[WFCORE-4362] Make the certificate authority used by a certificate-authority-account configurable

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
@@ -1023,7 +1023,7 @@ class AdvancedModifiableKeyStoreDecorator extends ModifiableKeyStoreDecorator {
 
     static AcmeAccount resetAcmeAccount(AcmeAccount acmeAccount, boolean staging) {
         String accountUrl = acmeAccount.getAccountUrl();
-        if (accountUrl != null) {
+        if (accountUrl != null && acmeAccount.getStagingServerUrl() != null) {
             String stagingEndpoint = acmeAccount.getStagingServerUrl().substring(0, acmeAccount.getStagingServerUrl().indexOf("/" + DIRECTORY));
             if ((accountUrl.startsWith(stagingEndpoint) && ! staging) || (! accountUrl.startsWith(stagingEndpoint) && staging)) {
                 // need to reset the account information so it will get populated with the correct staging / non-staging account URL

--- a/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
@@ -50,6 +50,7 @@ import org.wildfly.security.authz.RoleMapper;
 import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
 import org.wildfly.security.x500.cert.acme.AcmeAccount;
+import org.wildfly.security.x500.cert.acme.CertificateAuthority;
 
 
 /**
@@ -81,6 +82,12 @@ class Capabilities {
 
     static final RuntimeCapability<Void> CERTIFICATE_AUTHORITY_ACCOUNT_RUNTIME_CAPABILITY =  RuntimeCapability
             .Builder.of(CERTIFICATE_AUTHORITY_ACCOUNT_CAPABILITY, true, AcmeAccount.class)
+            .build();
+
+    static final String CERTIFICATE_AUTHORITY_CAPABILITY = CAPABILITY_BASE + "certificate-authority";
+
+    static final RuntimeCapability<Void> CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY =  RuntimeCapability
+            .Builder.of(CERTIFICATE_AUTHORITY_CAPABILITY, true, CertificateAuthority.class)
             .build();
 
     static final String CREDENTIAL_STORE_CAPABILITY = CAPABILITY_BASE + "credential-store";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityAccountDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityAccountDefinition.java
@@ -21,9 +21,11 @@ package org.wildfly.extension.elytron;
 import static org.wildfly.extension.elytron.AdvancedModifiableKeyStoreDecorator.resetAcmeAccount;
 import static org.wildfly.extension.elytron.Capabilities.CERTIFICATE_AUTHORITY_ACCOUNT_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.CERTIFICATE_AUTHORITY_ACCOUNT_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.Capabilities.CERTIFICATE_AUTHORITY_CAPABILITY;
+import static org.wildfly.extension.elytron.Capabilities.CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.KEY_STORE_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.KEY_STORE_RUNTIME_CAPABILITY;
-import static org.wildfly.extension.elytron.ElytronDefinition.commonDependencies;
+import static org.wildfly.extension.elytron.ElytronDefinition.commonRequirements;
 import static org.wildfly.extension.elytron.ElytronExtension.getRequiredService;
 import static org.wildfly.extension.elytron.ElytronExtension.isServerOrHostController;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
@@ -31,10 +33,10 @@ import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.RO
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.ServiceLoader;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -51,7 +53,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.operations.validation.StringAllowedValuesValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
@@ -70,6 +71,7 @@ import org.wildfly.security.x500.cert.acme.AcmeAccount;
 import org.wildfly.security.x500.cert.acme.AcmeClientSpi;
 import org.wildfly.security.x500.cert.acme.AcmeException;
 import org.wildfly.security.x500.cert.acme.AcmeMetadata;
+import org.wildfly.security.x500.cert.acme.CertificateAuthority;
 
 /**
  * A {@link ResourceDefinition} for a single certificate authority account.
@@ -77,43 +79,6 @@ import org.wildfly.security.x500.cert.acme.AcmeMetadata;
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
 class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
-    private static final String DIRECTORY = "directory";
-
-    enum CertificateAuthority {
-
-        LETS_ENCRYPT("LetsEncrypt", "https://acme-v02.api.letsencrypt.org/" + DIRECTORY, "https://acme-staging-v02.api.letsencrypt.org/" + DIRECTORY);
-
-        private final String name;
-        private final String url;
-        private final String stagingUrl;
-
-        CertificateAuthority(final String name, final String url, final String stagingUrl) {
-            this.name = name;
-            this.url = url;
-            this.stagingUrl = stagingUrl;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public String getStagingUrl() {
-            return stagingUrl;
-        }
-
-        public static CertificateAuthority fromName(final String name) {
-            switch (name.toUpperCase(Locale.ENGLISH)) {
-                case "LETSENCRYPT":
-                    return LETS_ENCRYPT;
-                default:
-                    throw new IllegalArgumentException(name);
-            }
-        }
-    }
 
     static final StringListAttributeDefinition CONTACT_URLS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.CONTACT_URLS)
             .setRequired(false)
@@ -122,11 +87,11 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
             .setRestartAllServices()
             .build();
 
-    static final SimpleAttributeDefinition CERTIFICATE_AUTHORITY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY, ModelType.STRING, true)
+    static final SimpleAttributeDefinition CERTIFICATE_AUTHORITY = new CertificateAuthorityDefinitionBuilder(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(CertificateAuthority.LETS_ENCRYPT.getName()))
-            .setValidator(new StringAllowedValuesValidator(CertificateAuthority.LETS_ENCRYPT.getName()))
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setCapabilityReference(CERTIFICATE_AUTHORITY_CAPABILITY, CERTIFICATE_AUTHORITY_ACCOUNT_RUNTIME_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition KEY_STORE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_STORE, ModelType.STRING, false)
@@ -170,6 +135,33 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
         throw ROOT_LOGGER.unableToInstatiateAcmeClientSpiImplementation();
     }
 
+    private static class CertificateAuthorityAttributeDefinition extends SimpleAttributeDefinition {
+
+        CertificateAuthorityAttributeDefinition(AbstractAttributeDefinitionBuilder<?, ? extends CertificateAuthorityAttributeDefinition> builder) {
+            super(builder);
+        }
+
+        @Override
+        public void addCapabilityRequirements(OperationContext context, Resource resource, ModelNode attributeValue) {
+            // Check the existence of certificate authority only if it is not null or LetsEncrypt, since LetsEncrypt does not have to be added
+            if (attributeValue.asStringOrNull() != null && !attributeValue.asString().equalsIgnoreCase(CertificateAuthority.LETS_ENCRYPT.getName())) {
+                super.addCapabilityRequirements(context, resource, attributeValue);
+            }
+        }
+    }
+
+    private static class CertificateAuthorityDefinitionBuilder extends AbstractAttributeDefinitionBuilder<CertificateAuthorityDefinitionBuilder, CertificateAuthorityAttributeDefinition> {
+
+        CertificateAuthorityDefinitionBuilder(String attributeName, ModelType type, boolean optional) {
+            super(attributeName, type, optional);
+        }
+
+        @Override
+        public CertificateAuthorityAttributeDefinition build() {
+            return new CertificateAuthorityAttributeDefinition(this);
+        }
+    }
+
     private static final AbstractAddStepHandler ADD = new CertificateAuthorityAccountAddHandler();
 
     private static class CertificateAuthorityAccountAddHandler extends BaseAddHandler {
@@ -181,7 +173,7 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
             ModelNode model = resource.getModel();
-            CertificateAuthority certificateAuthority = CertificateAuthority.fromName(CERTIFICATE_AUTHORITY.resolveModelAttribute(context, model).asString().toUpperCase(Locale.ENGLISH));
+            String certificateAuthorityName = CERTIFICATE_AUTHORITY.resolveModelAttribute(context, model).asString();
             final String alias = ALIAS.resolveModelAttribute(context, model).asString();
             final String keyStoreName = KEY_STORE.resolveModelAttribute(context, model).asString();
             ExceptionSupplier<CredentialSource, Exception> credentialSourceSupplier = null;
@@ -194,7 +186,7 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
                 contactUrlsList.add(contactUrl.asString());
             }
 
-            AcmeAccountService acmeAccountService = new AcmeAccountService(certificateAuthority, contactUrlsList, alias, keyStoreName);
+            AcmeAccountService acmeAccountService = new AcmeAccountService(certificateAuthorityName, contactUrlsList, alias, keyStoreName);
             ServiceTarget serviceTarget = context.getServiceTarget();
             RuntimeCapability<Void> certificateAuthorityAccountRuntimeCapability = CERTIFICATE_AUTHORITY_ACCOUNT_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
             ServiceName acmeAccountServiceName = certificateAuthorityAccountRuntimeCapability.getCapabilityServiceName(AcmeAccount.class);
@@ -203,8 +195,12 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
 
             String keyStoreCapabilityName = RuntimeCapability.buildDynamicCapabilityName(KEY_STORE_CAPABILITY, keyStoreName);
             acmeAccountServiceBuilder.addDependency(context.getCapabilityServiceName(keyStoreCapabilityName, KeyStore.class), KeyStore.class, acmeAccountService.getKeyStoreInjector());
-
-            commonDependencies(acmeAccountServiceBuilder).install();
+            if (certificateAuthorityName.equalsIgnoreCase(CertificateAuthority.LETS_ENCRYPT.getName())) {
+                commonRequirements(acmeAccountServiceBuilder).install();
+            } else {
+                acmeAccountServiceBuilder.requires(CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY.getCapabilityServiceName(certificateAuthorityName));
+                commonRequirements(acmeAccountServiceBuilder).install();
+            }
         }
     }
 
@@ -422,7 +418,6 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
 
         return (ModifiableKeyStoreService) serviceContainer.getService();
     }
-
 
     private static AcmeAccountService getAcmeAccountService(OperationContext context) throws OperationFailedException {
         ServiceRegistry serviceRegistry = context.getServiceRegistry(true);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityDefinition.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.security.x500.cert.acme.CertificateAuthority;
+import org.jboss.msc.service.ServiceController.Mode;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.wildfly.extension.elytron.Capabilities.CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.ElytronDefinition.commonRequirements;
+import static org.wildfly.extension.elytron.ElytronExtension.getRequiredService;
+import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
+
+/**
+ * A {@link ResourceDefinition} for a single certificate authority.
+ * This resource represents certificate authority that implements <a href="https://tools.ietf.org/html/rfc8555">Automatic Certificate
+ * Management Environment (ACME)</a> specification.
+ *
+ * @author <a href="mailto:dvilkola@redhat.com">Diana Vilkolakova</a>
+ */
+class CertificateAuthorityDefinition extends SimpleResourceDefinition {
+
+    static final SimpleAttributeDefinition URL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.URL, ModelType.STRING, false)
+            .setValidator(new URLValidator(false))
+            .setRestartAllServices()
+            .build();
+
+    static final SimpleAttributeDefinition STAGING_URL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.STAGING_URL, ModelType.STRING, true)
+            .setValidator(new URLValidator(false))
+            .setRestartAllServices()
+            .build();
+
+    private static class URLValidator extends StringLengthValidator {
+
+        private URLValidator(boolean nullable) {
+            super(1, nullable, false);
+        }
+
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+            String url = value.asString();
+            try {
+                new URL(url);
+            } catch (MalformedURLException e) {
+                throw ROOT_LOGGER.invalidURL(url, e);
+            }
+        }
+    }
+
+    private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{URL, STAGING_URL};
+    private static final AbstractAddStepHandler ADD = new CertificateAuthorityAddHandler();
+
+    private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY);
+    private static final AbstractWriteAttributeHandler WRITE = new ElytronReloadRequiredWriteAttributeHandler(ATTRIBUTES);
+
+    CertificateAuthorityDefinition() {
+        super(new Parameters(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY), ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY))
+                .setAddHandler(ADD)
+                .setRemoveHandler(REMOVE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setCapabilities(CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        for (AttributeDefinition current : ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(current, null, WRITE);
+        }
+    }
+
+    private static class CertificateAuthorityAddHandler extends BaseAddHandler {
+        private CertificateAuthorityAddHandler() {
+            super(CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY, ATTRIBUTES);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+            final String certificateAuthorityName = context.getCurrentAddressValue();
+
+            // Creation of certificate authority with name "LetsEncrypt" is not allowed, because it is used internally as a fallback.
+            if (certificateAuthorityName.equalsIgnoreCase(CertificateAuthority.LETS_ENCRYPT.getName())) {
+                throw ROOT_LOGGER.letsEncryptNameNotAllowed();
+            }
+            commonRequirements(installService(context, model)).setInitialMode(Mode.ACTIVE).install();
+        }
+
+        ServiceBuilder<CertificateAuthority> installService(OperationContext context, ModelNode model) {
+            ServiceTarget serviceTarget = context.getServiceTarget();
+            TrivialService<CertificateAuthority> certificateAuthorityTrivialService = new TrivialService<>(getValueSupplier(context, model));
+            return serviceTarget.addService(CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY.getCapabilityServiceName(context.getCurrentAddressValue()), certificateAuthorityTrivialService);
+        }
+
+        protected TrivialService.ValueSupplier<CertificateAuthority> getValueSupplier(OperationContext context, ModelNode model) {
+            return () -> {
+                String certificateAuthorityResourceName = context.getCurrentAddress().getLastElement().getValue();
+                return new CertificateAuthority(certificateAuthorityResourceName,
+                        model.get(ElytronDescriptionConstants.URL).asString(),
+                        model.get(ElytronDescriptionConstants.STAGING_URL).asStringOrNull());
+            };
+        }
+    }
+
+    static Service<CertificateAuthority> getCertificateAuthorityService(ServiceRegistry serviceRegistry, String certificateAuthorityName) {
+        RuntimeCapability<Void> runtimeCapability = CERTIFICATE_AUTHORITY_RUNTIME_CAPABILITY.fromBaseCapability(certificateAuthorityName);
+        ServiceName serviceName = runtimeCapability.getCapabilityServiceName();
+        ServiceController<CertificateAuthority> serviceContainer = getRequiredService(serviceRegistry, serviceName, CertificateAuthority.class);
+        return serviceContainer.getService();
+    }
+}

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityDefinition.java
@@ -63,11 +63,13 @@ class CertificateAuthorityDefinition extends SimpleResourceDefinition {
 
     static final SimpleAttributeDefinition URL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.URL, ModelType.STRING, false)
             .setValidator(new URLValidator(false))
+            .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition STAGING_URL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.STAGING_URL, ModelType.STRING, true)
             .setValidator(new URLValidator(false))
+            .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -279,6 +279,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(SSLDefinitions.getServerSSLContextDefinition(serverOrHostController));
         resourceRegistration.registerSubModel(SSLDefinitions.getClientSSLContextDefinition(serverOrHostController));
         resourceRegistration.registerSubModel(SSLDefinitions.getServerSNISSLContextDefinition());
+        resourceRegistration.registerSubModel(new CertificateAuthorityDefinition());
         resourceRegistration.registerSubModel(new CertificateAuthorityAccountDefinition());
 
         // Credential Store Block

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -84,6 +84,7 @@ interface ElytronDescriptionConstants {
     String CERTIFICATE = "certificate";
     String CERTIFICATE_ATTRIBUTE = "certificate-attribute";
     String CERTIFICATE_AUTHORITY = "certificate-authority";
+    String CERTIFICATE_AUTHORITIES = "certificate-authorities";
     String CERTIFICATE_AUTHORITY_ACCOUNT = "certificate-authority-account";
     String CERTIFICATE_AUTHORITY_ACCOUNTS = "certificate-authority-accounts";
     String CERTIFICATE_CHAIN = "certificate-chain";
@@ -508,6 +509,7 @@ interface ElytronDescriptionConstants {
     String SSL_SESSION = "ssl-session";
     String SNI_MAPPING = "sni-mapping";
     String STAGING = "staging";
+    String STAGING_URL = "staging-url";
     String START_SEGMENT = "start-segment";
     String STATE = "state";
     String STORE = "store";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser8_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser8_0.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.extension.elytron;
 
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+
 /**
  * The subsystem parser, which uses stax to read and write to and from xml.
  *
@@ -31,4 +33,7 @@ public class ElytronSubsystemParser8_0 extends ElytronSubsystemParser7_0 {
         return ElytronExtension.NAMESPACE_8_0;
     }
 
+    PersistentResourceXMLDescription getTlsParser() {
+        return new TlsParser().tlsParser_8_0;
+    }
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -19,6 +19,7 @@ package org.wildfly.extension.elytron;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ALGORITHM;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AUTOFLUSH;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.BCRYPT_MAPPER;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITY;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILE_AUDIT_LOG;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HASH_ENCODING;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.JDBC_REALM;
@@ -60,6 +61,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.security.password.interfaces.ScramDigestPassword;
+import org.wildfly.security.x500.cert.acme.CertificateAuthority;
 
 /**
  * Registers transformers for the elytron subsystem.
@@ -98,6 +100,23 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
 
     private static void from8(ChainedTransformationDescriptionBuilder chainedBuilder) {
         ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(ELYTRON_8_0_0, ELYTRON_7_0_0);
+
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY));
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNT))
+                .getAttributeBuilder()
+                .addRejectCheck(new RejectAttributeChecker.DefaultRejectAttributeChecker() {
+
+                    @Override
+                    protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode value, TransformationContext context) {
+                        // only 'LetsEncrypt' was allowed in older versions
+                        return value.isDefined() && !value.asString().equalsIgnoreCase(CertificateAuthority.LETS_ENCRYPT.getName());
+                    }
+
+                    @Override
+                    public String getRejectionLogMessage(Map<String, ModelNode> attributes) {
+                        return ROOT_LOGGER.invalidAttributeValue(CERTIFICATE_AUTHORITY).getMessage();
+                    }
+                }, ElytronDescriptionConstants.CERTIFICATE_AUTHORITY);
 
     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -20,6 +20,8 @@ package org.wildfly.extension.elytron;
 
 import static org.jboss.as.controller.PersistentResourceXMLDescription.decorator;
 import static org.jboss.as.controller.parsing.ParseUtils.requireAttributes;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITY;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITIES;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNTS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CLIENT_SSL_CONTEXT;
@@ -155,6 +157,11 @@ class TlsParser {
             .addAttribute(SSLDefinitions.PROVIDERS)
             .addAttribute(SSLDefinitions.PROVIDER_NAME);
 
+    private PersistentResourceXMLBuilder certificateAuthorityParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(CERTIFICATE_AUTHORITY))
+            .setXmlWrapperElement(CERTIFICATE_AUTHORITIES)
+            .addAttribute(CertificateAuthorityDefinition.URL)
+            .addAttribute(CertificateAuthorityDefinition.STAGING_URL);
+
     private PersistentResourceXMLBuilder certificateAuthorityAccountParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(CERTIFICATE_AUTHORITY_ACCOUNT))
             .setXmlWrapperElement(CERTIFICATE_AUTHORITY_ACCOUNTS)
             .addAttribute(CertificateAuthorityAccountDefinition.CERTIFICATE_AUTHORITY)
@@ -227,4 +234,18 @@ class TlsParser {
             .addChild(serverSslSniContextParser) // new
             .build();
 
+    final PersistentResourceXMLDescription tlsParser_8_0 = decorator(TLS)
+            .addChild(decorator(KEY_STORES)
+                    .addChild(keyStoreParser)
+                    .addChild(ldapKeyStoreParser)
+                    .addChild(filteringKeyStoreParser)
+            )
+            .addChild(keyManagerParser)
+            .addChild(trustManagerParser)
+            .addChild(serverSslContextParser)
+            .addChild(clientSslContextParser)
+            .addChild(certificateAuthorityParser) // new
+            .addChild(certificateAuthorityAccountParser)
+            .addChild(serverSslSniContextParser)
+            .build();
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -559,4 +559,10 @@ public interface ElytronSubsystemMessages extends BasicLogger {
 
     @Message(id = 1061, value = "Invalid value of host context map: '%s' is not valid hostname pattern.")
     OperationFailedException invalidHostContextMapValue(String hostname);
+
+    @Message(id = 1062, value = "Value for attribute '%s' is invalid.")
+    OperationFailedException invalidAttributeValue(String attributeName);
+
+    @Message(id = 1063, value = "LetsEncrypt certificate authority is configured by default.")
+    OperationFailedException letsEncryptNameNotAllowed();
 }

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1339,6 +1339,14 @@ elytron.server-ssl-context.ssl-session.peer-certificates.version=The certificate
 # Operations
 elytron.server-ssl-context.ssl-session.invalidate=Invalidate the SSLSession (Note: This does not terminate current connections, only prevents future connections from joining or resuming this session).
 
+elytron.certificate-authority=A certificate authority definition.
+# Operations
+elytron.certificate-authority.add=Add a new certificate authority definition.
+elytron.certificate-authority.remove=Remove the certificate authority definition.
+# Configuration Attributes
+elytron.certificate-authority.url=URL of the certificate authority.
+elytron.certificate-authority.staging-url=URL of the certificate authority to use in pre-production.
+
 elytron.certificate-authority-account=A certificate authority account definition.
 # Operations
 elytron.certificate-authority-account.add=Add a new certificate authority account definition.
@@ -1357,7 +1365,7 @@ elytron.certificate-authority-account.get-metadata=Get the metadata associated w
 elytron.certificate-authority-account.get-metadata.staging=Indicates whether or not the certificate authority's staging URL should be used. The default value is false. This should only be set to true for testing purposes. This should never be set to true in a production environment.
 
 # Configuration Attributes
-elytron.certificate-authority-account.certificate-authority=The name of the certificate authority to use. Allowed values: 'LetsEncrypt'
+elytron.certificate-authority-account.certificate-authority=The name of the certificate authority to use.
 elytron.certificate-authority-account.contact-urls=A list of URLs that the certificate authority can contact about any issues related to this account.
 elytron.certificate-authority-account.key-store=The keystore that contains the certificate authority account key.
 elytron.certificate-authority-account.alias=The alias of certificate authority account key in the keystore. If the alias does not already exist in the keystore, a certificate authority account key will be automatically generated and stored as a PrivateKeyEntry under the alias.

--- a/elytron/src/main/resources/schema/wildfly-elytron_8_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_8_0.xsd
@@ -4224,6 +4224,7 @@
             <xs:element name="trust-managers" type="trustManagersType" minOccurs="0"/>
             <xs:element name="server-ssl-contexts" type="serverSSLContextsType" minOccurs="0" />
             <xs:element name="client-ssl-contexts" type="clientSSLContextsType" minOccurs="0" />
+            <xs:element name="certificate-authorities" type="certificateAuthoritiesType" minOccurs="0" />
             <xs:element name="certificate-authority-accounts" type="certificateAuthorityAccountsType" minOccurs="0" />
             <xs:element name="server-ssl-sni-contexts" type="serverSSLSNIContextsType" minOccurs="0" />
         </xs:all>
@@ -5039,22 +5040,57 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="certificate-authority" default="LetsEncrypt">
+        <xs:attribute name="certificate-authority" type="xs:string" default="LetsEncrypt">
             <xs:annotation>
                 <xs:documentation>
-                    The certificate authority to use.
+                    The reference to certificate authority to use.
                 </xs:documentation>
             </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="LetsEncrypt"/>
-                </xs:restriction>
-            </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="contact-urls" type="stringListType" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     A list of URLs that the certificate authority can contact about any issues related to this account.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="certificateAuthoritiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for certificate authority definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="certificate-authority" type="certificateAuthorityType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="certificateAuthorityType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single certificate authority.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this certificate authority.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    URL of the certificate authority.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="staging-url" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    URL of the certificate authority to use in pre-production.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -127,7 +127,13 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                         FailedOperationTransformationConfig.REJECTED_RESOURCE
                 ).addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.KEY_STORE, "automatic.keystore")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE
-                ));
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNT, "invalidCAA")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.CERTIFICATE_AUTHORITY)),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+        );
     }
 
     @Test

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-8.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-8.0.xml
@@ -302,8 +302,16 @@
             <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
                                 provider-name="first"/>
         </client-ssl-contexts>
+        <certificate-authorities>
+            <certificate-authority name="testCA" url="https://www.test.com"/>
+        </certificate-authorities>
         <certificate-authority-accounts>
             <certificate-authority-account name="MyCA" certificate-authority="LetsEncrypt">
+                <account-key key-store="accounts.keystore" alias="server">
+                    <credential-reference clear-text="elytron"/>
+                </account-key>
+            </certificate-authority-account>
+            <certificate-authority-account name="MyCA2" certificate-authority="testCA">
                 <account-key key-store="accounts.keystore" alias="server">
                     <credential-reference clear-text="elytron"/>
                 </account-key>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -92,5 +92,20 @@
         <client-ssl-contexts>
             <client-ssl-context name="ClientContext"/>
         </client-ssl-contexts>
+        <certificate-authorities>
+            <certificate-authority name="testCA" url="http://www.test.com"/>
+        </certificate-authorities>
+        <certificate-authority-accounts>
+            <certificate-authority-account name="validCAA">
+                <account-key key-store="accounts.keystore" alias="alias">
+                    <credential-reference clear-text="elytron"/>
+                </account-key>
+            </certificate-authority-account>
+            <certificate-authority-account name="invalidCAA" certificate-authority="testCA">
+                <account-key key-store="accounts.keystore" alias="alias">
+                    <credential-reference clear-text="elytron"/>
+                </account-key>
+            </certificate-authority-account>
+        </certificate-authority-accounts>
     </tls>
 </subsystem>


### PR DESCRIPTION
This is a follow up PR due to a bug in the GitHub UI https://github.com/wildfly/wildfly-core/pull/3768 - although is no conflict the GitHub UI is unable to regenerate the diff correctly.

Jira issues:
https://issues.jboss.org/browse/WFCORE-4362
https://issues.jboss.org/browse/EAP7-1150

This also contains the Elytron subsystem version bump included in #3777

To pass CI, this will require an Elytron upgrade but this is ready for the subsystem changes to be reviewed.

Requires ELY-1797

Elytron PR: wildfly-security/wildfly-elytron#1280
Capabilities PR: wildfly/wildfly-capabilities#33
documentation PR: wildfly/wildfly#12262