### PR TITLE
WFCORE-4656 fix ConfigurationPersistenceException due to incorrect em…

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/mgmt_interfaces/HostMgmtInterfacesTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/mgmt_interfaces/HostMgmtInterfacesTestCase.java
@@ -45,6 +45,11 @@ public class HostMgmtInterfacesTestCase extends AbstractCoreModelTest {
         testConfiguration("host_legacy.xml");
     }
 
+    @Test
+    public void testEmptyAllowedOriginsConfiguration() throws Exception {
+        // Test for https://issues.jboss.org/browse/WFCORE-4656
+        testConfiguration("host_empty_allowed_origins.xml");
+    }
 
     private void testConfiguration(String fileName) throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(TestModelType.HOST)

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/mgmt_interfaces/StandaloneMgmtInterfacesTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/mgmt_interfaces/StandaloneMgmtInterfacesTestCase.java
@@ -45,6 +45,12 @@ public class StandaloneMgmtInterfacesTestCase extends AbstractCoreModelTest {
         testConfiguration("standalone_legacy.xml");
     }
 
+    @Test
+    public void testEmptyAllowedOriginsConfiguration() throws Exception {
+        // Test for https://issues.jboss.org/browse/WFCORE-4656
+        testConfiguration("standalone_empty_allowed_origins.xml");
+    }
+
     public void testConfiguration(String fileName) throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(TestModelType.STANDALONE)
                 .setXmlResource(fileName)

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/host_empty_allowed_origins.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/host_empty_allowed_origins.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<host name="master" xmlns="urn:jboss:domain:10.0">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true" />
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+            </security-realm>
+        </security-realms>
+
+        <management-interfaces>
+            <native-interface sasl-authentication-factory="management-sasl">
+                <socket interface="management" port="${jboss.management.native.port:9999}"/>
+            </native-interface>
+            <http-interface http-authentication-factory="management-http" allowed-origins="">
+                <http-upgrade enabled="true" sasl-authentication-factory="management-sasl" />
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+
+</host>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/standalone_empty_allowed_origins.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/mgmt_interfaces/standalone_empty_allowed_origins.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:10.0">
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface sasl-authentication-factory="management-sasl">
+                <socket-binding native="management-native"/>
+            </native-interface>
+            <http-interface http-authentication-factory="management-http" allowed-origins="">
+                <http-upgrade enabled="true" sasl-authentication-factory="managament-sasl" />
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="management" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
+    </socket-binding-group>
+</server>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_10.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_10.java
@@ -423,9 +423,7 @@ final class HostXml_10 extends CommonXml implements ManagementXmlDelegate {
                         break;
                     }
                     case ALLOWED_ORIGINS: {
-                        for (String origin : reader.getListAttributeValue(i)) {
-                            HttpManagementResourceDefinition.ALLOWED_ORIGINS.parseAndAddParameterElement(origin, addOp, reader);
-                        }
+                        HttpManagementResourceDefinition.ALLOWED_ORIGINS.getParser().parseAndSetParameter(HttpManagementResourceDefinition.ALLOWED_ORIGINS, value, addOp, reader);
                         break;
                     }
                     default:

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_10.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_10.java
@@ -301,9 +301,7 @@ final class StandaloneXml_10 extends CommonXml implements ManagementXmlDelegate 
                         break;
                     }
                     case ALLOWED_ORIGINS: {
-                        for (String origin : reader.getListAttributeValue(i)) {
-                            HttpManagementResourceDefinition.ALLOWED_ORIGINS.parseAndAddParameterElement(origin, addOp, reader);
-                        }
+                        HttpManagementResourceDefinition.ALLOWED_ORIGINS.getParser().parseAndSetParameter(HttpManagementResourceDefinition.ALLOWED_ORIGINS, value, addOp, reader);
                         break;
                     }
                     default:


### PR DESCRIPTION
…pty ALLOWED_ORIGINS list parsing

issue: https://issues.jboss.org/browse/WFCORE-4656

First add then clear ALLOWED_ORIGINS list cause ConfigurationPersistenceException at next server reload, because the parser doesn't handle the empty list properly.


