### PR TITLE
[WFCORE-4803] EJB Client authentication does not work using SASL DIGEST-MD5 and EXTERNAL mechanisms in Legacy security

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmService.java
@@ -690,7 +690,10 @@ public class SecurityRealmService implements Service<SecurityRealm>, SecurityRea
                     String preferredMechanism;
                     if(authMechanism == AuthMechanism.PLAIN && !registeredServices.containsKey(AuthMechanism.PLAIN) && registeredServices.containsKey(AuthMechanism.DIGEST)) {
                         preferredMechanism = AuthMechanism.DIGEST.name();
+                    } else if (authMechanism != null) {
+                        preferredMechanism = authMechanism.name();
                     } else {
+                        // mechanismName is ANONYMOUS
                         preferredMechanism = mechanismName;
                     }
 

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/SecurityRealmServiceUtilTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/SecurityRealmServiceUtilTestCase.java
@@ -16,16 +16,25 @@ limitations under the License.
 
 package org.jboss.as.domain.management.security;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.security.AccessController;
+import java.security.Security;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslServer;
 
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.msc.service.Service;
@@ -42,6 +51,13 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+import org.wildfly.security.sasl.digest.WildFlyElytronSaslDigestProvider;
+import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
 /**
  * Tests SecurityRealm.ServiceUtil handling for WFCORE-4099 / MSC-240.
@@ -136,6 +152,86 @@ public class SecurityRealmServiceUtilTestCase {
 
         Assert.assertSame(securityRealmService, legacy.getValue());
         Assert.assertSame(securityRealmService, current.getValue());
+    }
+
+    private static void registerElytronProviders() {
+        Security.insertProviderAt(WildFlyElytronSaslDigestProvider.getInstance(), 1);
+        Security.insertProviderAt(WildFlyElytronPasswordProvider.getInstance(), 1);
+    }
+
+    private static void removeElytronProviders() {
+        Security.removeProvider(WildFlyElytronSaslDigestProvider.getInstance().getName());
+        Security.removeProvider(WildFlyElytronPasswordProvider.getInstance().getName());
+    }
+
+    private File createPropertyFile(String filename, String... users) throws IOException {
+        File propertyUserFile = new File(tmpDir.toAbsolutePath().toString(), filename);
+        propertyUserFile.createNewFile();
+        try (FileOutputStream fos = new FileOutputStream(propertyUserFile)) {
+            Properties domainPropeties = new Properties();
+            if (users != null) {
+                for (int i = 0; i < users.length; i += 2) {
+                    domainPropeties.setProperty(users[i], users[i + 1]);
+                }
+            }
+            domainPropeties.store(fos, "");
+        }
+        return propertyUserFile;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testSaslAuthenticationFactoryDigest() throws Exception {
+        registerElytronProviders();
+        try {
+            File propsFile = createPropertyFile(TESTNAME + "-users.properties", "user1", "password1");
+            ServiceTarget serviceTarget = container.subTarget();
+            final Supplier<String> tmpDirSupplier = () -> tmpDir.toAbsolutePath().toString();
+
+            // register a realm service with a properties file to perform a SASL DIGEST-MD5 login
+            final ServiceName realmServiceName = SecurityRealm.ServiceUtil.createServiceName(TESTNAME);
+            final ServiceBuilder<?> realmBuilder = serviceTarget.addService(realmServiceName);
+            final Consumer<SecurityRealm> securityRealmConsumer = realmBuilder.provides(realmServiceName, SecurityRealm.ServiceUtil.createLegacyServiceName(TESTNAME));
+            // create the properties service to check username/password
+            final ServiceName propsServiceName = PropertiesCallbackHandler.ServiceUtil.createServiceName("PropertiesRealm");
+            final ServiceBuilder<?> propsBuilder = serviceTarget.addService(propsServiceName);
+            final Consumer<CallbackHandlerService> chsConsumer = propsBuilder.provides(propsServiceName);
+            propsBuilder.setInstance(new PropertiesCallbackHandler(chsConsumer, null, TESTNAME, propsFile.getAbsolutePath(), null, true));
+            propsBuilder.setInitialMode(ServiceController.Mode.ON_DEMAND);
+            propsBuilder.install();
+            final SecurityRealmService securityRealmService = new SecurityRealmService(
+                    securityRealmConsumer, null, null, null, null, tmpDirSupplier,
+                    Collections.singleton(CallbackHandlerService.ServiceUtil.requires(realmBuilder, propsServiceName)),
+                    TESTNAME, false);
+            realmBuilder.setInstance(securityRealmService);
+            realmBuilder.install();
+
+            // wait for server stability
+            container.awaitStability(60, TimeUnit.SECONDS);
+
+            // get the sasl factory for DIGEST-MD5 and create the sasl server with it
+            SaslAuthenticationFactory saslAuthFact = securityRealmService.getSaslAuthenticationFactory(new String[]{"DIGEST-MD5"}, true);
+            Assert.assertNotNull("Server Sasl Factory is not null", saslAuthFact);
+            SaslServer server = saslAuthFact.createMechanism("DIGEST-MD5");
+
+            // now create a sasl client and perform the sasl dance
+            final AuthenticationConfiguration authConfig = AuthenticationConfiguration.empty()
+                            .useName("user1")
+                            .usePassword("password1")
+                            .useRealm(TESTNAME)
+                            .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(SaslMechanismInformation.Names.DIGEST_MD5));
+            AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+            SaslClient client = contextConfigurationClient.createSaslClient(new URI("unknown://server"), authConfig, Collections.singletonList("DIGEST-MD5"));
+            Assert.assertNotNull("Sasl client is not null", client);
+            Assert.assertFalse("Sasl client has no initial response", client.hasInitialResponse());
+            byte[] message = server.evaluateResponse(new byte[0]);
+            message = client.evaluateChallenge(message);
+            server.evaluateResponse(message);
+            Assert.assertTrue("Sasl server is complete", server.isComplete());
+            Assert.assertEquals("Correct user is logged in", "user1", server.getAuthorizationID());
+        } finally {
+            removeElytronProviders();
+        }
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-4803
Test Issue: https://issues.redhat.com/browse/WFLY-12999
Test PR: https://github.com/wildfly/wildfly/pull/12936

Although there is a test in WFCORE the `SaslLegacyMechanismConfigurationTestCase` in WFLY is also modified to include a DIGEST-MD5 test.