### PR TITLE
[WFCORE-4688] Support OpenJ9 GC logging in the standalone scripts.

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/common.ps1
@@ -180,7 +180,10 @@ Param(
     if ($PROG_ARGS -notmatch "-Xlog:?gc"){
         Rotate-GC-Logs
 
-        if ($MODULAR_JDK -eq $true)
+        & $JAVA -Xverbosegclog:"$JBOSS_LOG_DIR\gc.log" java.se -version >$null 2>&1
+        if ($LastExitCode -eq 0){
+            $PROG_ARGS += "-Xverbosegclog:`\`"$JBOSS_LOG_DIR\gc.log`\`""
+        }elseif ($MODULAR_JDK -eq $true)
         {
             $PROG_ARGS += "-Xlog:gc*:file=`\`"$JBOSS_LOG_DIR\gc.log`\`":time,uptimemillis:filecount=5,filesize=3M"
         } else {

--- a/core-feature-pack/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.bat
@@ -241,7 +241,10 @@ if not "%PRESERVE_JAVA_OPT%" == "true" (
         move /y "%JBOSS_LOG_DIR%\gc.log.*.current" "%JBOSS_LOG_DIR%\backupgc.log.current" > nul 2>&1
 
             setlocal EnableDelayedExpansion
-            if "!MODULAR_JDK!" == "true" (
+            "!JAVA!" -Xverbosegclog:"!JBOSS_LOG_DIR!\gc.log" -version >nul 2>&1 && (set OPEN_J9_JDK=true) || (set OPEN_J9_JDK=false)
+            if "!OPEN_J9_JDK!" == "true" (
+                set TMP_PARAM=-Xverbosegclog:"!JBOSS_LOG_DIR!\gc.log"
+            ) else if "!MODULAR_JDK!" == "true" (
                 set TMP_PARAM=-Xlog:gc*:file="\"!JBOSS_LOG_DIR!\gc.log\"":time,uptimemillis:filecount=5,filesize=3M
             ) else (
                 set TMP_PARAM=-verbose:gc -Xloggc:"!JBOSS_LOG_DIR!\gc.log" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -278,7 +278,11 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
             mv -f "$JBOSS_LOG_DIR/gc.log.3" "$JBOSS_LOG_DIR/backupgc.log.3" >/dev/null 2>&1
             mv -f "$JBOSS_LOG_DIR/gc.log.4" "$JBOSS_LOG_DIR/backupgc.log.4" >/dev/null 2>&1
             mv -f "$JBOSS_LOG_DIR"/gc.log.*.current "$JBOSS_LOG_DIR/backupgc.log.current" >/dev/null 2>&1
-            if [ "$MODULAR_JDK" = "true" ]; then
+
+            "$JAVA" -Xverbosegclog:"$JBOSS_LOG_DIR/gc.log" -version > /dev/null 2>&1 && OPEN_J9_JDK=true || OPEN_J9_JDK=false
+            if [ "$OPEN_J9_JDK" = "true" ]; then
+                TMP_PARAM="-Xverbosegclog:\"$JBOSS_LOG_DIR/gc.log\""
+            elif [ "$MODULAR_JDK" = "true" ]; then
                 TMP_PARAM="-Xlog:gc*:file=\"$JBOSS_LOG_DIR/gc.log\":time,uptimemillis:filecount=5,filesize=3M"
             else
                 TMP_PARAM="-verbose:gc -Xloggc:\"$JBOSS_LOG_DIR/gc.log\" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading"

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -105,8 +105,6 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         // seem to work when a directory has a space. An error indicating the trailing quote cannot be found. Removing
         // the `\ parts and just keeping quotes ends in the error shown in JDK-8215398.
         Assume.assumeFalse(TestSuiteEnvironment.isWindows() && MODULAR_JVM && env.containsKey("GC_LOG") && script.getScript().toString().contains(" "));
-        Assume.assumeFalse("WFCORE-4688: Scripts do not currently support Eclipse OpenJ9 GC logging correctly.",
-                TestSuiteEnvironment.isJ9Jvm() && env.containsKey("GC_LOG"));
         script.start(env, DEFAULT_SERVER_JAVA_OPTS);
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());
@@ -130,7 +128,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
             Assert.assertTrue(Files.exists(logDir));
             final String fileName;
             // The IBM J9 JVM does seems to just use the gc.log name format for the current file name.
-            if (MODULAR_JVM || TestSuiteEnvironment.isIbmJvm()) {
+            if (MODULAR_JVM || TestSuiteEnvironment.isJ9Jvm()) {
                 fileName = "gc.log";
             } else {
                 fileName = "gc.log.0.current";


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4688

- OpenJ9 Linux: https://ci.wildfly.org/viewLog.html?buildId=172762&buildTypeId=WildFlyCore_MasterLinuxOpenJ911
- OpenJ9 Windows: https://ci.wildfly.org/viewLog.html?buildId=172764&buildTypeId=WildFlyCore_MasterWindowsOpenJ911