### PR TITLE
[WFCORE-4720] Clarify that SetupActions.dependencies() cannot return …

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/SetupAction.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SetupAction.java
@@ -27,9 +27,9 @@ import java.util.Set;
 import org.jboss.msc.service.ServiceName;
 
 /**
- * And action that sets up and tears down some form of context (e.g. the TCCL, JNDI context etc).
+ * An action that sets up and tears down some form of context (e.g. the TCCL, JNDI context etc).
  * <p>
- * Implementations need to be thread safe, as multiple threads can be setting up and tearing down contexts at any given time
+ * Implementations need to be thread safe, as multiple threads can be setting up and tearing down contexts at any given time.
  *
  * @author Stuart Douglas
  *
@@ -39,21 +39,33 @@ public interface SetupAction {
     /**
      * Sets up the context. If this method throws an exception then the {@link #teardown(java.util.Map)} method will not be called, so this
      * method should be implmeneted in an atomic manner.
+     *
+     * @param properties data that a caller may provide to help configure the behavior of the action. May be {@code null}. An implementation
+     *                   that expects certain properties should either require it is only used in cases where those properties will be provided,
+     *                   or do something reasonable (e.g. become a no-op) if they are not provided.
      */
     void setup(Map<String, Object> properties);
 
     /**
      * Tears down the context that was set up and restores the previous context state.
+     *
+     * @param properties data that a caller may provide to help configure the behavior of the action. May be {@code null}. An implementation
+     *                   that expects certain properties should either require it is only used in cases where those properties will be provided,
+     *                   or do something reasonable (e.g. become a no-op) if they are not provided.
      */
     void teardown(Map<String, Object> properties);
 
     /**
      * Higher priority setup actions run first
+     *
+     * @return the priority
      */
     int priority();
 
     /**
      * Any dependencies that this action requires
+     *
+     * @return the names of the services this action requires. Will not be {@code null}.
      */
     Set<ServiceName> dependencies();
 


### PR DESCRIPTION
…null; also some other javadoc tweaks

https://issues.jboss.org/browse/WFCORE-4720

Note that with https://github.com/wildfly/wildfly/pull/12727 the only impl in WildFly that returned null will no longer do so. There are a couple callers of this method in WildFly that assume it will not return null. So I figure the best thing to do is enhance the contract to require the best behavior.