### PR TITLE
[WFCORE-4564] ${maven.repository.url} in repository url is not evaluated when org.jboss:jboss-parent is missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,14 +93,6 @@
 
         <server.output.dir.prefix>wildfly-core</server.output.dir.prefix>
 
-        <!-- Protocol to use for communication with remote maven repositories.
-             You can set to 'http' if you are using a maven proxy and 'https' 
-             interferes with that. Use 'https' for builds that will be released
-             to non-snapshot public maven repos -->
-        <maven.repository.protocol>https</maven.repository.protocol>
-        <!-- The full remote maven repo URL; can be overridden via -D for special use cases -->
-        <maven.repository.url>${maven.repository.protocol}://repository.jboss.org/nexus/content/groups/public/</maven.repository.url>
-
         <!-- Surefire args -->
         <surefire.jpda.args></surefire.jpda.args>
         <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -Duser.timezone=America/Chicago -XX:MaxMetaspaceSize=256m
@@ -2045,7 +2037,7 @@
             </snapshots>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>${maven.repository.url}</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
         </repository>
     </repositories>
@@ -2061,7 +2053,7 @@
             </snapshots>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>${maven.repository.url}</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-4564
