### PR TITLE
[WFCORE-4550] Create a test to validate the console data from a CLI embedded server reload

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CliEmbedServerInProcessTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CliEmbedServerInProcessTestCase.java
@@ -21,12 +21,19 @@
  */
 package org.jboss.as.test.manualmode.management.cli;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.test.integration.management.cli.CliProcessWrapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.jboss.as.test.integration.management.cli.CliProcessWrapper;
 
 /**
  * Start an embedded server in the CLI remote process.
@@ -53,5 +60,54 @@ public class CliEmbedServerInProcessTestCase {
         } finally {
             cli.destroyProcess();
         }
+    }
+
+    @Test
+    public void testEmbedServerReloadProcess() throws Exception {
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
+                .addCliArgument("--no-color-output");
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            sendLine(cli, "embed-server");
+
+            // Reload the server, note this will reload and start the runtime which is important as we need the logging
+            // subsystem to execute runtime operations
+            sendLine(cli, "reload");
+
+            // Clear the output and send a command and check the output
+            cli.clearOutput();
+            sendLine(cli, "echo hello");
+            final String output = cli.getOutput();
+            // We should only end up with 3 lines;
+            // echo hello
+            // hello
+            // [statandalone@embedded /]
+            final List<String> lines = readLines(cli.getOutput());
+            assertEquals(String.format("Expected 3 lines got %d: %s", lines.size(), output), 3, lines.size());
+            assertEquals("Expected hello to be at line 2 found " + lines.get(1), "hello", lines.get(1));
+
+            final boolean result = cli.pushLineAndWaitForResults("stop-embedded-server", "[disconnected /]");
+            assertTrue("Invalid output " + cli.getOutput(), result);
+        } finally {
+            cli.destroyProcess();
+        }
+    }
+
+    private void sendLine(final CliProcessWrapper cli, final String command) throws IOException {
+        final boolean result = cli.pushLineAndWaitForResults(command, "[standalone@embedded /]");
+        assertTrue(String.format("Command \"%s\" failed: %s", command, cli.getOutput()), result);
+    }
+
+    private static List<String> readLines(final String output) throws IOException {
+        final List<String> lines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new StringReader(output))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+        }
+        return lines;
     }
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CliEmbedServerInProcessTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CliEmbedServerInProcessTestCase.java
@@ -19,23 +19,21 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.management.cli;
+package org.jboss.as.test.manualmode.management.cli;
 
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.jboss.as.test.integration.management.cli.CliProcessWrapper;
 
 /**
  * Start an embedded server in the CLI remote process.
  * embedded server updates System I/O in a way that impacts CLI output.
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
-public class CliEmbedServerTestCase {
+public class CliEmbedServerInProcessTestCase {
 
     @Rule
     public final TemporaryFolder temporaryUserHome = new TemporaryFolder();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4550

Note this can be combined with #3843 or will need to be created as a PR and merged after.

@jfdenise I've moved and renamed the `CliEmbeddedServerTestCase` from the standalone test suite to the manualmode test suite as I don't see the reason for the server to be started for these tests as they start an embedded server. Does that seem reasonable to you?