### PR TITLE
[WFCORE-4743] Upgrade WildFly Elytron to 1.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.10.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.10.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.6.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
Speaking to @jamezp we were not sure if this would need to target the 10.0.x branch so submitting just in case.

https://issues.jboss.org/browse/WFCORE-4743


        Release Notes - WildFly Elytron - Version 1.10.4.Final
                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1872'>ELY-1872</a>] -         elytron-tool.sh usage with symbolic links
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1895'>ELY-1895</a>] -         SyslogAuditEndpointTest Failing on later Kernel version
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1899'>ELY-1899</a>] -         Release WildFly Elytron 1.10.4.Final
</li>
</ul>
                    
