### PR TITLE
[WFCORE-4546] Upgrade WildFly Elytron to 1.10.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4546

        Release Notes - WildFly Elytron - Version 1.10.0.CR2
                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1800'>ELY-1800</a>] -         Enhanced mapping of X509Certificate to the underlying identity
</li>
</ul>
                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1830'>ELY-1830</a>] -         Release WildFly Elytron 1.10.0.CR2
</li>
</ul>
                    