### PR TITLE
[WFCORE-4543] Don't assume it's safe to use the system log context. I…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
@@ -34,6 +34,7 @@ import org.jboss.logmanager.ThreadLocalLogContextSelector;
 */
 class WildFlyLogContextSelectorImpl implements WildFlyLogContextSelector {
 
+    private final LogContextSelector defaultLogContextSelector;
     private final ClassLoaderLogContextSelector contextSelector;
 
     private final ThreadLocalLogContextSelector threadLocalContextSelector;
@@ -51,10 +52,16 @@ class WildFlyLogContextSelectorImpl implements WildFlyLogContextSelector {
 
     WildFlyLogContextSelectorImpl(final LogContextSelector defaultLogContextSelector) {
         // There is not a way to reset the LogContextSelector after a reload. If the current selector is already a
-        // WildFlyLogContextSelectorImpl we should use the system default selector. This avoids possibly wrapping the
+        // WildFlyLogContextSelectorImpl we should use the previous default selector. This avoids possibly wrapping the
         // same log context several times. It should also work with the embedded CLI selector as the commands handle
         // setting and resetting the contexts.
-        final LogContextSelector dft = (defaultLogContextSelector instanceof WildFlyLogContextSelectorImpl ? LogContext.DEFAULT_LOG_CONTEXT_SELECTOR : defaultLogContextSelector);
+        final LogContextSelector dft;
+        if (defaultLogContextSelector instanceof WildFlyLogContextSelectorImpl) {
+            dft = ((WildFlyLogContextSelectorImpl) defaultLogContextSelector).defaultLogContextSelector;
+        } else {
+            dft = defaultLogContextSelector;
+        }
+        this.defaultLogContextSelector = dft;
         counter = new AtomicInteger(0);
         contextSelector = new ClassLoaderLogContextSelector(dft, true);
         threadLocalContextSelector = new ThreadLocalLogContextSelector(contextSelector);


### PR DESCRIPTION
…n the case of a CLI embedded server this could configure logging on the incorrect LogContext.

https://issues.jboss.org/browse/WFCORE-4543

Note I do think we need to write a test for this, but it's going to take some thought on how to handle it. It seems we're going to need to use a separate process in a manual mode test. I've filed https://issues.jboss.org/browse/WFCORE-4550 to create the test.