### PR TITLE
[WFCORE-4498] Only obtain the Provider[] once and re-use it.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -200,10 +200,11 @@ class HttpServerDefinitions {
                 Predicate<Provider.Service> serviceFilter = (Provider.Service s) -> HttpServerAuthenticationMechanismFactory.class.getSimpleName().equals(s.getType());
 
                 return () -> {
-                    if ( findProviderService(providerSupplier, serviceFilter) == null ) {
+                    final Provider[] actualProviders = providerSupplier.get();
+                    if ( findProviderService(actualProviders, serviceFilter) == null ) {
                         throw ROOT_LOGGER.noSuitableProvider(HttpServerAuthenticationMechanismFactory.class.getSimpleName());
                     }
-                    return new SetMechanismInformationMechanismFactory(new SecurityProviderServerMechanismFactory(providerSupplier));
+                    return new SetMechanismInformationMechanismFactory(new SecurityProviderServerMechanismFactory(actualProviders));
                 };
             }
 


### PR DESCRIPTION
This is just a small optimisation to reuse a result we are guaranteed to want to use at least once more, if not many times more.

https://issues.jboss.org/browse/WFCORE-4498