### PR TITLE
[WFCORE-4689] Upgrade jboss remoting to 5.0.16.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.15.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.16.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4689

This is a follow up on JBEAP Jira https://issues.jboss.org/browse/JBEAP-17475 (it does not solve the original problem, but it fixes the configuration of MAX_OUTBOUND_CHANNELS and MAX_INBOUND_CHANNELS in remoting, an issue that was discovered during the investigation of JBEAP-17475) 

        Release Notes - JBoss Remoting (3+) - Version 5.0.16.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/REM3-348'>REM3-348</a>] -         Make remoting build in JDK11
</li>
</ul>
                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/REM3-346'>REM3-346</a>] -         Remote channels config for max outbound and inbound channels must be equal to min value of both ends
</li>
</ul>
                                            