### PR TITLE
[WFCORE-2147] Enable property replacements for permissions and jboss-permissions files

### DIFF
--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/deployment/PermissionsParserProcessor.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/deployment/PermissionsParserProcessor.java
@@ -25,15 +25,16 @@ package org.wildfly.extension.security.manager.deployment;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
 
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ExpressionStreamReaderDelegate;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.modules.ModuleIdentifier;
@@ -91,11 +92,13 @@ public class PermissionsParserProcessor implements DeploymentUnitProcessor {
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER);
         final ModuleIdentifier moduleIdentifier = deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER);
+        final Function<String, String> wflyResolverFunc = deploymentUnit.getAttachment(Attachments.WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION);
+        final Function<String, String> specResolverFunc = deploymentUnit.getAttachment(Attachments.SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION);
 
         // non-spec behavior: always process permissions declared in META-INF/jboss-permissions.xml.
         VirtualFile jbossPermissionsXML = deploymentRoot.getRoot().getChild(JBOSS_PERMISSIONS_XML);
         if (jbossPermissionsXML.exists() && jbossPermissionsXML.isFile()) {
-            List<PermissionFactory> factories = this.parsePermissions(jbossPermissionsXML, moduleLoader, moduleIdentifier);
+            List<PermissionFactory> factories = this.parsePermissions(jbossPermissionsXML, moduleLoader, moduleIdentifier, wflyResolverFunc);
             for (PermissionFactory factory : factories) {
                 moduleSpecification.addPermissionFactory(factory);
             }
@@ -112,7 +115,7 @@ public class PermissionsParserProcessor implements DeploymentUnitProcessor {
                 VirtualFile permissionsXML = deploymentRoot.getRoot().getChild(PERMISSIONS_XML);
                 if (permissionsXML.exists() && permissionsXML.isFile()) {
                     // parse the permissions and attach them in the deployment unit.
-                    List<PermissionFactory> factories = this.parsePermissions(permissionsXML, moduleLoader, moduleIdentifier);
+                    List<PermissionFactory> factories = this.parsePermissions(permissionsXML, moduleLoader, moduleIdentifier, specResolverFunc);
                     for (PermissionFactory factory : factories) {
                         moduleSpecification.addPermissionFactory(factory);
                     }
@@ -144,21 +147,23 @@ public class PermissionsParserProcessor implements DeploymentUnitProcessor {
      * be lazily instantiated after the deployment unit module has been created.
      * </p>
      *
-     * @param file the {@link VirtualFile} that contains the permissions declarations.
-     * @param loader the {@link ModuleLoader} that is to be used by the factory to instantiate the permission.
-     * @param identifier the {@link ModuleIdentifier} that is to be used by the factory to instantiate the permission.
+     * @param file               the {@link VirtualFile} that contains the permissions declarations.
+     * @param loader             the {@link ModuleLoader} that is to be used by the factory to instantiate the permission.
+     * @param identifier         the {@link ModuleIdentifier} that is to be used by the factory to instantiate the permission.
+     * @param exprExpandFunction A function which will be used, if provided, to expand any expressions (of the form of {@code ${foobar}})
+     *                           in the content being parsed. This function can be null, in which case the content is processed literally.
      * @return a list of {@link PermissionFactory} objects representing the parsed permissions.
      * @throws DeploymentUnitProcessingException if an error occurs while parsing the permissions.
      */
-    private List<PermissionFactory> parsePermissions(final VirtualFile file, final ModuleLoader loader, final ModuleIdentifier identifier)
+    private List<PermissionFactory> parsePermissions(final VirtualFile file, final ModuleLoader loader, final ModuleIdentifier identifier, final Function<String, String> exprExpandFunction)
             throws DeploymentUnitProcessingException {
 
         InputStream inputStream = null;
         try {
             inputStream = file.openStream();
             final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-            XMLStreamReader xmlReader = inputFactory.createXMLStreamReader(inputStream);
-            return PermissionsParser.parse(xmlReader, loader, identifier);
+            final ExpressionStreamReaderDelegate expressionStreamReaderDelegate = new ExpressionStreamReaderDelegate(inputFactory.createXMLStreamReader(inputStream), exprExpandFunction);
+            return PermissionsParser.parse(expressionStreamReaderDelegate, loader, identifier);
         } catch (Exception e) {
             throw new DeploymentUnitProcessingException(e.getMessage(), e);
         } finally {

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -26,6 +26,7 @@ import java.security.PermissionCollection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.jar.Manifest;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
@@ -107,6 +108,16 @@ public final class Attachments {
      * A builder used to install a deployment phase
      */
     public static final AttachmentKey<DeploymentUnitPhaseBuilder> DEPLOYMENT_UNIT_PHASE_BUILDER = AttachmentKey.create(DeploymentUnitPhaseBuilder.class);
+
+    /**
+     * A function which will be used to expand expressions within spec descriptors
+     */
+    public static final AttachmentKey<Function<String, String>> SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(Function.class);
+
+    /**
+     * A function which will be used to expand expressions within JBoss/WildFly (vendor specific) descriptors
+     */
+    public static final AttachmentKey<Function<String, String>> WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(Function.class);
 
     //
     // STRUCTURE

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ExpressionStreamReaderDelegate.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ExpressionStreamReaderDelegate.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server.deployment.module;
+
+import java.util.function.Function;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.StreamReaderDelegate;
+
+/**
+ * An XML Stream reader delegate adding methods that use a {@link Function} to resolve values retrieved by getElementTexts.
+ *
+ * @author Yeray Borges
+ */
+public class ExpressionStreamReaderDelegate extends StreamReaderDelegate {
+    private final Function<String, String> exprExpandFunction;
+
+    /**
+     * @param reader             The {@link XMLStreamReader} for the XML file
+     * @param exprExpandFunction A function which will be used, if provided, to expand any expressions (of the form of {@code ${foobar}})
+     *                           in the content being parsed. This function can be null, in which case the content is processed literally.
+     */
+    public ExpressionStreamReaderDelegate(XMLStreamReader reader, final Function<String, String> exprExpandFunction) {
+        super(reader);
+        this.exprExpandFunction = exprExpandFunction;
+    }
+
+    public String getElementText() throws XMLStreamException {
+        String elementText = super.getElementText();
+        return expand(elementText);
+    }
+
+    private String expand(final String content) {
+        if (content == null || content.isEmpty() || exprExpandFunction == null) {
+            return content;
+        }
+        return exprExpandFunction.apply(content);
+    }
+}


### PR DESCRIPTION
Enables the property replacements in permissions.xml and jboss-permissions.xml by using a Function passed by wildfly. This function will contain the resolved. We use a function there since all the java classes and code for the resolver resides in wildfly instead of core. 

An alternative approach to avoid pass a function could have been to move all the required dependencies from wildfly to wildfly core, however, the approach of using a function carries fewer modifications and it is enough. 

This is an RFE, tests will be added in wildfly.

Jira issue: https://issues.jboss.org/browse/WFCORE-2147