### PR TITLE
Fix Test Suite to Work with Eclipse OpenJ9

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -296,6 +296,18 @@
                 <surefire.argLine>-Xbootclasspath/a:${org.jboss.logmanager:jboss-logmanager} -Djava.util.logging.manager=org.jboss.logmanager.LogManager ${surefire.system.args}</surefire.argLine>
             </properties>
         </profile>
+        <profile>
+            <id>openj9</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>Eclipse OpenJ9</value>
+                </property>
+            </activation>
+            <properties>
+                <surefire.argLine>-Xbootclasspath/a:${org.jboss.logmanager:jboss-logmanager} -Djava.util.logging.manager=org.jboss.logmanager.LogManager ${surefire.system.args}</surefire.argLine>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
@@ -26,11 +26,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -44,6 +41,7 @@ import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.suites.DomainTestSuite;
 
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
@@ -64,10 +62,8 @@ public class JmxControlledStateNotificationsTestCase {
 
     private static DomainTestSupport testSupport;
     private static DomainLifecycleUtil domainMasterLifecycleUtil;
-    private static final boolean IS_IBM = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
-            -> System.getProperty("java.vendor.url", "whatever").toLowerCase(Locale.ENGLISH).contains("ibm.com"));
 
-    static final Path DATA = IS_IBM ? Paths.get("target/domains/JmxControlledStateNotificationsTestCase/master/target/notifications/data") : Paths.get("target/wildfly-core/target/notifications/data");
+    static final Path DATA = TestSuiteEnvironment.isJ9Jvm() ? Paths.get("target/domains/JmxControlledStateNotificationsTestCase/master/target/notifications/data") : Paths.get("target/wildfly-core/target/notifications/data");
 
     private static JMXListenerDeploymentSetupTask task = new JMXListenerDeploymentSetupTask();
     static final File JMX_FACADE_RUNNING = DATA.resolve(JMX_FACADE_FILE).resolve(RUNNING_FILENAME).toAbsolutePath().toFile();
@@ -83,7 +79,7 @@ public class JmxControlledStateNotificationsTestCase {
                         "domain-configs/domain-standard.xml", "host-configs/host-master.xml", null));
         testSupport.start();
         domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
-        task.setup(domainMasterLifecycleUtil.getDomainClient(), "main-server-group", IS_IBM);
+        task.setup(domainMasterLifecycleUtil.getDomainClient(), "main-server-group");
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
@@ -677,7 +677,7 @@ public class RespawnHttpTestCase {
         String[] getJpsCommand() {
             final File jreHome = new File(System.getProperty("java.home"));
             Assert.assertTrue("JRE home not found. File: " + jreHome.getAbsoluteFile(), jreHome.exists());
-            if (System.getProperty("java.vendor.url","whatever").contains("ibm.com")) {
+            if (TestSuiteEnvironment.isIbmJvm()) {
                 return new String[] { "sh", "-c", "ps -ef | awk '{$1=\"\"; print $0}'" };
             } else {
                 File jpsExe = new File(jreHome, "bin/jps");
@@ -685,7 +685,7 @@ public class RespawnHttpTestCase {
                     jpsExe = new File(jreHome, "../bin/jps");
                 }
                 Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
-                return new String[] { jpsExe.getAbsolutePath(), "-lv" };
+                return new String[] { jpsExe.getAbsolutePath(), "-l", "-v" };
             }
         }
 
@@ -711,7 +711,7 @@ public class RespawnHttpTestCase {
                 jpsExe = new File(jreHome, "../bin/jps.exe");
             }
             Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
-            return new String[] { jpsExe.getAbsolutePath(), "-lv" };
+            return new String[] { jpsExe.getAbsolutePath(), "-l", "-v" };
         }
 
         @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
@@ -697,7 +697,7 @@ public class RespawnTestCase {
         String[] getJpsCommand() {
             final File jreHome = new File(System.getProperty("java.home"));
             Assert.assertTrue("JRE home not found. File: " + jreHome.getAbsoluteFile(), jreHome.exists());
-            if (System.getProperty("java.vendor.url","whatever").contains("ibm.com")) {
+            if (TestSuiteEnvironment.isIbmJvm()) {
                 return new String[] { "sh", "-c", "ps -ef | awk '{$1=\"\"; print $0}'" };
             } else {
                 File jpsExe = new File(jreHome, "bin/jps");
@@ -705,7 +705,7 @@ public class RespawnTestCase {
                     jpsExe = new File(jreHome, "../bin/jps");
                 }
                 Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
-                return new String[] { jpsExe.getAbsolutePath(), "-lv" };
+                return new String[] { jpsExe.getAbsolutePath(), "-l", "-v" };
             }
         }
 
@@ -731,7 +731,7 @@ public class RespawnTestCase {
                 jpsExe = new File(jreHome, "../bin/jps.exe");
             }
             Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
-            return new String[] { jpsExe.getAbsolutePath(), "-lv" };
+            return new String[] { jpsExe.getAbsolutePath(), "-l", "-v" };
         }
 
         @Override

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
@@ -349,7 +349,7 @@ public class SuspendOnSoftKillTestCase {
         String[] getJpsCommand() {
             final File jreHome = new File(System.getProperty("java.home"));
             Assert.assertTrue("JRE home not found. File: " + jreHome.getAbsoluteFile(), jreHome.exists());
-            if (System.getProperty("java.vendor.url","whatever").contains("ibm.com")) {
+            if (TestSuiteEnvironment.isIbmJvm()) {
                 return new String[] { "sh", "-c", "ps -ef | awk '{$1=\"\"; print $0}'" };
             } else {
                 File jpsExe = new File(jreHome, "bin/jps");
@@ -357,7 +357,7 @@ public class SuspendOnSoftKillTestCase {
                     jpsExe = new File(jreHome, "../bin/jps");
                 }
                 Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
-                return new String[] { jpsExe.getAbsolutePath(), "-lv" };
+                return new String[] { jpsExe.getAbsolutePath(), "-l", "-v" };
             }
         }
 
@@ -378,7 +378,7 @@ public class SuspendOnSoftKillTestCase {
                 jpsExe = new File(jreHome, "../bin/jps.exe");
             }
             Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
-            return new String[] { jpsExe.getAbsolutePath(), "-lv" };
+            return new String[] { jpsExe.getAbsolutePath(), "-l", "-v" };
         }
 
         @Override

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -105,6 +105,8 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         // seem to work when a directory has a space. An error indicating the trailing quote cannot be found. Removing
         // the `\ parts and just keeping quotes ends in the error shown in JDK-8215398.
         Assume.assumeFalse(TestSuiteEnvironment.isWindows() && MODULAR_JVM && env.containsKey("GC_LOG") && script.getScript().toString().contains(" "));
+        Assume.assumeFalse("WFCORE-4688: Scripts do not currently support Eclipse OpenJ9 GC logging correctly.",
+                TestSuiteEnvironment.isJ9Jvm() && env.containsKey("GC_LOG"));
         script.start(env, DEFAULT_SERVER_JAVA_OPTS);
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -21,11 +21,13 @@ import org.wildfly.test.api.Authentication;
 public class TestSuiteEnvironment {
     private static final boolean IS_WINDOWS;
     private static final boolean IS_IBM_JVM;
+    private static final boolean IS_J9_JVM;
 
     static {
         final String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
         IS_WINDOWS = os.contains("win");
         IS_IBM_JVM = System.getProperty("java.vendor").startsWith("IBM");
+        IS_J9_JVM = System.getProperty("java.vendor").contains("OpenJ9") || IS_IBM_JVM;
     }
 
     public static ModelControllerClient getModelControllerClient() {
@@ -275,8 +277,19 @@ public class TestSuiteEnvironment {
      * Indicates whether or not this is a IBM JVM.
      *
      * @return {@code true} if this is a IBM JVM, otherwise {@code false}
+     *
+     * @see #isJ9Jvm()
      */
     public static boolean isIbmJvm() {
         return IS_IBM_JVM;
+    }
+
+    /**
+     * Indicates whether or not this is an Eclipse OpenJ9 or IBM J9 JVM.
+     *
+     * @return {@code true} if this is an Eclipse OpenJ9 or IBM J9 JVM, otherwise {@code false}
+     */
+    public static boolean isJ9Jvm() {
+        return IS_J9_JVM;
     }
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/jmx/JMXListenerDeploymentSetupTask.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/jmx/JMXListenerDeploymentSetupTask.java
@@ -41,6 +41,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.as.test.integration.management.rbac.Outcome;
 import org.jboss.as.test.integration.management.rbac.RbacUtil;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetupTask;
@@ -66,7 +67,7 @@ public class JMXListenerDeploymentSetupTask implements ServerSetupTask {
         deploy(managementClient.getControllerClient(), file);
     }
 
-    public void setup(ModelControllerClient client, String serverGroupName, boolean ibm) throws IOException {
+    public void setup(ModelControllerClient client, String serverGroupName) throws IOException {
         final File dir = new File("target/archives");
         if(dir.exists()) {
             cleanFile(dir);
@@ -75,7 +76,7 @@ public class JMXListenerDeploymentSetupTask implements ServerSetupTask {
         file = new File(dir, DEPLOYMENT);
 
         Set<Permission> additionalPermissions = new HashSet();
-        if(ibm) {
+        if(TestSuiteEnvironment.isJ9Jvm()) {
             //fix of WFCORE-3417
             additionalPermissions.add(new FilePermission(file.getAbsolutePath()
                     .replace("archives", "domains/JmxControlledStateNotificationsTestCase/master")


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4686
https://issues.jboss.org/browse/WFCORE-4690

The commit for [WFCORE-4687](https://issues.jboss.org/browse/WFCORE-4687) just ignores checking the of the GC log until [WFCORE-4688](https://issues.jboss.org/browse/WFCORE-4688) is resolved.

This passed the full test suite locally for me with:
```
openjdk version "11.0.4" 2019-07-16
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.4+11)
Eclipse OpenJ9 VM AdoptOpenJDK (build openj9-0.15.1, JRE 11 Linux amd64-64-Bit Compressed References 20190717_286 (JIT enabled, AOT enabled)
OpenJ9   - 0f66c6431
OMR      - ec782f26
JCL      - fa49279450 based on jdk-11.0.4+11)
```