### PR TITLE
[WFCORE-4725] Add the ability to make use of the IP address of a remote client when making authorization decisions

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -170,6 +170,11 @@ class DomainDefinition extends SimpleResourceDefinition {
         .setCapabilityReference(ROLE_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
+    static final SimpleAttributeDefinition ROLE_DECODER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ROLE_DECODER, ModelType.STRING, true)
+            .setMinSize(1)
+            .setCapabilityReference(ROLE_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
+            .build();
+
     static final ObjectTypeAttributeDefinition REALM = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.REALM, REALM_NAME, REALM_PRINCIPAL_TRANSFORMER, REALM_ROLE_DECODER, ROLE_MAPPER)
         .setRequired(true)
         .build();
@@ -211,7 +216,7 @@ class DomainDefinition extends SimpleResourceDefinition {
 
     private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PRE_REALM_PRINCIPAL_TRANSFORMER, POST_REALM_PRINCIPAL_TRANSFORMER, PRINCIPAL_DECODER,
             REALM_MAPPER, ROLE_MAPPER, PERMISSION_MAPPER, DEFAULT_REALM, REALMS, TRUSTED_SECURITY_DOMAINS, OUTFLOW_ANONYMOUS, OUTFLOW_SECURITY_DOMAINS, SECURITY_EVENT_LISTENER,
-            EVIDENCE_DECODER};
+            EVIDENCE_DECODER, ROLE_DECODER};
 
     private static final DomainAddHandler ADD = new DomainAddHandler();
     private static final OperationStepHandler REMOVE = new DomainRemoveHandler(ADD);
@@ -254,6 +259,7 @@ class DomainDefinition extends SimpleResourceDefinition {
         String roleMapper = ROLE_MAPPER.resolveModelAttribute(context, model).asStringOrNull();
         String evidenceDecoder = EVIDENCE_DECODER.resolveModelAttribute(context, model).asStringOrNull();
         String securityEventListener = SECURITY_EVENT_LISTENER.resolveModelAttribute(context, model).asStringOrNull();
+        String roleDecoder = ROLE_DECODER.resolveModelAttribute(context, model).asStringOrNull();
 
         DomainService domain = new DomainService(defaultRealm, trustedSecurityDomain, identityOperator);
 
@@ -298,6 +304,10 @@ class DomainDefinition extends SimpleResourceDefinition {
             domainBuilder.addDependency(
                     context.getCapabilityServiceName(SECURITY_EVENT_LISTENER_CAPABILITY, securityEventListener, SecurityEventListener.class),
                     SecurityEventListener.class, domain.getSecurityEventListenerInjector());
+        }
+
+        if (roleDecoder != null) {
+            injectRoleDecoder(roleDecoder, context, domainBuilder, domain.createDomainRoleDecoderInjector(roleDecoder));
         }
 
         if (realms.isDefined()) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainService.java
@@ -62,6 +62,7 @@ class DomainService implements Service<SecurityDomain> {
     private String preRealmPrincipalTransformer;
     private String postRealmPrincipalTransformer;
     private String roleMapper;
+    private String roleDecoder;
 
     private final Map<String, RealmDependency> realms = new HashMap<>();
     private final Map<String, InjectedValue<PrincipalTransformer>> principalTransformers = new HashMap<>();
@@ -157,6 +158,11 @@ class DomainService implements Service<SecurityDomain> {
         return securityEventListenerInjector;
     }
 
+    Injector<RoleDecoder> createDomainRoleDecoderInjector(final String name) {
+        this.roleDecoder = name;
+        return createRoleDecoderInjector(name);
+    }
+
     @Override
     public void start(StartContext context) throws StartException {
         SecurityDomain.Builder builder = SecurityDomain.builder();
@@ -185,6 +191,9 @@ class DomainService implements Service<SecurityDomain> {
         EvidenceDecoder evidenceDecoder = evidenceDecoderInjector.getOptionalValue();
         if (evidenceDecoder != null) {
             builder.setEvidenceDecoder(evidenceDecoder);
+        }
+        if (roleDecoder != null) {
+            builder.setRoleDecoder(roleDecoders.get(roleDecoder).getValue());
         }
         if (defaultRealm != null) {
             builder.setDefaultRealmName(defaultRealm);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -247,6 +247,8 @@ class ElytronDefinition extends SimpleResourceDefinition {
         // Role Decoders
         resourceRegistration.registerSubModel(new CustomComponentDefinition<>(RoleDecoder.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_ROLE_DECODER, ROLE_DECODER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(RoleDecoderDefinitions.getSimpleRoleDecoderDefinition());
+        resourceRegistration.registerSubModel(RoleDecoderDefinitions.getSourceAddressRoleDecoderDefinition());
+        resourceRegistration.registerSubModel(RoleDecoderDefinitions.getAggregateRoleDecoderDefinition());
 
         // Role Mappers
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getAddSuffixRoleMapperDefinition());

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -41,6 +41,7 @@ interface ElytronDescriptionConstants {
     String AGGREGATE_PRINCIPAL_TRANSFORMER = "aggregate-principal-transformer";
     String AGGREGATE_PROVIDERS = "aggregate-providers";
     String AGGREGATE_REALM = "aggregate-realm";
+    String AGGREGATE_ROLE_DECODER = "aggregate-role-decoder";
     String AGGREGATE_ROLE_MAPPER = "aggregate-role-mapper";
     String AGGREGATE_SASL_SERVER_FACTORY = "aggregate-sasl-server-factory";
     String AGGREGATE_SECURITY_EVENT_LISTENER = "aggregate-security-event-listener";
@@ -449,6 +450,7 @@ interface ElytronDescriptionConstants {
     String REVOKE_CERTIFICATE = "revoke-certificate";
     String RIGHT = "right";
     String ROLE_DECODER = "role-decoder";
+    String ROLE_DECODERS = "role-decoders";
     String ROLE_RECURSION = "role-recursion";
     String ROLE_RECURSION_NAME = "role-recursion-name";
     String ROLE_MAP = "role-map";
@@ -520,12 +522,14 @@ interface ElytronDescriptionConstants {
     String SIMPLE_ROLE_DECODER = "simple-role-decoder";
     String SIZE = "size";
     String SIZE_ROTATING_FILE_AUDIT_LOG = "size-rotating-file-audit-log";
+    String SOURCE_ADDRESS_ROLE_DECODER = "source-address-role-decoder";
     String SQL = "sql";
     String SSL_CONTEXT = "ssl-context";
     String SSL_CONTEXT_REGISTRATION = "ssl-context-registration";
     String SSL_SESSION = "ssl-session";
     String SNI_MAPPING = "sni-mapping";
     String SOFT_FAIL = "soft-fail";
+    String SOURCE_ADDRESS = "source-address";
     String STAGING = "staging";
     String STAGING_URL = "staging-url";
     String START_SEGMENT = "start-segment";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser10_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser10_0.java
@@ -18,6 +18,12 @@
 
 package org.wildfly.extension.elytron;
 
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SECURITY_DOMAIN;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SECURITY_DOMAINS;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+
 /**
  * The subsystem parser, which uses stax to read and write to and from xml.
  *
@@ -29,6 +35,34 @@ public class ElytronSubsystemParser10_0 extends ElytronSubsystemParser9_0 {
     @Override
     String getNameSpace() {
         return ElytronExtension.NAMESPACE_10_0;
+    }
+
+    final PersistentResourceXMLDescription domainParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(SECURITY_DOMAIN))
+            .setXmlWrapperElement(SECURITY_DOMAINS)
+            .addAttribute(DomainDefinition.DEFAULT_REALM)
+            .addAttribute(DomainDefinition.PERMISSION_MAPPER)
+            .addAttribute(DomainDefinition.PRE_REALM_PRINCIPAL_TRANSFORMER)
+            .addAttribute(DomainDefinition.POST_REALM_PRINCIPAL_TRANSFORMER)
+            .addAttribute(DomainDefinition.PRINCIPAL_DECODER)
+            .addAttribute(DomainDefinition.REALM_MAPPER)
+            .addAttribute(DomainDefinition.ROLE_MAPPER)
+            .addAttribute(DomainDefinition.TRUSTED_SECURITY_DOMAINS)
+            .addAttribute(DomainDefinition.OUTFLOW_ANONYMOUS)
+            .addAttribute(DomainDefinition.OUTFLOW_SECURITY_DOMAINS)
+            .addAttribute(DomainDefinition.SECURITY_EVENT_LISTENER)
+            .addAttribute(DomainDefinition.REALMS)
+            .addAttribute(DomainDefinition.EVIDENCE_DECODER)
+            .addAttribute(DomainDefinition.ROLE_DECODER) // new
+            .build();
+
+    @Override
+    PersistentResourceXMLDescription getDomainParser() {
+        return domainParser;
+    }
+
+    @Override
+    protected PersistentResourceXMLDescription getMapperParser() {
+        return new MapperParser().getParser();
     }
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser8_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser8_0.java
@@ -65,8 +65,9 @@ public class ElytronSubsystemParser8_0 extends ElytronSubsystemParser7_0 {
 
     @Override
     protected PersistentResourceXMLDescription getMapperParser() {
-        return new MapperParser().getParser();
+        return new MapperParser(MapperParser.Version.VERSION_5_0).getParser();
     }
+
 
     @Override
     PersistentResourceXMLDescription getDomainParser() {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -137,6 +137,13 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
                 .getAttributeBuilder()
                 .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CREDENTIAL_REFERENCE)
                 .end();
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN))
+                .getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ElytronDescriptionConstants.ROLE_DECODER)
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, DomainDefinition.ROLE_DECODER)
+                .end();
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.SOURCE_ADDRESS_ROLE_DECODER));
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_ROLE_DECODER));
 
     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RoleDecoderDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RoleDecoderDefinitions.java
@@ -20,7 +20,12 @@ package org.wildfly.extension.elytron;
 import static org.wildfly.extension.elytron.Capabilities.ROLE_DECODER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.ElytronDefinition.commonDependencies;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Pattern;
+
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -29,6 +34,7 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
@@ -39,6 +45,8 @@ import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.security.authz.RoleDecoder;
+import org.wildfly.security.authz.Roles;
+import org.wildfly.security.authz.SourceAddressRoleDecoder;
 
 /**
  * Container class for the {@link RoleDecoder} definitions.
@@ -53,8 +61,38 @@ class RoleDecoderDefinitions {
         .setRestartAllServices()
         .build();
 
+    static final SimpleAttributeDefinition SOURCE_ADDRESS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SOURCE_ADDRESS, ModelType.STRING)
+            .setAllowExpression(true)
+            .setMinSize(1)
+            .setRestartAllServices()
+            .setAlternatives(ElytronDescriptionConstants.PATTERN)
+            .build();
+
+    static final SimpleAttributeDefinition PATTERN = new SimpleAttributeDefinitionBuilder(RegexAttributeDefinitions.PATTERN)
+            .setRestartAllServices()
+            .setAlternatives(ElytronDescriptionConstants.SOURCE_ADDRESS)
+            .build();
+
+    static final StringListAttributeDefinition ROLES = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.ROLES)
+            .setAllowExpression(true)
+            .setMinSize(1)
+            .setRestartAllServices()
+            .build();
+
+    private static final AggregateComponentDefinition<RoleDecoder> AGGREGATE_ROLE_DECODER = AggregateComponentDefinition.create(RoleDecoder.class,
+            ElytronDescriptionConstants.AGGREGATE_ROLE_DECODER, ElytronDescriptionConstants.ROLE_DECODERS, ROLE_DECODER_RUNTIME_CAPABILITY,
+            (RoleDecoder[] r) -> RoleDecoder.aggregate(r));
+
     static ResourceDefinition getSimpleRoleDecoderDefinition() {
         return new SimpleRoleDecoderDefinition();
+    }
+
+    static ResourceDefinition getSourceAddressRoleDecoderDefinition() {
+        return new SourceAddressRoleDecoderDefinition();
+    }
+
+    static AggregateComponentDefinition<RoleDecoder> getAggregateRoleDecoderDefinition() {
+        return AGGREGATE_ROLE_DECODER;
     }
 
     private static class SimpleRoleDecoderDefinition extends SimpleResourceDefinition {
@@ -100,6 +138,63 @@ class RoleDecoderDefinitions {
             commonDependencies(roleDecoderBuilderBuilder)
                 .setInitialMode(Mode.LAZY)
                 .install();
+        }
+
+    }
+
+    private static class SourceAddressRoleDecoderDefinition extends SimpleResourceDefinition {
+
+        private static final AbstractAddStepHandler ADD = new SourceAddressRoleDecoderAddHandler();
+        private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, ROLE_DECODER_RUNTIME_CAPABILITY);
+        private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{SOURCE_ADDRESS, PATTERN, ROLES};
+
+        SourceAddressRoleDecoderDefinition() {
+            super(new Parameters(PathElement.pathElement(ElytronDescriptionConstants.SOURCE_ADDRESS_ROLE_DECODER), ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.SOURCE_ADDRESS_ROLE_DECODER))
+                    .setAddHandler(ADD)
+                    .setRemoveHandler(REMOVE)
+                    .setAddRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                    .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                    .setCapabilities(ROLE_DECODER_RUNTIME_CAPABILITY));
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+            for (AttributeDefinition attributeDefinition : ATTRIBUTES) {
+                resourceRegistration.registerReadWriteAttribute(attributeDefinition, null,
+                        new ElytronReloadRequiredWriteAttributeHandler(attributeDefinition));
+            }
+        }
+    }
+
+    private static class SourceAddressRoleDecoderAddHandler extends BaseAddHandler {
+
+        private SourceAddressRoleDecoderAddHandler() {
+            super(ROLE_DECODER_RUNTIME_CAPABILITY, SOURCE_ADDRESS, PATTERN, ROLES);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+                throws OperationFailedException {
+            ServiceTarget serviceTarget = context.getServiceTarget();
+            RuntimeCapability<Void> runtimeCapability = ROLE_DECODER_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue());
+            ServiceName roleDecoderName = runtimeCapability.getCapabilityServiceName(RoleDecoder.class);
+            final String sourceAddress = SOURCE_ADDRESS.resolveModelAttribute(context, model).asStringOrNull();
+            final String pattern = PATTERN.resolveModelAttribute(context, model).asStringOrNull();
+            final List<String> roles = ROLES.unwrap(context, model);
+
+            TrivialService<RoleDecoder> roleDecoderService;
+            // one of 'source-address' or 'pattern' must be specified
+            if (sourceAddress != null) {
+                roleDecoderService = new TrivialService<>(() -> new SourceAddressRoleDecoder(sourceAddress, Roles.fromSet(new HashSet<>(roles))));
+            } else {
+                roleDecoderService = new TrivialService<>(() -> new SourceAddressRoleDecoder(Pattern.compile(pattern), Roles.fromSet(new HashSet<>(roles))));
+            }
+
+            ServiceBuilder<RoleDecoder> roleDecoderBuilderBuilder = serviceTarget.addService(roleDecoderName, roleDecoderService);
+
+            commonDependencies(roleDecoderBuilderBuilder)
+                    .setInitialMode(Mode.LAZY)
+                    .install();
         }
 
     }

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -254,6 +254,7 @@ elytron.security-domain.permission-mapper=A reference to a PermissionMapper to b
 elytron.security-domain.principal-decoder=A reference to a PrincipalDecoder to be used by this domain.
 elytron.security-domain.realm-mapper=Reference to the RealmMapper to be used by this domain.
 elytron.security-domain.role-mapper=Reference to the RoleMapper to be used by this domain.
+elytron.security-domain.role-decoder=Reference to the RoleDecoder to be used by this domain.
 elytron.security-domain.evidence-decoder=A reference to an EvidenceDecoder to be used by this domain.
 elytron.security-domain.security-event-listener=Reference to a listener for security events.
 elytron.security-domain.default-realm=The default realm contained by this security domain.
@@ -608,6 +609,22 @@ elytron.simple-role-decoder.add=Add operation for the RoleDecoder
 elytron.simple-role-decoder.remove=Remove operation for the RoleDecoder
 # Attributes
 elytron.simple-role-decoder.attribute=The name of the attribute from the identity to map directly to roles.
+
+elytron.source-address-role-decoder=Definition of a RoleDecoder that maps roles based on the IP address of a remote client.
+# Operations
+elytron.source-address-role-decoder.add=Add operation for the RoleDecoder
+elytron.source-address-role-decoder.remove=Remove operation for the RoleDecoder
+# Attributes
+elytron.source-address-role-decoder.source-address=The IP address to match.
+elytron.source-address-role-decoder.pattern=A regular expression that specifies the IP address to match.
+elytron.source-address-role-decoder.roles=The list of roles to assign if the IP address of the remote client matches.
+
+elytron.aggregate-role-decoder=Definition of a RoleDecoder that is an aggregation of other role decoders.
+# Operations
+elytron.aggregate-role-decoder.add=The add operation for the role decoder.
+elytron.aggregate-role-decoder.remove=The remove operation for the role decoder.
+# Attributes
+elytron.aggregate-role-decoder.role-decoders=The referenced role decoders to aggregate.
 
 ################
 # Role Mappers #

--- a/elytron/src/main/resources/schema/wildfly-elytron_10_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_10_0.xsd
@@ -885,6 +885,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="role-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RoleDecoder to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="realm-mapper" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
@@ -2511,6 +2518,8 @@
             <xs:element name="mapped-regex-realm-mapper" type="mappedRegexRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="custom-role-decoder" type="customRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="simple-role-decoder" type="simpleRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="source-address-role-decoder" type="sourceAddressRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-role-decoder" type="aggregateRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="add-prefix-role-mapper" type="addPrefixRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="add-suffix-role-mapper" type="addSuffixRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="aggregate-role-mapper" type="aggregateRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
@@ -3322,6 +3331,73 @@
                 </xs:attribute>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sourceAddressRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleDecoder definition that maps roles based on the IP address of a remote client.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:attribute name="source-address" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The IP address to match.
+
+                            Exactly one of 'source-address' and 'pattern' must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="pattern" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A regular expression that specifies the IP address to match.
+
+                            Exactly one of 'source-address' and 'pattern' must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="roles" type="stringListType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The list of roles to assign if the IP address of the remote client matches.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleDecoder definition that is actually an aggregation of other RoleDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:sequence>
+                    <xs:element name="role-decoder" type="roleDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleDecoderRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a RoleDecoder.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the referenced RoleDecoder.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="roleMapperType" abstract="true">

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -103,6 +103,14 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.DIR_CONTEXT, "dirContext")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SOURCE_ADDRESS_ROLE_DECODER, "ipRoleDecoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SOURCE_ADDRESS_ROLE_DECODER, "regexRoleDecoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_ROLE_DECODER, "aggregateRoleDecoder")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN, "AggregateDomain")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(DomainDefinition.ROLE_DECODER))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SERVER_SSL_CONTEXT)),
                         new FailedOperationTransformationConfig.NewAttributesConfig(SSLDefinitions.CIPHER_SUITE_NAMES))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT)),
@@ -115,7 +123,7 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.AGGREGATE_EVIDENCE_DECODER, "aggregateEvidenceDecoder")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN)),
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SECURITY_DOMAIN, "X500Domain")),
                         new FailedOperationTransformationConfig.NewAttributesConfig(DomainDefinition.EVIDENCE_DECODER))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS, new FailedOperationTransformationConfig.NewAttributesConfig(ElytronDefinition.DEFAULT_SSL_CONTEXT))
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.JASPI_CONFIGURATION, "minimal")),

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
@@ -116,6 +116,12 @@
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
+        <source-address-role-decoder name="ipRoleDecoder" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="employee"/>
+        <aggregate-role-decoder name="aggregateRoleDecoder">
+            <role-decoder name="ipRoleDecoder"/>
+            <role-decoder name="regexRoleDecoder"/>
+        </aggregate-role-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
@@ -30,6 +30,9 @@
                          pre-realm-principal-transformer="MyChainedTransformer" evidence-decoder="subjectDecoder">
             <realm name="PropRealm"/>
         </security-domain>
+        <security-domain name="SourceAddressRoleDecoderDomain" default-realm="TestRealm" permission-mapper="ipPermissionMapper" role-decoder="ipRoleDecoder1">
+            <realm name="TestRealm" role-decoder="groups-to-roles"/>
+        </security-domain>
     </security-domains>
     <security-realms>
         <properties-realm name="PropRealm">
@@ -37,6 +40,10 @@
         </properties-realm>
         <properties-realm name="NonDomainRealm">
             <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
+        </properties-realm>
+        <properties-realm name="TestRealm">
+            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
+            <groups-properties path="users-roles.properties" relative-to="jboss.server.config.dir"/>
         </properties-realm>
         <filesystem-realm name="FileRealm" levels="2" encoded="false">
             <file path="filesystem-realm" relative-to="jboss.server.config.dir"/>
@@ -69,6 +76,12 @@
                 <permission-set name="login-permission"/>
             </permission-mapping>
         </simple-permission-mapper>
+        <simple-permission-mapper name="ipPermissionMapper">
+            <permission-mapping>
+                <role name="admin"/>
+                <permission-set name="login-permission"/>
+            </permission-mapping>
+        </simple-permission-mapper>
         <constant-permission-mapper name="ConstantPermissionMapperLegacy">
             <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
         </constant-permission-mapper>
@@ -96,6 +109,7 @@
         <regex-principal-transformer name="DnsRegex" pattern="(.*)@.*.com" replacement="$1"/>
         <simple-regex-realm-mapper name="MyRealmMapper" pattern=".*@(.*)"/>
         <simple-role-decoder attribute="roles" name="MyRoleDecoder"/>
+        <simple-role-decoder name="groups-to-roles" attribute="groups"/>
         <add-prefix-role-mapper name="RolePrefixer" prefix="prefix"/>
         <add-suffix-role-mapper name="RoleSuffixer" suffix="suffix"/>
         <aggregate-role-mapper name="MyRoleMapper">
@@ -109,6 +123,7 @@
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
+        <source-address-role-decoder name="ipRoleDecoder1" source-address="10.12.14.16" roles="admin user"/>
     </mappers>
     <permission-sets>
         <permission-set name="login-permission">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-10.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-10.0.xml
@@ -39,6 +39,9 @@
         <security-domain name="AnotherDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" trusted-security-domains="MyDomain">
             <realm name="PropRealm"/>
         </security-domain>
+        <security-domain name="AggregateRealm" default-realm="PropRealm" role-decoder="aggregateRoleDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
     </security-domains>
     <security-realms>
         <aggregate-realm name="AggregateOne" authentication-realm="PropRealm" authorization-realm="FileRealm" />
@@ -191,6 +194,12 @@
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
+        <source-address-role-decoder name="ipRoleDecoder" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="employee"/>
+        <aggregate-role-decoder name="aggregateRoleDecoder">
+            <role-decoder name="ipRoleDecoder"/>
+            <role-decoder name="regexRoleDecoder"/>
+        </aggregate-role-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -45,6 +45,9 @@
         <security-domain name="TestDomain" default-realm="FileRealm">
             <realm name="FileRealm" />
         </security-domain>
+        <security-domain name="AggregateDomain" default-realm="FileRealm" role-decoder="aggregateRoleDecoder">
+            <realm name="FileRealm"/>
+        </security-domain>
     </security-domains>
     <security-realms>
         <aggregate-realm name="AggregateOne" authentication-realm="JdbcBcryptHashHex" authorization-realms="JdbcBcryptSaltHex JdbcScramHashHex" />
@@ -110,6 +113,12 @@
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
         <regex-principal-transformer name="RegexOne" pattern="a" replacement="b" />
+        <source-address-role-decoder name="ipRoleDecoder" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="employee"/>
+        <aggregate-role-decoder name="aggregateRoleDecoder">
+            <role-decoder name="ipRoleDecoder"/>
+            <role-decoder name="regexRoleDecoder"/>
+        </aggregate-role-decoder>
     </mappers>
     <tls>
         <key-stores>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
@@ -1,6 +1,18 @@
 <subsystem xmlns="urn:wildfly:elytron:10.0">
     <security-domains>
-        <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder">
+        <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder" role-decoder="ipRoleDecoder1">
+            <realm name="PropRealm"/>
+        </security-domain>
+        <security-domain name="TestingDomainIPv6" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder" role-decoder="ipv6RoleDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
+        <security-domain name="TestingDomainRegex" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder" role-decoder="regexRoleDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
+        <security-domain name="TestingDomainRegexIPv6" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder" role-decoder="ipv6RegexRoleDecoder">
+            <realm name="PropRealm"/>
+        </security-domain>
+        <security-domain name="TestingDomainAggregate" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder" role-decoder="aggregateRoleDecoder">
             <realm name="PropRealm"/>
         </security-domain>
         <security-domain name="CustomTestingDomain" default-realm="PropRealm" evidence-decoder="customEvidenceDecoder">
@@ -44,5 +56,16 @@
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
 
+        <source-address-role-decoder name="ipRoleDecoder1" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="ipRoleDecoder2" source-address="10.12.14.18" roles="employee"/>
+        <source-address-role-decoder name="ipRoleDecoder3" pattern="10\.12\.14\.\d+$" roles="internal"/>
+        <source-address-role-decoder name="ipv6RoleDecoder" source-address="2001:db8:85a3:0:0:8a2e:370:7334" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="admin user"/>
+        <source-address-role-decoder name="ipv6RegexRoleDecoder" pattern="2001\:db8\:85a3\:0\:0\:8a2e\:370\:\d+$" roles="admin user"/>
+        <aggregate-role-decoder name="aggregateRoleDecoder">
+            <role-decoder name="ipRoleDecoder1"/>
+            <role-decoder name="ipRoleDecoder2"/>
+            <role-decoder name="ipRoleDecoder3"/>
+        </aggregate-role-decoder>
     </mappers>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -116,6 +116,12 @@
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
+        <source-address-role-decoder name="ipRoleDecoder" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="employee"/>
+        <aggregate-role-decoder name="aggregateRoleDecoder">
+            <role-decoder name="ipRoleDecoder"/>
+            <role-decoder name="regexRoleDecoder"/>
+        </aggregate-role-decoder>
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/users-roles.properties
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/users-roles.properties
@@ -1,0 +1,7 @@
+# TestRealm roles
+# user1 : admin
+# user2 : employee
+
+#$REALM_NAME=TestRealm1$
+user1=admin
+user2=employee

--- a/testsuite/elytron/configure-elytron.cli
+++ b/testsuite/elytron/configure-elytron.cli
@@ -20,6 +20,8 @@ embed-server --admin-only=true
 /subsystem=elytron/filesystem-realm=ManagementFsRealm:add-identity(identity=guest)
 /subsystem=elytron/filesystem-realm=ManagementFsRealm:add-identity(identity=jwt)
 /subsystem=elytron/filesystem-realm=ManagementFsRealm:add-identity(identity=client)
+/subsystem=elytron/filesystem-realm=ManagementFsRealm:add-identity(identity=alice)
+/subsystem=elytron/filesystem-realm=ManagementFsRealm:add-identity(identity=bob)
 
 /subsystem=elytron/filesystem-realm=ApplicationFsRealm:add-identity(identity=user1)
 /subsystem=elytron/filesystem-realm=ApplicationFsRealm:set-password(identity=user1, clear={password="password1"})

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
@@ -219,9 +219,13 @@ public abstract class AbstractMgmtSaslTestBase {
      * Executes :whoami operation and returns the result ModelNode.
      */
     protected static ModelNode executeWhoAmI() throws IOException {
+        return executeWhoAmI(null);
+    }
+
+    protected static ModelNode executeWhoAmI(String clientBindAddress) throws IOException {
         try (ModelControllerClient client = ModelControllerClient.Factory
                 .create(new ModelControllerClientConfiguration.Builder().setHostName(TestSuiteEnvironment.getServerAddress())
-                        .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS).build())) {
+                        .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS).setClientBindAddress(clientBindAddress).build())) {
 
             ModelNode operation = new ModelNode();
             operation.get("operation").set("whoami");
@@ -235,8 +239,12 @@ public abstract class AbstractMgmtSaslTestBase {
      * Asserts that :whoami operation execution finishes successfully and returned identity (username) is the expected one.
      */
     protected static void assertWhoAmI(String expected) {
+        assertWhoAmI(expected, null);
+    }
+
+    protected static void assertWhoAmI(String expected, String clientBindAddress) {
         try {
-            ModelNode result = executeWhoAmI();
+            ModelNode result = clientBindAddress != null ? executeWhoAmI(clientBindAddress) : executeWhoAmI();
             assertTrue("The whoami operation should finish with success", Operations.isSuccessfulOutcome(result));
             assertEquals("The whoami operation returned unexpected value", expected,
                     Operations.readResult(result).get("identity").get("username").asString());

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
+import org.wildfly.test.security.common.elytron.AggregateRoleDecoder;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.FileSystemRealm;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import org.wildfly.test.security.common.elytron.MechanismRealmConfiguration;
+import org.wildfly.test.security.common.elytron.PermissionMapper;
+import org.wildfly.test.security.common.elytron.SaslFilter;
+import org.wildfly.test.security.common.elytron.SimpleConfigurableSaslServerFactory;
+import org.wildfly.test.security.common.elytron.SimplePermissionMapper;
+import org.wildfly.test.security.common.elytron.SimpleSaslAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SourceAddressRoleDecoder;
+import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
+import org.wildfly.test.security.common.other.SimpleSocketBinding;
+import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
+
+/**
+ * Test authentication with the use of a source address role decoder where the IP address of the remote
+ * client matches the address configured on the decoder.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerSetup({ AuthenticationWithSourceAddressRoleDecoderMatchTestCase.ServerSetup.class })
+public class AuthenticationWithSourceAddressRoleDecoderMatchTestCase extends AbstractMgmtSaslTestBase {
+
+    private static final String MECHANISM = "DIGEST-MD5";
+    private static final String NAME = AuthenticationWithSourceAddressRoleDecoderMatchTestCase.class.getSimpleName();
+    private static final String AGGREGATE_ROLE_DECODER = "aggregateRoleDecoder";
+    private static final String DECODER_1 = "decoder1";
+    private static final String DECODER_2 = "decoder2";
+    private static final String IP_PERMISSION_MAPPER = "ipPermissionMapper";
+
+    @Override
+    protected String getMechanism() {
+        return MECHANISM;
+    }
+
+    /* The security domain being used in this test is configured with:
+    1) a source-address-role-decoder that assigns the "Admin" role if the IP address of the remote client is TestSuiteEnvironment.getServerAddress()
+    2) a permission-mapper that assigns the "LoginPermission" if the identity has the "Admin" role unless the principal
+    is "user3"
+    */
+
+    @Test
+    public void testAuthenticationIPAddressAndPermissionMapperMatch() {
+        assertMechPassWhoAmI(MECHANISM, "alice");
+        assertMechPassWhoAmI(MECHANISM, "bob");
+    }
+
+    @Test
+    public void testAuthenticationIPAddressMatchAndPermissionMapperMismatch() {
+        createValidConfigForMechanism(MECHANISM, "user3").run(() -> assertAuthenticationFails());
+    }
+
+    public static class ServerSetup extends TestRunnerConfigSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = createConfigurableElementsForSaslMech();
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+
+    protected void assertMechPassWhoAmI(String mechanismName, String expectedUsername) {
+        createValidConfigForMechanism(mechanismName, expectedUsername).run(() -> assertWhoAmI(expectedUsername, TestSuiteEnvironment.getServerAddress()));
+    }
+
+    private static String getIPAddress() throws IllegalStateException {
+        try {
+            return InetAddress.getByName(TestSuiteEnvironment.getServerAddress()).getHostAddress();
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    protected static List<ConfigurableElement> createConfigurableElementsForSaslMech() {
+        List<ConfigurableElement> elements = new ArrayList<>();
+        HashSet<String> roles = new HashSet<>();
+        roles.add("Admin");
+        HashSet<String> permissionSets = new HashSet<>();
+        permissionSets.add("login-permission");
+        permissionSets.add("default-permissions");
+        HashSet<String> principals = new HashSet<>();
+        principals.add("user3");
+        elements.add(SimplePermissionMapper.builder()
+                .withName(IP_PERMISSION_MAPPER)
+                .withMapping(Collections.emptySet(), roles, permissionSets)
+                .withMapping(principals, Collections.emptySet(), Collections.emptySet())
+                .withMappingMode(PermissionMapper.MappingMode.AND)
+                .build());
+        elements.add(SourceAddressRoleDecoder.builder()
+                .withName(DECODER_1)
+                .withIPAddress(getIPAddress())
+                .withRole("Admin")
+                .build());
+        elements.add(SourceAddressRoleDecoder.builder()
+                .withName(DECODER_2)
+                .withIPAddress("99.99.99.99")
+                .withRole("Employee")
+                .build());
+        elements.add(AggregateRoleDecoder.builder()
+                .withName("aggregateRoleDecoder")
+                .withRoleDecoder(DECODER_1)
+                .withRoleDecoder(DECODER_2)
+                .build());
+        elements.add(FileSystemRealm.builder().withName("fsRealm")
+                .withUser(USERNAME, USERNAME + PASSWORD_SFX, ROLE_SASL)
+                .withUser("alice", "alice" + PASSWORD_SFX, "Employee")
+                .withUser("bob", "bob" + PASSWORD_SFX, "Admin")
+                .withUser("user3", "user3" + PASSWORD_SFX, "Employee")
+                .build());
+        elements.add(SimpleSecurityDomain.builder().withName(NAME).withDefaultRealm("fsRealm").withRoleDecoder("groups-to-roles").withPermissionMapper(IP_PERMISSION_MAPPER)
+                .withRealms(SimpleSecurityDomain.SecurityDomainRealm.builder().withRealm("fsRealm").build())
+                .withPermissionMapper(IP_PERMISSION_MAPPER)
+                .withRoleDecoder(AGGREGATE_ROLE_DECODER)
+                .build());
+        elements.add(TrustedDomainsConfigurator.builder().withName("ManagementDomain").withTrustedSecurityDomains(NAME).build());
+
+        elements.add(SimpleConfigurableSaslServerFactory.builder().withName(NAME).withSaslServerFactory("elytron")
+                .addFilter(SaslFilter.builder().withPatternFilter(MECHANISM).build()).build());
+        elements.add(
+                SimpleSaslAuthenticationFactory.builder().withName(NAME).withSaslServerFactory(NAME).withSecurityDomain(NAME)
+                        .addMechanismConfiguration(
+                                MechanismConfiguration.builder().withMechanismName(MECHANISM)
+                                        .addMechanismRealmConfiguration(
+                                                MechanismRealmConfiguration.builder().withRealmName(NAME).build())
+                                        .build())
+                        .build());
+
+        elements.add(SimpleSocketBinding.builder().withName(NAME).withPort(PORT_NATIVE).build());
+        elements.add(SimpleMgmtNativeInterface.builder().withSocketBinding(NAME).withSaslAuthenticationFactory(NAME).build());
+        return elements;
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
+import org.wildfly.test.security.common.elytron.AggregateRoleDecoder;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.FileSystemRealm;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import org.wildfly.test.security.common.elytron.MechanismRealmConfiguration;
+import org.wildfly.test.security.common.elytron.PermissionMapper;
+import org.wildfly.test.security.common.elytron.SaslFilter;
+import org.wildfly.test.security.common.elytron.SimpleConfigurableSaslServerFactory;
+import org.wildfly.test.security.common.elytron.SimplePermissionMapper;
+import org.wildfly.test.security.common.elytron.SimpleSaslAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SourceAddressRoleDecoder;
+import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
+import org.wildfly.test.security.common.other.SimpleSocketBinding;
+import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
+
+/**
+ * Test authentication with the use of a source address role decoder where the IP address of the remote
+ * client does not match the address configured on the decoder.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerSetup({ AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.ServerSetup.class })
+public class AuthenticationWithSourceAddressRoleDecoderMismatchTestCase extends AbstractMgmtSaslTestBase {
+
+    private static final String MECHANISM = "DIGEST-MD5";
+    private static final String NAME = AuthenticationWithSourceAddressRoleDecoderMatchTestCase.class.getSimpleName();
+    private static final String AGGREGATE_ROLE_DECODER = "aggregateRoleDecoder";
+    private static final String DECODER_1 = "decoder1";
+    private static final String DECODER_2 = "decoder2";
+    private static final String IP_PERMISSION_MAPPER = "ipPermissionMapper";
+
+    @Override
+    protected String getMechanism() {
+        return MECHANISM;
+    }
+
+    /* The security domain being used in this test is configured with:
+    1) a source-address-role-decoder that assigns the "Admin" role if the IP address of the remote client is 999.999.999.999
+    2) a permission-mapper that assigns the "LoginPermission" if the identity has the "Admin" role unless the principal
+    is "user3"
+    */
+
+    @Test
+    public void testAuthenticationIPAddressMismatch() {
+        createValidConfigForMechanism(MECHANISM, "alice").run(() -> assertAuthenticationFails());
+        createValidConfigForMechanism(MECHANISM, "user3").run(() -> assertAuthenticationFails());
+    }
+
+    @Test
+    public void testAuthenticationIPAddressMismatchWithSecurityRealmRole() {
+        assertMechPassWhoAmI(MECHANISM, "bob");
+    }
+
+    public static class ServerSetup extends TestRunnerConfigSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = createConfigurableElementsForSaslMech();
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+
+    protected void assertMechPassWhoAmI(String mechanismName, String expectedUsername) {
+        createValidConfigForMechanism(mechanismName, expectedUsername).run(() -> assertWhoAmI(expectedUsername));
+    }
+
+    protected static List<ConfigurableElement> createConfigurableElementsForSaslMech() {
+        List<ConfigurableElement> elements = new ArrayList<>();
+        HashSet<String> roles = new HashSet<>();
+        roles.add("Admin");
+        HashSet<String> permissionSets = new HashSet<>();
+        permissionSets.add("login-permission");
+        permissionSets.add("default-permissions");
+        HashSet<String> principals = new HashSet<>();
+        principals.add("user3");
+        elements.add(SimplePermissionMapper.builder()
+                .withName(IP_PERMISSION_MAPPER)
+                .withMapping(Collections.emptySet(), roles, permissionSets)
+                .withMapping(principals, Collections.emptySet(), Collections.emptySet())
+                .withMappingMode(PermissionMapper.MappingMode.AND)
+                .build());
+        elements.add(SourceAddressRoleDecoder.builder()
+                .withName(DECODER_1)
+                .withIPAddress("999.999.999.999")
+                .withRole("Admin")
+                .build());
+        elements.add(SourceAddressRoleDecoder.builder()
+                .withName(DECODER_2)
+                .withIPAddress("99.99.99.99")
+                .withRole("Employee")
+                .build());
+        elements.add(AggregateRoleDecoder.builder()
+                .withName("aggregateRoleDecoder")
+                .withRoleDecoder(DECODER_1)
+                .withRoleDecoder(DECODER_2)
+                .build());
+        elements.add(FileSystemRealm.builder().withName("fsRealm")
+                .withUser(USERNAME, USERNAME + PASSWORD_SFX, ROLE_SASL)
+                .withUser("alice", "alice" + PASSWORD_SFX, "Employee")
+                .withUser("bob", "bob" + PASSWORD_SFX, "Admin")
+                .withUser("user3", "user3" + PASSWORD_SFX, "Employee")
+                .build());
+        elements.add(SimpleSecurityDomain.builder().withName(NAME).withDefaultRealm("fsRealm").withPermissionMapper(IP_PERMISSION_MAPPER)
+                .withRealms(SimpleSecurityDomain.SecurityDomainRealm.builder().withRealm("fsRealm").withRoleDecoder("groups-to-roles").build())
+                .withPermissionMapper(IP_PERMISSION_MAPPER)
+                .withRoleDecoder(AGGREGATE_ROLE_DECODER)
+                .build());
+        elements.add(TrustedDomainsConfigurator.builder().withName("ManagementDomain").withTrustedSecurityDomains(NAME).build());
+
+        elements.add(SimpleConfigurableSaslServerFactory.builder().withName(NAME).withSaslServerFactory("elytron")
+                .addFilter(SaslFilter.builder().withPatternFilter(MECHANISM).build()).build());
+        elements.add(
+                SimpleSaslAuthenticationFactory.builder().withName(NAME).withSaslServerFactory(NAME).withSecurityDomain(NAME)
+                        .addMechanismConfiguration(
+                                MechanismConfiguration.builder().withMechanismName(MECHANISM)
+                                        .addMechanismRealmConfiguration(
+                                                MechanismRealmConfiguration.builder().withRealmName(NAME).build())
+                                        .build())
+                        .build());
+
+        elements.add(SimpleSocketBinding.builder().withName(NAME).withPort(PORT_NATIVE).build());
+        elements.add(SimpleMgmtNativeInterface.builder().withSocketBinding(NAME).withSaslAuthenticationFactory(NAME).build());
+        return elements;
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AggregateRoleDecoder.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AggregateRoleDecoder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Configuration for aggregate-role-decoder Elytron resource.
+ */
+public class AggregateRoleDecoder extends AbstractConfigurableElement {
+
+    private static final String AGGREGATE_ROLE_DECODER = "aggregate-role-decoder";
+    private static final PathAddress PATH_ELYTRON = PathAddress.pathAddress().append("subsystem", "elytron");
+    private List<String> roleDecoders;
+
+    private AggregateRoleDecoder(Builder builder) {
+        super(builder);
+        this.roleDecoders = builder.roleDecoders;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(PATH_ELYTRON.append(AGGREGATE_ROLE_DECODER, name));
+        if (roleDecoders != null && ! roleDecoders.isEmpty()) {
+            for (String roleDecoder : roleDecoders) {
+                op.get("role-decoders").add(roleDecoder);
+            }
+            CoreUtils.applyUpdate(op, client);
+        }
+
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        CoreUtils.applyUpdate(Util.createRemoveOperation(PATH_ELYTRON.append(AGGREGATE_ROLE_DECODER, name)), client);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for this class.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<AggregateRoleDecoder.Builder> {
+        private List<String> roleDecoders = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        public AggregateRoleDecoder build() {
+            return new AggregateRoleDecoder(this);
+        }
+
+        public Builder withRoleDecoder(String roleDecoder) {
+            roleDecoders.add(roleDecoder);
+            return this;
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimplePermissionMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimplePermissionMapper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Configuration for simple-permission-mapper Elytron resource.
+ */
+public class SimplePermissionMapper extends AbstractConfigurableElement implements PermissionMapper {
+
+    private static final String SIMPLE_PERMISSION_MAPPER = "simple-permission-mapper";
+    private static final PathAddress PATH_ELYTRON = PathAddress.pathAddress().append("subsystem", "elytron");
+    private final List<Mapping> mappingList;
+    private final MappingMode mappingMode;
+
+    private SimplePermissionMapper(Builder builder) {
+        super(builder);
+        this.mappingList = builder.mappingList;
+        this.mappingMode = builder.mappingMode;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(PATH_ELYTRON.append(SIMPLE_PERMISSION_MAPPER, name));
+        if (mappingList != null && ! mappingList.isEmpty()) {
+            for (Mapping mapping : mappingList) {
+                ModelNode permissionMapping = new ModelNode();
+                for (String role : mapping.roles) {
+                    permissionMapping.get("roles").add(role);
+                }
+                for (String principal : mapping.principals) {
+                    permissionMapping.get("principals").add(principal);
+                }
+                for (String permissionSetName : mapping.permissionSets) {
+                    ModelNode permissionSet = new ModelNode();
+                    permissionSet.get("permission-set").set(permissionSetName);
+                    permissionMapping.get("permission-sets").add(permissionSet);
+                }
+                op.get("permission-mappings").add(permissionMapping);
+                op.get("mapping-mode").set(mappingMode.toString());
+            }
+            CoreUtils.applyUpdate(op, client);
+        }
+
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        CoreUtils.applyUpdate(Util.createRemoveOperation(PATH_ELYTRON.append(SIMPLE_PERMISSION_MAPPER, name)), client);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for this class.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<SimplePermissionMapper.Builder> {
+        private List<Mapping> mappingList = new ArrayList<>();
+        private MappingMode mappingMode;
+
+        private Builder() {
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        public SimplePermissionMapper build() {
+            return new SimplePermissionMapper(this);
+        }
+
+        public Builder withMapping(Set<String> principals, Set<String> roles, Set<String> permissionSets) {
+            mappingList.add(new Mapping(principals, roles, permissionSets));
+            return this;
+        }
+
+        public Builder withMappingMode(MappingMode mappingMode) {
+            this.mappingMode = mappingMode;
+            return this;
+        }
+    }
+
+    private static final class Mapping {
+        final Set<String> principals;
+        final Set<String> roles;
+        final Set<String> permissionSets;
+
+        Mapping(Set<String> principals, Set<String> roles, Set<String> permissionSets) {
+            this.principals = principals;
+            this.roles = roles;
+            this.permissionSets = permissionSets;
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleSecurityDomain.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleSecurityDomain.java
@@ -44,6 +44,7 @@ public class SimpleSecurityDomain extends AbstractConfigurableElement {
     private final String roleMapper;
     private final String securityEventListener;
     private final String[] trustedSecurityDomains;
+    private final String roleDecoder;
 
     private SimpleSecurityDomain(Builder builder) {
         super(builder);
@@ -59,6 +60,7 @@ public class SimpleSecurityDomain extends AbstractConfigurableElement {
         this.roleMapper = builder.roleMapper;
         this.securityEventListener = builder.securityEventListener;
         this.trustedSecurityDomains = builder.trustedSecurityDomains;
+        this.roleDecoder = builder.roleDecoder;
     }
 
     @Override
@@ -89,6 +91,7 @@ public class SimpleSecurityDomain extends AbstractConfigurableElement {
         setIfNotNull(op, "role-mapper", roleMapper);
         setIfNotNull(op, "security-event-listener", securityEventListener);
         setIfNotNull(op, "trusted-security-domains", trustedSecurityDomains);
+        setIfNotNull(op, "role-decoder", roleDecoder);
         CoreUtils.applyUpdate(op, client);
     }
 
@@ -123,6 +126,7 @@ public class SimpleSecurityDomain extends AbstractConfigurableElement {
         private String roleMapper;
         private String securityEventListener;
         private String[] trustedSecurityDomains;
+        private String roleDecoder;
 
         private Builder() {
         }
@@ -184,6 +188,11 @@ public class SimpleSecurityDomain extends AbstractConfigurableElement {
 
         public Builder withTrustedSecurityDomains(String[] trustedSecurityDomains) {
             this.trustedSecurityDomains = trustedSecurityDomains;
+            return this;
+        }
+
+        public Builder withRoleDecoder(String roleDecoder) {
+            this.roleDecoder = roleDecoder;
             return this;
         }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SourceAddressRoleDecoder.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SourceAddressRoleDecoder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Configuration for source-address-role-decoder Elytron resource.
+ */
+public class SourceAddressRoleDecoder extends AbstractConfigurableElement {
+
+    private static final String SOURCE_ADDRESS_ROLE_DECODER = "source-address-role-decoder";
+    private static final PathAddress PATH_ELYTRON = PathAddress.pathAddress().append("subsystem", "elytron");
+    private final String ipAddress;
+    private final String role;
+
+    private SourceAddressRoleDecoder(Builder builder) {
+        super(builder);
+        this.ipAddress = builder.ipAddress;
+        this.role = builder.role;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(PATH_ELYTRON.append(SOURCE_ADDRESS_ROLE_DECODER, name));
+        op.get("source-address").set(ipAddress);
+        op.get("roles").add(role);
+        CoreUtils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        CoreUtils.applyUpdate(Util.createRemoveOperation(PATH_ELYTRON.append(SOURCE_ADDRESS_ROLE_DECODER, name)), client);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for this class.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<SourceAddressRoleDecoder.Builder> {
+        private String ipAddress;
+        private String role;
+
+        private Builder() {
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        public SourceAddressRoleDecoder build() {
+            return new SourceAddressRoleDecoder(this);
+        }
+
+        public Builder withIPAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+            return this;
+        }
+
+        public Builder withRole(String role) {
+            this.role = role;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4725

To pass CI, this will require both an Elytron upgrade and a Remoting upgrade but this is ready for the subsystem changes to be reviewed.

Analysis document: https://github.com/wildfly/wildfly-proposals/pull/254
WildFly PR with tests and documentation updates: https://github.com/wildfly/wildfly/pull/12825
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/1355
Depends on https://github.com/jboss-remoting/jboss-remoting/pull/225
Depends on https://github.com/wildfly/wildfly-core/pull/4018
