### PR TITLE
[WFCORE-4579] Upgrade jboss-logging from 3.4.0.Final to 3.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.14.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>
-        <version.org.jboss.logging.jboss-logging>3.4.0.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.13.Final</version.org.jboss.logmanager.jboss-logmanager>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4579

---


## Release Notes - JBoss Logging - Version 3.4.1.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/JBLOGGING-140'>JBLOGGING-140</a>] -         Avoid ClassCastException in Slf4jLoggerProvider
</li>
<li>[<a href='https://issues.jboss.org/browse/JBLOGGING-141'>JBLOGGING-141</a>] -         At Logger.getMessageLogger, safeguard the doPrivileged call by a SecurityManager check
</li>
</ul>
                                                                                                                    