### PR TITLE
WFCORE-4599 Handle wildfly-config.xml better for authentication

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -50,6 +50,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
         <!-- Temporary due to backward compatibility with the configuration of JACC and related services -->

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationContextAssociationProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationContextAssociationProcessor.java
@@ -19,12 +19,19 @@ package org.wildfly.extension.elytron;
 
 import static org.jboss.as.server.deployment.Attachments.MODULE;
 import static org.wildfly.extension.elytron.ElytronExtension.AUTHENTICATION_CONTEXT_KEY;
+import static org.wildfly.extension.elytron.SecurityActions.doPrivileged;
+
+import java.security.PrivilegedAction;
+import java.util.function.Supplier;
 
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.modules.ModuleClassLoader;
 import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.ElytronXmlParser;
+import org.wildfly.security.auth.client.InvalidAuthenticationConfigurationException;
 
 /**
  * A {@link DeploymentUnitProcessor} to associate a previously obtained {@link AuthenticationContext} with the
@@ -37,9 +44,40 @@ class AuthenticationContextAssociationProcessor implements DeploymentUnitProcess
     @Override
     public void deploy(DeploymentPhaseContext context) throws DeploymentUnitProcessingException {
         AuthenticationContext authenticationContext = context.getAttachment(AUTHENTICATION_CONTEXT_KEY);
+        ModuleClassLoader classLoader = context.getDeploymentUnit().getAttachment(MODULE).getClassLoader();
         if (authenticationContext != null) {
             AuthenticationContext.getContextManager().setClassLoaderDefault(
-                    context.getDeploymentUnit().getAttachment(MODULE).getClassLoader(), authenticationContext);
+                    classLoader, authenticationContext);
+        } else {
+            AuthenticationContext.getContextManager().setClassLoaderDefaultSupplier(
+                    classLoader, new Supplier<AuthenticationContext>() {
+
+                        private volatile AuthenticationContext context;
+
+                        @Override
+                        public AuthenticationContext get() {
+                            if (context != null) {
+                                return context;
+                            }
+                            synchronized (this) {
+                                if (context != null) {
+                                    return context;
+                                }
+                                return context = doPrivileged((PrivilegedAction<AuthenticationContext>) () -> {
+                                    ClassLoader old = Thread.currentThread().getContextClassLoader();
+                                    try {
+                                        Thread.currentThread().setContextClassLoader(classLoader);
+                                        return ElytronXmlParser.parseAuthenticationClientConfiguration().create();
+                                    } catch (Throwable t) {
+                                        throw new InvalidAuthenticationConfigurationException(t);
+                                    } finally {
+                                        Thread.currentThread().setContextClassLoader(old);
+                                    }
+                                });
+                            }
+                        }
+                    });
+
         }
     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -437,6 +437,13 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
         @Override
         protected void performBoottime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+            //the normal default context manager will attempt to look up wildfly-config.xml on the class path
+            //parse it and store the result in a static. The means that the default can essentially be
+            //random of there are multiple deployments with different configurations
+            //to make sure there is no random behaviour we set the global default to an empty context
+            AuthenticationContext.getContextManager().setGlobalDefault(AuthenticationContext.empty());
+
+
             ModelNode model = resource.getModel();
             final String defaultAuthenticationContext = DEFAULT_AUTHENTICATION_CONTEXT.resolveModelAttribute(context, model).asStringOrNull();
             AUTHENITCATION_CONTEXT_PROCESSOR.setDefaultAuthenticationContext(defaultAuthenticationContext);


### PR DESCRIPTION
This was previously cached in a static, which does not work for
multiple deployments. This uses an empty authentication context
for the default (if it was not explicitly set), then explicitly
sets per-deployment ClassLoader defaults if the relevant file is
present in the deployment.