### PR TITLE
[WFCORE-2356] Failure in a step ResultHandler should not always be reported as occurring during rollback

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -1521,7 +1521,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 }
             } catch (Exception e) {
                 final String failedRollbackMessage =
-                        MGMT_OP_LOGGER.stepHandlerFailedRollback(handler, operation.get(OP).asString(), address, e);
+                        MGMT_OP_LOGGER.stepHandlerFailed(handler, operation.get(OP).asString(), address, e);
                 MGMT_OP_LOGGER.errorf(e, failedRollbackMessage);
                 report(MessageSeverity.ERROR, failedRollbackMessage);
             }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -2162,7 +2162,7 @@ public interface ControllerLogger extends BasicLogger {
 //    String stepHandlerFailed(OperationStepHandler handler);
 
     /**
-     * A message indicating the step handler for the operation failed handling operation rollback.
+     * A message indicating the step handler for the operation failed.
      *
      * @param handler the handler that failed.
      * @param op      the operation.
@@ -2171,8 +2171,8 @@ public interface ControllerLogger extends BasicLogger {
      *
      * @return the message.
      */
-    @Message(id = 190, value = "Step handler %s for operation %s at address %s failed handling operation rollback -- %s")
-    String stepHandlerFailedRollback(OperationStepHandler handler, String op, PathAddress address, Throwable cause);
+    @Message(id = 190, value = "Step handler %s for operation %s at address %s failed -- %s")
+    String stepHandlerFailed(OperationStepHandler handler, String op, PathAddress address, Throwable cause);
 
     /**
      * A message indicating an interruption awaiting subsystem boot operation execution.


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2356