### PR TITLE
[WFCORE-4336] Add the ability for a user to add custom filters for loggers and log handlers

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -38,9 +38,26 @@
     <name>WildFly: Logging Subsystem</name>
     <properties>
         <surefire.argLine>${surefire.system.args}</surefire.argLine>
+        <jboss.modules.dir>${project.build.testOutputDirectory}/modules</jboss.modules.dir>
+        <test.class.path>${project.build.testOutputDirectory}</test.class.path>
     </properties>
 
     <build>
+        <testResources>
+            <!-- Process default resources -->
+            <testResource>
+                <directory>src/test/resources</directory>
+                <targetPath>${project.build.testOutputDirectory}</targetPath>
+            </testResource>
+            <!-- Process modules for a fake modular environment, this is used for custom-handler's, custom-formatter's
+                 and filters.
+             -->
+            <testResource>
+                <directory>src/test/modules</directory>
+                <filtering>true</filtering>
+                <targetPath>${project.build.testOutputDirectory}/modules</targetPath>
+            </testResource>
+        </testResources>
         <plugins>
             <!-- this is only needed on windows -->
             <plugin>
@@ -61,6 +78,11 @@
                 <configuration>
                     <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar} ${surefire.argLine}</argLine>
                     <systemPropertyVariables>
+                        <!-- Configure a module directory as custom-handler's, custom-formatter's and filters require
+                             a module to be used
+                        -->
+                        <jboss.modules.dir>${jboss.modules.dir}</jboss.modules.dir>
+                        <module.path>${jboss.modules.dir}</module.path>
                         <jboss.server.log.dir>${project.build.directory}${file.separator}logs</jboss.server.log.dir>
                         <jboss.server.config.dir>${project.build.directory}${file.separator}config</jboss.server.config.dir>
                         <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -158,21 +158,7 @@ public interface CommonAttributes {
 
     SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder("properties", true)
             .setAllowExpression(true)
-            .setAttributeMarshaller(new DefaultAttributeMarshaller() {
-                @Override
-                public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
-                    resourceModel = resourceModel.get(attribute.getName());
-                    if (resourceModel.isDefined()) {
-                        writer.writeStartElement(attribute.getName());
-                        for (ModelNode property : resourceModel.asList()) {
-                            writer.writeEmptyElement(Element.PROPERTY.getLocalName());
-                            writer.writeAttribute("name", property.asProperty().getName());
-                            writer.writeAttribute("value", property.asProperty().getValue().asString());
-                        }
-                        writer.writeEndElement();
-                    }
-                }
-            })
+            .setAttributeMarshaller(PropertyAttributeMarshaller.INSTANCE)
             .build();
 
     /**

--- a/logging/src/main/java/org/jboss/as/logging/Element.java
+++ b/logging/src/main/java/org/jboss/as/logging/Element.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.logging.filters.FilterResourceDefinition;
 import org.jboss.as.logging.formatters.CustomFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.PatternFormatterResourceDefinition;
@@ -59,6 +60,7 @@ enum Element {
     ASYNC_HANDLER(AsyncHandlerResourceDefinition.NAME),
     CHANGE_LEVEL(CommonAttributes.CHANGE_LEVEL),
     CONSOLE_HANDLER(ConsoleHandlerResourceDefinition.NAME),
+    CONSTRUCTOR_PROPERTIES(FilterResourceDefinition.CONSTRUCTOR_PROPERTIES),
     CUSTOM_FORMATTER(CustomFormatterResourceDefinition.CUSTOM_FORMATTER),
     CUSTOM_HANDLER(CustomHandlerResourceDefinition.NAME),
     DENY(CommonAttributes.DENY),

--- a/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
+++ b/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
@@ -16,6 +16,7 @@ public enum KnownModelVersion {
     VERSION_6_0_0(ModelVersion.create(6, 0, 0), true),
     VERSION_7_0_0(ModelVersion.create(7, 0, 0), true),
     VERSION_8_0_0(ModelVersion.create(8, 0, 0), false),
+    VERSION_9_0_0(ModelVersion.create(9, 0, 0), false),
     ;
     private final ModelVersion modelVersion;
     private final boolean hasTransformers;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -55,6 +55,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.as.logging.LoggingProfileOperations.LoggingProfileAdd;
 import org.jboss.as.logging.deployments.resources.LoggingDeploymentResources;
+import org.jboss.as.logging.filters.FilterResourceDefinition;
 import org.jboss.as.logging.formatters.CustomFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.PatternFormatterResourceDefinition;
@@ -335,6 +336,7 @@ public class LoggingExtension implements Extension {
         registration.registerSubModel(JsonFormatterResourceDefinition.INSTANCE);
         registration.registerSubModel(XmlFormatterResourceDefinition.INSTANCE);
         registration.registerSubModel(SocketHandlerResourceDefinition.INSTANCE);
+        registration.registerSubModel(FilterResourceDefinition.INSTANCE);
 
         if (registerTransformers) {
             registerTransformers(subsystem,
@@ -353,14 +355,16 @@ public class LoggingExtension implements Extension {
                     CustomFormatterResourceDefinition.INSTANCE,
                     JsonFormatterResourceDefinition.INSTANCE,
                     XmlFormatterResourceDefinition.INSTANCE,
-                    SocketHandlerResourceDefinition.INSTANCE);
+                    SocketHandlerResourceDefinition.INSTANCE,
+                    FilterResourceDefinition.INSTANCE);
         }
     }
 
     private void registerTransformers(final SubsystemRegistration registration, final TransformerResourceDefinition... defs) {
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getSubsystemVersion());
 
-        registerTransformers(chainedBuilder, registration.getSubsystemVersion(), KnownModelVersion.VERSION_7_0_0, defs);
+        registerTransformers(chainedBuilder, registration.getSubsystemVersion(), KnownModelVersion.VERSION_8_0_0, defs);
+        registerTransformers(chainedBuilder, KnownModelVersion.VERSION_8_0_0, KnownModelVersion.VERSION_7_0_0, defs);
         registerTransformers(chainedBuilder, KnownModelVersion.VERSION_7_0_0, KnownModelVersion.VERSION_6_0_0, defs);
         registerTransformers(chainedBuilder, KnownModelVersion.VERSION_6_0_0, KnownModelVersion.VERSION_5_0_0, defs);
         registerTransformers(chainedBuilder, KnownModelVersion.VERSION_5_0_0, KnownModelVersion.VERSION_2_0_0, defs);
@@ -372,6 +376,7 @@ public class LoggingExtension implements Extension {
                 KnownModelVersion.VERSION_2_0_0.getModelVersion(),
                 KnownModelVersion.VERSION_6_0_0.getModelVersion(),
                 KnownModelVersion.VERSION_7_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_8_0_0.getModelVersion(),
         }, new ModelVersion[] {
                 KnownModelVersion.VERSION_1_5_0.getModelVersion(),
                 KnownModelVersion.VERSION_3_0_0.getModelVersion(),
@@ -379,6 +384,7 @@ public class LoggingExtension implements Extension {
                 KnownModelVersion.VERSION_5_0_0.getModelVersion(),
                 KnownModelVersion.VERSION_6_0_0.getModelVersion(),
                 KnownModelVersion.VERSION_7_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_8_0_0.getModelVersion(),
         });
     }
 
@@ -436,6 +442,10 @@ public class LoggingExtension implements Extension {
                 } else if (CustomFormatterResourceDefinition.NAME.equals(key1)) {
                     result = LESS;
                 } else if (CustomFormatterResourceDefinition.NAME.equals(key2)) {
+                    result = GREATER;
+                } else if (FilterResourceDefinition.NAME.equals(key1)) {
+                    result = LESS;
+                } else if (FilterResourceDefinition.NAME.equals(key2)) {
                     result = GREATER;
                 } else if (RootLoggerResourceDefinition.NAME.equals(key1)) {
                     result = GREATER;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -98,7 +98,7 @@ public class LoggingExtension implements Extension {
 
     private static final GenericSubsystemDescribeHandler DESCRIBE_HANDLER = GenericSubsystemDescribeHandler.create(LoggingChildResourceComparator.INSTANCE);
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 8;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 9;
     private static final int MANAGEMENT_API_MINOR_VERSION = 0;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
@@ -270,6 +270,7 @@ public class LoggingExtension implements Extension {
         setParser(context, Namespace.LOGGING_5_0, new LoggingSubsystemParser_5_0());
         setParser(context, Namespace.LOGGING_6_0, new LoggingSubsystemParser_6_0());
         setParser(context, Namespace.LOGGING_7_0, new LoggingSubsystemParser_7_0());
+        setParser(context, Namespace.LOGGING_8_0, new LoggingSubsystemParser_8_0());
 
         // Hack to ensure the Element and Attribute enums are loaded during this call which
         // is part of concurrent boot. These enums trigger a lot of classloading and static

--- a/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.logging.filters.Filters;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.dmr.ModelNode;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -48,6 +48,7 @@ import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.logging.filters.Filters;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_8_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_8_0.java
@@ -19,10 +19,310 @@
 
 package org.jboss.as.logging;
 
+import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.logging.CommonAttributes.LOGGING_PROFILE;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.logging.filters.FilterResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
 /**
  * Subsystem parser for 8.0 of the logging subsystem.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 class LoggingSubsystemParser_8_0 extends LoggingSubsystemParser_7_0 {
+
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> operations) throws XMLStreamException {
+        // No attributes
+        ParseUtils.requireNoAttributes(reader);
+
+        // Subsystem add operation
+        final ModelNode subsystemAddOp = Util.createAddOperation(SUBSYSTEM_ADDRESS);
+        operations.add(subsystemAddOp);
+
+        final List<ModelNode> loggerOperations = new ArrayList<>();
+        final List<ModelNode> asyncHandlerOperations = new ArrayList<>();
+        final List<ModelNode> handlerOperations = new ArrayList<>();
+        final List<ModelNode> formatterOperations = new ArrayList<>();
+        final List<ModelNode> filterOperations = new ArrayList<>();
+
+        // Elements
+        final Set<String> loggerNames = new HashSet<>();
+        final Set<String> handlerNames = new HashSet<>();
+        final Set<String> formatterNames = new HashSet<>();
+        final Set<String> filterNames = new HashSet<>();
+        boolean rootDefined = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case ADD_LOGGING_API_DEPENDENCIES: {
+                    final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
+                    LoggingResourceDefinition.ADD_LOGGING_API_DEPENDENCIES.parseAndSetParameter(value, subsystemAddOp, reader);
+                    break;
+                }
+                case USE_DEPLOYMENT_LOGGING_CONFIG: {
+                    final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
+                    LoggingResourceDefinition.USE_DEPLOYMENT_LOGGING_CONFIG.parseAndSetParameter(value, subsystemAddOp, reader);
+                    break;
+                }
+                case LOGGER: {
+                    parseLoggerElement(reader, SUBSYSTEM_ADDRESS, loggerOperations, loggerNames);
+                    break;
+                }
+                case ROOT_LOGGER: {
+                    if (rootDefined) {
+                        throw unexpectedElement(reader);
+                    }
+                    rootDefined = true;
+                    parseRootLoggerElement(reader, SUBSYSTEM_ADDRESS, loggerOperations);
+                    break;
+                }
+                case CONSOLE_HANDLER: {
+                    parseConsoleHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case FILE_HANDLER: {
+                    parseFileHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case CUSTOM_HANDLER: {
+                    parseCustomHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_ROTATING_FILE_HANDLER: {
+                    parsePeriodicRotatingFileHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_SIZE_ROTATING_FILE_HANDLER: {
+                    parsePeriodicSizeRotatingHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case SIZE_ROTATING_FILE_HANDLER: {
+                    parseSizeRotatingHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case SOCKET_HANDLER: {
+                    parseSocketHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case ASYNC_HANDLER: {
+                    parseAsyncHandlerElement(reader, SUBSYSTEM_ADDRESS, asyncHandlerOperations, handlerNames);
+                    break;
+                }
+                case SYSLOG_HANDLER: {
+                    parseSyslogHandler(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case LOGGING_PROFILES: {
+                    parseLoggingProfilesElement(reader, operations);
+                }
+                break;
+                case FORMATTER: {
+                    parseFormatter(reader, SUBSYSTEM_ADDRESS, formatterOperations, formatterNames);
+                    break;
+                }
+                case FILTER: {
+                    parseFilterElement(reader, SUBSYSTEM_ADDRESS, filterOperations, filterNames);
+                    break;
+                }
+                default: {
+                    reader.handleAny(operations);
+                    break;
+                }
+            }
+        }
+        // Filters have no dependencies, but may be dependencies of handlers and/or loggers so they should be processed
+        // first.
+        operations.addAll(filterOperations);
+        operations.addAll(formatterOperations);
+        operations.addAll(handlerOperations);
+        operations.addAll(asyncHandlerOperations);
+        operations.addAll(loggerOperations);
+    }
+
+    @Override
+    void parseLoggingProfileElement(final XMLExtendedStreamReader reader, final List<ModelNode> operations, final Set<String> profileNames) throws XMLStreamException {
+        // Attributes
+        String name = null;
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            if (attribute == Attribute.NAME) {
+                name = value;
+            } else {
+                throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        if (!profileNames.add(name)) {
+            throw duplicateNamedElement(reader, name);
+        }
+        // Setup the address
+        final PathAddress profileAddress = SUBSYSTEM_ADDRESS.append(LOGGING_PROFILE, name);
+        operations.add(Util.createAddOperation(profileAddress));
+
+        final List<ModelNode> loggerOperations = new ArrayList<>();
+        final List<ModelNode> asyncHandlerOperations = new ArrayList<>();
+        final List<ModelNode> handlerOperations = new ArrayList<>();
+        final List<ModelNode> formatterOperations = new ArrayList<>();
+        final List<ModelNode> filterOperations = new ArrayList<>();
+
+        final Set<String> loggerNames = new HashSet<>();
+        final Set<String> handlerNames = new HashSet<>();
+        final Set<String> formatterNames = new HashSet<>();
+        final Set<String> filterNames = new HashSet<>();
+        boolean gotRoot = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case LOGGER: {
+                    parseLoggerElement(reader, profileAddress, loggerOperations, loggerNames);
+                    break;
+                }
+                case ROOT_LOGGER: {
+                    if (gotRoot) {
+                        throw unexpectedElement(reader);
+                    }
+                    gotRoot = true;
+                    parseRootLoggerElement(reader, profileAddress, loggerOperations);
+                    break;
+                }
+                case CONSOLE_HANDLER: {
+                    parseConsoleHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case FILE_HANDLER: {
+                    parseFileHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case CUSTOM_HANDLER: {
+                    parseCustomHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_ROTATING_FILE_HANDLER: {
+                    parsePeriodicRotatingFileHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_SIZE_ROTATING_FILE_HANDLER: {
+                    parsePeriodicSizeRotatingHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case SIZE_ROTATING_FILE_HANDLER: {
+                    parseSizeRotatingHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case SOCKET_HANDLER: {
+                    parseSocketHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case ASYNC_HANDLER: {
+                    parseAsyncHandlerElement(reader, profileAddress, asyncHandlerOperations, handlerNames);
+                    break;
+                }
+                case SYSLOG_HANDLER: {
+                    parseSyslogHandler(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case FORMATTER: {
+                    parseFormatter(reader, profileAddress, formatterOperations, formatterNames);
+                    break;
+                }
+                case FILTER: {
+                    parseFilterElement(reader, profileAddress, filterOperations, filterNames);
+                    break;
+                }
+                default: {
+                    reader.handleAny(operations);
+                    break;
+                }
+            }
+        }
+        // Filters have no dependencies, but may be dependencies of handlers and/or loggers so they should be processed
+        // first.
+        operations.addAll(filterOperations);
+        operations.addAll(formatterOperations);
+        operations.addAll(handlerOperations);
+        operations.addAll(asyncHandlerOperations);
+        operations.addAll(loggerOperations);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    void parseFilterElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> operations, final Set<String> filterNames) throws XMLStreamException {
+        final ModelNode operation = Util.createAddOperation();
+        // Attributes
+        String name = null;
+        // Attributes
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.CLASS, Attribute.MODULE);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                case CLASS: {
+                    CommonAttributes.CLASS.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                case MODULE: {
+                    CommonAttributes.MODULE.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        if (!filterNames.add(name)) {
+            throw duplicateNamedElement(reader, name);
+        }
+
+        // Setup the operation address
+        addOperationAddress(operation, address, FilterResourceDefinition.NAME, name);
+
+
+        final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        while (reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            if (!encountered.add(element)) {
+                throw unexpectedElement(reader);
+            }
+            if (element == Element.CONSTRUCTOR_PROPERTIES) {
+                parsePropertyElement(operation, reader, FilterResourceDefinition.CONSTRUCTOR_PROPERTIES.getName());
+            } else if (element == Element.PROPERTIES) {
+                parsePropertyElement(operation, reader);
+            } else {
+                throw unexpectedElement(reader);
+            }
+        }
+        operations.add(operation);
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_8_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_8_0.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging;
+
+/**
+ * Subsystem parser for 8.0 of the logging subsystem.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class LoggingSubsystemParser_8_0 extends LoggingSubsystemParser_7_0 {
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -64,6 +64,7 @@ import javax.xml.stream.XMLStreamException;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.as.logging.filters.FilterResourceDefinition;
 import org.jboss.as.logging.formatters.CustomFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.PatternFormatterResourceDefinition;
@@ -235,6 +236,13 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
         writeStructuredFormatters(writer, JsonFormatterResourceDefinition.NAME, model);
         writeStructuredFormatters(writer, XmlFormatterResourceDefinition.NAME, model,
                 XmlFormatterResourceDefinition.PRINT_NAMESPACE, XmlFormatterResourceDefinition.NAMESPACE_URI);
+
+        // Write the filters
+        if (model.hasDefined(FilterResourceDefinition.NAME)) {
+            for (String name : model.get(FilterResourceDefinition.NAME).keys()) {
+                writeFilterElement(writer, model.get(FilterResourceDefinition.NAME, name), name);
+            }
+        }
     }
 
     private void writeCommonLogger(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
@@ -440,5 +448,15 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
                 writer.writeEndElement(); // end formatter
             }
         }
+    }
+
+    private void writeFilterElement(final XMLExtendedStreamWriter writer, final ModelNode model, final String name) throws XMLStreamException {
+        writer.writeStartElement(Element.FILTER.getLocalName());
+        writer.writeAttribute(NAME.getXmlName(), name);
+        CLASS.marshallAsAttribute(model, writer);
+        MODULE.marshallAsAttribute(model, writer);
+        FilterResourceDefinition.CONSTRUCTOR_PROPERTIES.marshallAsElement(model, writer);
+        PROPERTIES.marshallAsElement(model, writer);
+        writer.writeEndElement();
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/Namespace.java
+++ b/logging/src/main/java/org/jboss/as/logging/Namespace.java
@@ -58,12 +58,14 @@ public enum Namespace {
     LOGGING_6_0("urn:jboss:domain:logging:6.0"),
 
     LOGGING_7_0("urn:jboss:domain:logging:7.0"),
+
+    LOGGING_8_0("urn:jboss:domain:logging:8.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = LOGGING_7_0;
+    public static final Namespace CURRENT = LOGGING_8_0;
 
     private final String name;
 

--- a/logging/src/main/java/org/jboss/as/logging/PropertyAttributeMarshaller.java
+++ b/logging/src/main/java/org/jboss/as/logging/PropertyAttributeMarshaller.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.DefaultAttributeMarshaller;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class PropertyAttributeMarshaller extends DefaultAttributeMarshaller {
+    public static final PropertyAttributeMarshaller INSTANCE = new PropertyAttributeMarshaller();
+
+    @Override
+    public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+        resourceModel = resourceModel.get(attribute.getName());
+        if (resourceModel.isDefined()) {
+            writer.writeStartElement(attribute.getName());
+            for (Property property : resourceModel.asPropertyList()) {
+                writer.writeEmptyElement(Element.PROPERTY.getLocalName());
+                writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                writer.writeAttribute(Attribute.VALUE.getLocalName(), property.getValue().asString());
+            }
+            writer.writeEndElement();
+        }
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/filters/FilterReferenceRecorder.java
+++ b/logging/src/main/java/org/jboss/as/logging/filters/FilterReferenceRecorder.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging.filters;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.logging.CommonAttributes;
+
+/**
+ * <p>
+ * This somewhat mimics the relationships normally managed by the capabilities API. A {@code filter-spec} attribute will
+ * not quite work correctly with capabilities. The reason being is the {@code filter-spec} is a string attribute which
+ * uses an expression format to create filters for handler and loggers. This means the {@code filter-spec} can have a
+ * one to many relationship with custom filters.
+ * </p>
+ *
+ * <p>
+ * As an example; {@code any(myFilter1, myFilter2, myFilter3)}. All three of these are valid and could be registered
+ * against a single {@code filter-spec} associated with either a logger or a handler.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class FilterReferenceRecorder {
+
+    private final Map<String, Set<String>> filterRefs;
+
+    /**
+     * Creates a new reference recorder.
+     */
+    FilterReferenceRecorder() {
+        filterRefs = new HashMap<>();
+    }
+
+    /**
+     * Gets all the references of a filter associated with a logger or handler.
+     *
+     * @param filterAddress the filters address
+     *
+     * @return the logger and handler references or an empty set
+     */
+    Set<String> getFilterReferences(final PathAddress filterAddress) {
+        final String key = formatName(filterAddress);
+        final Set<String> refs = new LinkedHashSet<>();
+        synchronized (filterRefs) {
+            if (filterRefs.containsKey(key)) {
+                refs.addAll(filterRefs.get(key));
+            }
+        }
+        return refs;
+    }
+
+    /**
+     * Registers a handler with the filter name.
+     *
+     * @param filterName       the name of the filter
+     * @param referenceAddress the handlers address
+     */
+    void registerFilter(final String filterName, final PathAddress referenceAddress) {
+        final String key = formatName(referenceAddress, filterName);
+        synchronized (filterRefs) {
+            final Set<String> filters = filterRefs.compute(key, (value, values) -> new LinkedHashSet<>());
+            filters.add(referenceAddress.toCLIStyleString());
+        }
+    }
+
+    /**
+     * Unregisters the filter name with a handler.
+     *
+     * @param filterName       the name of the filter to unregister
+     * @param referenceAddress the handlers address
+     */
+    @SuppressWarnings("DuplicatedCode")
+    void unregisterFilter(final String filterName, final PathAddress referenceAddress) {
+        final String key = formatName(referenceAddress, filterName);
+        synchronized (filterRefs) {
+            final Set<String> filters = filterRefs.get(key);
+            if (filters != null) {
+                filters.remove(referenceAddress.toCLIStyleString());
+                if (filters.isEmpty()) {
+                    filterRefs.remove(key);
+                }
+            }
+        }
+    }
+
+    private static String formatName(final PathAddress address, final String dynamicName) {
+        for (PathElement pathElement : address) {
+            if (CommonAttributes.LOGGING_PROFILE.equals(pathElement.getKey())) {
+                return pathElement.getValue() + "." + dynamicName;
+            }
+        }
+        return dynamicName;
+    }
+
+    private static String formatName(final PathAddress address) {
+        return formatName(address, address.getLastElement().getValue());
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/filters/FilterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/filters/FilterResourceDefinition.java
@@ -1,0 +1,250 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging.filters;
+
+import static org.jboss.as.logging.CommonAttributes.CLASS;
+import static org.jboss.as.logging.CommonAttributes.MODULE;
+import static org.jboss.as.logging.CommonAttributes.PROPERTIES;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.logging.KnownModelVersion;
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.as.logging.LoggingOperations;
+import org.jboss.as.logging.LoggingOperations.LoggingWriteAttributeHandler;
+import org.jboss.as.logging.PropertyAttributeMarshaller;
+import org.jboss.as.logging.TransformerResourceDefinition;
+import org.jboss.as.logging.logging.LoggingLogger;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.logmanager.config.FilterConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+
+/**
+ * The resource definition for {@code /subsystem=logging/filter=*}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class FilterResourceDefinition extends TransformerResourceDefinition {
+    public static final String NAME = "filter";
+
+    public static final SimpleMapAttributeDefinition CONSTRUCTOR_PROPERTIES = new SimpleMapAttributeDefinition.Builder("constructor-properties", true)
+            .setAllowExpression(true)
+            .setAttributeMarshaller(PropertyAttributeMarshaller.INSTANCE)
+            .setXmlName("constructor-properties")
+            .build();
+
+    private static final PathElement PATH = PathElement.pathElement(NAME);
+
+    private static final AttributeDefinition[] ATTRIBUTES = {
+            CLASS,
+            MODULE,
+            CONSTRUCTOR_PROPERTIES,
+            PROPERTIES,
+    };
+
+
+    /**
+     * A step handler to add a custom filter
+     */
+    private static final OperationStepHandler ADD = new LoggingOperations.LoggingAddOperationStepHandler(ATTRIBUTES) {
+        private final List<String> reservedNames = Arrays.asList(
+                "accept",
+                "deny",
+                "not",
+                "all",
+                "any",
+                "levelChange",
+                "levels",
+                "levelRange",
+                "match",
+                "substitute",
+                "substituteAll"
+        );
+
+        @Override
+        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
+            // Check the name isn't a reserved filter name
+            final String name = context.getCurrentAddressValue();
+            if (reservedNames.contains(name)) {
+                throw LoggingLogger.ROOT_LOGGER.reservedFilterName(name, reservedNames);
+            }
+            // Check the name has no special characters
+            if (!Character.isJavaIdentifierStart(name.charAt(0))) {
+                throw LoggingLogger.ROOT_LOGGER.invalidFilterNameStart(name, name.charAt(0));
+            }
+            for (char c : name.toCharArray()) {
+                if (!Character.isJavaIdentifierPart(c)) {
+                    throw LoggingLogger.ROOT_LOGGER.invalidFilterName(name, c);
+                }
+            }
+            super.populateModel(context, operation, resource);
+        }
+
+        @Override
+        public void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            final String name = context.getCurrentAddressValue();
+            FilterConfiguration configuration = logContextConfiguration.getFilterConfiguration(name);
+            final String className = CLASS.resolveModelAttribute(context, model).asString();
+            final ModelNode moduleNameNode = MODULE.resolveModelAttribute(context, model);
+            final String moduleName = moduleNameNode.isDefined() ? moduleNameNode.asString() : null;
+            final ModelNode properties = PROPERTIES.resolveModelAttribute(context, model);
+            final ModelNode constructorProperties = CONSTRUCTOR_PROPERTIES.resolveModelAttribute(context, model);
+
+            final Map<String, String> constProps = new LinkedHashMap<>();
+            if (constructorProperties.isDefined()) {
+                for (Property property : constructorProperties.asPropertyList()) {
+                    constProps.put(property.getName(), property.getValue().asString());
+                }
+            }
+
+            boolean replaceConfiguration = false;
+            if (configuration != null) {
+                if (!className.equals(configuration.getClassName()) || (moduleName == null ? configuration.getModuleName() != null : !moduleName.equals(configuration.getModuleName()))) {
+                    replaceConfiguration = true;
+                }
+                final List<String> configuredConstProps = configuration.getConstructorProperties();
+                for (Map.Entry<String, String> entry : constProps.entrySet()) {
+                    if (configuredConstProps.contains(entry.getKey())) {
+                        if (!configuration.getPropertyValueString(entry.getKey()).equals(entry.getValue())) {
+                            replaceConfiguration = true;
+                            break;
+                        }
+                    } else {
+                        replaceConfiguration = true;
+                        break;
+                    }
+                }
+            } else {
+                LoggingLogger.ROOT_LOGGER.tracef("Adding filter '%s' at '%s'", name, context.getCurrentAddress());
+                configuration = logContextConfiguration.addFilterConfiguration(moduleName, className, name, constProps.keySet().toArray(new String[0]));
+            }
+            if (replaceConfiguration) {
+                LoggingLogger.ROOT_LOGGER.tracef("Replacing filter '%s' at '%s'", name, context.getCurrentAddress());
+                logContextConfiguration.removeFilterConfiguration(name);
+                configuration = logContextConfiguration.addFilterConfiguration(moduleName, className, name, constProps.keySet().toArray(new String[0]));
+            }
+            for (Map.Entry<String, String> entry : constProps.entrySet()) {
+                configuration.setPropertyValueString(entry.getKey(), entry.getValue());
+            }
+            if (properties.isDefined()) {
+                for (Property property : properties.asPropertyList()) {
+                    configuration.setPropertyValueString(property.getName(), property.getValue().asString());
+                }
+            }
+        }
+    };
+
+    private static final OperationStepHandler WRITE = new LoggingWriteAttributeHandler(ATTRIBUTES) {
+
+        @Override
+        protected boolean applyUpdate(final OperationContext context, final String attributeName, final String addressName, final ModelNode value, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            final FilterConfiguration configuration = logContextConfiguration.getFilterConfiguration(addressName);
+            String modelClass = CLASS.resolveModelAttribute(context, context.readResource(PathAddress.EMPTY_ADDRESS).getModel()).asString();
+            if (PROPERTIES.getName().equals(attributeName) && configuration.getClassName().equals(modelClass)) {
+                if (value.isDefined()) {
+                    for (Property property : value.asPropertyList()) {
+                        configuration.setPropertyValueString(property.getName(), property.getValue().asString());
+                    }
+                } else {
+                    // Remove all current properties
+                    final List<String> names = configuration.getPropertyNames();
+                    for (String name : names) {
+                        configuration.removeProperty(name);
+                    }
+                }
+            }
+
+            // Writing a class attribute or module will require the previous filter to be removed and a new filter
+            // added. This also would require each logger or handler that has the filter assigned to reassign the
+            // filter. The configuration API does not handle this so a reload will be required.
+            return CLASS.getName().equals(attributeName) || MODULE.getName().equals(attributeName) ||
+                    CONSTRUCTOR_PROPERTIES.getName().equals(attributeName);
+        }
+    };
+
+    /**
+     * A step handler to remove
+     */
+    private static final OperationStepHandler REMOVE = new LoggingOperations.LoggingRemoveOperationStepHandler() {
+
+        @Override
+        @SuppressWarnings("Convert2Lambda")
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            super.execute(context, operation);
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                    final Collection<String> references = Filters.getFilterReferences(context.getCurrentAddress());
+                    if (!references.isEmpty()) {
+                        throw LoggingLogger.ROOT_LOGGER.cannotRemoveFilter(context.getCurrentAddressValue(), references);
+                    }
+                }
+            }, OperationContext.Stage.MODEL);
+        }
+
+        @Override
+        public void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            final String name = context.getCurrentAddressValue();
+            final FilterConfiguration configuration = logContextConfiguration.getFilterConfiguration(name);
+            if (configuration == null) {
+                throw LoggingLogger.ROOT_LOGGER.filterNotFound(name);
+            }
+            logContextConfiguration.removeFilterConfiguration(name);
+        }
+    };
+
+    public static final FilterResourceDefinition INSTANCE = new FilterResourceDefinition();
+
+    private FilterResourceDefinition() {
+        super(new Parameters(PATH, LoggingExtension.getResourceDescriptionResolver(NAME))
+                .setAddHandler(ADD)
+                .setRemoveHandler(REMOVE));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        for (AttributeDefinition def : ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(def, null, WRITE);
+        }
+    }
+
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder rootResourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        if (modelVersion == KnownModelVersion.VERSION_8_0_0) {
+            rootResourceBuilder.rejectChildResource(getPathElement());
+            loggingProfileBuilder.rejectChildResource(getPathElement());
+        }
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -758,7 +758,7 @@ public interface LoggingLogger extends BasicLogger {
      * @return an {@link IllegalArgumentException} for the error
      */
     @Message(id = 72, value = "Filter '%s' is not found")
-    IllegalArgumentException filterNotFound(String name);
+    OperationFailedException filterNotFound(String name);
 
     /**
      * Creates an exception indicating an identifier was expected next in the filter expression.
@@ -985,4 +985,48 @@ public interface LoggingLogger extends BasicLogger {
      */
     @Message(id = 94, value = "Formatter name cannot end with '" + PatternFormatterResourceDefinition.DEFAULT_FORMATTER_SUFFIX + "'")
     OperationFailedException illegalFormatterName();
+
+    /**
+     * Creates an exception indicating the name of the filter is a reserved filter name.
+     *
+     * @param name          the invalid name
+     * @param reservedNames the collection of reserved names
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 95, value = "The name %s cannot be used as a filter name as it is a reserved filter name. Reserved names are: %s")
+    OperationFailedException reservedFilterName(String name, Collection<String> reservedNames);
+
+    /**
+     * Creates an exception indicating the name of the filter is a reserved filter name.
+     *
+     * @param name        the invalid name
+     * @param invalidChar the invalid character
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 96, value = "The name %s cannot be used as a filter name as it starts with an invalid character %s")
+    OperationFailedException invalidFilterNameStart(String name, char invalidChar);
+
+    /**
+     * Creates an exception indicating the name of the filter is a reserved filter name.
+     *
+     * @param name        the invalid name
+     * @param invalidChar the invalid character
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 97, value = "The name %s cannot be used as a filter name as it contains an invalid character %s")
+    OperationFailedException invalidFilterName(String name, char invalidChar);
+
+    /**
+     * Creates an exception indicating the filter is assigned to either loggers or handlers.
+     *
+     * @param name       the name of the filter
+     * @param references the loggers and/or handlers the filter is assigned to
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 98, value = "Cannot remove filter %s as it's assigned to: %s")
+    OperationFailedException cannotRemoveFilter(String name, Collection<String> references);
 }

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -745,6 +745,23 @@ logging.custom-formatter.properties=Defines the properties used for the logging 
 logging.custom-formatter.properties.name=Defines the name of the property to set.
 logging.custom-formatter.properties.value=Defines value of the property.
 
+# Custom filter descriptions
+logging.filter=A filter to be used with handlers and loggers. Please note the name of the filter should start with an \
+  alpha character and not contain any special characters. The following names are considered reserved names; \
+  accept, deny, not, all, any, levelChange, levels, levelRange, match, substitute, substituteAll.
+# Operations
+logging.filter.add=Adds a new filter.
+logging.filter.remove=Removes the filter.
+# Attributes
+logging.filter.class=The logging filter class to be used.
+logging.filter.module=The module that the logging filter depends on.
+logging.filter.constructor-properties=Defines the constructor properties used for the logging filter.
+logging.filter.constructor-properties.name=Defines the name of the constructor property to set.
+logging.filter.constructor-properties.value=Defines value of the constructor property.
+logging.filter.properties=Defines the properties used for the logging filter. All properties must be accessible via a setter method.
+logging.filter.properties.name=Defines the name of the property to set.
+logging.filter.properties.value=Defines value of the property.
+
 # Logging Deployment descriptions
 logging.deployment=Information about the logging configuration for this deployment. Note that this may not be accurate \
   if the deployment is using some other means of configuring a log manager such as logback. The resolved configuration \

--- a/logging/src/main/resources/schema/jboss-as-logging_8_0.xsd
+++ b/logging/src/main/resources/schema/jboss-as-logging_8_0.xsd
@@ -50,6 +50,7 @@
             <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
             <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="filter" type="filterType"/>
             <xs:element name="add-logging-api-dependencies" type="booleanTrueValueType">
                 <xs:annotation>
                     <xs:documentation>
@@ -102,6 +103,7 @@
             <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
             <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="filter" type="filterType"/>
         </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
@@ -820,6 +822,23 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="filterType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                Defines a filter to be used to filter log messages.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="constructor-properties" type="propertiesType" minOccurs="0"/>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
 
 </xs:schema>

--- a/logging/src/main/resources/schema/jboss-as-logging_8_0.xsd
+++ b/logging/src/main/resources/schema/jboss-as-logging_8_0.xsd
@@ -1,0 +1,825 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:logging:8.0"
+           xmlns="urn:jboss:domain:logging:8.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="8.0">
+
+    <!-- The logging subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the logging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="socket-handler" type="socketHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="add-logging-api-dependencies" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Determines whether or not the default logging dependencies should be added to deployments during the deployment process.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="use-deployment-logging-config" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Determines whether or not deployments should be scanned for configuration files. If set to
+                        true and a configuration file is found the log manager will be configured based on the
+                        configuration file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profilesType">
+        <xs:annotation>
+            <xs:documentation>
+                Contains a list of profiles available for use in deployments
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="logging-profile" type="logging-profileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profileType">
+        <xs:annotation>
+            <xs:documentation>
+                A logging profile that can be used in a deployment for a custom logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="socket-handler" type="socketHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="refType">
+        <xs:annotation>
+            <xs:documentation>
+                A named reference to another object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlersType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of handlers to apply to the enclosing object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="handler" type="refType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="rootLoggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines the root logger for this log context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all minOccurs="1" maxOccurs="1">
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="handlers" type="handlersType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="loggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a logger category.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="rootLoggerType">
+                <xs:attribute name="use-parent-handlers" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="consoleHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the console.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="target" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="name" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="System.out"/>
+                                <xs:enumeration value="System.err"/>
+                                <xs:enumeration value="console"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="fileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType" minOccurs="1"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a time period derived from the given
+                suffix string, which should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicSizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after the size of the file grows beyond a
+                certain point or the time period derived from the given suffix string and keeping a fixed number of
+                backups. The suffix should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after the size of the file grows beyond a
+                certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="suffix" type="valueType" minOccurs="0"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="asyncHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which
+                introduce a substantial amount of lag.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
+            <xs:element name="subhandlers" type="handlersType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="customHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a custom handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="socketHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a socket.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="named-formatter" type="namedFormatterType"/>
+            <xs:element name="protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="value" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="SSL_TCP"/>
+                                <xs:enumeration value="TCP"/>
+                                <xs:enumeration value="UDP"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" default="true"/>
+        <xs:attribute name="block-on-reconnect" type="xs:boolean" default="false"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+        <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+        <xs:attribute name="ssl-context" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a syslog handler for UNIX/Linux based operating systems.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="server-address" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The address of the syslog server. The default is localhost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hostname" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the host the messages are being sent from. For example the name of the host the
+                        application server is running on.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="port" type="positiveIntType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The port the syslog server is listening on. The default is 514.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="app-name" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The app name used when formatting the message in RFC5424 format. By default the app name is
+                        &quot;java&quot;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="formatter" type="syslogFormatterType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="facility" type="facilityType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="queueLengthType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                    <xs:minExclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="overflowActionType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="block"/>
+                    <xs:enumeration value="discard"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="positiveIntType">
+        <xs:attribute name="value" use="required" type="xs:positiveInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanValueType">
+        <xs:attribute name="value" use="required" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanTrueValueType">
+        <xs:attribute name="value" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="valueType">
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="relative-to" use="optional" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeType">
+        <xs:attribute name="value">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <!-- XSD doesn't allow ^ or $ so ^[0-9]+[bkmgtp]?$ is invalid -->
+                    <xs:pattern value="[0-9]+[bkmgtp]"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="facilityType">
+        <xs:annotation>
+            <xs:documentation>
+                Facility as defined by RFC-5424 (http://tools.ietf.org/html/rfc5424)and RFC-3164
+                (http://tools.ietf.org/html/rfc3164).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="kernel"/>
+                    <xs:enumeration value="user-level"/>
+                    <xs:enumeration value="mail-system"/>
+                    <xs:enumeration value="system-daemons"/>
+                    <xs:enumeration value="security"/>
+                    <xs:enumeration value="syslogd"/>
+                    <xs:enumeration value="line-printer"/>
+                    <xs:enumeration value="network-news"/>
+                    <xs:enumeration value="uucp"/>
+                    <xs:enumeration value="clock-daemon"/>
+                    <xs:enumeration value="security2"/>
+                    <xs:enumeration value="ftp-daemon"/>
+                    <xs:enumeration value="ntp"/>
+                    <xs:enumeration value="log-audit"/>
+                    <xs:enumeration value="log-alert"/>
+                    <xs:enumeration value="clock-daemon2"/>
+                    <xs:enumeration value="local-use-0"/>
+                    <xs:enumeration value="local-use-1"/>
+                    <xs:enumeration value="local-use-2"/>
+                    <xs:enumeration value="local-use-3"/>
+                    <xs:enumeration value="local-use-4"/>
+                    <xs:enumeration value="local-use-5"/>
+                    <xs:enumeration value="local-use-6"/>
+                    <xs:enumeration value="local-use-7"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Formatters -->
+
+    <xs:complexType name="formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                A formatter that can be assigned to a handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
+            <xs:element name="custom-formatter" type="customFormatterType" maxOccurs="1"/>
+            <xs:element name="json-formatter" type="structuredFormatterType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Defines a JSON formatter to be used to format log messages.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="xml-formatter" type="xmlFormatterType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Defines a XML formatter to be used to format log messages.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="handlerPatternFormatterType" maxOccurs="1"/>
+            <xs:element name="named-formatter" type="namedFormatterType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="handlerPatternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="patternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+
+                The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
+                format is level-name:color-name.
+
+                Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred,
+                brightgreen,
+                brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The format pattern as defined in org.jboss.logmanager.formatters.FormatStringParser.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="color-map" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The color-map attribute allows for a comma delimited list of colors to be used for different levels.
+                    The
+                    format is level-name:color-name.
+
+                    Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                    Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred,
+                    brightgreen,
+                    brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="structuredFormatterType">
+        <xs:all>
+            <xs:element name="exception-output-type" type="exceptionOutputType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates how the cause of the logged message, if one is available, will be added to the output.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="record-delimiter" type="valueType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The value to be used to indicate the end of a record. If set to null no delimiter will be used
+                        at the end of the record. The default value is a line feed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="key-overrides" type="keyOverrideType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows the names of the keys or elements for the properties to be overridden.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="meta-data" type="propertiesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the meta data to use in the structured format. Properties will be added to each log message.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="date-format" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The date/time format pattern. The pattern must be a valid
+                    java.time.format.DateTimeFormatter.ofPattern() pattern.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pretty-print" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates whether or not pretty printing should be used when formatting.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="print-details" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets whether or not details should be printed. Printing the details can be expensive as the values
+                    are retrieved from the caller. The details include the source class name, source file name, source
+                    method name and source line number.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="zone-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The zone ID for formatting the date and time. The system default is used if left undefined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="xmlFormatterType">
+        <xs:complexContent>
+            <xs:extension base="structuredFormatterType">
+                <xs:attribute name="namespace-uri" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Allows the namespace to be overridden. If not defined a default will be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="print-namespace" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates whether or no the namespace should be added to each record element.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                Defines a formatter to be used to format log messages.
+
+                Note that most log records are formatted in the printf format. Formatters may require invocation of org.jboss.logmanager.ExtLogRecord#getFormattedMessage() for the message to be properly formatted.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a defined formatter that will be used to format the log message.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="exceptionOutputType">
+        <xs:annotation>
+            <xs:documentation>
+                Set the output type for exceptions. The default is detailed.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="detailed">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be an array of stack trace elements. This will include
+                                suppressed exceptions and the cause of the exception.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="formatted">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be a string representation of the stack trace in a
+                                stackTrace property. The property value is a string created by
+                                Throwable.printStackTrace().
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="detailed-and-formatted">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be a string representation of the stack trace in a
+                                stackTrace property. The property value is a string created by
+                                Throwable.printStackTrace().
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyOverrideType">
+        <xs:attribute name="exception" type="xs:string"/>
+        <xs:attribute name="exception-caused-by" type="xs:string"/>
+        <xs:attribute name="exception-circular-reference" type="xs:string"/>
+        <xs:attribute name="exception-frame" type="xs:string"/>
+        <xs:attribute name="exception-frame-class" type="xs:string"/>
+        <xs:attribute name="exception-frame-line" type="xs:string"/>
+        <xs:attribute name="exception-frame-method" type="xs:string"/>
+        <xs:attribute name="exception-frames" type="xs:string"/>
+        <xs:attribute name="exception-message" type="xs:string"/>
+        <xs:attribute name="exception-reference-id" type="xs:string"/>
+        <xs:attribute name="exception-suppressed" type="xs:string"/>
+        <xs:attribute name="exception-type" type="xs:string"/>
+        <xs:attribute name="host-name" type="xs:string"/>
+        <xs:attribute name="level" type="xs:string"/>
+        <xs:attribute name="logger-class-name" type="xs:string"/>
+        <xs:attribute name="logger-name" type="xs:string"/>
+        <xs:attribute name="mdc" type="xs:string"/>
+        <xs:attribute name="message" type="xs:string"/>
+        <xs:attribute name="ndc" type="xs:string"/>
+        <xs:attribute name="process-id" type="xs:string"/>
+        <xs:attribute name="process-name" type="xs:string"/>
+        <xs:attribute name="record" type="xs:string"/>
+        <xs:attribute name="sequence" type="xs:string"/>
+        <xs:attribute name="source-class-name" type="xs:string"/>
+        <xs:attribute name="source-file-name" type="xs:string"/>
+        <xs:attribute name="source-line-number" type="xs:string"/>
+        <xs:attribute name="source-method-name" type="xs:string"/>
+        <xs:attribute name="source-module-name" type="xs:string"/>
+        <xs:attribute name="source-module-version" type="xs:string"/>
+        <xs:attribute name="stack-trace" type="xs:string"/>
+        <xs:attribute name="thread-id" type="xs:string"/>
+        <xs:attribute name="thread-name" type="xs:string"/>
+        <xs:attribute name="timestamp" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all minOccurs="1" maxOccurs="1">
+            <xs:element name="syslog-format" type="syslogFormatType" maxOccurs="1"/>
+            <xs:element name="named-formatter" type="namedFormatterType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatType">
+        <xs:annotation>
+            <xs:documentation>
+                Formats the log message according to the RFC specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="syslog-type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="RFC5424">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-5424 specification
+                                (http://tools.ietf.org/html/rfc5424#section-6)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="RFC3164">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-3164 specification
+                                (http://tools.ietf.org/html/rfc3164#section-4.1)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/logging/src/main/resources/subsystem-templates/logging.xml
+++ b/logging/src/main/resources/subsystem-templates/logging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.logging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:logging:7.0">
+   <subsystem xmlns="urn:jboss:domain:logging:8.0">
        <?HANDLERS?>
        <periodic-rotating-file-handler name="FILE" autoflush="true">
            <formatter>

--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
+import org.jboss.as.logging.filters.FilterResourceDefinition;
 import org.jboss.as.logging.formatters.CustomFormatterResourceDefinition;
 import org.jboss.as.logging.formatters.PatternFormatterResourceDefinition;
 import org.jboss.as.logging.handlers.AbstractHandlerDefinition;
@@ -596,6 +597,10 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
             } else if (CustomFormatterResourceDefinition.NAME.equals(key1)) {
                 result = LESS;
             } else if (CustomFormatterResourceDefinition.NAME.equals(key2)) {
+                result = GREATER;
+            } else if (FilterResourceDefinition.NAME.equals(key1)) {
+                result = LESS;
+            } else if (FilterResourceDefinition.NAME.equals(key2)) {
                 result = GREATER;
             } else if (RootLoggerResourceDefinition.NAME.equals(key1)) {
                 result = GREATER;

--- a/logging/src/test/java/org/jboss/as/logging/FilterConversionTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/FilterConversionTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.as.logging.filters.Filters;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;

--- a/logging/src/test/java/org/jboss/as/logging/FilterOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/FilterOperationsTestCase.java
@@ -1,0 +1,229 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.logging.filters.FilterResourceDefinition;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.SubsystemOperations;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class FilterOperationsTestCase extends AbstractOperationsTestCase {
+
+    private KernelServices kernelServices;
+
+    @Before
+    public void startTestContainer() throws Exception {
+        kernelServices = boot();
+    }
+
+    @After
+    public void shutdown() {
+        if (kernelServices != null) {
+            kernelServices.shutdown();
+        }
+    }
+
+    @Override
+    protected void standardSubsystemTest(final String configId) {
+        // do nothing as this is not a subsystem parsing test
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("/empty-subsystem.xml");
+    }
+
+    @Test
+    public void testAddFilter() {
+        testAddFilter(null);
+        testAddFilter(PROFILE);
+    }
+
+    @Test
+    public void testLoggerFilter() {
+        testLoggerFilter(null);
+        testLoggerFilter(PROFILE);
+    }
+
+    @Test
+    public void testHandlerFilter() {
+        testHandlerFilter(null);
+        testHandlerFilter(PROFILE);
+    }
+
+    @Test
+    public void testInvalidFilterNames() {
+        executeOperationForFailure(kernelServices,
+                createAddFilterOp(createAddress("filter", "test-filter").toModelNode()));
+        executeOperationForFailure(kernelServices,
+                createAddFilterOp(createAddress("filter", "0test").toModelNode()));
+        executeOperationForFailure(kernelServices,
+                createAddFilterOp(createAddress("filter", "levelRange").toModelNode()));
+    }
+
+    @Test
+    public void testFilterRemoveFailure() {
+        testFilterRemoveFailure(null);
+        testFilterRemoveFailure(PROFILE);
+    }
+
+    private void testAddFilter(final String profileName) {
+        final ModelNode address = createAddress(profileName, "filter", "test").toModelNode();
+        executeOperation(kernelServices, createAddFilterOp(address));
+
+        final ModelNode constructorProperties = new ModelNode().setEmptyObject();
+        constructorProperties.get("constructorText").set(" | constructor property text");
+        testWrite(kernelServices, address, FilterResourceDefinition.CONSTRUCTOR_PROPERTIES, constructorProperties);
+
+        final ModelNode properties = new ModelNode().setEmptyObject();
+        properties.get("propertyText").set(" | property text");
+        testWrite(kernelServices, address, CommonAttributes.PROPERTIES, properties);
+
+        // These should likely be tests last as they are not valid values
+        testWrite(kernelServices, address, CommonAttributes.MODULE, "org.jboss.as.logging.changed");
+        testWrite(kernelServices, address, CommonAttributes.CLASS, "org.jboss.as.logging.test.ChangedFilter");
+
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
+        verifyRemoved(kernelServices, address);
+    }
+
+    private void testLoggerFilter(final String profileName) {
+        CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        final ModelNode filterAddress = createAddress(profileName, "filter", "test").toModelNode();
+        builder.addStep(createAddFilterOp(filterAddress));
+
+        // Add to the root logger
+        final ModelNode rootLoggerAddress = createRootLoggerAddress(profileName).toModelNode();
+        ModelNode op = SubsystemOperations.createAddOperation(rootLoggerAddress);
+        op.get("filter-spec").set("test");
+        builder.addStep(op);
+
+        // Add to a logger
+        final ModelNode loggerAddress = createLoggerAddress(profileName, "org.jboss.as.logging").toModelNode();
+        op = SubsystemOperations.createAddOperation(loggerAddress);
+        op.get("filter-spec").set("any(test, accept, match(\".*\"))");
+        builder.addStep(op);
+
+        executeOperation(kernelServices, builder.build().getOperation());
+
+        testWrite(kernelServices, rootLoggerAddress, CommonAttributes.FILTER_SPEC, "all(accept, test)");
+        testWrite(kernelServices, loggerAddress, CommonAttributes.FILTER_SPEC, "test");
+
+        executeOperationForFailure(kernelServices, SubsystemOperations.createRemoveOperation(filterAddress));
+
+        // Remove the loggers, then the filter
+        builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createRemoveOperation(rootLoggerAddress));
+        builder.addStep(Operations.createRemoveOperation(loggerAddress));
+        builder.addStep(Operations.createRemoveOperation(filterAddress));
+        executeOperation(kernelServices, builder.build().getOperation());
+        verifyRemoved(kernelServices, filterAddress);
+    }
+
+    private void testHandlerFilter(final String profileName) {
+        CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        final ModelNode filterAddress = createAddress(profileName, "filter", "test").toModelNode();
+        ModelNode op = SubsystemOperations.createAddOperation(filterAddress);
+        op.get("module").set("org.jboss.as.logging.test");
+        op.get("class").set(TestFilter.class.getName());
+        builder.addStep(op);
+
+        // Add to the root logger
+        final ModelNode handlerAddress = createConsoleHandlerAddress(profileName, "CONSOLE").toModelNode();
+        op = SubsystemOperations.createAddOperation(handlerAddress);
+        op.get("filter-spec").set("test");
+        builder.addStep(op);
+
+        executeOperation(kernelServices, builder.build().getOperation());
+
+        testWrite(kernelServices, handlerAddress, CommonAttributes.FILTER_SPEC, "all(levels(DEBUG, INFO, WARN, ERROR), test)");
+
+        executeOperationForFailure(kernelServices, SubsystemOperations.createRemoveOperation(filterAddress));
+
+        // Remove the loggers, then the filter
+        builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createRemoveOperation(handlerAddress));
+        builder.addStep(Operations.createRemoveOperation(filterAddress));
+        executeOperation(kernelServices, builder.build().getOperation());
+        verifyRemoved(kernelServices, filterAddress);
+    }
+
+    private void testFilterRemoveFailure(final String profileName) {
+        CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        final ModelNode filterAddress = createAddress(profileName, "filter", "test").toModelNode();
+        ModelNode op = SubsystemOperations.createAddOperation(filterAddress);
+        op.get("module").set("org.jboss.as.logging.test");
+        op.get("class").set(TestFilter.class.getName());
+        builder.addStep(op);
+
+        // Add to the root logger
+        final ModelNode handlerAddress = createConsoleHandlerAddress(profileName, "CONSOLE").toModelNode();
+        op = SubsystemOperations.createAddOperation(handlerAddress);
+        op.get("filter-spec").set("test");
+        builder.addStep(op);
+
+        // Add to a logger
+        final ModelNode loggerAddress = createLoggerAddress(profileName, "org.jboss.as.logging").toModelNode();
+        op = SubsystemOperations.createAddOperation(loggerAddress);
+        op.get("filter-spec").set("any(test, accept, match(\".*\"))");
+        builder.addStep(op);
+
+        executeOperation(kernelServices, builder.build().getOperation());
+
+        // Remove the filter, then the filter from the handler which should fail
+        builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createRemoveOperation(filterAddress));
+        builder.addStep(Operations.createRemoveOperation(handlerAddress));
+        executeOperationForFailure(kernelServices, builder.build().getOperation());
+
+        // Remove the filter, then the filter from the logger which should fail
+        builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createRemoveOperation(filterAddress));
+        builder.addStep(Operations.createRemoveOperation(loggerAddress));
+        executeOperationForFailure(kernelServices, builder.build().getOperation());
+
+
+        builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createRemoveOperation(loggerAddress));
+        builder.addStep(Operations.createRemoveOperation(handlerAddress));
+        builder.addStep(Operations.createRemoveOperation(filterAddress));
+        executeOperation(kernelServices, builder.build().getOperation());
+    }
+
+    private static ModelNode createAddFilterOp(final ModelNode address) {
+        final ModelNode op = SubsystemOperations.createAddOperation(address);
+        op.get("module").set("org.jboss.as.logging.test");
+        op.get("class").set(TestFilter.class.getName());
+        return op;
+    }
+}

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -169,7 +169,11 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                         .addFailedAttribute(loggingProfileAddress.append("socket-handler"),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE)
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("syslog-handler"),
-                                new NewAttributesConfig(SyslogHandlerResourceDefinition.NAMED_FORMATTER)));
+                                new NewAttributesConfig(SyslogHandlerResourceDefinition.NAMED_FORMATTER))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("filter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("filter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
     @Test
@@ -196,7 +200,34 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("socket-handler"),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE)
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("syslog-handler"),
-                                new NewAttributesConfig(SyslogHandlerResourceDefinition.NAMED_FORMATTER)));
+                                new NewAttributesConfig(SyslogHandlerResourceDefinition.NAMED_FORMATTER))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("filter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("filter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
+    }
+
+    @Test
+    public void testTransformersEAP720() throws Exception {
+        testEap7Transformer(ModelTestControllerVersion.EAP_7_2_0, ModelVersion.create(7, 0, 0), readResource("/logging_6_0.xml"));
+    }
+
+    @Test
+    public void testFailedTransformersEAP720() throws Exception {
+        final ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.EAP_7_2_0;
+        final ModelVersion modelVersion = ModelVersion.create(7, 0, 0);
+
+        // Test against current
+        testEap7FailedTransformers(controllerVersion, modelVersion, readResource("/expressions.xml"),
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("syslog-handler"),
+                                new NewAttributesConfig(SyslogHandlerResourceDefinition.NAMED_FORMATTER))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("syslog-handler"),
+                                new NewAttributesConfig(SyslogHandlerResourceDefinition.NAMED_FORMATTER))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("filter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("filter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
     private void testEap7Transformer(final ModelTestControllerVersion controllerVersion, final ModelVersion legacyModelVersion, final String subsystemXml, final ModelFixer... modelFixers) throws Exception {

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -72,7 +72,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/jboss-as-logging_7_0.xsd";
+        return "schema/jboss-as-logging_8_0.xsd";
     }
 
     @Test

--- a/logging/src/test/java/org/jboss/as/logging/LoggingTestEnvironment.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingTestEnvironment.java
@@ -94,6 +94,8 @@ class LoggingTestEnvironment extends AdditionalInitialization implements Seriali
     @Override
     protected void setupController(final ControllerInitializer controllerInitializer) {
         super.setupController(controllerInitializer);
+        System.setProperty("jboss.server.log.dir", logDir.toAbsolutePath().toString());
+        System.setProperty("jboss.server.config.dir", configDir.toAbsolutePath().toString());
         controllerInitializer.addPath("jboss.server.log.dir", logDir.toAbsolutePath().toString(), null);
         controllerInitializer.addPath("jboss.server.config.dir", configDir.toAbsolutePath().toString(), null);
         if (runningMode == RunningMode.NORMAL) {

--- a/logging/src/test/java/org/jboss/as/logging/TestFilter.java
+++ b/logging/src/test/java/org/jboss/as/logging/TestFilter.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging;
+
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class TestFilter implements Filter {
+    private final String constructorText;
+    private final boolean isLoggable;
+    private String propertyText;
+
+    public TestFilter() {
+        this(null, true);
+    }
+
+    public TestFilter(final boolean isLoggable) {
+        this(null, isLoggable);
+    }
+
+    public TestFilter(final String constructorText) {
+        this(constructorText, true);
+    }
+
+    public TestFilter(final String constructorText, final boolean isLoggable) {
+        this.constructorText = constructorText;
+        this.isLoggable = isLoggable;
+    }
+
+    @Override
+    public boolean isLoggable(final LogRecord record) {
+        if (isLoggable) {
+            final StringBuilder newMsg = new StringBuilder(ExtLogRecord.wrap(record).getFormattedMessage());
+            if (constructorText != null) {
+                newMsg.append(constructorText);
+            }
+            if (propertyText != null) {
+                newMsg.append(propertyText);
+            }
+            record.setMessage(newMsg.toString());
+        }
+        return isLoggable;
+    }
+
+    public String getPropertyText() {
+        return propertyText;
+    }
+
+    public void setPropertyText(final String propertyText) {
+        this.propertyText = propertyText;
+    }
+
+    public String getConstructorText() {
+        return constructorText;
+    }
+
+    @Override
+    public String toString() {
+        return TestFilter.class.getName() +
+                "[constructorText=" + constructorText +
+                ", isLoggable=" + isLoggable +
+                ", propertyText=" + propertyText +
+                "]";
+    }
+}

--- a/logging/src/test/modules/javax/json/api/main/module.xml
+++ b/logging/src/test/modules/javax/json/api/main/module.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.6" name="javax.json.api">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <resources>
+        <artifact name="javax.json:javax.json-api:${version.javax.json.javax-json-api}"/>
+    </resources>
+    <dependencies>
+        <!--
+            This is required as a circular dependency because the RI does not include a META-INF/services provider file.
+            It must also be exported so that modules that depend on the API, e.g. deployments, will be able to see the
+            implementation.
+        -->
+        <module name="org.glassfish.javax.json" export="true"/>
+    </dependencies>
+</module>

--- a/logging/src/test/modules/org/glassfish/javax/json/main/module.xml
+++ b/logging/src/test/modules/org/glassfish/javax/json/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.6" name="org.glassfish.javax.json">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.json.api" />
+    </dependencies>
+    <resources>
+        <artifact name="org.glassfish:javax.json:${version.org.glassfish.javax.json}"/>
+    </resources>
+
+</module>

--- a/logging/src/test/modules/org/jboss/as/logging/test/main/module.xml
+++ b/logging/src/test/modules/org/jboss/as/logging/test/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.logging.test">
+    <resources>
+        <resource-root path="${test.class.path}"/>
+    </resources>
+
+    <dependencies>
+        <!-- for java.beans -->
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="org.jboss.logmanager"/>
+    </dependencies>
+</module>

--- a/logging/src/test/modules/org/jboss/logging/main/module.xml
+++ b/logging/src/test/modules/org/jboss/logging/main/module.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging">
+    <resources>
+        <artifact name="org.jboss.logging:jboss-logging:${version.org.jboss.logging}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.logmanager"/>
+    </dependencies>
+</module>

--- a/logging/src/test/modules/org/jboss/logmanager/main/module.xml
+++ b/logging/src/test/modules/org/jboss/logmanager/main/module.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.logmanager">
+    <resources>
+        <artifact name="org.jboss.logmanager:jboss-logmanager:${version.org.jboss.logmanager.jboss-logmanager}"/>
+    </resources>
+
+    <dependencies>
+        <!-- for java.beans -->
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="javax.json.api"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.wildfly.common"/>
+    </dependencies>
+</module>

--- a/logging/src/test/modules/org/wildfly/common/main/module.xml
+++ b/logging/src/test/modules/org/wildfly/common/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.wildfly.common">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="org.wildfly.common:wildfly-common:${version.org.wildfly.common}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.management"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/logging/src/test/resources/default-subsystem.xml
+++ b/logging/src/test/resources/default-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:7.0">
+<subsystem xmlns="urn:jboss:domain:logging:8.0">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>

--- a/logging/src/test/resources/empty-subsystem.xml
+++ b/logging/src/test/resources/empty-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:7.0">
+<subsystem xmlns="urn:jboss:domain:logging:8.0">
 
     <!-- Set-up a default logging profile -->
     <logging-profiles>

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -160,6 +160,15 @@
         </xml-formatter>
     </formatter>
 
+    <filter module="org.jboss.as.logging.test" class="org.jboss.as.logging.TestFilter" name="testFilter">
+        <constructor-properties>
+            <property name="constructorText" value="${test.filter.constructor.value:cText}"/>
+        </constructor-properties>
+        <properties>
+            <property name="propertyText" value="${test.filter.property.value:text}"/>
+        </properties>
+    </filter>
+
     <logging-profiles>
         <logging-profile name="test-profile">
 
@@ -246,6 +255,15 @@
             <formatter name="PATTERN">
                 <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
             </formatter>
+
+            <filter module="org.jboss.as.logging.test" class="org.jboss.as.logging.TestFilter" name="testProfileFilter">
+                <constructor-properties>
+                    <property name="constructorText" value="${test.filter.profile.constructor.value:pcText}"/>
+                </constructor-properties>
+                <properties>
+                    <property name="propertyText" value="${test.filter.profile.property.value:pText}"/>
+                </properties>
+            </filter>
         </logging-profile>
     </logging-profiles>
 </subsystem>

--- a/logging/src/test/resources/expressions_7_0.xml
+++ b/logging/src/test/resources/expressions_7_0.xml
@@ -1,26 +1,23 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
   ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
   ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:8.0">
+<subsystem xmlns="urn:jboss:domain:logging:7.0">
     <add-logging-api-dependencies value="${test.add.deps:true}"/>
     <use-deployment-logging-config value="${test.use.dep.config:true}"/>
 

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -183,6 +183,15 @@
         </xml-formatter>
     </formatter>
 
+    <filter module="org.jboss.as.logging.test" class="org.jboss.as.logging.TestFilter" name="testFilter">
+        <constructor-properties>
+            <property name="constructorText" value=" | test constructor value"/>
+        </constructor-properties>
+        <properties>
+            <property name="propertyText" value=" | test property value"/>
+        </properties>
+    </filter>
+
     <logging-profiles>
         <logging-profile name="test-profile">
 
@@ -270,6 +279,15 @@
             <formatter name="PATTERN">
                 <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan"/>
             </formatter>
+
+            <filter module="org.jboss.as.logging.test" class="org.jboss.as.logging.TestFilter" name="testProfileFilter">
+                <constructor-properties>
+                    <property name="constructorText" value=" | test constructor value in profile"/>
+                </constructor-properties>
+                <properties>
+                    <property name="propertyText" value=" | test property value in profile"/>
+                </properties>
+            </filter>
         </logging-profile>
     </logging-profiles>
 </subsystem>

--- a/logging/src/test/resources/logging_7_0.xml
+++ b/logging/src/test/resources/logging_7_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:8.0">
+<subsystem xmlns="urn:jboss:domain:logging:7.0">
     <add-logging-api-dependencies value="false"/>
     <use-deployment-logging-config value="false"/>
 

--- a/logging/src/test/resources/operations.xml
+++ b/logging/src/test/resources/operations.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:logging:7.0">
+<subsystem xmlns="urn:jboss:domain:logging:8.0">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>

--- a/logging/src/test/resources/rollback-logging.xml
+++ b/logging/src/test/resources/rollback-logging.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:7.0">
+<subsystem xmlns="urn:jboss:domain:logging:8.0">
 
     <console-handler name="CONSOLE">
         <level name="INFO"/>

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:7.0">
+<subsystem xmlns="urn:jboss:domain:logging:8.0">
 
     <file-handler name="FILE" autoflush="true">
         <formatter>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/TestFilter.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/TestFilter.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging;
+
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class TestFilter implements Filter {
+    private final String constructorText;
+    private final boolean isLoggable;
+    private String propertyText;
+
+    public TestFilter() {
+        this(null, true);
+    }
+
+    public TestFilter(final boolean isLoggable) {
+        this(null, isLoggable);
+    }
+
+    public TestFilter(final String constructorText) {
+        this(constructorText, true);
+    }
+
+    public TestFilter(final String constructorText, final boolean isLoggable) {
+        this.constructorText = constructorText;
+        this.isLoggable = isLoggable;
+    }
+
+    @Override
+    public boolean isLoggable(final LogRecord record) {
+        if (isLoggable) {
+            final StringBuilder newMsg = new StringBuilder(ExtLogRecord.wrap(record).getFormattedMessage());
+            if (constructorText != null) {
+                newMsg.append(constructorText);
+            }
+            if (propertyText != null) {
+                newMsg.append(propertyText);
+            }
+            record.setMessage(newMsg.toString());
+        }
+        return isLoggable;
+    }
+
+    public String getPropertyText() {
+        return propertyText;
+    }
+
+    public void setPropertyText(final String propertyText) {
+        this.propertyText = propertyText;
+    }
+
+    public String getConstructorText() {
+        return constructorText;
+    }
+
+    @Override
+    public String toString() {
+        return TestFilter.class.getName() +
+                "[constructorText=" + constructorText +
+                ", isLoggable=" + isLoggable +
+                ", propertyText=" + propertyText +
+                "]";
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/filters/FilterTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/filters/FilterTestCase.java
@@ -1,0 +1,305 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging.filters;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.logging.TestFilter;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Tests user defined filters in the logging subsystem.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(WildflyTestRunner.class)
+public class FilterTestCase extends AbstractLoggingTestCase {
+
+    private static final String FILE_NAME = "json-file-filter.log";
+    private static final String JSON_HANDLER_NAME = "test-handler";
+    private static final String JSON_FORMATTER_NAME = "json";
+    private static final String FILTER_NAME = "testFilter";
+    private static final ModelNode HANDLER_ADDRESS = createAddress("file-handler", JSON_HANDLER_NAME);
+    private static final ModelNode FORMATTER_ADDRESS = createAddress("json-formatter", JSON_FORMATTER_NAME);
+    private static final ModelNode LOGGER_ADDRESS = createAddress("logger", LoggingServiceActivator.LOGGER.getName());
+    private static final ModelNode FILTER_ADDRESS = createAddress("filter", FILTER_NAME);
+
+    private Path logFile = null;
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        createModule();
+        deploy(createDeployment(), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Before
+    public void setLogFile() {
+        if (logFile == null) {
+            logFile = getAbsoluteLogFilePath(FILE_NAME);
+        }
+    }
+
+    @After
+    public void remove() throws Exception {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create()
+                // Remove the logger
+                .addStep(Operations.createRemoveOperation(LOGGER_ADDRESS))
+                // Remove the file handler
+                .addStep(Operations.createRemoveOperation(HANDLER_ADDRESS))
+                // Remove the formatter
+                .addStep(Operations.createRemoveOperation(FORMATTER_ADDRESS))
+                // Remove the filter
+                .addStep(Operations.createRemoveOperation(FILTER_ADDRESS));
+
+        executeOperation(builder.build());
+    }
+
+    @Test
+    public void testHandlerFilter() throws Exception {
+        configure(null, FILTER_NAME);
+        final String msg = "Test handler filter";
+        final String expectedMsg = msg + " | constructor text | property text";
+        test(msg, expectedMsg);
+    }
+
+    @Test
+    public void testNestedHandlerFilter() throws Exception {
+        configure(null, "any(deny, " + FILTER_NAME + ")");
+        final String msg = "Test nested handler allowed filter";
+        final String expectedMsg = msg + " | constructor text | property text";
+        test(msg, expectedMsg);
+    }
+
+    @Test
+    public void testNestedHandlerDenyFilter() throws Exception {
+        configure(null, "all(" + FILTER_NAME + ", deny)");
+        final String msg = "Test handler no log filter";
+        test(msg, null);
+    }
+
+    @Test
+    public void testLoggerFilter() throws Exception {
+        configure(FILTER_NAME, null);
+        final String msg = "Test logger filter";
+        final String expectedMsg = msg + " | constructor text | property text";
+        test(msg, expectedMsg);
+    }
+
+    @Test
+    public void testNestedLoggerFilter() throws Exception {
+        configure("any(deny, " + FILTER_NAME + ")", null);
+        final String msg = "Test nexted logger logged filter";
+        final String expectedMsg = msg + " | constructor text | property text";
+        test(msg, expectedMsg);
+    }
+
+    @Test
+    public void testNestedLoggerDenyFilter() throws Exception {
+        configure("all(" + FILTER_NAME + ", deny)", null);
+        final String msg = "Test logger no log filter";
+        test(msg, null);
+    }
+
+    @Test
+    public void testLoggerAndHandlerFilter() throws Exception {
+        configure(FILTER_NAME, FILTER_NAME);
+        final String msg = "Test handler filter";
+        final String expectedMsg = msg + " | constructor text | property text | constructor text | property text";
+        test(msg, expectedMsg);
+    }
+
+    @Test
+    public void testNestedLoggerAndHandlerFilter() throws Exception {
+        configure("any(deny, " + FILTER_NAME + ")", "any(" + FILTER_NAME + ", deny)");
+        final String msg = "Test handler filter";
+        final String expectedMsg = msg + " | constructor text | property text | constructor text | property text";
+        test(msg, expectedMsg);
+    }
+
+    @Test
+    public void testLoggerAndHandlerPropertyChangeFilter() throws Exception {
+        configure(FILTER_NAME, FILTER_NAME);
+        final String msg = "Test handler filter";
+        String expectedMsg = msg + " | constructor text | property text | constructor text | property text";
+        final int offset = test(msg, expectedMsg);
+
+        final String changedPropertyMsg = " | changed text";
+        final ModelNode properties = new ModelNode().setEmptyObject();
+        properties.get("propertyText").set(changedPropertyMsg);
+        final ModelNode op = Operations.createWriteAttributeOperation(FILTER_ADDRESS, "properties", properties);
+        executeOperation(op);
+        expectedMsg = msg + " | constructor text | changed text | constructor text | changed text";
+        test(msg, expectedMsg, offset);
+    }
+
+    @Test
+    public void testLoggerAndHandlerConstructorChangeFilter() throws Exception {
+        configure(FILTER_NAME, FILTER_NAME);
+        final String msg = "Test handler filter";
+        String expectedMsg = msg + " | constructor text | property text | constructor text | property text";
+        final int offset = test(msg, expectedMsg);
+
+        final String changedPropertyMsg = " | changed text";
+        final ModelNode properties = new ModelNode().setEmptyObject();
+        properties.get("constructorText").set(changedPropertyMsg);
+        final ModelNode op = Operations.createWriteAttributeOperation(FILTER_ADDRESS, "constructor-properties", properties);
+        executeOperation(Operation.Factory.create(op), true);
+        expectedMsg = msg + " | changed text | property text | changed text | property text";
+        test(msg, expectedMsg, offset);
+    }
+
+    private int test(final String msg, final String expectedMsg) throws IOException {
+        return test(msg, expectedMsg, 0);
+    }
+
+    private int test(final String msg, final String expectedMsg, final int offset) throws IOException {
+        int linesRead = 0;
+        final int statusCode = getResponse(msg);
+        Assert.assertEquals("Invalid response statusCode: " + statusCode, statusCode, HttpStatus.SC_OK);
+
+        // Validate each line
+        final List<String> jsonLines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        if (expectedMsg == null) {
+            Assert.assertTrue("Expected no lines, but got: " + jsonLines, jsonLines.isEmpty());
+        } else {
+            for (String s : jsonLines.subList(offset, jsonLines.size())) {
+                linesRead++;
+                if (s.trim().isEmpty()) continue;
+                try (JsonReader reader = Json.createReader(new StringReader(s))) {
+                    final JsonObject json = reader.readObject();
+                    Assert.assertEquals(expectedMsg, json.getString("message"));
+                }
+            }
+        }
+        return linesRead;
+    }
+
+    private void configure(final String loggerFilter, final String handlerFilter) throws IOException {
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        // Create a JSON formatter
+        ModelNode op = Operations.createAddOperation(FORMATTER_ADDRESS);
+        // This should always be false so that the each line will be a separate entry since we're writing to a file
+        op.get("pretty-print").set(false);
+        builder.addStep(op);
+
+        // Create the filter
+        op = Operations.createAddOperation(FILTER_ADDRESS);
+        op.get("module").set("org.jboss.as.logging.test");
+        op.get("class").set(TestFilter.class.getName());
+        ModelNode constructorProperties = op.get("constructor-properties").setEmptyObject();
+        constructorProperties.get("constructorText").set(" | constructor text");
+        ModelNode properties = op.get("properties").setEmptyObject();
+        properties.get("propertyText").set(" | property text");
+        builder.addStep(op);
+
+        // Create the handler
+        op = Operations.createAddOperation(HANDLER_ADDRESS);
+        final ModelNode fileNode = op.get("file").setEmptyObject();
+        fileNode.get("relative-to").set("jboss.server.log.dir");
+        fileNode.get("path").set(logFile.getFileName().toString());
+        op.get("autoFlush").set(true);
+        op.get("append").set(false);
+        op.get("named-formatter").set(JSON_FORMATTER_NAME);
+        if (handlerFilter != null) {
+            op.get("filter-spec").set(handlerFilter);
+        }
+        builder.addStep(op);
+
+        // Add the handler to the root-logger
+        op = Operations.createAddOperation(LOGGER_ADDRESS);
+        op.get("handlers").setEmptyList().add(JSON_HANDLER_NAME);
+        if (loggerFilter != null) {
+            op.get("filter-spec").set(loggerFilter);
+        }
+        builder.addStep(op);
+
+        executeOperation(builder.build());
+    }
+
+    private static void createModule() {
+        final String jbossHome = WildFlySecurityManager.getPropertyPrivileged("jboss.home", ".");
+        final Path modulesDir = Paths.get(jbossHome, "modules");
+        Assert.assertTrue("Could not find modules directory: " + modulesDir, Files.exists(modulesDir));
+        // Create an archive for the module
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "logging-test.jar")
+                .addClasses(TestFilter.class);
+
+        final Path testModule = Paths.get(modulesDir.toString(), "org", "jboss", "as", "logging", "test", "main");
+        try {
+            Files.createDirectories(testModule);
+            try (
+                    BufferedInputStream in = new BufferedInputStream(AbstractLoggingTestCase.class.getResourceAsStream("module.xml"));
+                    BufferedOutputStream out = new BufferedOutputStream(Files.newOutputStream(testModule.resolve("module.xml")))
+            ) {
+                final byte[] buffer = new byte[512];
+                int len;
+                while ((len = in.read(buffer)) > 0) {
+                    out.write(buffer, 0, len);
+                }
+            }
+
+            // Copy the JAR
+            try (OutputStream out = Files.newOutputStream(testModule.resolve("logging-test.jar"), StandardOpenOption.CREATE_NEW)) {
+                jar.as(ZipExporter.class).exportTo(out);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/module.xml
+++ b/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.logging.test">
+    <resources>
+        <resource-root path="logging-test.jar"/>
+    </resources>
+
+    <dependencies>
+        <!-- for java.beans -->
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="org.jboss.logmanager"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFCORE-4336
Model Upgrade JIRA: https://issues.jboss.org/browse/WFCORE-4591
Feature JIRA: https://issues.jboss.org/browse/EAP7-1199

For testing with the subsystem tests I added some modules to the subsystem test resources. I'm not sure whether or not this was a good idea as these will require maintenance. However there is a potential to catch issues with unit tests which seems like a decent trade-off for now.

For the integration test I also add a module. I didn't see, or I'm unaware of, a standard way of doing this. If I missed that please let me know and I'll fix it.

I also went with using two attributes `constructor-properties` and `properties` for configuring the filter. I had considered `properties` with a boolean to indicate whether or not this was a constructor property, however this seemed less user friendly as the stand key/value pair properties are already widely used and likely understood.