### PR TITLE
[WFCORE-4691] Upgrade XNIO 3.7.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.7.3.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.7.5.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFCORE-4691


----


##  Release Notes - XNIO - Version 3.7.5.Final
                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/XNIO-328'>XNIO-328</a>] -         Thread allocation hash can result in only allocating to 50% of IO threads
</li>
<li>[<a href='https://issues.jboss.org/browse/XNIO-350'>XNIO-350</a>] -         xnio.nio.alt-queued-server breaks undertow ssl under load
</li>
<li>[<a href='https://issues.jboss.org/browse/XNIO-351'>XNIO-351</a>] -         Queued executor (v2) can accept into the wrong thread
</li>
</ul>
                                            

## Release Notes - XNIO - Version 3.7.4.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/XNIO-343'>XNIO-343</a>] -         Upgrade wildfly-common to 1.5.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/XNIO-258'>XNIO-258</a>] -         No indication of &quot;too many open files&quot; problem in the logs / error messages
</li>
</ul>
                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/XNIO-265'>XNIO-265</a>] -         Accept thread blocks forever on java.nio.channels.SelectableChannel.register
</li>
<li>[<a href='https://issues.jboss.org/browse/XNIO-286'>XNIO-286</a>] -         QueuedNioTcpServer does not respond if accept fails
</li>
<li>[<a href='https://issues.jboss.org/browse/XNIO-335'>XNIO-335</a>] -         XNIO I/O threads are taking high CPU (may be because its not closing CLOSE_WAIT TCP connections)
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/XNIO-341'>XNIO-341</a>] -         Upgrade jboss-parent pom version to 35
</li>
</ul>
                                    