### PR TITLE
[WFCORE-3948] Revert the CopyOnWriteArrayList approach in favor of Sy…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/ManifestClassPathProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ManifestClassPathProcessor.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -129,9 +130,14 @@ public final class ManifestClassPathProcessor implements DeploymentUnitProcessor
         // note that if a resource root has been added to two different additional modules
         // and is then referenced via a Class-Path entry the behaviour is undefined
         final Map<VirtualFile, AdditionalModuleSpecification> additionalModules = new HashMap<VirtualFile, AdditionalModuleSpecification>();
-        for (AdditionalModuleSpecification module : topLevelDeployment.getAttachmentList(Attachments.ADDITIONAL_MODULES)) {
-            for (ResourceRoot additionalModuleResourceRoot : module.getResourceRoots()) {
-                additionalModules.put(additionalModuleResourceRoot.getRoot(), module);
+        final List<AdditionalModuleSpecification> additionalModuleList = topLevelDeployment.getAttachmentList(Attachments.ADDITIONAL_MODULES);
+        // Must synchronize on list as subdeployments executing Phase.STRUCTURE may be concurrently modifying it
+        //noinspection SynchronizationOnLocalVariableOrMethodParameter
+        synchronized (additionalModuleList) {
+            for (AdditionalModuleSpecification module : additionalModuleList) {
+                for (ResourceRoot additionalModuleResourceRoot : module.getResourceRoots()) {
+                    additionalModules.put(additionalModuleResourceRoot.getRoot(), module);
+                }
             }
         }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ManifestDependencyProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ManifestDependencyProcessor.java
@@ -69,9 +69,14 @@ public final class ManifestDependencyProcessor implements DeploymentUnitProcesso
         final List<ResourceRoot> allResourceRoots = DeploymentUtils.allResourceRoots(deploymentUnit);
         DeploymentUnit top = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();
 
-        Set<ModuleIdentifier> additionalModules = new HashSet<>();
-        for(AdditionalModuleSpecification i : top.getAttachmentList(Attachments.ADDITIONAL_MODULES)) {
-            additionalModules.add(i.getModuleIdentifier());
+        final Set<ModuleIdentifier> additionalModules = new HashSet<>();
+        final List<AdditionalModuleSpecification> additionalModuleList = top.getAttachmentList(Attachments.ADDITIONAL_MODULES);
+        // Must synchronize on list as subdeployments executing Phase.STRUCTURE may be concurrently modifying it
+        //noinspection SynchronizationOnLocalVariableOrMethodParameter
+        synchronized (additionalModuleList) {
+            for (AdditionalModuleSpecification i : additionalModuleList) {
+                additionalModules.add(i.getModuleIdentifier());
+            }
         }
         for (final ResourceRoot resourceRoot : allResourceRoots) {
             final Manifest manifest = resourceRoot.getAttachment(Attachments.MANIFEST);

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
@@ -131,8 +131,13 @@ public class DeploymentStructureDescriptorParser implements DeploymentUnitProces
             if (deploymentRoot.hasAttachment(SUB_DEPLOYMENT_STRUCTURE)) {
                 final ModuleSpecification subModuleSpec = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
                 Map<ModuleIdentifier, AdditionalModuleSpecification> additionalModules = new HashMap<>();
-                for(AdditionalModuleSpecification i : deploymentUnit.getParent().getAttachmentList(Attachments.ADDITIONAL_MODULES)) {
-                    additionalModules.put(i.getModuleIdentifier(), i);
+                final List<AdditionalModuleSpecification> additionalModuleList = deploymentUnit.getParent().getAttachmentList(Attachments.ADDITIONAL_MODULES);
+                // Must synchronize on list as subdeployments executing Phase.STRUCTURE may be concurrently modifying it
+                //noinspection SynchronizationOnLocalVariableOrMethodParameter
+                synchronized (additionalModuleList) {
+                    for (AdditionalModuleSpecification i : additionalModuleList) {
+                        additionalModules.put(i.getModuleIdentifier(), i);
+                    }
                 }
                 handleDeployment(phaseContext, deploymentUnit, subModuleSpec, deploymentRoot.getAttachment(SUB_DEPLOYMENT_STRUCTURE), additionalModules);
             }


### PR DESCRIPTION
…nchronizedList semantics and synchronized iteration where needed

The first attempt at this backed AttachmentList with a CopyOnWriteArrayList but that meant not supporting modifications from the iterators. It turns out that was a breaking change.

Iteration while concurrent writes are going on is not a common case, so go with SynchronizedList semantics and require uses that need thread safe iteration to synchronize on the list.

https://issues.redhat.com/browse/WFCORE-3948