### PR TITLE
[WFCORE-4766] Report error if triggering rollback due to missing services.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3562,4 +3562,8 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 458, value = "Disallowed HTTP Header name '%s'")
     OperationFailedException disallowedHeaderName(String value);
 
+    @LogMessage(level = ERROR)
+    @Message(id = 459, value = "Triggering roll back due to missing management services.")
+    void missingManagementServices();
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/management/ManagementInterfaceAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/management/ManagementInterfaceAddStepHandler.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.as.controller.management;
 
+import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -108,6 +109,7 @@ public abstract class ManagementInterfaceAddStepHandler extends AbstractAddStepH
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             Boolean attachment = context.getAttachment(MANAGEMENT_INTERFACE_KEY);
             if (attachment == null ||!context.getAttachment(MANAGEMENT_INTERFACE_KEY)) {
+                ROOT_LOGGER.missingManagementServices();
                 context.setRollbackOnly();
             }
         }


### PR DESCRIPTION
Addition of an additional error message: -

https://issues.jboss.org/browse/WFCORE-4766

I haven't added loads of detail to the message as in general this is a situation that should not occur but as discovered recently if it does occur we don't log anything to provide a starting point.  With this message we can see the starting point more clearly and at least know where to attach the debugger.