### PR TITLE
[WFCORE-4733] Rename a Host Controller does not work properly

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
@@ -214,7 +214,7 @@ public abstract class ProcessEnvironment {
         return result;
     }
 
-    private class ProcessNameWriteAttributeHandler implements OperationStepHandler {
+    protected class ProcessNameWriteAttributeHandler implements OperationStepHandler {
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.host.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -31,14 +33,19 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.operations.common.ProcessEnvironment;
 import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.as.host.controller.jvm.JvmType;
+import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.version.ProductConfig;
+import org.jboss.dmr.ModelNode;
 import org.wildfly.common.Assert;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -852,5 +859,39 @@ public class HostControllerEnvironment extends ProcessEnvironment {
     @Override
     public UUID getInstanceUuid() {
         return this.hostControllerUUID;
+    }
+
+    /**
+     * Gets an {@link OperationStepHandler} that can write the {@code name} attribute for a host controller.
+     *
+     * @return the handler
+     */
+    public OperationStepHandler getHostNameWriteHandler(LocalHostControllerInfoImpl hostControllerInfo) {
+        return new HostNameWriteAttributeHandler(hostControllerInfo);
+    }
+
+    protected class HostNameWriteAttributeHandler extends ProcessNameWriteAttributeHandler {
+        private final LocalHostControllerInfoImpl hostControllerInfo;
+
+        private HostNameWriteAttributeHandler(LocalHostControllerInfoImpl hostControllerInfo) {
+            this.hostControllerInfo = hostControllerInfo;
+        }
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            final boolean booting = context.isBooting();
+            if (booting) {
+                final ModelNode newValue = operation.hasDefined(VALUE) ? operation.get(VALUE) : new ModelNode();
+                if (newValue.isDefined()) {
+                    context.addStep(new OperationStepHandler() {
+                        @Override
+                        public void execute(OperationContext context, ModelNode operation) {
+                            hostControllerInfo.clearOverrideLocalHostName();
+                        }
+                    }, OperationContext.Stage.RUNTIME);
+                }
+            }
+            super.execute(context, operation);
+        }
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -339,7 +339,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         hostRegistration.registerReadOnlyAttribute(MASTER, IsMasterHandler.INSTANCE);
         hostRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.NAMESPACES, null);
         hostRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.SCHEMA_LOCATIONS, null);
-        hostRegistration.registerReadWriteAttribute(HostResourceDefinition.NAME, environment.getProcessNameReadHandler(), environment.getProcessNameWriteHandler());
+        hostRegistration.registerReadWriteAttribute(HostResourceDefinition.NAME, environment.getProcessNameReadHandler(), environment.getHostNameWriteHandler(hostControllerInfo));
         hostRegistration.registerReadOnlyAttribute(HostResourceDefinition.RUNTIME_CONFIGURATION_STATE, new ProcessStateAttributeHandler(processState));
         hostRegistration.registerReadOnlyAttribute(HostResourceDefinition.HOST_STATE, new ProcessStateAttributeHandler(processState));
         hostRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.RUNNING_MODE, new RunningModeReadHandler(runningModeControl));

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
@@ -88,6 +88,10 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
         this.localHostName = hostName;
     }
 
+    public void clearOverrideLocalHostName() {
+        this.overrideLocalHostName = false;
+    }
+
     @Override
     public ControlledProcessState.State getProcessState() {
         return processState.getState();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/RenameHostControllerTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/RenameHostControllerTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.suites.DomainTestSuite;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies we are able to rename a Host Controller and, after reloading it, it gets registered in the domain with the new name.
+ *
+ * @author Yeray Borges
+ */
+public class RenameHostControllerTestCase {
+    private static final String RENAMED_SLAVE = "renamed-slave";
+    private static final PathAddress SLAVE_ADDR = PathAddress.pathAddress(HOST, "slave");
+    private static final PathAddress MASTER_ADDR = PathAddress.pathAddress(HOST, "master");
+    private static final PathAddress RENAMED_SLAVE_ADDR = PathAddress.pathAddress(HOST, RENAMED_SLAVE);
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+
+    @BeforeClass
+    public static void setupDomain() {
+        testSupport = DomainTestSuite.createSupport(RenameHostControllerTestCase.class.getSimpleName());
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+
+    }
+
+    @AfterClass
+    public static void tearDownDomain() {
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @Test
+    public void renameSlave() throws Exception {
+        DomainClient masterClient = domainMasterLifecycleUtil.getDomainClient();
+
+        ModelNode operation = Util.getWriteAttributeOperation(SLAVE_ADDR, "name", RENAMED_SLAVE);
+        DomainTestUtils.executeForResult(operation, masterClient);
+
+        DomainClient slaveClient = reloadHost(domainSlaveLifecycleUtil, "slave");
+
+        String result = DomainTestUtils.executeForResult(
+                Util.getReadAttributeOperation(PathAddress.EMPTY_ADDRESS, "local-host-name"), slaveClient).asString();
+
+        Assert.assertEquals(RENAMED_SLAVE, result);
+
+        // verify all is running, it also verifies the slave is registered in the domain with the new name
+        result = DomainTestUtils.executeForResult(
+                Util.getReadAttributeOperation(RENAMED_SLAVE_ADDR, "host-state"), masterClient).asString();
+
+        Assert.assertEquals("running", result);
+
+        result = DomainTestUtils.executeForResult(
+                Util.getReadAttributeOperation(MASTER_ADDR, "host-state"), masterClient).asString();
+
+        Assert.assertEquals("running", result);
+    }
+
+    private DomainClient reloadHost(DomainLifecycleUtil util, String host) throws Exception {
+        ModelNode reload = Util.createEmptyOperation("reload", getRootAddress(host));
+        util.executeAwaitConnectionClosed(reload);
+        util.connect();
+        util.getConfiguration().setHostName(RENAMED_SLAVE);
+        util.awaitHostController(System.currentTimeMillis());
+        return util.createDomainClient();
+    }
+
+    private PathAddress getRootAddress(String host) {
+        return host == null ? PathAddress.EMPTY_ADDRESS : PathAddress.pathAddress(HOST, host);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -726,28 +726,7 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
     }
 
     private void assertState(String expected, int timeout) throws IOException, InterruptedException {
-        long done = timeout < 1 ? 0 : System.currentTimeMillis() + timeout;
-        StringBuilder history = new StringBuilder();
-        String state = null;
-        do {
-            try {
-                cli.sendLine(":read-attribute(name=server-state)", true);
-                CLIOpResult result = cli.readAllAsOpResult();
-                ModelNode resp = result.getResponseNode();
-                ModelNode stateNode = result.isIsOutcomeSuccess() ? resp.get(RESULT) : resp.get(FAILURE_DESCRIPTION);
-                state = stateNode.asString();
-                history.append(state).append("\n");
-            } catch (Exception ignored) {
-                //
-                history.append(ignored.toString()).append("--").append(cli.readOutput()).append("\n");
-            }
-            if (expected.equals(state)) {
-                return;
-            } else {
-                Thread.sleep(20);
-            }
-        } while (timeout > 0 && System.currentTimeMillis() < done);
-        assertEquals(history.toString(), expected, state);
+        assertState(expected,timeout, ":read-attribute(name=server-state)");
     }
 
     private void checkNoLogging(String line) throws IOException {


### PR DESCRIPTION
LocalHostControllerInfoImpl stores information about the environment of the local host controller. When a  Host Controller is reloaded, the current host controller name is kept to allow the embedded host controller to work with fictitious names that are not finally persisted in the host.xml. See https://issues.jboss.org/browse/WFCORE-2933 for more information

The problem is the LocalHostControllerInfoImpl#overrideLocalHostName flag is never cleared when a new name is read from the host.xml. That means, when we rename a host controller and later we reload it, the old name is still taken. This patch fixes this situation.

Jira issue: https://issues.jboss.org/browse/WFCORE-4733