### PR TITLE
[WFCORE-4375] Implement a different comparator loading the jar files

### DIFF
--- a/server/src/main/java/org/jboss/as/server/moduleservice/ExternalModuleSpecService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ExternalModuleSpecService.java
@@ -236,46 +236,56 @@ public class ExternalModuleSpecService implements Service<ModuleDefinition> {
 
         @Override
         public int compare(Path path1, Path path2) {
-            if (path1 == null && path2 != null ) return -1;
-            if (path1 != null && path2 == null ) return 1;
-            if (path1 == null && path2 == null ) return 0;
+            if (path1 == null && path2 != null) return -1;
+            if (path1 != null && path2 == null) return 1;
+            if (path1 == null && path2 == null) return 0;
 
             Path parentPath1 = path1.getParent();
             Path parentPath2 = path2.getParent();
 
-            if (parentPath1 == null && parentPath2 != null ) return -1;
-            if (parentPath1 != null && parentPath2 == null ) return 1;
-            if (parentPath1 == null && parentPath2 == null ) return 0;
+            if (parentPath1 == null && parentPath2 != null) return -1;
+            if (parentPath1 != null && parentPath2 == null) return 1;
+            if (parentPath1 == null && parentPath2 == null) return 0;
 
             int path1Count = parentPath1.getNameCount();
             int path2Count = parentPath2.getNameCount();
 
             if (path1Count < path2Count) {
-                if ( path1Count == 0 ) return -1;
+                if (path1Count == 0) return -1;
                 Path sameLevel = parentPath2.getRoot().resolve(parentPath2.subpath(0, path1Count));
-                int comparison = ignoreSeparator(parentPath1).compareTo(ignoreSeparator(sameLevel));
+                int comparison = compareBySameLevel(parentPath1, sameLevel);
                 return comparison == 0 ? -1 : comparison;
             }
 
             if (path2Count < path1Count) {
-                if ( path2Count == 0 ) return -1;
+                if (path2Count == 0) return 1;
                 Path sameLevel = parentPath1.getRoot().resolve(parentPath1.subpath(0, path2Count));
-                int comparison = ignoreSeparator(sameLevel).compareTo(ignoreSeparator(parentPath2));
+                int comparison = compareBySameLevel(sameLevel, parentPath2);
                 return comparison == 0 ? 1 : comparison;
             }
 
-            return ignoreSeparator(path1).compareTo(ignoreSeparator(path2));
-        }
-
-        private String ignoreSeparator(Path path){
-            StringBuilder sb = new StringBuilder();
-            Iterator<Path> iterator = path.iterator();
-            while(iterator.hasNext()) {
-                sb.append(iterator.next());
+            if (path2Count == path1Count) {
+                int comparison = compareBySameLevel(parentPath1, parentPath2);
+                if (comparison != 0) {
+                    return comparison;
+                }
             }
-            return sb.toString();
+
+            return path1.getFileName().compareTo(path2.getFileName());
         }
 
+        private int compareBySameLevel(Path path1, Path path2) {
+            int i = 0;
+            int comparison = 0;
+            for (Iterator<Path> iterPath1 = path1.iterator(); iterPath1.hasNext(); i++) {
+                Path levelPath1 = iterPath1.next();
+                Path levelPath2 = path2.getName(i);
+                comparison = levelPath1.compareTo(levelPath2);
+                if (comparison!=0) {
+                    break;
+                }
+            }
+            return comparison;
+        }
     }
-
 }

--- a/server/src/test/java/org/jboss/as/server/moduleservice/PathComparatorTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/moduleservice/PathComparatorTestCase.java
@@ -34,42 +34,102 @@ import org.junit.Test;
 public class PathComparatorTestCase {
 
     @Test
-    public void pathComparatorOrderTest() {
+    public void pathComparatorOrderCaseOne() {
         Path root = Paths.get("").toAbsolutePath().getRoot();
+
         List<Path> pathsUnderTests = Arrays.asList(
-                root.resolve(Paths.get("C","E","A.txt")),
-                root.resolve(Paths.get("C","B","F","A.txt")),
-                root.resolve(Paths.get("A","A","A.txt")),
-                root.resolve(Paths.get("A","A","C.txt")),
-                root.resolve(Paths.get("A","B","B.txt")),
-                root.resolve(Paths.get("AB","C","A.txt")),
-                root.resolve(Paths.get("Z","A.txt")),
-                root.resolve(Paths.get("Z","B.txt")),
-                root.resolve(Paths.get("A","A.txt")),
-                root.resolve(Paths.get("A","B.txt")),
                 root,
                 root.resolve(Paths.get("B.txt")),
-                root.resolve(Paths.get("A.txt"))
+                root.resolve(Paths.get("A.txt")),
+                root.resolve(Paths.get("AB","A.txt"))
         );
-
-        Collections.sort(pathsUnderTests, new ExternalModuleSpecService.PathComparator());
 
         List<Path> pathsExpectedOrder = Arrays.asList(
                 root,
                 root.resolve(Paths.get("A.txt")),
                 root.resolve(Paths.get("B.txt")),
-                root.resolve(Paths.get("A","A.txt")),
-                root.resolve(Paths.get("A","B.txt")),
-                root.resolve(Paths.get("A","A","A.txt")),
-                root.resolve(Paths.get("A","A","C.txt")),
-                root.resolve(Paths.get("A","B","B.txt")),
-                root.resolve(Paths.get("AB","C","A.txt")),
-                root.resolve(Paths.get("C","B","F","A.txt")),
-                root.resolve(Paths.get("C","E","A.txt")),
-                root.resolve(Paths.get("Z","A.txt")),
-                root.resolve(Paths.get("Z","B.txt"))
+                root.resolve(Paths.get("AB","A.txt"))
         );
 
+        Collections.sort(pathsUnderTests, new ExternalModuleSpecService.PathComparator());
+        assertArrayEquals("Unexpected order found", pathsUnderTests.toArray(), pathsExpectedOrder.toArray());
+    }
+
+    @Test
+    public void pathComparatorOrderCaseTwo() {
+        Path root = Paths.get("").toAbsolutePath().getRoot();
+
+        List<Path> pathsUnderTests = Arrays.asList(
+                root.resolve(Paths.get("A", "Z.txt")),
+                root.resolve(Paths.get("AB", "A.txt"))
+        );
+
+        List<Path> pathsExpectedOrder = Arrays.asList(
+                root.resolve(Paths.get("A", "Z.txt")),
+                root.resolve(Paths.get("AB", "A.txt"))
+        );
+
+        Collections.sort(pathsUnderTests, new ExternalModuleSpecService.PathComparator());
+        assertArrayEquals("Unexpected order found", pathsUnderTests.toArray(), pathsExpectedOrder.toArray());
+    }
+
+    @Test
+    public void pathComparatorOrderCaseThree() {
+        Path root = Paths.get("").toAbsolutePath().getRoot();
+
+        List<Path> pathsUnderTests = Arrays.asList(
+                root.resolve(Paths.get("A","A","C", "A.txt")),
+                root.resolve(Paths.get("A","AB","A", "A.txt"))
+        );
+
+        List<Path> pathsExpectedOrder = Arrays.asList(
+                root.resolve(Paths.get("A","A","C", "A.txt")),
+                root.resolve(Paths.get("A","AB","A", "A.txt"))
+        );
+
+        Collections.sort(pathsUnderTests, new ExternalModuleSpecService.PathComparator());
+        assertArrayEquals("Unexpected order found", pathsUnderTests.toArray(), pathsExpectedOrder.toArray());
+    }
+
+    @Test
+    public void pathComparatorOrderCaseFour() {
+        Path root = Paths.get("").toAbsolutePath().getRoot();
+
+        List<Path> pathsUnderTests = Arrays.asList(
+                root,
+                root.resolve(Paths.get("B.txt")),
+                root.resolve(Paths.get("A.txt")),
+                root.resolve(Paths.get("AB", "A.txt")),
+                root.resolve(Paths.get("C", "E", "A.txt")),
+                root.resolve(Paths.get("C", "B", "F", "A.txt")),
+                root.resolve(Paths.get("A", "A", "A.txt")),
+                root.resolve(Paths.get("A", "A", "C.txt")),
+                root.resolve(Paths.get("A", "B", "B.txt")),
+                root.resolve(Paths.get("AB", "C", "A.txt")),
+                root.resolve(Paths.get("Z", "A.txt")),
+                root.resolve(Paths.get("Z", "B.txt")),
+                root.resolve(Paths.get("A", "A.txt")),
+                root.resolve(Paths.get("A", "Z.txt"))
+        );
+
+        List<Path> pathsExpectedOrder = Arrays.asList(
+                root,
+                root.resolve(Paths.get("A.txt")),
+                root.resolve(Paths.get("B.txt")),
+                root.resolve(Paths.get("A", "A.txt")),
+                root.resolve(Paths.get("A", "Z.txt")),
+                root.resolve(Paths.get("A", "A", "A.txt")),
+                root.resolve(Paths.get("A", "A", "C.txt")),
+                root.resolve(Paths.get("A", "B", "B.txt")),
+                root.resolve(Paths.get("AB", "A.txt")),
+                root.resolve(Paths.get("AB", "C", "A.txt")),
+                root.resolve(Paths.get("C", "B", "F", "A.txt")),
+                root.resolve(Paths.get("C", "E", "A.txt")),
+                root.resolve(Paths.get("Z", "A.txt")),
+                root.resolve(Paths.get("Z", "B.txt"))
+        );
+
+        Collections.sort(pathsUnderTests, new ExternalModuleSpecService.PathComparator());
         assertArrayEquals("Unexpected order found", pathsUnderTests.toArray(), pathsExpectedOrder.toArray());
     }
 }


### PR DESCRIPTION
Follows up https://github.com/wildfly/wildfly-core/pull/3932

I realized there are still cases that could lead to invalid sorting. Re-work the comparator and cover the cases by the test.

Jira issue: https://issues.jboss.org/browse/WFCORE-4375