### PR TITLE
[WFCORE-4681] Add MP OpenAPI constants; bump Jandex to current release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <server.output.dir.prefix>wildfly-core</server.output.dir.prefix>
 
         <!-- Protocol to use for communication with remote maven repositories.
-             You can set to 'http' if you are using a maven proxy and 'https' 
+             You can set to 'http' if you are using a maven proxy and 'https'
              interferes with that. Use 'https' for builds that will be released
              to non-snapshot public maven repos -->
         <maven.repository.protocol>https</maven.repository.protocol>
@@ -172,7 +172,7 @@
         <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.4.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.2.Final</version.org.jboss.invocation>
-        <version.org.jboss.jandex>2.0.5.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.14.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -446,6 +446,7 @@ public enum Phase {
     public static final int DEPENDENCIES_MICROPROFILE_METRICS           = 0x1860;
     public static final int DEPENDENCIES_MICROPROFILE_HEALTH            = 0x1870;
     public static final int DEPENDENCIES_MICROPROFILE_OPENTRACING       = 0x1880;
+    public static final int DEPENDENCIES_MICROPROFILE_OPENAPI           = 0x1890;
 
     /**
      * @deprecated there is no phase processing associated with this constant - it was used for OSGi integration
@@ -610,6 +611,7 @@ public enum Phase {
     public static final int POST_MODULE_MICROPROFILE_METRICS            = 0x3760;
     public static final int POST_MODULE_MICROPROFILE_HEALTH             = 0x3770;
     public static final int POST_MODULE_MICROPROFILE_OPENTRACING        = 0x3780;
+    public static final int POST_MODULE_MICROPROFILE_OPENAPI            = 0x3790;
 
 
     // INSTALL


### PR DESCRIPTION
Fixes WFCORE-4681, in support of WFLY-12313