### PR TITLE
WFCORE-4560 Allow management interface to be able to use a https socket binding

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -307,6 +307,12 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
         final ChannelUpgradeHandler upgradeHandler = new ChannelUpgradeHandler();
         final ServiceBuilder<?> builder = context.getChildTarget().addService(HTTP_UPGRADE_SERVICE_NAME);
         final Consumer<Object> upgradeHandlerConsumer = builder.provides(HTTP_UPGRADE_SERVICE_NAME, HTTPS_UPGRADE_SERVICE_NAME);
+        // TODO: An "alias" shouldn't actually be needed since we already do a
+        // builder.provides(...) with this same ServiceName. However, without this explicit aliasing
+        // the call to (service)registry.getService(...) returns null if it's queried by the "provided"
+        // ServiceName. It works fine if it's instead queried by the "alias".
+        // See WFCORE-4560 for more details.
+        builder.addAliases(HTTPS_UPGRADE_SERVICE_NAME);
         builder.setInstance(org.jboss.msc.Service.newInstance(upgradeHandlerConsumer, upgradeHandler));
         builder.install();
         for (ListenerRegistry.Listener listener : listeners) {


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFCORE-4560. 
This fix however is more of a workaround to what seems like a (reproducible) issue in JBoss MSC, where the service registry returns null when it is queried by a "provided" name. This results in the `ManagementInterfaceAddStepHandler` failing in its `verify` step here https://github.com/wildfly/wildfly-core/blob/master/controller/src/main/java/org/jboss/as/controller/management/ManagementInterfaceAddStepHandler.java#L85 due to the "missing" service.

I don't have an easy way to add a test for this, but my manual testing with this change, against a patched WildFly instance, for the use case reported in that thread, worked fine.

