### PR TITLE
[WFCORE-4658] Upgrade jboss-remoting to 5.0.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.9.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.14.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.15.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4658

Release notes:

        Release Notes - JBoss Remoting (3+) - Version 5.0.15.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/REM3-345'>REM3-345</a>] -         Add trace logging for ClientServiceHandle opening and closing channels
</li>
</ul>
                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/REM3-344'>REM3-344</a>] -         ConnectionPeerIdentityContext Doesn&#39;t Clean Up authMap Entry if SaslClient is null, Which Leaks Memory
</li>
<li>[<a href='https://issues.jboss.org/browse/REM3-347'>REM3-347</a>] -         CloseListener of http connections not being invoked when connection is upgraded to remoting
</li>
</ul>
                                            