### PR TITLE
[WFCORE-4769] Upgrade WildFly Elytron to 1.11.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.11.0.CR2</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.0.CR3</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.0.CR2</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4769


        Release Notes - WildFly Elytron - Version 1.11.0.CR3
                                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1853'>ELY-1853</a>] -         WS integration with WildFly Elytron - AuthenticationClient for Authentication / SSL
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1908'>ELY-1908</a>] -         Typo in SimpleSecurityEventFormatter
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1900'>ELY-1900</a>] -         Add version 1.5 of the Elytron client schema
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1903'>ELY-1903</a>] -         Emit SecurityEvent when RealmUnavailableException is thrown
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1912'>ELY-1912</a>] -         Release WildFly Elytron 1.11.0.CR3
</li>
</ul>
                    