### PR TITLE
[WFCORE-4604] Disable testEndpointConfigurationViaSubsystemRoot

### DIFF
--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -247,6 +247,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
      * WFCORE-3327. Use the management API to add the subsystem, with the endpoint configuration done via
      * the root /subsystem=remoting resource.
      */
+    @Ignore("WFCORE-4604")
     @Test
     public void testEndpointConfigurationViaSubsystemRoot() throws Exception {
         KernelServices services = createKernelServicesBuilder(createRuntimeAdditionalInitialization())


### PR DESCRIPTION
Test is failing intermittently on WildFly CI (success rate < 95%)

JIRA: https://issues.jboss.org/browse/WFCORE-4604