### PR TITLE
[WFCORE-4759] Upgrade to Galleon and WFGP 4.2.1.Final

### DIFF
--- a/core-galleon-pack/wildfly-feature-pack-build.xml
+++ b/core-galleon-pack/wildfly-feature-pack-build.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
+<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
     <default-packages>
         <package name="modules.all"/>
         <package name="docs"/>

--- a/pom.xml
+++ b/pom.xml
@@ -110,10 +110,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>4.1.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.2.1.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>4.0.4.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.2.2.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->


### PR DESCRIPTION
Upgrade to the latest Galleon and WildFly Galleon Plugins that at the moment are at 4.2.1.Final.

https://issues.jboss.org/browse/WFCORE-4759