### PR TITLE
[WFCORE-4375] Provide ability to easily apply certain JBoss module libraries to all deployments running in a server

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -267,6 +267,7 @@ public enum Phase {
     public static final int STRUCTURE_BEAN_VALIDATION_RESOURCE_INJECTION_REGISTRY   = 0x1C03;
     public static final int STRUCTURE_DEPLOYMENT_DEPENDENCIES           = 0x1D00;
     public static final int STRUCTURE_GLOBAL_MODULES                    = 0x1E00;
+    public static final int STRUCTURE_GLOBAL_DIRECTORIES                = 0x1E01;
     public static final int STRUCTURE_NAMING_EXTERNAL_CONTEXTS          = 0x1F00;
     public static final int STRUCTURE_GLOBAL_REQUEST_CONTROLLER         = 0x2000;
     public static final int STRUCTURE_WS_SERVICES_DEPS                  = 0x2100;

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1336,6 +1336,12 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 274, value = "Excluded dependency %s via jboss-deployment-structure.xml does not exist.")
     void excludedDependenciesNotExist(String dependency);
 
+    @Message(id = 275, value = "Maximum number of allowed jar resources reached for global-directory module name '%s'. The maximum allowed is %d files")
+    RuntimeException maximumNumberOfJarResources(String globalDirectory, long max);
+
+    @Message(id = 276, value = "There is an error in opening zip file %s")
+    StartException errorOpeningZipFile(String filename, @Cause Throwable throwable);
+
     ////////////////////////////////////////////////
     //Messages without IDs
 
@@ -1362,5 +1368,6 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = DEBUG)
     @Message(id = Message.NONE, value = "Deleting file %s")
     void deletingFile(Path name);
+
 
 }

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ExternalModuleService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ExternalModuleService.java
@@ -62,15 +62,20 @@ public class ExternalModuleService implements Service<ExternalModuleService> {
      * @return true if valid, false otherwise
      */
     public boolean isValid(String externalModule) {
-        return new File(externalModule).exists();
+        File f = new File(externalModule);
+        return f.exists() && !f.isDirectory();
     }
 
-    public ModuleIdentifier addExternalModule(String externalModule, ServiceRegistry serviceRegistry, ServiceTarget serviceTarget) {
-        ModuleIdentifier identifier = ModuleIdentifier.create(EXTERNAL_MODULE_PREFIX + externalModule);
+    public ModuleIdentifier addExternalModule(String moduleName, ServiceRegistry serviceRegistry, ServiceTarget serviceTarget) {
+        return addExternalModule(moduleName, serviceRegistry, serviceTarget, moduleName);
+    }
+
+    public ModuleIdentifier addExternalModule(String moduleName, ServiceRegistry serviceRegistry, ServiceTarget serviceTarget, String path) {
+        ModuleIdentifier identifier = ModuleIdentifier.create(EXTERNAL_MODULE_PREFIX + moduleName);
         ServiceName serviceName = ServiceModuleLoader.moduleSpecServiceName(identifier);
         ServiceController<?> controller = serviceRegistry.getService(serviceName);
         if (controller == null) {
-            ExternalModuleSpecService service = new ExternalModuleSpecService(identifier, new File(externalModule));
+            ExternalModuleSpecService service = new ExternalModuleSpecService(identifier, new File(path));
             serviceTarget.addService(serviceName)
                     .setInstance(service)
                     .setInitialMode(Mode.ON_DEMAND)


### PR DESCRIPTION
Wildfly core changes to allow the uses of an external folder as a module that can be added as a dependency for a deployment.

Basically, it uses an exiting service that creates a module from an external jar file expanding the functionality to scan a directory and create a module spec using all the Jar files found in that directory and subdirectories.

This feature should be still on hold since it is being blocked by https://issues.jboss.org/browse/WFCORE-4597, however, after discussing it, I open the issue to get some early feedback about the feature implementation.

Jira issue: https://issues.jboss.org/browse/WFCORE-4375