### PR TITLE
[WFCORE-4705] / [WFCORE-4706] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.11.0.CR1</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.6.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.7.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4705
https://issues.jboss.org/browse/WFCORE-4706


        Release Notes - WildFly Elytron - Version 1.11.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1885'>ELY-1885</a>] -         Component Version Maintenance
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1886'>ELY-1886</a>] -         Switch to the JBoss / Jakarta Fork for JACC
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1887'>ELY-1887</a>] -         Switch to the JBoss / Jakarta fork for JASPI
</li>
</ul>
                                                                                                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1889'>ELY-1889</a>] -         Release WildFly Elytron 1.11.0.CR1
</li>
</ul>


        Release Notes - Elytron Web - Version 1.7.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-66'>ELYWEB-66</a>] -         Upgrade WildFly Elytron to 1.10.3.Final + component upgrades
</li>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-69'>ELYWEB-69</a>] -         Upgrade WildFly Elytron 1.11.0.CR1
</li>
</ul>
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-67'>ELYWEB-67</a>] -         A doPrivileged it required to access the JASPI AuthConfigFactory
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-68'>ELYWEB-68</a>] -         Upgrade Travis CI to OpenJDK 11
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-70'>ELYWEB-70</a>] -         Release Elytron Web 1.7.0.CR1
</li>
</ul>
                    