### PR TITLE
WFCORE-4701 SecurityCommandsTestCase and SyslogAuditLogTestCase cleanup

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/SyslogAuditLogTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SyslogAuditLogTestCase.java
@@ -15,7 +15,6 @@ limitations under the License.
  */
 package org.wildfly.extension.elytron;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
@@ -56,7 +55,6 @@ public class SyslogAuditLogTestCase extends AbstractSubsystemTest {
     private final String RFC5424_STRING = "RFC5424";
     private final String RFC5424_SYSLOG_MESSAGE = BASE_SYSLOG_MESSAGE + RFC5424_STRING;
     private final String BAD_RFC_STRING = "RFC1";
-    private String failString = "";
 
     private KernelServices services = null;
     private static SimpleSyslogServer udpServer = null;
@@ -253,16 +251,6 @@ public class SyslogAuditLogTestCase extends AbstractSubsystemTest {
     private ModelNode assertFailed(ModelNode response) {
         if (! response.get(OUTCOME).asString().equals(FAILED)) {
             Assert.fail(response.toJSONString(false));
-        }
-        return response;
-    }
-
-    /**
-     * Verifies the operation cancelled before completion
-     */
-    private ModelNode assertCancelled(ModelNode response) {
-        if (! response.get(OUTCOME).asString().equals(CANCELLED)) {
-            this.failString = response.toJSONString(false);
         }
         return response;
     }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -238,11 +238,11 @@ public class SecurityCommandsTestCase {
                 Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload"
                                 + " --lets-encrypt"
                                 + " --ca-account=" + CA_ACCOUNT_NAME,
-                        (useCaAccount ? "Key-store file name (default management.keystore):" : "File name (default accounts.keystore.jks)")));
+                        ("Key-store file name (default management.keystore):")));
             } else {
                 Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload"
                                 + " --lets-encrypt",
-                        (useCaAccount ? "Key-store file name (default management.keystore):" : "File name (default accounts.keystore.jks)")));
+                        ("File name (default accounts.keystore.jks)")));
 
                 //skip this when ca Account already created
                 Assert.assertTrue(cli.pushLineAndWaitForResults(ACCOUNTS_KEYSTORE_FILE_NAME, "Password (blank generated):"));


### PR DESCRIPTION
SecurityCommandsTestCase and SyslogAuditLogTestCase cleanup
https://issues.jboss.org/browse/WFCORE-4701

 - SyslogAuditLogTestCase: unused field and method
 - SecurityCommandsTestCase: simplified assert thanks to `if (useCaAccount) {` statement on line 229 

https://github.com/wildfly/wildfly-core/blob/master/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java#L229