### PR TITLE
[WFCORE-4764] Enable web console just before starting the managed server when the domain controller is booting up

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -50,6 +50,8 @@
         <module name="org.jboss.xnio"/>
         <module name="org.wildfly.common" />
         <module name="org.wildfly.security.elytron-web.undertow-server" />
+        <module name="org.jboss.msc"/>
+        <module name="javax.api"/>
     </dependencies>
 
 

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ConsoleAvailability.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ConsoleAvailability.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.domain.http.server;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+
+/**
+ * Allows callers to check the availability of the web console.
+ * <p>
+ * By default, the web console is not available until the process controller transitions to RUNNING.
+ * The callers can try to make the console available even before by using the {@link #isAvailable()} method.
+ *
+ * @author <a href="mailto:yborgessf@redhat.com">Yeray Borges</a>
+ */
+public interface ConsoleAvailability {
+
+    /**
+     * Capability users of the controller use to read the web console availability and force it to make it available
+     * before the process controller is in RUNNING state.
+     *
+     * This capability isn't necessarily directly related to this class but we declare it
+     * here as it's as good a place as any at this time.
+     */
+    RuntimeCapability<Void> CONSOLE_AVAILABILITY_CAPABILITY =
+            RuntimeCapability.Builder.of("org.wildfly.management.console-availability", ConsoleAvailability.class)
+                    .build();
+
+    /**
+     * Gets the availability of the web console.
+     *
+     * @return Whether the console is available at this moment.
+     */
+    boolean isAvailable();
+
+    /**
+     * Tries to make the console available. The console will be available only if the process controller is not
+     * stopping.
+     */
+    void setAvailable();
+}

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ConsoleAvailabilityService.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ConsoleAvailabilityService.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.domain.http.server;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.concurrent.atomic.AtomicStampedReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ControlledProcessStateService;
+import org.jboss.as.controller.ProcessStateNotifier;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * Exposes a {@link ConsoleAvailability} to check the availability of the web console.
+ * <p>
+ *     By default the console is not available, this service listen to changes in the process controller state.
+ *     The web console is available as soon as the process controller transitions to running. This service allows
+ *     to make the console available even before than the process controller is running by using {@link #setAvailable()}
+ *     method.
+ * </p>
+ *
+ * @author @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+public final class ConsoleAvailabilityService implements Service, ConsoleAvailability, PropertyChangeListener {
+
+    private final Supplier<ProcessStateNotifier> notifier;
+    private final Consumer<ConsoleAvailability> serviceConsumer;
+    private final LogAdminConsole logAdminConsole;
+
+    private final AtomicStampedReference<Boolean> available = new AtomicStampedReference<>(Boolean.FALSE, 0);
+
+    public ConsoleAvailabilityService(Consumer<ConsoleAvailability> serviceConsumer, Supplier<ProcessStateNotifier> notifier, final LogAdminConsole logMessageAction) {
+        this.notifier = notifier;
+        this.serviceConsumer = serviceConsumer;
+        this.logAdminConsole = logMessageAction;
+    }
+
+    public static void addService(ServiceTarget serviceTarget, LogAdminConsole logMessageAction) {
+        ServiceName serviceName = CONSOLE_AVAILABILITY_CAPABILITY.getCapabilityServiceName();
+
+        ServiceBuilder<?> sb = serviceTarget.addService(serviceName);
+        Consumer<ConsoleAvailability> caConsumer = sb.provides(serviceName);
+        Supplier<ProcessStateNotifier> psnSupplier = sb.requires(ControlledProcessStateService.INTERNAL_SERVICE_NAME);
+
+        ConsoleAvailabilityService consoleAvailabilityService = new ConsoleAvailabilityService(caConsumer, psnSupplier, logMessageAction);
+        sb.setInstance(consoleAvailabilityService);
+
+        sb.install();
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        notifier.get().addPropertyChangeListener(this);
+        serviceConsumer.accept(this);
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        notifier.get().removePropertyChangeListener(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAvailable() {
+        return this.available.getReference();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAvailable() {
+        if (this.available.compareAndSet(Boolean.FALSE, Boolean.TRUE, 0, 1)) {
+            logAdminConsole.logAdminConsole();
+        }
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (ControlledProcessState.State.RUNNING == evt.getNewValue()) {
+            if (this.available.compareAndSet(Boolean.FALSE, Boolean.TRUE, 0, 1)) {
+                logAdminConsole.logAdminConsole();
+            }
+        } else if (ControlledProcessState.State.STOPPING == evt.getNewValue()) {
+            this.available.set(Boolean.FALSE, 1);
+        } else if (ControlledProcessState.State.STARTING == evt.getNewValue()) {
+            this.available.set(Boolean.FALSE, 0);
+        } else if (ControlledProcessState.State.STOPPED == evt.getNewValue()) {
+            this.available.set(Boolean.FALSE, 0);
+        }
+    }
+
+    @FunctionalInterface
+    public interface LogAdminConsole {
+        void logAdminConsole();
+    }
+}

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -408,8 +408,8 @@ public class ManagementHttpServer {
         HttpHandler domainApiHandler = StreamReadLimitHandler.wrap(CorrelationHandler.wrap(
                 InExecutorHandler.wrap(
                     builder.executor,
-                    associateIdentity(new DomainApiCheckHandler(builder.modelController, builder.processStateNotifier,
-                        builder.allowedOrigins), builder)
+                    associateIdentity(new DomainApiCheckHandler(builder.modelController,
+                        builder.allowedOrigins, builder.consoleAvailability), builder)
                 )));
 
         final Function<HttpServerExchange, Boolean> readyFunction = createReadyFunction(builder);
@@ -522,6 +522,7 @@ public class ManagementHttpServer {
         private XnioWorker worker;
         private Executor executor;
         private Map<String, List<Header>> constantHeaders;
+        private ConsoleAvailability consoleAvailability;
 
         private Builder() {
         }
@@ -583,6 +584,12 @@ public class ManagementHttpServer {
             return this;
         }
 
+        /**
+         * @deprecated The management Http Server no longer needs the processStateNotifier. This class was used to see if it was possible
+         * to process an Http Request to the server. If the process status was starting or stopping, those requests were rejected.
+         * Now its use has been replaced by using {@link ConsoleAvailability} which maintains this behavior.
+         */
+        @Deprecated
         public Builder setControlledProcessStateNotifier(ProcessStateNotifier processStateNotifier) {
             assertNotBuilt();
             this.processStateNotifier = processStateNotifier;
@@ -673,6 +680,13 @@ public class ManagementHttpServer {
             if (built) {
                 throw ROOT_LOGGER.managementHttpServerAlreadyBuild();
             }
+        }
+
+        public Builder setConsoleAvailability(ConsoleAvailability consoleAvailability) {
+            assertNotBuilt();
+            this.consoleAvailability = consoleAvailability;
+
+            return this;
         }
     }
 

--- a/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/ConsoleAvailabilityUnitTestCase.java
+++ b/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/ConsoleAvailabilityUnitTestCase.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.domain.http.server;
+
+import static org.jboss.as.domain.http.server.ConsoleAvailability.CONSOLE_AVAILABILITY_CAPABILITY;
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ControlledProcessStateService;
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.capability.registry.CapabilityScope;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
+import org.jboss.as.controller.persistence.NullConfigurationPersister;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests the transitions of the console availability based on a process state transitions when they are installed as
+ * part of a model controller service.
+ *
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+public class ConsoleAvailabilityUnitTestCase {
+    private ServiceContainer container;
+    private ControlledProcessState controlledProcessState;
+    private Supplier<ConsoleAvailability> caSupplier;
+
+    @Before
+    public void setupController() throws InterruptedException {
+        container = ServiceContainer.Factory.create("test");
+        ServiceTarget target = container.subTarget();
+
+        this.controlledProcessState = new ControlledProcessState(true);
+
+        ServiceBuilder<?> sb = target.addService(ServiceName.of("ModelController"));
+        this.caSupplier = sb.requires(CONSOLE_AVAILABILITY_CAPABILITY.getCapabilityServiceName());
+
+        ConsoleAvailabilityControllerTmp caService = new ConsoleAvailabilityControllerTmp(controlledProcessState);
+
+        ControlledProcessStateService.addService(target, controlledProcessState);
+        ConsoleAvailabilityService.addService(target, () -> {});
+
+        sb.setInstance(caService)
+                .install();
+
+        caService.awaitStartup(30, TimeUnit.SECONDS);
+    }
+
+    @After
+    public void shutdownServiceContainer() {
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+    }
+
+    @Test
+    public void testConsoleAvailabilityTransitions(){
+        assertEquals(ControlledProcessState.State.RUNNING, controlledProcessState.getState());
+        ConsoleAvailability consoleAvailability = this.caSupplier.get();
+        assertEquals(true, consoleAvailability.isAvailable());
+
+        this.controlledProcessState.setStopping();
+        assertEquals(false, consoleAvailability.isAvailable());
+
+        this.controlledProcessState.setStopped();
+        assertEquals(false, consoleAvailability.isAvailable());
+
+        this.controlledProcessState.setStarting();
+        assertEquals(false, consoleAvailability.isAvailable());
+
+        consoleAvailability.setAvailable();
+        assertEquals(true, consoleAvailability.isAvailable());
+        assertEquals(ControlledProcessState.State.STARTING, controlledProcessState.getState());
+
+        this.controlledProcessState.setStopping();
+        consoleAvailability.setAvailable();
+        assertEquals(false, consoleAvailability.isAvailable());
+
+        this.controlledProcessState.setStopped();
+        this.controlledProcessState.setStarting();
+        this.controlledProcessState.setRunning();
+        assertEquals(true, consoleAvailability.isAvailable());
+        this.controlledProcessState.setReloadRequired();
+        assertEquals(true, consoleAvailability.isAvailable());
+        this.controlledProcessState.setRestartRequired();
+        assertEquals(true, consoleAvailability.isAvailable());
+    }
+
+    class ConsoleAvailabilityControllerTmp extends TestModelControllerService {
+
+        ConsoleAvailabilityControllerTmp(ControlledProcessState controlledProcessState) {
+            super(ProcessType.EMBEDDED_SERVER, new NullConfigurationPersister(), controlledProcessState);
+        }
+
+        @Override
+        protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
+            final ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+            final RuntimeCapabilityRegistry capabilityReg = managementModel.getCapabilityRegistry();
+
+            capabilityReg.registerCapability(
+                    new RuntimeCapabilityRegistration(PROCESS_STATE_NOTIFIER_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
+            capabilityReg.registerCapability(
+                    new RuntimeCapabilityRegistration(CONSOLE_AVAILABILITY_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
+
+            rootRegistration.registerCapability(PROCESS_STATE_NOTIFIER_CAPABILITY);
+            rootRegistration.registerCapability(CONSOLE_AVAILABILITY_CAPABILITY);
+        }
+    }
+}

--- a/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/TestModelControllerService.java
+++ b/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/TestModelControllerService.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.domain.http.server;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.jboss.as.controller.AbstractControllerService;
+import org.jboss.as.controller.CapabilityRegistry;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ResourceBuilder;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
+import org.jboss.as.controller.access.management.ManagementSecurityIdentitySupplier;
+import org.jboss.as.controller.audit.AuditLogger;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.persistence.ConfigurationPersister;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+
+/**
+ * A simple {@code Service<ModelController>} base class for use in unit tests.
+ *
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+public abstract class TestModelControllerService extends AbstractControllerService {
+    private final CountDownLatch latch = new CountDownLatch(2);
+    private final CapabilityRegistry capabilityRegistry;
+
+    protected TestModelControllerService(ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
+        this(processType, configurationPersister, processState, ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+    }
+
+    protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+                                         final ResourceDefinition rootResourceDefinition) {
+        this(processType, configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
+    }
+
+    protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+                                         final ResourceDefinition rootResourceDefinition, final CapabilityRegistry capabilityRegistry) {
+        this(processType, new RunningModeControl(RunningMode.NORMAL), null, configurationPersister, processState, rootResourceDefinition, capabilityRegistry);
+    }
+
+    protected TestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, Supplier<ExecutorService> executorService,
+                                         final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+                                         final ResourceDefinition rootResourceDefinition, final CapabilityRegistry capabilityRegistry) {
+        super(executorService, null, processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER,
+                AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer(), new ManagementSecurityIdentitySupplier(), capabilityRegistry);
+        this.capabilityRegistry = capabilityRegistry;
+    }
+
+    public void awaitStartup(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        if (!latch.await(timeout, timeUnit)) {
+            throw new RuntimeException("Failed to boot in timely fashion");
+        }
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        super.start(context);
+        latch.countDown();
+    }
+
+    @Override
+    protected void bootThreadDone() {
+        super.bootThreadDone();
+        latch.countDown();
+    }
+
+    public CapabilityRegistry getCapabilityRegistry() {
+        return capabilityRegistry;
+    }
+}

--- a/host-controller/pom.xml
+++ b/host-controller/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-domain-http-interface</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-process-controller</artifactId>
         </dependency>
         <dependency>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
 import org.jboss.as.controller.CapabilityRegistry;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.domain.http.server.ConsoleAvailabilityService;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.as.remoting.HttpListenerRegistryService;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
@@ -209,9 +210,10 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
 
+        ConsoleAvailabilityService.addService(serviceTarget, bootstrapListener::logAdminConsole);
+
         DomainModelControllerService.addService(serviceTarget, environment, runningModeControl, processState,
                 bootstrapListener, hostPathManagerService, capabilityRegistry, threadGroup);
-
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.management.BaseHttpInterfaceAddStepHandler;
 import org.jboss.as.controller.management.HttpInterfaceCommonPolicy;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.domain.http.server.ConsoleAvailability;
 import org.jboss.as.domain.http.server.ConsoleMode;
 import org.jboss.as.domain.http.server.ManagementHttpRequestProcessor;
 import org.jboss.as.domain.management.SecurityRealm;
@@ -156,6 +157,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
         final Supplier<NetworkInterfaceBinding> ibSupplier = builder.requiresCapability("org.wildfly.network.interface", NetworkInterfaceBinding.class, interfaceName);
         final Supplier<NetworkInterfaceBinding> sibSupplier = builder.requiresCapability("org.wildfly.network.interface", NetworkInterfaceBinding.class, secureInterfaceName);
         final Supplier<ProcessStateNotifier> cpsnSupplier = builder.requiresCapability("org.wildfly.management.process-state-notifier", ProcessStateNotifier.class);
+        final Supplier<ConsoleAvailability> caSupplier = builder.requiresCapability("org.wildfly.management.console-availability", ConsoleAvailability.class);
         final Supplier<ManagementHttpRequestProcessor> rpSupplier = builder.requires(requestProcessorName);
         final Supplier<XnioWorker> xwSupplier = builder.requires(ManagementWorkerService.SERVICE_NAME);
         final Supplier<Executor> eSupplier = builder.requires(ExternalManagementRequestExecutor.SERVICE_NAME);
@@ -164,7 +166,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
         final Supplier<SSLContext> scSupplier = sslContext != null ? builder.requiresCapability(SSL_CONTEXT_CAPABILITY, SSLContext.class, sslContext) : null;
         final UndertowHttpManagementService service = new UndertowHttpManagementService(hmConsumer, lrSupplier, mcSupplier, null, null, null, ibSupplier, sibSupplier,
                 cpsnSupplier, rpSupplier, xwSupplier, eSupplier, hafSupplier, srSupplier, scSupplier, port, securePort, commonPolicy.getAllowedOrigins(), consoleMode,
-                environment.getProductConfig().getConsoleSlot(), commonPolicy.getConstantHeaders());
+                environment.getProductConfig().getConsoleSlot(), commonPolicy.getConstantHeaders(), caSupplier);
         builder.setInstance(service);
         builder.setInitialMode(onDemand ? ServiceController.Mode.ON_DEMAND : ServiceController.Mode.ACTIVE).install();
 

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
 
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.domain.http.server.ConsoleAvailabilityService;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.server.controller.git.GitContentRepository;
 import org.jboss.as.server.deployment.ContentCleanerService;
@@ -171,6 +172,8 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         DeploymentMountProvider.Factory.addService(serviceTarget);
         ServiceModuleLoader.addService(serviceTarget, configuration);
         ExternalModuleService.addService(serviceTarget, EXTERNAL_MODULE_CAPABILITY.getCapabilityServiceName());
+
+        ConsoleAvailabilityService.addService(serviceTarget, bootstrapListener::logAdminConsole);
 
         //Add server path manager service
         ServerPathManagerService.addService(serviceTarget, new ServerPathManagerService(configuration.getCapabilityRegistry()), serverEnvironment);

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -95,8 +95,6 @@ public final class BootstrapListener {
             return;
         }
 
-        logAdminConsole();
-
         final int active = statistics.getActiveCount();
         final int failed = statistics.getFailedCount();
         final int lazy = statistics.getLazyCount();
@@ -141,7 +139,7 @@ public final class BootstrapListener {
         }
     }
 
-    private void logAdminConsole() {
+    public void logAdminConsole() {
         ServiceController<?> controller = serviceContainer.getService(UndertowHttpManagementService.SERVICE_NAME);
         if (controller != null) {
             HttpManagement mgmt = (HttpManagement)controller.getValue();

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+import static org.jboss.as.domain.http.server.ConsoleAvailability.CONSOLE_AVAILABILITY_CAPABILITY;
 
 import java.io.File;
 import java.security.PrivilegedAction;
@@ -267,6 +268,8 @@ public final class ServerService extends AbstractControllerService {
         serviceBuilder.addDependency(EXTERNAL_MODULE_CAPABILITY.getCapabilityServiceName(), ExternalModule.class,
                 service.injectedExternalModule);
         serviceBuilder.addDependency(PATH_MANAGER_CAPABILITY.getCapabilityServiceName(), PathManager.class, service.injectedPathManagerService);
+        serviceBuilder.requires(CONSOLE_AVAILABILITY_CAPABILITY.getCapabilityServiceName());
+
         serviceBuilder.install();
 
         ExternalManagementRequestExecutor.install(serviceTarget, threadGroup, EXECUTOR_CAPABILITY.getCapabilityServiceName(), service.getStabilityMonitor());
@@ -484,6 +487,8 @@ public final class ServerService extends AbstractControllerService {
                 new RuntimeCapabilityRegistration(PROCESS_STATE_NOTIFIER_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
         capabilityRegistry.registerCapability(
                 new RuntimeCapabilityRegistration(EXTERNAL_MODULE_CAPABILITY, CapabilityScope.GLOBAL,new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
+        capabilityRegistry.registerCapability(
+                new RuntimeCapabilityRegistration(CONSOLE_AVAILABILITY_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
 
         // Record the core capabilities with the root MRR so reads of it will show it as their provider
         // This also gets them recorded as 'possible capabilities' in the capability registry
@@ -493,6 +498,7 @@ public final class ServerService extends AbstractControllerService {
         rootRegistration.registerCapability(SUSPEND_CONTROLLER_CAPABILITY);
         rootRegistration.registerCapability(PROCESS_STATE_NOTIFIER_CAPABILITY);
         rootRegistration.registerCapability(EXTERNAL_MODULE_CAPABILITY);
+        rootRegistration.registerCapability(CONSOLE_AVAILABILITY_CAPABILITY);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.management.BaseHttpInterfaceAddStepHandler;
 import org.jboss.as.controller.management.HttpInterfaceCommonPolicy;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.domain.http.server.ConsoleAvailability;
 import org.jboss.as.domain.http.server.ConsoleMode;
 import org.jboss.as.domain.http.server.ManagementHttpRequestProcessor;
 import org.jboss.as.domain.management.SecurityRealm;
@@ -152,6 +153,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
         final Supplier<SocketBinding> ssbSupplier = secureSocketBindingName != null ? builder.requiresCapability(SOCKET_BINDING_CAPABILITY_NAME, SocketBinding.class, secureSocketBindingName) : null;
         final Supplier<SocketBindingManager> sbmSupplier = builder.requiresCapability("org.wildfly.management.socket-binding-manager", SocketBindingManager.class);
         final Supplier<ProcessStateNotifier> cpsnSupplier = builder.requiresCapability("org.wildfly.management.process-state-notifier", ProcessStateNotifier.class);
+        final Supplier<ConsoleAvailability> caSupplier = builder.requiresCapability("org.wildfly.management.console-availability", ConsoleAvailability.class);
         final Supplier<ManagementHttpRequestProcessor> rpSupplier = builder.requires(requestProcessorName);
         final Supplier<XnioWorker> xwSupplier = builder.requires(ManagementWorkerService.SERVICE_NAME);
         final Supplier<Executor> eSupplier = builder.requires(ExternalManagementRequestExecutor.SERVICE_NAME);
@@ -160,7 +162,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
         final Supplier<SSLContext> scSupplier = sslContext != null ? builder.requiresCapability(SSL_CONTEXT_CAPABILITY, SSLContext.class, sslContext) : null;
         final UndertowHttpManagementService undertowService = new UndertowHttpManagementService(hmConsumer, lrSupplier, mcSupplier, sbSupplier, ssbSupplier, sbmSupplier,
                 null, null, cpsnSupplier, rpSupplier, xwSupplier, eSupplier, hafSupplier, srSupplier, scSupplier, null, null, commonPolicy.getAllowedOrigins(), consoleMode,
-                environment.getProductConfig().getConsoleSlot(), commonPolicy.getConstantHeaders());
+                environment.getProductConfig().getConsoleSlot(), commonPolicy.getConstantHeaders(), caSupplier);
         builder.setInstance(undertowService);
         builder.install();
 


### PR DESCRIPTION
Basically it adds a service that can be used to check the web console availability and callers can use it to enable it before the DC has transitioned to running.

I temporarily open it as a draft since it will require review HAL with this in.

Jira issue: https://issues.redhat.com/browse/WFCORE-4764

