### PR TITLE
Fix WFCORE-4572 

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -299,7 +299,7 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
             listeners.add(http);
         }
         if(secureBindAddress != null) {
-            ListenerRegistry.Listener https = new ListenerRegistry.Listener("https", HTTPS_MANAGEMENT, SERVER_NAME, bindAddress);
+            ListenerRegistry.Listener https = new ListenerRegistry.Listener("https", HTTPS_MANAGEMENT, SERVER_NAME, secureBindAddress);
             https.setContextInformation("socket-binding", secureBinding);
             listeners.add(https);
         }


### PR DESCRIPTION
The commit here fixes the issue noted in https://issues.jboss.org/browse/WFCORE-4572, by using the correct bind address while creating a `ListenerRegistry.Listener` instance for `https` socket binding.