### PR TITLE
Fix for WFCORE-4776, NPE in EmbeddedServer for version/help arguments

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -267,7 +267,10 @@ public class EmbeddedStandaloneServerFactory {
 
                     // Determine the ServerEnvironment
                     ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv, ServerEnvironment.LaunchType.EMBEDDED, startTime).getServerEnvironment();
-
+                    if (serverEnvironment == null) {
+                        // Nothing to do
+                        return;
+                    }
                     bootstrap = Bootstrap.Factory.newInstance();
 
                     Bootstrap.Configuration configuration = new Bootstrap.Configuration(serverEnvironment);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-4776

Avoid NPE by returning in cases where we don't have a server env and status is normal.