### PR TITLE
[WFCORE-4647] Upgrade WildFly Elytron to 1.10.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/projects/WFCORE/issues/WFCORE-4647


        Release Notes - WildFly Elytron - Version 1.10.1.Final
                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1868'>ELY-1868</a>] -         Fix the infinite reconnect attempts test case for udp syslog audit logging
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1873'>ELY-1873</a>] -         JaccDelegatingPolicy should allow non JACC modifications to pass through.
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1867'>ELY-1867</a>] -         Update the syslog audit endpoint to use the current reconnect attempts in the infinite case
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1875'>ELY-1875</a>] -         Release WildFly Elytron 1.10.1.Final
</li>
</ul>
                    