### PR TITLE
[WFCORE-4777] Upgrade JBoss Remoting to 5.0.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.9.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.16.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.18.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Upgrade JBoss Remoting to 5.0.18.Final
Jira: https://issues.redhat.com/browse/WFCORE-4777


        Release Notes - JBoss Remoting (3+) - Version 5.0.17.Final
                                                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-350'>REM3-350</a>] -         Add API for closing the channel at ClientServiceHandle 
</li>
</ul>
                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-349'>REM3-349</a>] -         Update ServerConnectionOpenListener and ConnectionImpl to inform the callback handler of the local socket address and the peer socket address
</li>
</ul>
                                    