### PR TITLE
[WFCORE-4686] Add a profile to add the log manager to the boot class path and add set the log manager for Eclipse OpenJ9.

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -296,6 +296,18 @@
                 <surefire.argLine>-Xbootclasspath/a:${org.jboss.logmanager:jboss-logmanager} -Djava.util.logging.manager=org.jboss.logmanager.LogManager ${surefire.system.args}</surefire.argLine>
             </properties>
         </profile>
+        <profile>
+            <id>openj9</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>Eclipse OpenJ9</value>
+                </property>
+            </activation>
+            <properties>
+                <surefire.argLine>-Xbootclasspath/a:${org.jboss.logmanager:jboss-logmanager} -Djava.util.logging.manager=org.jboss.logmanager.LogManager ${surefire.system.args}</surefire.argLine>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -105,6 +105,8 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         // seem to work when a directory has a space. An error indicating the trailing quote cannot be found. Removing
         // the `\ parts and just keeping quotes ends in the error shown in JDK-8215398.
         Assume.assumeFalse(TestSuiteEnvironment.isWindows() && MODULAR_JVM && env.containsKey("GC_LOG") && script.getScript().toString().contains(" "));
+        Assume.assumeFalse("WFCORE-4688: Scripts do not currently support Eclipse OpenJ9 GC logging correctly.",
+                TestSuiteEnvironment.isJ9Jvm() && env.containsKey("GC_LOG"));
         script.start(env, DEFAULT_SERVER_JAVA_OPTS);
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -21,11 +21,13 @@ import org.wildfly.test.api.Authentication;
 public class TestSuiteEnvironment {
     private static final boolean IS_WINDOWS;
     private static final boolean IS_IBM_JVM;
+    private static final boolean IS_J9_JVM;
 
     static {
         final String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
         IS_WINDOWS = os.contains("win");
         IS_IBM_JVM = System.getProperty("java.vendor").startsWith("IBM");
+        IS_J9_JVM = System.getProperty("java.vendor").contains("OpenJ9") || IS_IBM_JVM;
     }
 
     public static ModelControllerClient getModelControllerClient() {
@@ -275,8 +277,19 @@ public class TestSuiteEnvironment {
      * Indicates whether or not this is a IBM JVM.
      *
      * @return {@code true} if this is a IBM JVM, otherwise {@code false}
+     *
+     * @see #isJ9Jvm()
      */
     public static boolean isIbmJvm() {
         return IS_IBM_JVM;
+    }
+
+    /**
+     * Indicates whether or not this is an Eclipse OpenJ9 or IBM J9 JVM.
+     *
+     * @return {@code true} if this is an Eclipse OpenJ9 or IBM J9 JVM, otherwise {@code false}
+     */
+    public static boolean isJ9Jvm() {
+        return IS_J9_JVM;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4686

Also ignore the standalone script tests that check for GC logging. This could be a separate PR if desired.