### PR TITLE
[WFLY-4612] ExternalModuleDependencySpecService should make dependenc…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/moduleservice/ExternalModuleSpecService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ExternalModuleSpecService.java
@@ -23,6 +23,7 @@ package org.jboss.as.server.moduleservice;
 
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.modules.DependencySpec;
+import org.jboss.modules.ModuleDependencySpecBuilder;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleSpec;
 import org.jboss.modules.ResourceLoaderSpec;
@@ -69,8 +70,8 @@ public class ExternalModuleSpecService implements Service<ModuleDefinition> {
         final ModuleSpec.Builder specBuilder = ModuleSpec.build(moduleIdentifier);
         addResourceRoot(specBuilder, jarFile);
         //TODO: We need some way of configuring module dependencies for external archives
-        ModuleIdentifier javaee = ModuleIdentifier.create("javaee.api");
-        specBuilder.addDependency(DependencySpec.createModuleDependencySpec(javaee));
+        DependencySpec javaee = new ModuleDependencySpecBuilder().setName("javaee.api").setOptional(true).build();
+        specBuilder.addDependency(javaee);
         specBuilder.addDependency(DependencySpec.createLocalDependencySpec());
         // TODO: external resource need some kind of dependency mechanism
         ModuleSpec moduleSpec = specBuilder.create();


### PR DESCRIPTION
…ies on 'javaee.api' optional

https://issues.jboss.org/browse/WFCORE-4612

This allows app dependencies added via Class-Path entries in MANIFEST.MF or from files in $JBOSS_HOME/lib/ext or the java.ext.dirs dirs to work even with no javaee.api module provisioned. Of course the dependency can't need any of the javaee.api artifacts.

@yersan @jfdenise FYI.