### PR TITLE
[WFCORE-4295] Upgrading JBoss VFS to 3.2.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <version.org.jboss.invocation>1.5.2.Final</version.org.jboss.invocation>
         <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
-        <version.org.jboss.jboss-vfs>3.2.14.Final</version.org.jboss.jboss-vfs>
+        <version.org.jboss.jboss-vfs>3.2.15.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>
         <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.0.Final</version.org.jboss.logging.jboss-logging-tools>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4295
Incorporates:
 * [JBVFS-207] Provide a way to retrieve VirtualFile instance from url.openConnection()