### PR TITLE
[WFCORE-4368] / [WFCORE-4369] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.0.CR6</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.10.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.6.0.CR1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.6.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4638
https://issues.jboss.org/browse/WFCORE-4639


        Release Notes - WildFly Elytron - Version 1.10.0.Final
                                                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1870'>ELY-1870</a>] -         Upgrade dependencies to match WildFly Core
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1871'>ELY-1871</a>] -         Release WildFly Elytron 1.10.0.Final
</li>
</ul>
            

        Release Notes - Elytron Web - Version 1.6.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-63'>ELYWEB-63</a>] -         Upgrade WildFly Elytron to 1.10.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-64'>ELYWEB-64</a>] -         Bring the dependency versions in-line with WildFly Core
</li>
</ul>
                                                                                                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-65'>ELYWEB-65</a>] -         Release Elytron Web 1.6.0.Final
</li>
</ul>
                    