### PR TITLE
[WFCORE-4603]: Replace Deployment --runtime-name option not working.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentReplaceHandler.java
@@ -66,6 +66,7 @@ public class DeploymentReplaceHandler implements OperationStepHandler {
         return new DeploymentReplaceHandler(contentRepository, vaultReader);
     }
 
+    @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         for (AttributeDefinition def : DeploymentAttributes.REPLACE_DEPLOYMENT_ATTRIBUTES.values()) {
             def.validateOperation(operation);
@@ -122,7 +123,8 @@ public class DeploymentReplaceHandler implements OperationStepHandler {
             if (ENABLED.resolveModelAttribute(context, deployNode).asBoolean()) {
                 throw ServerLogger.ROOT_LOGGER.deploymentAlreadyStarted(toReplace);
             }
-            runtimeName = deployNode.require(RUNTIME_NAME).asString();
+            runtimeName = operation.hasDefined(RUNTIME_NAME) ? DeploymentAttributes.REPLACE_DEPLOYMENT_ATTRIBUTES.get(RUNTIME_NAME).resolveModelAttribute(context, operation).asString() : deployNode.require(RUNTIME_NAME).asString();
+            deployNode.get(RUNTIME_NAME).set(runtimeName);
         }
 
         deployNode.get(ENABLED.getName()).set(true);


### PR DESCRIPTION
* Taking the runtime-name into account when replacing 2 deployments.

Jira: https://issues.jboss.org/browse/WFCORE-4603