### PR TITLE
[WFCORE-4709] Upgrade Undertow to 2.0.27.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.com.jcraft.jzlib>1.1.1</version.com.jcraft.jzlib>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.0.26.Final</version.io.undertow>
+        <version.io.undertow>2.0.27.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4709

Release notes:

        Release Notes - Undertow - Version 2.0.27.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1606'>UNDERTOW-1606</a>] -         Output undertow version logging at INFO level on Undertow#start() and Undertow#stop()
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1607'>UNDERTOW-1607</a>] -         Add a test for ByteRange
</li>
</ul>
                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1576'>UNDERTOW-1576</a>] -         EMBARGOED - BASIC auth password is output as plain text at DEBUG level logging in BasicAuthenticationMechanism
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1595'>UNDERTOW-1595</a>] -         NullPointerException can happen on a range request for a static content
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1598'>UNDERTOW-1598</a>] -         Bug in CachedResource range request handling
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1599'>UNDERTOW-1599</a>] -         ServletRequestLineAttribute does not output the original query string after the request is forwarded with new query strings
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1602'>UNDERTOW-1602</a>] -         CVE-2019-9511 HTTP/2: large amount of data requests leads to denial of service
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1603'>UNDERTOW-1603</a>] -         CVE-2019-9512 HTTP/2: flood using PING frames results in unbounded memory growth
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1604'>UNDERTOW-1604</a>] -         CVE-2019-9514 HTTP/2: flood using HEADERS frames results in unbounded memory growth
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1605'>UNDERTOW-1605</a>] -         CVE-2019-9515 HTTP/2: flood using SETTINGS frames results in unbounded memory growth
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1608'>UNDERTOW-1608</a>] -         IndexOutOfBounds in StoredResponseStreamSinkConduit
</li>
<li>[<a href='https://issues.jboss.org/browse/UNDERTOW-1610'>UNDERTOW-1610</a>] -         RewriteHandler routes to original URI instead of new destination URI
</li>
</ul>
                                            