### PR TITLE
[WFCORE-4679] Update the mock-server-netty dep; specify the logback dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
         <version.io.undertow>2.0.26.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
+        <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
         <version.org.aesh>2.4</version.org.aesh>
@@ -199,7 +200,7 @@
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>2.18.0</version.org.mockito>
-        <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
+        <version.org.mock-server.mockserver-netty>5.6.1</version.org.mock-server.mockserver-netty>
         <version.org.picketbox>5.0.3.Final</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22.jbossorg-1</version.org.slf4j>
@@ -2000,6 +2001,15 @@
                         <artifactId>bcpkix-jdk15on</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <!-- We have to specify this one because mockserver-netty transitively depends
+                     on two different versions, which we have the maven-enforcer-plugin configured
+                     to reject -->
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.javax.xml.bind.jaxb-api}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.syslog4j</groupId>

--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -70,6 +70,18 @@
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${version.ch.qos.logback}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.ch.qos.logback}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4679

If this mock-server-netty upgrade is a problem, then an alternative approach to getting rid of the annoying vulnerability warns is to fix the logback version to 1.2.3 in the root pom dependencyManagement.