### PR TITLE
[WFCORE-4728] Add javax.inject as a banned dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,7 @@
                                             <exclude>concurrent:concurrent</exclude>
                                             <exclude>jacorb:jacorb</exclude>
                                             <exclude>javassist:javassist</exclude>
+                                            <exclude>javax.inject:javax.inject</exclude>
                                             <exclude>javax.xml:jaxrpc-api</exclude>
                                             <exclude>javax.xml.soap:saaj-api</exclude>
                                             <exclude>javax.xml.stream:stax-api</exclude>


### PR DESCRIPTION
This PR follows up on https://github.com/wildfly/wildfly-core/pull/3995.

It adds javax.inject:javax.inject to the banned dependency list. 

Jira issue: https://issues.jboss.org/browse/WFCORE-4728

FYI @darranl 