### PR TITLE
[WFCORE-4634] Upgrade WildFly Elytron to 1.10.0.CR6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.0.CR5</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.0.CR6</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4634


        Release Notes - WildFly Elytron - Version 1.10.0.CR6
                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1829'>ELY-1829</a>] -         Need to use principal-transformer in aggregate-realm in between authentication-realm and authorization-realm
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1862'>ELY-1862</a>] -         Fix infinite loop in SecurityEventVisitor#handleSyslogAuditEvent
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1864'>ELY-1864</a>] -         UDP reconnect should not endlessly loop and attempt to resend the message
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1865'>ELY-1865</a>] -         Release WildFly Elytron 1.10.0.CR6
</li>
</ul>
                    