### PR TITLE
[WFCORE-4557] Do not acquire the write lock to read http-upgrade-enabled attribute

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/management/BaseHttpInterfaceResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/management/BaseHttpInterfaceResourceDefinition.java
@@ -51,7 +51,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -179,17 +178,22 @@ public abstract class BaseHttpInterfaceResourceDefinition extends SimpleResource
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
-            final ModelNode submodel = resource.getModel();
-            final ModelNode httpUpgrade = submodel.get(ModelDescriptionConstants.HTTP_UPGRADE);
-
-            String operationName = operation.require(ModelDescriptionConstants.OP).asString();
+            final String operationName = operation.require(ModelDescriptionConstants.OP).asString();
             assert ModelDescriptionConstants.HTTP_UPGRADE_ENABLED.equals(operation.require(ModelDescriptionConstants.NAME).asString());
             switch (operationName) {
-                case ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION:
+                case ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION: {
+                    final ModelNode httpUpgrade = context.readResource(PathAddress.EMPTY_ADDRESS, false)
+                            .getModel()
+                            .get(ModelDescriptionConstants.HTTP_UPGRADE);
+
                     context.getResult().set(ENABLED.resolveModelAttribute(context, httpUpgrade));
                     break;
+                }
                 case ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION:
+                    final ModelNode httpUpgrade = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS)
+                            .getModel()
+                            .get(ModelDescriptionConstants.HTTP_UPGRADE);
+
                     httpUpgrade.get(ModelDescriptionConstants.ENABLED).set(operation.require(ModelDescriptionConstants.VALUE).asBoolean());
                     context.reloadRequired();
                     context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);


### PR DESCRIPTION
The same handler is used to write and read, in case of reads, the model was being retrieved for an update, which acquired the model controller lock unnecessarily.

This patch changes the read of the attribute to use `readResource` instead of `readResourceForUpdate`

Jira issue: https://issues.jboss.org/browse/WFCORE-4557