### PR TITLE
[WFCORE-4629] Upgrading JBoss MSC to 1.4.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.4.8.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.4.9.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.14.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
Incorporates:
 * [MSC-247] Allow also provided not just aliased services to be accessible
 * [MSC-248] Fix Suplier.get() lock contention
 * [MSC-250] StabilityMonitor problematic and failed services are improperly reported