### PR TITLE
WFCORE-1446 EJB thread pool keepalive not honored and is not reusing …

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/CommonAttributes.java
+++ b/threads/src/main/java/org/jboss/as/threads/CommonAttributes.java
@@ -56,6 +56,7 @@ public interface CommonAttributes {
     String THREAD_FACTORY = "thread-factory";
     String THREAD_NAME_PATTERN = "thread-name-pattern";
     String UNBOUNDED_QUEUE_THREAD_POOL = "unbounded-queue-thread-pool";
+    String ENHANCED_QUEUE_THREAD_POOL = "enhanced-queue-thread-pool";
     String UNIT = "unit";
     String VALUE = "value";
 }

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorAdd.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.threads.ThreadPoolManagementUtils.EnhancedQueueThreadPoolParameters;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Adds an {@code org.jboss.threads.EnhancedQueueExecutor}.
+ *
+ */
+public class EnhancedQueueExecutorAdd extends AbstractAddStepHandler {
+
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
+        PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS, PoolAttributeDefinitions.THREAD_FACTORY};
+
+    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
+        PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS};
+
+    private final ThreadFactoryResolver threadFactoryResolver;
+    private final ServiceName serviceNameBase;
+    private final RuntimeCapability<Void> capability;
+    private final boolean allowCoreThreadTimeout;
+
+    public EnhancedQueueExecutorAdd(ThreadFactoryResolver threadFactoryResolver, ServiceName serviceNameBase) {
+        this(threadFactoryResolver, serviceNameBase, null, false);
+    }
+
+    public EnhancedQueueExecutorAdd(ThreadFactoryResolver threadFactoryResolver, ServiceName serviceNameBase, RuntimeCapability<Void> capability, boolean allowCoreThreadTimeout) {
+        super(ATTRIBUTES);
+        this.threadFactoryResolver = threadFactoryResolver;
+        this.serviceNameBase = serviceNameBase;
+        this.capability = capability;
+        this.allowCoreThreadTimeout = allowCoreThreadTimeout;
+    }
+
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+        final EnhancedQueueThreadPoolParameters params = ThreadPoolManagementUtils.parseEnhancedQueueThreadPoolParameters(context, operation, model);
+
+        final EnhancedQueueExecutorService service = new EnhancedQueueExecutorService(allowCoreThreadTimeout, params.getMaxThreads(), params.getCoreThreads(), params.getKeepAliveTime());
+
+        ThreadPoolManagementUtils.installThreadPoolService(service, params.getName(), capability, context.getCurrentAddress(),
+                serviceNameBase, params.getThreadFactory(), threadFactoryResolver, service.getThreadFactoryInjector(),
+                null, null, null, context.getServiceTarget());
+    }
+
+    ServiceName getServiceNameBase() {
+        return serviceNameBase;
+    }
+
+    ThreadFactoryResolver getThreadFactoryResolver() {
+        return threadFactoryResolver;
+    }
+
+    RuntimeCapability<Void> getCapability() {
+        return capability;
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorAdd.java
@@ -33,26 +33,25 @@ import org.jboss.msc.service.ServiceName;
 
 /**
  * Adds an {@code org.jboss.threads.EnhancedQueueExecutor}.
- *
  */
-public class EnhancedQueueExecutorAdd extends AbstractAddStepHandler {
+class EnhancedQueueExecutorAdd extends AbstractAddStepHandler {
 
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
-        PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS, PoolAttributeDefinitions.THREAD_FACTORY};
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{PoolAttributeDefinitions.KEEPALIVE_TIME,
+            PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS, PoolAttributeDefinitions.THREAD_FACTORY};
 
-    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
-        PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS};
+    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[]{PoolAttributeDefinitions.KEEPALIVE_TIME,
+            PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS};
 
     private final ThreadFactoryResolver threadFactoryResolver;
     private final ServiceName serviceNameBase;
     private final RuntimeCapability<Void> capability;
     private final boolean allowCoreThreadTimeout;
 
-    public EnhancedQueueExecutorAdd(ThreadFactoryResolver threadFactoryResolver, ServiceName serviceNameBase) {
+    EnhancedQueueExecutorAdd(ThreadFactoryResolver threadFactoryResolver, ServiceName serviceNameBase) {
         this(threadFactoryResolver, serviceNameBase, null, false);
     }
 
-    public EnhancedQueueExecutorAdd(ThreadFactoryResolver threadFactoryResolver, ServiceName serviceNameBase, RuntimeCapability<Void> capability, boolean allowCoreThreadTimeout) {
+    EnhancedQueueExecutorAdd(ThreadFactoryResolver threadFactoryResolver, ServiceName serviceNameBase, RuntimeCapability<Void> capability, boolean allowCoreThreadTimeout) {
         super(ATTRIBUTES);
         this.threadFactoryResolver = threadFactoryResolver;
         this.serviceNameBase = serviceNameBase;

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorMetricsHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorMetricsHandler.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+
+
+/**
+ * Handles metrics for an {@code org.jboss.threads.EnhancedQueueExecutor}.
+ */
+public class EnhancedQueueExecutorMetricsHandler extends ThreadPoolMetricsHandler {
+
+    private static final List<AttributeDefinition> METRICS = Arrays.asList(PoolAttributeDefinitions.ACTIVE_COUNT,
+            PoolAttributeDefinitions.COMPLETED_TASK_COUNT, PoolAttributeDefinitions.CURRENT_THREAD_COUNT,
+            PoolAttributeDefinitions.LARGEST_THREAD_COUNT, PoolAttributeDefinitions.REJECTED_COUNT,
+            PoolAttributeDefinitions.TASK_COUNT, PoolAttributeDefinitions.QUEUE_SIZE);
+
+    public EnhancedQueueExecutorMetricsHandler(final ServiceName serviceNameBase) {
+        this(null, serviceNameBase);
+    }
+
+    public EnhancedQueueExecutorMetricsHandler(final RuntimeCapability capability, final ServiceName serviceNameBase) {
+        super(METRICS, capability, serviceNameBase);
+    }
+
+    @Override
+    protected void setResult(OperationContext context, final String attributeName, final Service<?> service) {
+        final EnhancedQueueExecutorService pool = (EnhancedQueueExecutorService) service;
+        switch (attributeName) {
+            case CommonAttributes.ACTIVE_COUNT:
+                context.getResult().set(pool.getActiveCount());
+                break;
+            case CommonAttributes.COMPLETED_TASK_COUNT:
+                context.getResult().set(pool.getCompletedTaskCount());
+                break;
+            case CommonAttributes.CURRENT_THREAD_COUNT:
+                context.getResult().set(pool.getCurrentThreadCount());
+                break;
+            case CommonAttributes.LARGEST_THREAD_COUNT:
+                context.getResult().set(pool.getLargestThreadCount());
+                break;
+            case CommonAttributes.REJECTED_COUNT:
+                context.getResult().set(pool.getRejectedCount());
+                break;
+            case CommonAttributes.TASK_COUNT:
+                context.getResult().set(pool.getTaskCount());
+                break;
+            case CommonAttributes.QUEUE_SIZE:
+                context.getResult().set(pool.getQueueSize());
+                break;
+            default:
+                // Programming bug. Throw a RuntimeException, not OFE, as this is not a client error
+                throw ThreadsLogger.ROOT_LOGGER.unsupportedEnhancedQueueExecutorMetric(attributeName);
+        }
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorMetricsHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorMetricsHandler.java
@@ -35,18 +35,14 @@ import org.jboss.msc.service.ServiceName;
 /**
  * Handles metrics for an {@code org.jboss.threads.EnhancedQueueExecutor}.
  */
-public class EnhancedQueueExecutorMetricsHandler extends ThreadPoolMetricsHandler {
+class EnhancedQueueExecutorMetricsHandler extends ThreadPoolMetricsHandler {
 
     private static final List<AttributeDefinition> METRICS = Arrays.asList(PoolAttributeDefinitions.ACTIVE_COUNT,
             PoolAttributeDefinitions.COMPLETED_TASK_COUNT, PoolAttributeDefinitions.CURRENT_THREAD_COUNT,
             PoolAttributeDefinitions.LARGEST_THREAD_COUNT, PoolAttributeDefinitions.REJECTED_COUNT,
             PoolAttributeDefinitions.TASK_COUNT, PoolAttributeDefinitions.QUEUE_SIZE);
 
-    public EnhancedQueueExecutorMetricsHandler(final ServiceName serviceNameBase) {
-        this(null, serviceNameBase);
-    }
-
-    public EnhancedQueueExecutorMetricsHandler(final RuntimeCapability capability, final ServiceName serviceNameBase) {
+    EnhancedQueueExecutorMetricsHandler(final RuntimeCapability capability, final ServiceName serviceNameBase) {
         super(METRICS, capability, serviceNameBase);
     }
 

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorRemove.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorRemove.java
@@ -29,13 +29,12 @@ import org.jboss.dmr.ModelNode;
 
 /**
  * Removes an {@code org.jboss.threads.EnhancedQueueExecutor}.
- *
  */
-public class EnhancedQueueExecutorRemove extends AbstractRemoveStepHandler {
+class EnhancedQueueExecutorRemove extends AbstractRemoveStepHandler {
 
     private final EnhancedQueueExecutorAdd addHandler;
 
-    public EnhancedQueueExecutorRemove(EnhancedQueueExecutorAdd addHandler) {
+    EnhancedQueueExecutorRemove(EnhancedQueueExecutorAdd addHandler) {
         this.addHandler = addHandler;
     }
 
@@ -43,7 +42,7 @@ public class EnhancedQueueExecutorRemove extends AbstractRemoveStepHandler {
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         final EnhancedQueueThreadPoolParameters params =
                 ThreadPoolManagementUtils.parseEnhancedQueueThreadPoolParameters(context, operation, model);
-        ThreadPoolManagementUtils.removeThreadPoolService(params.getName(),  addHandler.getCapability(), addHandler.getServiceNameBase(),
+        ThreadPoolManagementUtils.removeThreadPoolService(params.getName(), addHandler.getCapability(), addHandler.getServiceNameBase(),
                 params.getThreadFactory(), addHandler.getThreadFactoryResolver(),
                 context);
     }

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorRemove.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorRemove.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.threads.ThreadPoolManagementUtils.EnhancedQueueThreadPoolParameters;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Removes an {@code org.jboss.threads.EnhancedQueueExecutor}.
+ *
+ */
+public class EnhancedQueueExecutorRemove extends AbstractRemoveStepHandler {
+
+    private final EnhancedQueueExecutorAdd addHandler;
+
+    public EnhancedQueueExecutorRemove(EnhancedQueueExecutorAdd addHandler) {
+        this.addHandler = addHandler;
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        final EnhancedQueueThreadPoolParameters params =
+                ThreadPoolManagementUtils.parseEnhancedQueueThreadPoolParameters(context, operation, model);
+        ThreadPoolManagementUtils.removeThreadPoolService(params.getName(),  addHandler.getCapability(), addHandler.getServiceNameBase(),
+                params.getThreadFactory(), addHandler.getThreadFactoryResolver(),
+                context);
+    }
+
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        addHandler.performRuntime(context, operation, model);
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorResourceDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorResourceDefinition.java
@@ -22,8 +22,11 @@
 
 package org.jboss.as.threads;
 
+import static org.jboss.as.threads.CommonAttributes.ENHANCED_QUEUE_THREAD_POOL;
+
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
@@ -34,19 +37,13 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.msc.service.ServiceName;
 
-import static org.jboss.as.threads.CommonAttributes.ENHANCED_QUEUE_THREAD_POOL;
-
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for an {@code org.jboss.threads.EnhancedQueueExecutor} resource.
- *
  */
-public class EnhancedQueueExecutorResourceDefinition extends PersistentResourceDefinition {
+public final class EnhancedQueueExecutorResourceDefinition extends PersistentResourceDefinition {
     private final EnhancedQueueExecutorWriteAttributeHandler writeAttributeHandler;
     private final EnhancedQueueExecutorMetricsHandler metricsHandler;
-
     private final boolean registerRuntimeOnly;
-    public static final RuntimeCapability<Void> CAPABILITY =
-            ThreadsServices.createCapability(ENHANCED_QUEUE_THREAD_POOL, ManagedEnhancedQueueExecutor.class);
 
     public static EnhancedQueueExecutorResourceDefinition create(boolean registerRuntimeOnly) {
         return create(ENHANCED_QUEUE_THREAD_POOL, ThreadsServices.getThreadFactoryResolver(ENHANCED_QUEUE_THREAD_POOL),
@@ -55,12 +52,9 @@ public class EnhancedQueueExecutorResourceDefinition extends PersistentResourceD
 
     public static EnhancedQueueExecutorResourceDefinition create(String type, ThreadFactoryResolver threadFactoryResolver,
                                                                  ServiceName serviceNameBase, boolean registerRuntimeOnly) {
-        return create(PathElement.pathElement(type), threadFactoryResolver, serviceNameBase, registerRuntimeOnly);
-    }
-
-    public static EnhancedQueueExecutorResourceDefinition create(PathElement path, ThreadFactoryResolver threadFactoryResolver,
-                                                                 ServiceName serviceNameBase, boolean registerRuntimeOnly) {
-        return create(path, threadFactoryResolver, serviceNameBase, registerRuntimeOnly, CAPABILITY, false);
+        return create(type, threadFactoryResolver, serviceNameBase, registerRuntimeOnly,
+                ThreadsServices.createCapability(type, ExecutorService.class),
+                false);
     }
 
     public static EnhancedQueueExecutorResourceDefinition create(String type, ThreadFactoryResolver threadFactoryResolver,

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorResourceDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorResourceDefinition.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.threads;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.msc.service.ServiceName;
+
+import static org.jboss.as.threads.CommonAttributes.ENHANCED_QUEUE_THREAD_POOL;
+
+/**
+ * {@link org.jboss.as.controller.ResourceDefinition} for an {@code org.jboss.threads.EnhancedQueueExecutor} resource.
+ *
+ */
+public class EnhancedQueueExecutorResourceDefinition extends PersistentResourceDefinition {
+    private final EnhancedQueueExecutorWriteAttributeHandler writeAttributeHandler;
+    private final EnhancedQueueExecutorMetricsHandler metricsHandler;
+
+    private final boolean registerRuntimeOnly;
+    public static final RuntimeCapability<Void> CAPABILITY =
+            ThreadsServices.createCapability(ENHANCED_QUEUE_THREAD_POOL, ManagedEnhancedQueueExecutor.class);
+
+    public static EnhancedQueueExecutorResourceDefinition create(boolean registerRuntimeOnly) {
+        return create(ENHANCED_QUEUE_THREAD_POOL, ThreadsServices.getThreadFactoryResolver(ENHANCED_QUEUE_THREAD_POOL),
+                ThreadsServices.EXECUTOR, registerRuntimeOnly);
+    }
+
+    public static EnhancedQueueExecutorResourceDefinition create(String type, ThreadFactoryResolver threadFactoryResolver,
+                                                                 ServiceName serviceNameBase, boolean registerRuntimeOnly) {
+        return create(PathElement.pathElement(type), threadFactoryResolver, serviceNameBase, registerRuntimeOnly);
+    }
+
+    public static EnhancedQueueExecutorResourceDefinition create(PathElement path, ThreadFactoryResolver threadFactoryResolver,
+                                                                 ServiceName serviceNameBase, boolean registerRuntimeOnly) {
+        return create(path, threadFactoryResolver, serviceNameBase, registerRuntimeOnly, CAPABILITY, false);
+    }
+
+    public static EnhancedQueueExecutorResourceDefinition create(String type, ThreadFactoryResolver threadFactoryResolver,
+                                                                 ServiceName serviceNameBase, boolean registerRuntimeOnly,
+                                                                 RuntimeCapability<Void> capability, boolean allowCoreThreadTimeout) {
+        return create(PathElement.pathElement(type), threadFactoryResolver, serviceNameBase, registerRuntimeOnly, capability, allowCoreThreadTimeout);
+    }
+
+    public static EnhancedQueueExecutorResourceDefinition create(PathElement path, ThreadFactoryResolver threadFactoryResolver,
+                                                                 ServiceName serviceNameBase, boolean registerRuntimeOnly,
+                                                                 RuntimeCapability<Void> capability, boolean allowCoreThreadTimeout) {
+        EnhancedQueueExecutorAdd addHandler = new EnhancedQueueExecutorAdd(threadFactoryResolver, serviceNameBase, capability, allowCoreThreadTimeout);
+        return new EnhancedQueueExecutorResourceDefinition(path, addHandler, capability, serviceNameBase, registerRuntimeOnly);
+    }
+
+    private EnhancedQueueExecutorResourceDefinition(PathElement path, EnhancedQueueExecutorAdd addHandler,
+                                                    RuntimeCapability<Void> capability, ServiceName serviceNameBase,
+                                                    boolean registerRuntimeOnly) {
+        super(new SimpleResourceDefinition.Parameters(path,
+                new ThreadPoolResourceDescriptionResolver(ENHANCED_QUEUE_THREAD_POOL, ThreadsExtension.RESOURCE_NAME,
+                        ThreadsExtension.class.getClassLoader()))
+                .setAddHandler(addHandler)
+                .setRemoveHandler(new EnhancedQueueExecutorRemove(addHandler))
+                .setCapabilities(capability));
+        this.registerRuntimeOnly = registerRuntimeOnly;
+        this.writeAttributeHandler = new EnhancedQueueExecutorWriteAttributeHandler(capability, serviceNameBase);
+        this.metricsHandler = new EnhancedQueueExecutorMetricsHandler(capability, serviceNameBase);
+    }
+
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerReadOnlyAttribute(PoolAttributeDefinitions.NAME, ReadResourceNameOperationStepHandler.INSTANCE);
+        writeAttributeHandler.registerAttributes(resourceRegistration);
+        if (registerRuntimeOnly) {
+            metricsHandler.registerAttributes(resourceRegistration);
+        }
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(writeAttributeHandler.attributes);
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorService.java
@@ -34,9 +34,8 @@ import org.jboss.threads.EnhancedQueueExecutor;
 
 /**
  * Service responsible for creating, starting and stopping an {@code org.jboss.threads.EnhancedQueueExecutor}.
- *
  */
-public class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueueExecutor> {
+class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueueExecutor> {
     private final InjectedValue<ThreadFactory> threadFactoryValue = new InjectedValue<ThreadFactory>();
 
     private ManagedEnhancedQueueExecutor executor;
@@ -46,11 +45,11 @@ public class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueu
     private TimeSpec keepAlive;
     private boolean allowCoreThreadTimeout;
 
-    public EnhancedQueueExecutorService(boolean allowCoreThreadTimeout, int maxThreads, int coreThreads, TimeSpec keepAlive) {
+    EnhancedQueueExecutorService(boolean allowCoreThreadTimeout, int maxThreads, int coreThreads, TimeSpec keepAlive) {
         this.maxThreads = maxThreads;
         this.coreThreads = coreThreads;
         this.keepAlive = keepAlive;
-        this.allowCoreThreadTimeout= allowCoreThreadTimeout;
+        this.allowCoreThreadTimeout = allowCoreThreadTimeout;
     }
 
     public synchronized void start(final StartContext context) {
@@ -86,11 +85,11 @@ public class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueu
         return value;
     }
 
-    public Injector<ThreadFactory> getThreadFactoryInjector() {
+    Injector<ThreadFactory> getThreadFactoryInjector() {
         return threadFactoryValue;
     }
 
-    public synchronized void setMaxThreads(final int maxThreads) {
+    synchronized void setMaxThreads(final int maxThreads) {
         final ManagedEnhancedQueueExecutor executor = this.executor;
         if (executor != null) {
             executor.setMaxThreads(maxThreads);
@@ -98,7 +97,7 @@ public class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueu
         this.maxThreads = maxThreads;
     }
 
-    public synchronized void setCoreThreads(final int coreThreads) {
+    synchronized void setCoreThreads(final int coreThreads) {
         final ManagedEnhancedQueueExecutor executor = this.executor;
         if (executor != null) {
             executor.setCoreThreads(coreThreads);
@@ -106,50 +105,50 @@ public class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueu
         this.coreThreads = coreThreads;
     }
 
-    public synchronized void setKeepAlive(final TimeSpec keepAlive) {
+    synchronized void setKeepAlive(final TimeSpec keepAlive) {
         this.keepAlive = keepAlive;
         final ManagedEnhancedQueueExecutor executor = this.executor;
-        if(executor != null) {
+        if (executor != null) {
             executor.setKeepAlive(keepAlive);
         }
     }
 
-    public int getActiveCount() {
+    int getActiveCount() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getActiveCount();
     }
 
-    public long getCompletedTaskCount() {
+    long getCompletedTaskCount() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getCompletedTaskCount();
     }
 
-    public int getCurrentThreadCount() {
+    int getCurrentThreadCount() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getCurrentThreadCount();
     }
 
-    public int getLargestPoolSize() {
+    int getLargestPoolSize() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getLargestPoolSize();
     }
 
-    public int getLargestThreadCount() {
+    int getLargestThreadCount() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getLargestThreadCount();
     }
 
-    public int getRejectedCount() {
+    int getRejectedCount() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getRejectedCount();
     }
 
-    public long getTaskCount() {
+    long getTaskCount() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getTaskCount();
     }
 
-    public int getQueueSize() {
+    int getQueueSize() {
         final ManagedEnhancedQueueExecutor executor = getValue();
         return executor.getQueueSize();
     }

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorService.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.threads;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.threads.EnhancedQueueExecutor;
+
+/**
+ * Service responsible for creating, starting and stopping an {@code org.jboss.threads.EnhancedQueueExecutor}.
+ *
+ */
+public class EnhancedQueueExecutorService implements Service<ManagedEnhancedQueueExecutor> {
+    private final InjectedValue<ThreadFactory> threadFactoryValue = new InjectedValue<ThreadFactory>();
+
+    private ManagedEnhancedQueueExecutor executor;
+
+    private int maxThreads;
+    private int coreThreads;
+    private TimeSpec keepAlive;
+    private boolean allowCoreThreadTimeout;
+
+    public EnhancedQueueExecutorService(boolean allowCoreThreadTimeout, int maxThreads, int coreThreads, TimeSpec keepAlive) {
+        this.maxThreads = maxThreads;
+        this.coreThreads = coreThreads;
+        this.keepAlive = keepAlive;
+        this.allowCoreThreadTimeout= allowCoreThreadTimeout;
+    }
+
+    public synchronized void start(final StartContext context) {
+        final TimeSpec keepAliveSpec = keepAlive;
+        long keepAliveTime = keepAliveSpec == null ? Long.MAX_VALUE : keepAliveSpec.getUnit().toNanos(keepAliveSpec.getDuration());
+
+        final EnhancedQueueExecutor enhancedQueueExecutor = new EnhancedQueueExecutor.Builder()
+                .setMaximumPoolSize(maxThreads)
+                .setCorePoolSize(coreThreads > 0 ? coreThreads : maxThreads)
+                .setKeepAliveTime(keepAliveTime, TimeUnit.NANOSECONDS)
+                .setThreadFactory(threadFactoryValue.getValue())
+                .allowCoreThreadTimeOut(allowCoreThreadTimeout)
+                .build();
+        executor = new ManagedEnhancedQueueExecutor(enhancedQueueExecutor);
+    }
+
+    public void stop(final StopContext context) {
+        final ManagedEnhancedQueueExecutor executor;
+        synchronized (this) {
+            executor = this.executor;
+            this.executor = null;
+        }
+        context.asynchronous();
+        executor.internalShutdown();
+        executor.addShutdownListener(StopContextEventListener.getInstance(), context);
+    }
+
+    public synchronized ManagedEnhancedQueueExecutor getValue() throws IllegalStateException {
+        final ManagedEnhancedQueueExecutor value = this.executor;
+        if (value == null) {
+            throw ThreadsLogger.ROOT_LOGGER.enhancedQueueExecutorUninitialized();
+        }
+        return value;
+    }
+
+    public Injector<ThreadFactory> getThreadFactoryInjector() {
+        return threadFactoryValue;
+    }
+
+    public synchronized void setMaxThreads(final int maxThreads) {
+        final ManagedEnhancedQueueExecutor executor = this.executor;
+        if (executor != null) {
+            executor.setMaxThreads(maxThreads);
+        }
+        this.maxThreads = maxThreads;
+    }
+
+    public synchronized void setCoreThreads(final int coreThreads) {
+        final ManagedEnhancedQueueExecutor executor = this.executor;
+        if (executor != null) {
+            executor.setCoreThreads(coreThreads);
+        }
+        this.coreThreads = coreThreads;
+    }
+
+    public synchronized void setKeepAlive(final TimeSpec keepAlive) {
+        this.keepAlive = keepAlive;
+        final ManagedEnhancedQueueExecutor executor = this.executor;
+        if(executor != null) {
+            executor.setKeepAlive(keepAlive);
+        }
+    }
+
+    public int getActiveCount() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getActiveCount();
+    }
+
+    public long getCompletedTaskCount() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getCompletedTaskCount();
+    }
+
+    public int getCurrentThreadCount() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getCurrentThreadCount();
+    }
+
+    public int getLargestPoolSize() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getLargestPoolSize();
+    }
+
+    public int getLargestThreadCount() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getLargestThreadCount();
+    }
+
+    public int getRejectedCount() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getRejectedCount();
+    }
+
+    public long getTaskCount() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getTaskCount();
+    }
+
+    public int getQueueSize() {
+        final ManagedEnhancedQueueExecutor executor = getValue();
+        return executor.getQueueSize();
+    }
+
+    TimeUnit getKeepAliveUnit() {
+        return keepAlive == null ? TimeSpec.DEFAULT_KEEPALIVE.getUnit() : keepAlive.getUnit();
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorWriteAttributeHandler.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+
+
+/**
+ * Handles attribute writes for an {@code org.jboss.threads.EnhancedQueueExecutor}.
+ *
+ */
+public class EnhancedQueueExecutorWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
+
+    private final ServiceName serviceNameBase;
+    private final RuntimeCapability capability;
+
+    @Deprecated
+    public EnhancedQueueExecutorWriteAttributeHandler(ServiceName serviceNameBase) {
+        this(null, serviceNameBase);
+    }
+
+    public EnhancedQueueExecutorWriteAttributeHandler(final RuntimeCapability capability, ServiceName serviceNameBase) {
+        super(EnhancedQueueExecutorAdd.ATTRIBUTES, EnhancedQueueExecutorAdd.RW_ATTRIBUTES);
+        this.serviceNameBase = serviceNameBase;
+        this.capability = capability;
+    }
+
+    @Override
+    protected void applyOperation(final OperationContext context, ModelNode model, String attributeName,
+                                  ServiceController<?> service, boolean forRollback) throws OperationFailedException {
+
+        final EnhancedQueueExecutorService pool =  (EnhancedQueueExecutorService) service.getService();
+
+        if (PoolAttributeDefinitions.KEEPALIVE_TIME.getName().equals(attributeName)) {
+            TimeUnit defaultUnit = pool.getKeepAliveUnit();
+            final TimeSpec spec = getTimeSpec(context, model, defaultUnit);
+            pool.setKeepAlive(spec);
+        } else if(PoolAttributeDefinitions.MAX_THREADS.getName().equals(attributeName)) {
+            pool.setMaxThreads(PoolAttributeDefinitions.MAX_THREADS.resolveModelAttribute(context, model).asInt());
+        }else if(PoolAttributeDefinitions.CORE_THREADS.getName().equals(attributeName)) {
+            pool.setCoreThreads(PoolAttributeDefinitions.CORE_THREADS.resolveModelAttribute(context, model).asInt());
+        } else if (!forRollback) {
+            // Programming bug. Throw a RuntimeException, not OFE, as this is not a client error
+            throw ThreadsLogger.ROOT_LOGGER.unsupportedEnhancedQueueExecutorAttribute(attributeName);
+        }
+    }
+
+    @Override
+    protected ServiceController<?> getService(final OperationContext context, final ModelNode model) throws OperationFailedException {
+        final String name = context.getCurrentAddressValue();
+        ServiceName serviceName = null;
+        ServiceController<?> controller = null;
+        if(capability != null) {
+            serviceName = capability.getCapabilityServiceName(context.getCurrentAddress());
+            controller = context.getServiceRegistry(true).getService(serviceName);
+            if(controller != null) {
+                return controller;
+            }
+        }
+        if (serviceNameBase != null) {
+            serviceName = serviceNameBase.append(name);
+            controller = context.getServiceRegistry(true).getService(serviceName);
+        }
+        if(controller == null) {
+            throw ThreadsLogger.ROOT_LOGGER.enhancedQueueExecutorServiceNotFound(serviceName);
+        }
+        return controller;
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/EnhancedQueueExecutorWriteAttributeHandler.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.threads;
 
-
-
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.OperationContext;
@@ -32,22 +30,15 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
-
 /**
  * Handles attribute writes for an {@code org.jboss.threads.EnhancedQueueExecutor}.
- *
  */
-public class EnhancedQueueExecutorWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
+class EnhancedQueueExecutorWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
 
     private final ServiceName serviceNameBase;
     private final RuntimeCapability capability;
 
-    @Deprecated
-    public EnhancedQueueExecutorWriteAttributeHandler(ServiceName serviceNameBase) {
-        this(null, serviceNameBase);
-    }
-
-    public EnhancedQueueExecutorWriteAttributeHandler(final RuntimeCapability capability, ServiceName serviceNameBase) {
+    EnhancedQueueExecutorWriteAttributeHandler(final RuntimeCapability capability, ServiceName serviceNameBase) {
         super(EnhancedQueueExecutorAdd.ATTRIBUTES, EnhancedQueueExecutorAdd.RW_ATTRIBUTES);
         this.serviceNameBase = serviceNameBase;
         this.capability = capability;
@@ -57,15 +48,15 @@ public class EnhancedQueueExecutorWriteAttributeHandler extends ThreadsWriteAttr
     protected void applyOperation(final OperationContext context, ModelNode model, String attributeName,
                                   ServiceController<?> service, boolean forRollback) throws OperationFailedException {
 
-        final EnhancedQueueExecutorService pool =  (EnhancedQueueExecutorService) service.getService();
+        final EnhancedQueueExecutorService pool = (EnhancedQueueExecutorService) service.getService();
 
         if (PoolAttributeDefinitions.KEEPALIVE_TIME.getName().equals(attributeName)) {
             TimeUnit defaultUnit = pool.getKeepAliveUnit();
             final TimeSpec spec = getTimeSpec(context, model, defaultUnit);
             pool.setKeepAlive(spec);
-        } else if(PoolAttributeDefinitions.MAX_THREADS.getName().equals(attributeName)) {
+        } else if (PoolAttributeDefinitions.MAX_THREADS.getName().equals(attributeName)) {
             pool.setMaxThreads(PoolAttributeDefinitions.MAX_THREADS.resolveModelAttribute(context, model).asInt());
-        }else if(PoolAttributeDefinitions.CORE_THREADS.getName().equals(attributeName)) {
+        } else if (PoolAttributeDefinitions.CORE_THREADS.getName().equals(attributeName)) {
             pool.setCoreThreads(PoolAttributeDefinitions.CORE_THREADS.resolveModelAttribute(context, model).asInt());
         } else if (!forRollback) {
             // Programming bug. Throw a RuntimeException, not OFE, as this is not a client error
@@ -78,10 +69,10 @@ public class EnhancedQueueExecutorWriteAttributeHandler extends ThreadsWriteAttr
         final String name = context.getCurrentAddressValue();
         ServiceName serviceName = null;
         ServiceController<?> controller = null;
-        if(capability != null) {
+        if (capability != null) {
             serviceName = capability.getCapabilityServiceName(context.getCurrentAddress());
             controller = context.getServiceRegistry(true).getService(serviceName);
-            if(controller != null) {
+            if (controller != null) {
                 return controller;
             }
         }
@@ -89,7 +80,7 @@ public class EnhancedQueueExecutorWriteAttributeHandler extends ThreadsWriteAttr
             serviceName = serviceNameBase.append(name);
             controller = context.getServiceRegistry(true).getService(serviceName);
         }
-        if(controller == null) {
+        if (controller == null) {
             throw ThreadsLogger.ROOT_LOGGER.enhancedQueueExecutorServiceNotFound(serviceName);
         }
         return controller;

--- a/threads/src/main/java/org/jboss/as/threads/ManagedEnhancedQueueExecutor.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedEnhancedQueueExecutor.java
@@ -42,7 +42,7 @@ class ManagedEnhancedQueueExecutor extends ManagedExecutorService {
         shutdownListenable.shutdown();
     }
 
-    public int getCoreThreads() {
+    int getCoreThreads() {
         return executor.getCorePoolSize();
     }
 
@@ -51,7 +51,7 @@ class ManagedEnhancedQueueExecutor extends ManagedExecutorService {
         executor.setCorePoolSize(coreThreads);
     }
 
-    public boolean isAllowCoreTimeout() {
+    boolean isAllowCoreTimeout() {
         return executor.allowsCoreThreadTimeOut();
     }
 
@@ -59,7 +59,7 @@ class ManagedEnhancedQueueExecutor extends ManagedExecutorService {
         executor.allowCoreThreadTimeOut(allowCoreTimeout);
     }
 
-    public int getMaxThreads() {
+    int getMaxThreads() {
         return executor.getMaximumPoolSize();
     }
 
@@ -67,7 +67,7 @@ class ManagedEnhancedQueueExecutor extends ManagedExecutorService {
         executor.setMaximumPoolSize(maxThreads);
     }
 
-    public long getKeepAlive() {
+    long getKeepAlive() {
         return executor.getKeepAliveTime(TimeUnit.MILLISECONDS);
     }
 
@@ -75,35 +75,35 @@ class ManagedEnhancedQueueExecutor extends ManagedExecutorService {
         executor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
     }
 
-    public int getRejectedCount() {
+    int getRejectedCount() {
         return (int) executor.getRejectedTaskCount();
     }
 
-    public long getTaskCount() {
+    long getTaskCount() {
         return executor.getSubmittedTaskCount();
     }
 
-    public int getLargestThreadCount() {
+    int getLargestThreadCount() {
         return executor.getLargestPoolSize();
     }
 
-    public int getLargestPoolSize() {
+    int getLargestPoolSize() {
         return executor.getLargestPoolSize();
     }
 
-    public int getCurrentThreadCount() {
+    int getCurrentThreadCount() {
         return executor.getPoolSize();
     }
 
-    public long getCompletedTaskCount() {
+    long getCompletedTaskCount() {
         return executor.getCompletedTaskCount();
     }
 
-    public int getActiveCount() {
+    int getActiveCount() {
         return executor.getActiveCount();
     }
 
-    public int getQueueSize() {
+    int getQueueSize() {
         return executor.getQueueSize();
     }
 

--- a/threads/src/main/java/org/jboss/as/threads/ManagedEnhancedQueueExecutor.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedEnhancedQueueExecutor.java
@@ -1,0 +1,113 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.threads.EnhancedQueueExecutor;
+import org.jboss.threads.EventListener;
+import org.jboss.threads.SimpleShutdownListenable;
+
+class ManagedEnhancedQueueExecutor extends ManagedExecutorService {
+    private final EnhancedQueueExecutor executor;
+    private final SimpleShutdownListenable shutdownListenable = new SimpleShutdownListenable();
+
+    ManagedEnhancedQueueExecutor(EnhancedQueueExecutor executor) {
+        super(executor);
+        this.executor = executor;
+    }
+
+    @Override
+    void internalShutdown() {
+        executor.shutdown();
+        shutdownListenable.shutdown();
+    }
+
+    public int getCoreThreads() {
+        return executor.getCorePoolSize();
+    }
+
+    // Package protected for subsys write-attribute handlers
+    void setCoreThreads(int coreThreads) {
+        executor.setCorePoolSize(coreThreads);
+    }
+
+    public boolean isAllowCoreTimeout() {
+        return executor.allowsCoreThreadTimeOut();
+    }
+
+    void setAllowCoreTimeout(boolean allowCoreTimeout) {
+        executor.allowCoreThreadTimeOut(allowCoreTimeout);
+    }
+
+    public int getMaxThreads() {
+        return executor.getMaximumPoolSize();
+    }
+
+    void setMaxThreads(int maxThreads) {
+        executor.setMaximumPoolSize(maxThreads);
+    }
+
+    public long getKeepAlive() {
+        return executor.getKeepAliveTime(TimeUnit.MILLISECONDS);
+    }
+
+    void setKeepAlive(TimeSpec keepAlive) {
+        executor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
+    }
+
+    public int getRejectedCount() {
+        return (int) executor.getRejectedTaskCount();
+    }
+
+    public long getTaskCount() {
+        return executor.getSubmittedTaskCount();
+    }
+
+    public int getLargestThreadCount() {
+        return executor.getLargestPoolSize();
+    }
+
+    public int getLargestPoolSize() {
+        return executor.getLargestPoolSize();
+    }
+
+    public int getCurrentThreadCount() {
+        return executor.getPoolSize();
+    }
+
+    public long getCompletedTaskCount() {
+        return executor.getCompletedTaskCount();
+    }
+
+    public int getActiveCount() {
+        return executor.getActiveCount();
+    }
+
+    public int getQueueSize() {
+        return executor.getQueueSize();
+    }
+
+    <A> void addShutdownListener(final EventListener<A> shutdownListener, final A attachment) {
+        shutdownListenable.addShutdownListener(shutdownListener, attachment);
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/ThreadPoolManagementUtils.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadPoolManagementUtils.java
@@ -21,6 +21,11 @@
 */
 package org.jboss.as.threads;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.threads.CommonAttributes.KEEPALIVE_TIME;
+import static org.jboss.as.threads.CommonAttributes.TIME;
+import static org.jboss.as.threads.CommonAttributes.UNIT;
+
 import java.util.Locale;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -36,11 +41,6 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.threads.CommonAttributes.KEEPALIVE_TIME;
-import static org.jboss.as.threads.CommonAttributes.TIME;
-import static org.jboss.as.threads.CommonAttributes.UNIT;
 
 /**
  * Utilities related to management of thread pools.

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsLogger.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsLogger.java
@@ -144,5 +144,17 @@ interface ThreadsLogger extends BasicLogger {
     @Message(id = 30, value = "Failed to parse '%s', allowed values are: %s")
     OperationFailedException failedToParseUnit(String unit, List<TimeUnit> allowed);
 
-    // id = 31; redundant parameter null check message
+    @Message(id = 31, value = "Unsupported attribute '%s'")
+    IllegalStateException unsupportedEnhancedQueueExecutorAttribute(String attributeName);
+
+    @Message(id = 32, value = "Service '%s' not found.")
+    OperationFailedException enhancedQueueExecutorServiceNotFound(ServiceName serviceName);
+
+    @Message(id = 33, value = "The executor service hasn't been initialized.")
+    IllegalStateException enhancedQueueExecutorUninitialized();
+
+    @Message(id = 34, value = "Unsupported metric '%s'")
+    IllegalStateException unsupportedEnhancedQueueExecutorMetric(String attributeName);
+
+    // id = 35; redundant parameter null check message
 }

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsParser.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsParser.java
@@ -22,28 +22,6 @@
 
 package org.jboss.as.threads;
 
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-
-import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
-import org.wildfly.common.cpu.ProcessorInfo;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -65,6 +43,28 @@ import static org.jboss.as.threads.CommonAttributes.THREAD_FACTORY;
 import static org.jboss.as.threads.CommonAttributes.TIME;
 import static org.jboss.as.threads.CommonAttributes.UNBOUNDED_QUEUE_THREAD_POOL;
 import static org.jboss.as.threads.CommonAttributes.UNIT;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+import org.wildfly.common.cpu.ProcessorInfo;
 
 /**
  * Parser for the threads subsystem or for other subsystems that use pieces of the basic threads subsystem

--- a/threads/src/main/resources/org/jboss/as/threads/LocalDescriptions.properties
+++ b/threads/src/main/resources/org/jboss/as/threads/LocalDescriptions.properties
@@ -8,6 +8,7 @@ threads.blocking-queueless-thread-pool=A set of thread pools where are not queue
 threads.bounded-queue-thread-pool=A set of thread pools where tasks are stored in a bounded-size queue and where if no space is available in the queue tasks will either be discarded or passed off to another 'handoff-executor' for execution.
 threads.queueless-thread-pool=A set of thread pools where are not queued and where if no pool thread is available to handle a task the tasks will either be discarded or passed off to another 'handoff-executor' for execution.
 threads.unbounded-queue-thread-pool=A set of thread pools where tasks are stored in a queue with no maximum size.
+threads.enhanced-queue-thread-pool=A set of thread pools where core and max size are configured independently, idle threads are always reused when available.
 threads.scheduled-thread-pool=A set of scheduled thread pools.
 
 thread-factory=A thread factory (implementing java.util.concurrent.ThreadFactory).
@@ -63,4 +64,9 @@ unbounded-queue-thread-pool=A thread pool executor with an unbounded queue.  Suc
 unbounded-queue-thread-pool.add=Adds an unbounded thread pool.
 unbounded-queue-thread-pool.remove=Removes an unbounded thread pool.
 unbounded-queue-thread-pool.rejected-count=The number of tasks that have been rejected.
+
+enhanced-queue-thread-pool=A thread pool executor with an enhanced queue.  In such a thread pool, its core and max size are configured independently, idle threads are always reused when available, and threads count is kept to a minimum.
+enhanced-queue-thread-pool.add=Adds an enhanced thread pool.
+enhanced-queue-thread-pool.remove=Removes an enhanced thread pool.
+enhanced-queue-thread-pool.rejected-count=The number of tasks that have been rejected.
 


### PR DESCRIPTION
…inactive threads.

JIRA: https://issues.jboss.org/browse/WFCORE-1446

The proposed changes add a new thread pool service backed by `org.jboss.threads.EnhancedQueueExecutor`, and related classes in order to support more flexible configuration of ejb thread pool.  They may also be used by other subsystems that wish to support similar requirements .  Current ejb thread-pool uses `UnboundedQueueThreadPoolService`, which is shared by some other subsystem and so is untouched.

These changes in wildfly-core are needed to implement WildFly RFE:

EJB subsystem configure max threads and core threads independently
https://issues.jboss.org/browse/WFLY-10057
https://issues.jboss.org/browse/EAP7-488

The related analysis document proposal: 
https://github.com/wildfly/wildfly-proposals/pull/227

Once these changes are incorporated into wildfly-core release, other changes to wildfly/ejb3 that depend on this change will be proposed to wildfly repo.