### PR TITLE
[WFCORE-4283] Move the starting of HC servers after cleaning the HC booting flag

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -171,6 +171,7 @@ public class ModelDescriptionConstants {
     public static final String EMPTY = "empty";
     public static final String ENABLE = "enable";
     public static final String ENABLED = "enabled";
+    public static final String ENABLE_AUTO_START = "enabled-auto-start";
     public static final String ENABLED_CIPHER_SUITES = "enabled-cipher-suites";
     public static final String ENABLED_PROTOCOLS = "enabled-protocols";
     public static final String ENABLED_TIME = "enabled-time";

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -802,4 +802,7 @@ public interface DomainControllerLogger extends BasicLogger {
 
     @Message(id = 97, value = "Cannot explode a subdeployment of an unexploded deployment")
     OperationFailedException cannotExplodeSubDeploymentOfUnexplodedDeployment();
+
+    @Message(id = 98, value = "The following servers %s are starting; execution of remote management operations is not currently available")
+    OperationFailedException serverManagementUnavailableDuringBoot(String serverNames);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationSlaveStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationSlaveStepHandler.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.operations.SyncModelOperationHandlerWrapper;
+import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.dmr.ModelNode;
 
@@ -60,6 +61,7 @@ class OperationSlaveStepHandler {
     private final Map<String, ProxyController> serverProxies;
     private final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry;
     private final ExtensionRegistry extensionRegistry;
+    private ServerInventory serverInventory;
 
     OperationSlaveStepHandler(final LocalHostControllerInfo localHostControllerInfo, Map<String, ProxyController> serverProxies,
                               final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
@@ -142,7 +144,7 @@ class OperationSlaveStepHandler {
 
         ServerOperationResolver resolver = new ServerOperationResolver(localHostControllerInfo.getLocalHostName(), serverProxies);
         ServerOperationsResolverHandler sorh = new ServerOperationsResolverHandler(
-                resolver, hostControllerExecutionSupport, originalAddress, originalRegistration, multiPhaseLocalContext);
+                resolver, hostControllerExecutionSupport, originalAddress, originalRegistration, multiPhaseLocalContext, this.serverInventory);
         context.addStep(sorh, OperationContext.Stage.DOMAIN);
 
         return hostControllerExecutionSupport;
@@ -199,5 +201,9 @@ class OperationSlaveStepHandler {
             }
             return domainModelResource;
         }
+    }
+
+    public void setServerInventory(ServerInventory serverInventory) {
+        this.serverInventory = serverInventory;
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.dmr.ModelNode;
 
@@ -147,4 +148,7 @@ public class PrepareStepHandler  implements OperationStepHandler {
         }
     }
 
+    public void setServerInventory(ServerInventory serverInventory) {
+        this.slaveHandler.setServerInventory(serverInventory);
+    }
 }

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -82,10 +82,27 @@
             <artifactId>wildfly-jmx</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-maven-plugin</artifactId>
@@ -175,6 +192,7 @@
                         <settings.localRepository>${settings.localRepository}</settings.localRepository>
                         <cli.args>-Dmaven.repo.local=${settings.localRepository}</cli.args>
                         <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
+                        <jboss.test.host.server.byteman.javaagent>${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar},sys:${org.wildfly.core:wildfly-core-testsuite-shared:jar},script:${project.build.directory}/test-classes/byteman-scripts/</jboss.test.host.server.byteman.javaagent>
                     </systemPropertyVariables>
                     <includes>
                         <include>org/jboss/as/test/integration/domain/autoignore/*TestCase.java</include>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.client.helpers.domain.ServerStatus;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Validates the execution of management operations when a HC is starting.
+ * <p>
+ * The test case uses two byteman rules to delay the Server Registration Request, which delays the server transition
+ * from STOPPED to STARTING, and the ServerService#finishBoot, which delays the server transition from STARTING to STARTED
+ * and keeps the server booting flag set.
+ * <p>
+ * The test validates that read resource operations executed from the DC success when the servers are in its booting phase.
+ * Write operations should be rejected when the servers are in STARTING state.
+ * <p>
+ * Notice that some read operations at server root level are still being rejected, for example /host=x/server=y:read-attribute(name=status-server)
+ * That could be improved if it is necessary. As an alternative, we can use /host=x/server-config=y:read-attribute(name=status)
+ * which will read the server status from the HC server inventory, without the need to send it to the proxy server.
+ *
+ * @author Yeray Borges
+ */
+public class HostControllerBootOperationsTestCase {
+    protected static final PathAddress SLAVE_ADDR = PathAddress.pathAddress(HOST, "slave");
+    protected static final PathAddress SERVER_CONFIG_MAIN_THREE = PathAddress.pathAddress(SERVER_CONFIG, "main-three");
+    protected static final PathAddress SERVER_MAIN_THREE = PathAddress.pathAddress(SERVER, "main-three");
+    protected static final PathAddress CORE_SERVICE_MANAGEMENT = PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT);
+    protected static final PathAddress SERVER_GROUP_MAIN_SERVER_GROUP = PathAddress.pathAddress(SERVER_GROUP, "main-server-group");
+    protected static final PathAddress JVM_DEFAULT = PathAddress.pathAddress(JVM, "default");
+    protected static final PathAddress JVM_BYTEMAN = PathAddress.pathAddress(JVM, "byteman");
+
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+    private static DomainLifecycleUtil masterLifecycleUtil;
+    private static DomainLifecycleUtil slaveLifecycleUtil;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+
+        final DomainTestSupport.Configuration configuration = DomainTestSupport.Configuration.create(OperationTimeoutTestCase.class.getSimpleName(),
+                "domain-configs/domain-standard.xml",
+                "host-configs/host-master.xml",
+                "host-configs/host-slave-main-three-without-jvm.xml"
+        );
+
+        testSupport = DomainTestSupport.create(configuration);
+
+        masterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        slaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+
+        testSupport.start();
+
+        masterClient = masterLifecycleUtil.getDomainClient();
+        ModelNode op = Util.createAddOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        op = Util.createEmptyOperation("add-jvm-option", SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
+        op.get("jvm-option").set("-Dorg.jboss.byteman.verbose=true");
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        op = Util.createEmptyOperation("add-jvm-option", SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
+        op.get("jvm-option").set("-Djboss.modules.system.pkgs=org.jboss.byteman");
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        String bytemanJavaAgent = System.getProperty("jboss.test.host.server.byteman.javaagent")+"DelayServerRegistrationAndRunningState.btm";
+        op = Util.getWriteAttributeOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN), "java-agent", bytemanJavaAgent);
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    @AfterClass
+    public static void shutdownDomain() {
+        testSupport.close();
+        testSupport = null;
+        masterClient = null;
+        slaveLifecycleUtil = null;
+        masterLifecycleUtil = null;
+    }
+
+    @Test
+    public void testManagementOperationsWhenSlaveHCisBooting() throws Exception {
+        ModelNode op = Util.createEmptyOperation("reload", SLAVE_ADDR);
+        op.get(RESTART_SERVERS).set(true);
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        slaveLifecycleUtil.awaitHostController(System.currentTimeMillis(), ControlledProcessState.State.STARTING);
+        // At this point server-three should be waiting before being registered in the domain and HC is still booting up, this gives us a window
+        // where we can tests the operations that were failing and reporting errors in HAL on WFCORE-4283
+
+        checkReadOperations();
+
+        //assert the server at this point reports STOPPED, which means it has not been registered yet in the domain
+        Assert.assertTrue("server-three should be stopped at this point to validate this test conditions. Check if a previous read operation acquired the write lock or if the \"Delay Server Registration Request\" byteman rule needs more time sleeping the server registration request",
+                DomainTestUtils.executeForResult(Util.getReadAttributeOperation(SLAVE_ADDR.append(SERVER_MAIN_THREE), "server-state"), masterClient).asString().equals("STOPPED")
+        );
+
+        // Wait until the delayed server is registered in the domain
+        DomainTestUtils.waitUntilState(masterClient, SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE), ServerStatus.STARTING.toString());
+
+        // At this point server-three should be waiting before transitioning to STARTED, this gives us a window to test operations that are
+        // likely to fail since the server is still starting, write operations should fail, read operations should pass
+
+        op = Util.getWriteAttributeOperation(SERVER_GROUP_MAIN_SERVER_GROUP.append(JVM_DEFAULT), "heap-size", "64m");
+        ModelNode failureDescription = DomainTestUtils.executeForFailure(op, masterClient);
+        Assert.assertTrue("The slave host does not return the expected error. Failure Description was:"+failureDescription, failureDescription.get("host-failure-descriptions").get("slave").asString().startsWith("WFLYDC0098"));
+
+        checkReadOperations();
+
+        // assert server is still starting at this moment
+        Assert.assertTrue("server-three should be starting at this point to validate this test conditions. Check if the \"Delay Server Started Request\" byteman rule needs more time sleeping the server started request",
+                DomainTestUtils.executeForResult(Util.getReadAttributeOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE), "status"), masterClient).asString().equals(ServerStatus.STARTING.toString())
+        );
+
+        // Wait for all the servers until they are started and HC is running
+        slaveLifecycleUtil.awaitHostController(System.currentTimeMillis(), ControlledProcessState.State.RUNNING);
+        DomainTestUtils.waitUntilState(masterClient, SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE), ServerStatus.STARTED.toString());
+
+        // write operation should success at this moment
+        op = Util.getWriteAttributeOperation(SERVER_GROUP_MAIN_SERVER_GROUP.append(JVM_DEFAULT), "heap-size", "64m");
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private void checkReadOperations() throws IOException, MgmtOperationException {
+        // assert we are able to run the operation under test :read-child-resources
+        ModelNode op  = Util.createEmptyOperation("read-children-resources", PathAddress.EMPTY_ADDRESS);
+        op.get("child-type").set("host");
+        op.get("recursive").set(true);
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        // assert we are also able to read the HC slave model recursively
+        op = Util.createEmptyOperation("read-resource", SLAVE_ADDR);
+        op.get("recursive").set(true);
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        // assert we are also able to read the Domain model recursively
+        op = Util.createEmptyOperation("read-resource", PathAddress.EMPTY_ADDRESS);
+        op.get("recursive").set(true);
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        // assert we are also able to read the Domain model recursively
+        op = Util.createEmptyOperation("read-children-resources", CORE_SERVICE_MANAGEMENT);
+        op.get("child-type").set("access");
+        op.get("recursive-depth").set("1");
+        op.get("include-runtime").set("true");
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        op = Util.getReadAttributeOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE), "status");
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+}

--- a/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
+++ b/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
@@ -1,0 +1,15 @@
+RULE Delay Server Registration Request
+CLASS org.jboss.as.server.mgmt.domain.HostControllerConnection$ServerRegisterRequest
+METHOD sendRequest
+AT ENTRY
+IF NOT waiting($this)
+DO waitFor($this, 15*1000)
+ENDRULE
+
+RULE Delay Server finish boot
+CLASS org.jboss.as.server.ServerService
+METHOD finishBoot
+AT ENTRY
+IF NOT waiting($this)
+DO waitFor($this, 15*1000)
+ENDRULE

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-main-three-without-jvm.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-main-three-without-jvm.xml
@@ -1,0 +1,153 @@
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<host xmlns="urn:jboss:domain:10.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
+      name="slave">
+
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+    </extensions>
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true" />
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="19999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="19990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+            <ignored-resources type="extension">
+                <instance name="org.jboss.as.threads"/>
+            </ignored-resources>
+            <ignored-resources type="profile">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="socket-binding-group">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="foo" wildcard="true">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="server-group">
+                <instance name="ignored-sockets"/>
+                <instance name="ignored-profile"/>
+                <instance name="minimal" />
+            </ignored-resources>
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+       <jvm name="default">
+          <heap size="64m" max-size="128m"/>
+           <jvm-options>
+               <option value="-ea"/>
+           </jvm-options>
+       </jvm>
+    </jvms>
+
+    <servers directory-grouping="by-type">
+        <server name="main-three" group="main-server-group">
+            <socket-bindings socket-binding-group="standard-sockets" port-offset="350"/>
+        </server>
+        <server name="main-four" group="main-server-group" auto-start="false">
+            <socket-bindings port-offset="450"/>
+            <jvm name="default">
+                <heap size="64m" max-size="256m"/>
+            </jvm>
+        </server>
+        <server name="other-two" group="other-server-group">
+            <!--AS7-4177 override the host level config to smoke test that handling
+                Note we use the same values; this is just to check for obvious fatal errors -->
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.slave.address}"/>
+                </interface>
+            </interfaces>
+            <socket-bindings socket-binding-group="other-sockets" port-offset="550"/>
+            <jvm name="default"/>
+        </server>
+        <server name="reload-two" group="reload-test-group"  auto-start="false">
+            <jvm name="default" />
+        </server>
+    </servers>
+
+
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+    </profile>
+</host>


### PR DESCRIPTION
This patch reduces the time where the HC boot flag is set, so read operations on the HC can success. That helps HAL to be able to display the HC slave nodes and its servers when the servers are still starting after botting up the HC.

There are additional tweaks to do in HAL to allow the console work with domains with non-patched HC servers. @hpehl Maybe you could link this PR with the one required for HAL.

Jira issue: https://issues.jboss.org/browse/WFCORE-4283
