### PR TITLE
[WFCORE-4407] Allow TrivialAddHandler applying the initial service mode when the embedded server is starting

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/TrivialAddHandler.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TrivialAddHandler.java
@@ -78,7 +78,7 @@ abstract class TrivialAddHandler<T> extends BaseAddHandler {
         trivialService.setValueSupplier(getValueSupplier(serviceBuilder, context, resource.getModel()));
 
         installedForResource(commonDependencies(serviceBuilder, dependOnProperties(), dependOnProviderRegistration())
-                .setInitialMode(!context.isBooting() && context.getProcessType() == ProcessType.EMBEDDED_SERVER && context.getRunningMode() == RunningMode.ADMIN_ONLY ? embeddedInitialMode : initialMode)
+                .setInitialMode(context.getProcessType() == ProcessType.EMBEDDED_SERVER && context.getRunningMode() == RunningMode.ADMIN_ONLY ? embeddedInitialMode : initialMode)
                 .install(), resource);
     }
 


### PR DESCRIPTION
This patch follows up https://github.com/wildfly/wildfly-core/pull/3729

With this patch we are also covering the case, not only when we are configuring Elytron in an embedded server already started, but also, removing the `!context.isBooting()` check, when the embedded server starts from a configuration that activates Elytron services that do not have all the dependencies up at that moment.

I used the existing Jira issue since this was a mistake on that issue.

Jira issue: https://issues.jboss.org/browse/WFCORE-4407


To sum up, before https://github.com/wildfly/wildfly-core/pull/3729 we were unable to do this configuration:
```
embed-server --server-config=standalone-full-ha.xml --std-out=echo
batch
  /subsystem=security/security-domain=test-sec-domain:add(cache-type=default)
  /subsystem=security/security-domain=test-sec-domain/authentication=classic:add(login-modules=[{code=RealmUsersRoles, flag=required, module=RealmUsersRoles, module-options={("usersProperties"=>"${jboss.server.config.dir}/users.properties"),("rolesProperties"=>"${jboss.server.config.dir}/roles.properties")}}])
  /subsystem=elytron/security-domain=my-sec-domain:add(realms=[{realm=my-sec-domain}],default-realm=my-sec-domain,permission-mapper=default-permission-mapper)
  /subsystem=elytron/http-authentication-factory=test-sec-domain-http:add(http-server-mechanism-factory=global,security-domain=test-sec-domain,mechanism-configurations=[{mechanism-name=BASIC},{mechanism-name=FORM}])
  /subsystem=undertow/application-security-domain=test-sec-domain:add(security-domain=test-sec-domain)
  /subsystem=ejb3/application-security-domain=test-sec-domain:add(security-domain=test-sec-domain)
run-batch
``` 

Without this patch, we are able to do that configuration but we are unable to start an embedded instance after applying the above configuration.

@darranl This is now hitting the security-domains script used in the WildFly image creation.
