### PR TITLE
[WFCORE-4659] reverting change of not defining the static auth context

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -437,12 +437,6 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
         @Override
         protected void performBoottime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-            //the normal default context manager will attempt to look up wildfly-config.xml on the class path
-            //parse it and store the result in a static. The means that the default can essentially be
-            //random of there are multiple deployments with different configurations
-            //to make sure there is no random behaviour we set the global default to an empty context
-            AuthenticationContext.getContextManager().setGlobalDefault(AuthenticationContext.empty());
-
 
             ModelNode model = resource.getModel();
             final String defaultAuthenticationContext = DEFAULT_AUTHENTICATION_CONTEXT.resolveModelAttribute(context, model).asStringOrNull();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4659

This is reversion of part of the WFCORE-4599 where global static auth
context was disabled to be set to empty and it was expected
every component will manage the context on its own.
That makes troubles for transaction recovery as it has no such context
and it depended on the the global one workaround.
For the time being this change is to get the workaround to work again
but the proper fix should follow.

/CC @stuartwdouglas @darranl