### PR TITLE
[WFCORE-4597] Use PhaseContext target to start external module spec services being tracked by the stability monitor

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/ManifestClassPathProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ManifestClassPathProcessor.java
@@ -155,7 +155,7 @@ public final class ManifestClassPathProcessor implements DeploymentUnitProcessor
                 final VirtualFile topLevelClassPathFile = deploymentRoot.getRoot().getParent().getChild(item);
                 if (item.startsWith("/")) {
                     if (externalModuleService.isValid(item)) {
-                        final ModuleIdentifier moduleIdentifier = externalModuleService.addExternalModule(item);
+                        final ModuleIdentifier moduleIdentifier = externalModuleService.addExternalModule(item, phaseContext.getServiceRegistry(), phaseContext.getServiceTarget());
                         target.addToAttachmentList(Attachments.CLASS_PATH_ENTRIES, moduleIdentifier);
                         ServerLogger.DEPLOYMENT_LOGGER.debugf("Resource %s added as external jar %s", classPathFile, resourceRoot.getRoot());
                     } else {


### PR DESCRIPTION
Spec module services for external modules were not being tracked by the container stability monitor checked after the management operations. Rarely, this was throwing missing service errors.

Using PhaseContext service target we are ensuring the spec services are tracked and then the stability monitor will wait for them until their start.

Jira issue: https://issues.jboss.org/browse/WFCORE-4597