### PR TITLE
[WFCORE-4802] Upgrade httpcomponents httpclient to 4.5.11 and httpcore to 4.4.13.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,8 @@
              (the current workaround causes test failures in domain-management tests).
              Cannot bump to AM25 due to https://issues.apache.org/jira/browse/DIRSERVER-2247.
         -->
-        <version.org.apache.httpcomponents.httpclient>4.5.10</version.org.apache.httpcomponents.httpclient>
-        <version.org.apache.httpcomponents.httpcore>4.4.12</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpclient>4.5.11</version.org.apache.httpcomponents.httpclient>
+        <version.org.apache.httpcomponents.httpcore>4.4.13</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.xerces>2.12.0.SP02</version.org.apache.xerces>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4802

This is used within the testsuite and within the server the only module to depend upon it is "org.eclipse.jgit"