### PR TITLE
[WFCORE-4677] Upgrade WildFly Elytron to 1.10.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4677

The only code change in this release is the following change to use a doPrivileged when required using the StackWalker APIs on Java 11: -

https://github.com/wildfly-security/wildfly-elytron/commit/8b2a9664f901f241004364837ac4aa256f5d08bf
