### PR TITLE
[WFCORE-4751] / [WFCORE-4752] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.11.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.11.0.CR2</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.7.0.CR1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.7.0.CR2</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4751
https://issues.jboss.org/browse/WFCORE-4752


        Release Notes - WildFly Elytron - Version 1.11.0.CR2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1901'>ELY-1901</a>] -         Upgrade JBoss Modules to 1.9.2.Final
</li>
</ul>
                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1866'>ELY-1866</a>] -         Broken symbolic link to LICENSE.txt
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1874'>ELY-1874</a>] -         Fix for checking max-cert-path specified in X509RevocationTrustManager
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1876'>ELY-1876</a>] -         Log messages are not logged when KeyStoreCredentialStore is initialized with Provider[]  in getKeyStoreInstance.
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1895'>ELY-1895</a>] -         SyslogAuditEndpointTest Failing on later Kernel version
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1898'>ELY-1898</a>] -         SecurityFactory&lt;Credential&gt; used in API is too strict
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1905'>ELY-1905</a>] -         Fix OCSP Tests which are failing
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1906'>ELY-1906</a>] -         Release WildFly Elytron 1.11.0.CR2
</li>
</ul>


        Release Notes - Elytron Web - Version 1.7.0.CR2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-73'>ELYWEB-73</a>] -         Upgrade Undertow to 2.0.27.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-74'>ELYWEB-74</a>] -         Upgrade WildFly Elytron to 1.11.0.CR2
</li>
</ul>
                                                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-75'>ELYWEB-75</a>] -         Release Elytron Web 1.7.0.CR2
</li>
</ul>
                                        