### PR TITLE
Upgrade Undertow to 2.0.29.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.com.jcraft.jzlib>1.1.1</version.com.jcraft.jzlib>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.0.28.Final</version.io.undertow>
+        <version.io.undertow>2.0.29.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-4784

        Release Notes - Undertow - Version 2.0.29.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1616'>UNDERTOW-1616</a>] -         Avoid unnecessary reflection in setUseCipherSuitesOrder now that java8 is required
</li>
</ul>
                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1570'>UNDERTOW-1570</a>] -         Websocket messages lost when ClientEndpointConfig provided
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1609'>UNDERTOW-1609</a>] -         New RangeRequestTestCase.testLargeCachedResourceHandler fails on Windows
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1618'>UNDERTOW-1618</a>] -         AbstractFramedStreamSourceChannel.wakeupReads is ignored on certain race conditions
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1619'>UNDERTOW-1619</a>] -         AbstractFramedStreamSourceChannel.lastFrame is not entirely synchronized
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1620'>UNDERTOW-1620</a>] -         AbstractFramedChannel polls the taskRunQueue at two points, which could result in NPE
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1621'>UNDERTOW-1621</a>] -         AbstractFramedChannel.flushSenders could throw NPE when polling newFrames
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1623'>UNDERTOW-1623</a>] -         Undertow Deadlock
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1624'>UNDERTOW-1624</a>] -         AbstractFramedStreamSinkChannel listener check for loop fails with EJB over HTTP
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1627'>UNDERTOW-1627</a>] -         gzip encoding is not be enabled by RequestEncodingHandler$Builder
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1630'>UNDERTOW-1630</a>] -         RewriteHandler URL env lost
</li>
</ul>
                                            