### PR TITLE
[WFCORE-4700] Adding MicroProfile JWT

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -65,6 +65,7 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-jacc}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-jaspi}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-json-util}"/>
+        <!-- <artifact name="${org.wildfly.security:wildfly-elytron-jwt}"/> To be added as independent module in WildFly -->
         <artifact name="${org.wildfly.security:wildfly-elytron-keystore}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-mechanism}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-mechanism-digest}"/>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -514,6 +514,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
                             processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.CONFIGURE_MODULE, Phase.CONFIGURE_DEFAULT_SSL_CONTEXT, new SSLContextDependencyProcessor());
                         }
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.FIRST_MODULE_USE, Phase.FIRST_MODULE_USE_AUTHENTICATION_CONTEXT, new AuthenticationContextAssociationProcessor());
+                        processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_VIRTUAL_SECURITY_DOMAIN, new VirtualSecurityDomainProcessor());
                     }
                 }, Stage.RUNTIME);
             }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/VirtualSecurityDomainProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/VirtualSecurityDomainProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import static org.jboss.as.server.security.VirtualDomainMarkerUtility.isVirtualDomainRequired;
+import static org.jboss.as.server.security.VirtualDomainMarkerUtility.virtualDomainName;
+
+import java.util.function.Consumer;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.security.auth.server.SecurityDomain;
+
+/**
+ * A {@link DeploymentUnitProcessor} to install a virtual {@link SecurityDomain} if required.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class VirtualSecurityDomainProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (deploymentUnit.getParent() != null || !isVirtualDomainRequired(deploymentUnit)) {
+            return;  // Only interested in installation if this is really the root deployment.
+        }
+
+        ServiceName virtualDomainName = virtualDomainName(deploymentUnit);
+        ServiceTarget serviceTarget = phaseContext.getServiceTarget();
+
+        ServiceBuilder<?> serviceBuilder = serviceTarget.addService(virtualDomainName);
+
+        final SecurityDomain virtualDomain = SecurityDomain.builder().build();
+        final Consumer<SecurityDomain> consumer = serviceBuilder.provides(virtualDomainName);
+
+        serviceBuilder.setInstance(Service.newInstance(consumer, virtualDomain));
+        serviceBuilder.setInitialMode(Mode.ON_DEMAND);
+        serviceBuilder.install();
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit deploymentUnit) {}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1648,6 +1648,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-jwt</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-keystore</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -401,6 +401,7 @@ public enum Phase {
     public static final int PARSE_ORIENT_DRIVER                         = 0x4C01;
     public static final int PARSE_CASSANDRA_DRIVER                      = 0x4C02;
     public static final int PARSE_MONGO_DRIVER                          = 0x4C03;
+    public static final int PARSE_MICROPROFILE_JWT_DETECTION            = 0x4C0D;
 
     // REGISTER
     /**
@@ -450,7 +451,9 @@ public enum Phase {
     public static final int DEPENDENCIES_MICROPROFILE_HEALTH            = 0x1870;
     public static final int DEPENDENCIES_MICROPROFILE_OPENTRACING       = 0x1880;
     public static final int DEPENDENCIES_MICROPROFILE_OPENAPI           = 0x1890;
+    public static final int DEPENDENCIES_MICROPROFILE_JWT               = 0x18A0;
     public static final int DEPENDENCIES_MICROPROFILE_FAULT_TOLERANCE   = 0x1900;
+
 
     /**
      * @deprecated there is no phase processing associated with this constant - it was used for OSGi integration

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -628,6 +628,7 @@ public enum Phase {
     // INSTALL
     public static final int INSTALL_SHARED_SESSION_MANAGER              = 0x0100;
     public static final int INSTALL_JACC_POLICY                         = 0x0350;
+    public static final int INSTALL_VIRTUAL_SECURITY_DOMAIN             = 0x0360;
     public static final int INSTALL_COMPONENT_AGGREGATION               = 0x0400;
     public static final int INSTALL_RESOLVE_MESSAGE_DESTINATIONS        = 0x0403;
     public static final int INSTALL_EJB_CLIENT_CONTEXT                  = 0x0404;

--- a/server/src/main/java/org/jboss/as/server/security/VirtualDomainMarkerUtility.java
+++ b/server/src/main/java/org/jboss/as/server/security/VirtualDomainMarkerUtility.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server.security;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Utility class to mark a {@link DeploymentUnit} as requiring a virtual SecurityDomain.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class VirtualDomainMarkerUtility {
+
+    private static final AttachmentKey<Boolean> REQUIRED = AttachmentKey.create(Boolean.class);
+    private static final ServiceName DOMAIN_SUFFIX = ServiceName.of("security-domain", "virtual");
+
+    public static void virtualDomainRequired(final DeploymentUnit deploymentUnit) {
+        DeploymentUnit rootUnit = toRoot(deploymentUnit);
+        rootUnit.putAttachment(REQUIRED, Boolean.TRUE);
+    }
+
+    public static boolean isVirtualDomainRequired(final DeploymentUnit deploymentUnit) {
+        DeploymentUnit rootUnit = toRoot(deploymentUnit);
+        Boolean required = rootUnit.getAttachment(REQUIRED);
+
+        return required == null ? false : required.booleanValue();
+    }
+
+    public static ServiceName virtualDomainName(final DeploymentUnit deploymentUnit) {
+        DeploymentUnit rootUnit = toRoot(deploymentUnit);
+
+        return rootUnit.getServiceName().append(DOMAIN_SUFFIX);
+    }
+
+    private static DeploymentUnit toRoot(final DeploymentUnit deploymentUnit) {
+        DeploymentUnit result = deploymentUnit;
+        DeploymentUnit parent = result.getParent();
+        while (parent != null) {
+            result = parent;
+            parent = result.getParent();
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4700

The changes to WildFly Core to add support for MicroProfile JWT are relatively small.

This adds a dependency on the elytron-jwt module, however this is not used or installed as a module until WildFly.

Additional phases are added for DUPs which will be added to WildFly.

Finally an internal utility is added to define a virtual security domain to be dynamically associated with a deployment - when working with MicroProfile JWT this means configuration can be 100% bundled with the deployment without relying on central security configuration.

This PR depends on (and will fail CI) without https://github.com/wildfly-security/wildfly-elytron/pull/1358