### PR TITLE
[WFCORE-4577] Upgrade WildFly Elytron to 1.10.0.CR4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.0.CR3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.0.CR4</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4577


        Release Notes - WildFly Elytron - Version 1.10.0.CR4
                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1843'>ELY-1843</a>] -         The Digest NonceManager creates a ScheduledThreadPoolExecutor which is never shut down
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1847'>ELY-1847</a>] -         WildFlyElytronProvider Loading wrong class for Bearer
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1849'>ELY-1849</a>] -         WildFlyElytronSaslDigestProvider does not register necessary password factories
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1841'>ELY-1841</a>] -         Update the pre-recorded messages in AcmeClientSpiTest using the latest Boulder instance
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1852'>ELY-1852</a>] -         Address Message ID Allocation
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1857'>ELY-1857</a>] -         Release WildFly Elytron 1.10.0.CR4
</li>
</ul>
                    