### PR TITLE
[WFCORE-4783] Upgrade WildFly Elytron to 1.11.0.CR4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.11.0.CR3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.0.CR4</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.0.CR3</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4783


        Release Notes - WildFly Elytron - Version 1.11.0.CR4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1914'>ELY-1914</a>] -         Upgrade org.jboss.logging tools to 2.2.1.Final
</li>
</ul>
                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1831'>ELY-1831</a>] -         When manipulating a store the password should only be prompted for once.
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1884'>ELY-1884</a>] -         Add new elytron-jwt module with SmallRye and MP JWT dependencies
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1916'>ELY-1916</a>] -         Release WildFly Elytron 1.11.0.CR4
</li>
</ul>
                   