### PR TITLE
[WFCORE-4768] WFLYIO001: Worker 'default' has auto-configured to 24 core threads should be IO threads

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/logging/IOLogger.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/logging/IOLogger.java
@@ -51,19 +51,19 @@ public interface IOLogger extends BasicLogger {
 
 
     @LogMessage(level = INFO)
-    @Message(id = 1, value = "Worker '%s' has auto-configured to %d core threads with %d task threads based on your %d available processors")
+    @Message(id = 1, value = "Worker '%s' has auto-configured to %d IO threads with %d max task threads based on your %d available processors")
     void printDefaults(String workerName, int ioThreads, int workerThreads, int cpuCount);
 
     @LogMessage(level = INFO)
-    @Message(id = 2, value = "Worker '%s' has auto-configured to %d core threads based on your %d available processors")
+    @Message(id = 2, value = "Worker '%s' has auto-configured to %d IO threads based on your %d available processors")
     void printDefaultsIoThreads(String workerName, int ioThreads, int cpuCount);
 
     @LogMessage(level = INFO)
-    @Message(id = 3, value = "Worker '%s' has auto-configured to %d task threads based on your %d available processors")
+    @Message(id = 3, value = "Worker '%s' has auto-configured to %d max task threads based on your %d available processors")
     void printDefaultsWorkerThreads(String workerName, int workerThreads, int cpuCount);
 
     @LogMessage(level = WARN)
-    @Message(id = 4, value = "Worker '%s' would auto-configure to %d task threads based on %d available processors, however your system does not have enough file descriptors configured to support this configuration. It is likely you will experience application degradation unless you increase your file descriptor limit.")
+    @Message(id = 4, value = "Worker '%s' would auto-configure to %d max task threads based on %d available processors, however your system does not have enough file descriptors configured to support this configuration. It is likely you will experience application degradation unless you increase your file descriptor limit.")
     void lowFD(String workerName, int suggestedWorkerThreadCount, int cpuCount);
 
     @LogMessage(level = WARN)


### PR DESCRIPTION
Jira issue: https://issues.jboss.org/browse/WFCORE-4768

It's a silly change about the messages for the auto-configured values in the IO subsystem. Current messages seems to be confusing for users. We are using now a more similar similar words to the ones present in the CLI option (`io-threads` => `XX IO threads` and `task-max-threads` => `XX max task threads`). The main problem seems to be the core instead IO. I asked Brad to decide the final message, but if you prefer something different just let me know.