### PR TITLE
[WFCORE-4533] Upgrade jboss-logmanager from 2.1.11.Final to 2.1.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.org.jboss.logging.jboss-logging>3.4.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.11.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.13.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.7.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4533


# Release Notes - JBoss Log Manager - Version 2.1.13.Final
                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/LOGMGR-255'>LOGMGR-255</a>] -         PeriodicRotatingFileHandler doesn&#39;t rotate log content when using Compression
</li>
</ul>
                                            
Please note the 2.1.12.Final release was pushed to Nexus, but was released on the wrong branch which is why it was skipped.