### PR TITLE
[WFCORE-4596] Do not acquire the write lock reading core-service patching resource

### DIFF
--- a/patching/src/main/java/org/jboss/as/patching/management/ElementProviderAttributeReadHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/ElementProviderAttributeReadHandler.java
@@ -92,6 +92,10 @@ abstract class ElementProviderAttributeReadHandler extends PatchStreamResourceOp
      */
     abstract static class LayerAttributeReadHandler extends ElementProviderAttributeReadHandler {
 
+        LayerAttributeReadHandler() {
+            this.acquireWriteLock = false;
+        }
+
         @Override
         protected Layer getProvider(final String name, final InstalledIdentity identity) throws OperationFailedException {
             final Layer target = identity.getLayer(name);

--- a/patching/src/main/java/org/jboss/as/patching/management/PatchAttributeReadHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/PatchAttributeReadHandler.java
@@ -33,6 +33,10 @@ import org.jboss.dmr.ModelNode;
 
 abstract class PatchAttributeReadHandler extends PatchStreamResourceOperationStepHandler {
 
+    PatchAttributeReadHandler() {
+        this.acquireWriteLock = false;
+    }
+
     @Override
     protected void execute(final OperationContext context, final ModelNode operation, final InstalledIdentity installedIdentity) throws OperationFailedException {
 

--- a/patching/src/main/java/org/jboss/as/patching/management/PatchStreamResourceOperationStepHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/PatchStreamResourceOperationStepHandler.java
@@ -40,6 +40,7 @@ import org.jboss.msc.service.ServiceController;
  * @author Alexey Loubyansky
  */
 abstract class PatchStreamResourceOperationStepHandler implements OperationStepHandler {
+    boolean acquireWriteLock = true;
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -51,7 +52,9 @@ abstract class PatchStreamResourceOperationStepHandler implements OperationStepH
     }
 
     private void executeRuntime(OperationContext context, ModelNode operation) throws OperationFailedException {
-        context.acquireControllerLock();
+        if (acquireWriteLock) {
+            context.acquireControllerLock();
+        }
         execute(context, operation, getInstallationManager(context), getPatchStreamName(context));
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
@@ -63,6 +63,7 @@ public class HostControllerBootOperationsTestCase {
     protected static final PathAddress SERVER_CONFIG_MAIN_THREE = PathAddress.pathAddress(SERVER_CONFIG, "main-three");
     protected static final PathAddress SERVER_MAIN_THREE = PathAddress.pathAddress(SERVER, "main-three");
     protected static final PathAddress CORE_SERVICE_MANAGEMENT = PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT);
+    protected static final PathAddress CORE_SERVICE_PATCHING = PathAddress.pathAddress(CORE_SERVICE, "patching");
     protected static final PathAddress SERVER_GROUP_MAIN_SERVER_GROUP = PathAddress.pathAddress(SERVER_GROUP, "main-server-group");
     protected static final PathAddress JVM_DEFAULT = PathAddress.pathAddress(JVM, "default");
     protected static final PathAddress JVM_BYTEMAN = PathAddress.pathAddress(JVM, "byteman");
@@ -166,6 +167,12 @@ public class HostControllerBootOperationsTestCase {
 
         // assert we are also able to read the HC slave model recursively
         op = Util.createEmptyOperation("read-resource", SLAVE_ADDR);
+        op.get("recursive").set(true);
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        // WFCORE-4596. assert we are able to read patching resource using include-runtime
+        op = Util.createEmptyOperation("read-resource", SLAVE_ADDR.append(CORE_SERVICE_PATCHING));
+        op.get("include-runtime").set(true);
         op.get("recursive").set(true);
         DomainTestUtils.executeForResult(op, masterClient);
 


### PR DESCRIPTION
The read operation should not acquire the write lock, I haven't found a useful use case where this could be necessary. This patch prevents that HAL could get stuck clicking on Patching when there is already a write operation in progress.

Jira issue: https://issues.jboss.org/browse/WFCORE-4596