### PR TITLE
[WFCORE-4809] Do not acquire the Dc write lock for composite operations targeting to a single host

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
@@ -16,16 +16,23 @@
 
 package org.jboss.as.test.integration.domain;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_TYPES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_SERVERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.PathAddress;
@@ -62,8 +69,6 @@ public class HostControllerBootOperationsTestCase {
     protected static final PathAddress SLAVE_ADDR = PathAddress.pathAddress(HOST, "slave");
     protected static final PathAddress SERVER_CONFIG_MAIN_THREE = PathAddress.pathAddress(SERVER_CONFIG, "main-three");
     protected static final PathAddress SERVER_MAIN_THREE = PathAddress.pathAddress(SERVER, "main-three");
-    protected static final PathAddress CORE_SERVICE_MANAGEMENT = PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT);
-    protected static final PathAddress CORE_SERVICE_PATCHING = PathAddress.pathAddress(CORE_SERVICE, "patching");
     protected static final PathAddress SERVER_GROUP_MAIN_SERVER_GROUP = PathAddress.pathAddress(SERVER_GROUP, "main-server-group");
     protected static final PathAddress JVM_DEFAULT = PathAddress.pathAddress(JVM, "default");
     protected static final PathAddress JVM_BYTEMAN = PathAddress.pathAddress(JVM, "byteman");
@@ -72,6 +77,9 @@ public class HostControllerBootOperationsTestCase {
     private static DomainClient masterClient;
     private static DomainLifecycleUtil masterLifecycleUtil;
     private static DomainLifecycleUtil slaveLifecycleUtil;
+
+    private static List<String> slaveChildrenTypes;
+    private static List<String> emptyAddressChildrenTypes;
 
     @BeforeClass
     public static void setupDomain() throws Exception {
@@ -90,7 +98,9 @@ public class HostControllerBootOperationsTestCase {
         testSupport.start();
 
         masterClient = masterLifecycleUtil.getDomainClient();
-        ModelNode op = Util.createAddOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
+
+        ModelNode op;
+        op = Util.createAddOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
         DomainTestUtils.executeForResult(op, masterClient);
 
         op = Util.createEmptyOperation("add-jvm-option", SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
@@ -104,6 +114,15 @@ public class HostControllerBootOperationsTestCase {
         String bytemanJavaAgent = System.getProperty("jboss.test.host.server.byteman.javaagent")+"DelayServerRegistrationAndRunningState.btm";
         op = Util.getWriteAttributeOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN), "java-agent", bytemanJavaAgent);
         DomainTestUtils.executeForResult(op, masterClient);
+
+        ModelNode result;
+        op = Util.createEmptyOperation(READ_CHILDREN_TYPES_OPERATION, SLAVE_ADDR);
+        result = DomainTestUtils.executeForResult(op, masterClient);
+        slaveChildrenTypes = result.asList().stream().map(m -> m.asString()).collect(Collectors.toList());
+
+        op = Util.createEmptyOperation(READ_CHILDREN_TYPES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        result = DomainTestUtils.executeForResult(op, masterClient);
+        emptyAddressChildrenTypes = result.asList().stream().map(m -> m.asString()).collect(Collectors.toList());
     }
 
     @AfterClass
@@ -124,8 +143,10 @@ public class HostControllerBootOperationsTestCase {
         slaveLifecycleUtil.awaitHostController(System.currentTimeMillis(), ControlledProcessState.State.STARTING);
         // At this point server-three should be waiting before being registered in the domain and HC is still booting up, this gives us a window
         // where we can tests the operations that were failing and reporting errors in HAL on WFCORE-4283
+        // The slave write lock is acquired at this time because the servers are starting, although they have not been registered in the domain yet
+        // Read operations should pass, even those that use proxies because at this point, the servers are not registered, proxies does not exists yet
 
-        checkReadOperations();
+        checkReadOperations(false);
 
         //assert the server at this point reports STOPPED, which means it has not been registered yet in the domain
         Assert.assertTrue("server-three should be stopped at this point to validate this test conditions. Check if a previous read operation acquired the write lock or if the \"Delay Server Registration Request\" byteman rule needs more time sleeping the server registration request",
@@ -136,13 +157,13 @@ public class HostControllerBootOperationsTestCase {
         DomainTestUtils.waitUntilState(masterClient, SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE), ServerStatus.STARTING.toString());
 
         // At this point server-three should be waiting before transitioning to STARTED, this gives us a window to test operations that are
-        // likely to fail since the server is still starting, write operations should fail, read operations should pass
+        // likely to fail since the server is still starting, write operations should fail, read operations should pass except those executed with proxies enabled
 
         op = Util.getWriteAttributeOperation(SERVER_GROUP_MAIN_SERVER_GROUP.append(JVM_DEFAULT), "heap-size", "64m");
         ModelNode failureDescription = DomainTestUtils.executeForFailure(op, masterClient);
         Assert.assertTrue("The slave host does not return the expected error. Failure Description was:"+failureDescription, failureDescription.get("host-failure-descriptions").get("slave").asString().startsWith("WFLYDC0098"));
 
-        checkReadOperations();
+        checkReadOperations(true);
 
         // assert server is still starting at this moment
         Assert.assertTrue("server-three should be starting at this point to validate this test conditions. Check if the \"Delay Server Started Request\" byteman rule needs more time sleeping the server started request",
@@ -158,37 +179,108 @@ public class HostControllerBootOperationsTestCase {
         DomainTestUtils.executeForResult(op, masterClient);
     }
 
-    private void checkReadOperations() throws IOException, MgmtOperationException {
-        // assert we are able to run the operation under test :read-child-resources
-        ModelNode op  = Util.createEmptyOperation("read-children-resources", PathAddress.EMPTY_ADDRESS);
-        op.get("child-type").set("host");
-        op.get("recursive").set(true);
+    private void checkReadOperations(boolean skipServerDirectReads) throws IOException, MgmtOperationException {
+        ModelNode op;
+
+        // assert we are also able to read the Domain model recursively
+        // this also test WFCORE-4596
+        op = Util.createEmptyOperation(READ_RESOURCE_OPERATION, PathAddress.EMPTY_ADDRESS);
+        addCommonReadOperationAttributes(op, skipServerDirectReads);
         DomainTestUtils.executeForResult(op, masterClient);
 
         // assert we are also able to read the HC slave model recursively
-        op = Util.createEmptyOperation("read-resource", SLAVE_ADDR);
+        op = Util.createEmptyOperation(READ_RESOURCE_OPERATION, SLAVE_ADDR);
         op.get("recursive").set(true);
         DomainTestUtils.executeForResult(op, masterClient);
 
-        // WFCORE-4596. assert we are able to read patching resource using include-runtime
-        op = Util.createEmptyOperation("read-resource", SLAVE_ADDR.append(CORE_SERVICE_PATCHING));
-        op.get("include-runtime").set(true);
-        op.get("recursive").set(true);
+        // assert we are also able to read the server config of the server under test
+        op = Util.createEmptyOperation(READ_RESOURCE_OPERATION, SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE));
+        addCommonReadOperationAttributes(op, skipServerDirectReads);
         DomainTestUtils.executeForResult(op, masterClient);
 
-        // assert we are also able to read the Domain model recursively
-        op = Util.createEmptyOperation("read-resource", PathAddress.EMPTY_ADDRESS);
-        op.get("recursive").set(true);
+        // The following read operations could be redundant since the read information should have been already returned
+        // by the above operations that were executed to read recursively. However, just in case to be more confident
+        for(String childType : emptyAddressChildrenTypes) {
+            op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, PathAddress.EMPTY_ADDRESS);
+            op.get("child-type").set(childType);
+            addCommonReadOperationAttributes(op, skipServerDirectReads);
+
+            DomainTestUtils.executeForResult(op, masterClient);
+        }
+
+        for(String childType : slaveChildrenTypes) {
+            op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, SLAVE_ADDR);
+            op.get("child-type").set(childType);
+            addCommonReadOperationAttributes(op, skipServerDirectReads);
+
+            DomainTestUtils.executeForResult(op, masterClient);
+        }
+
+        // Check also read in composite operations
+        List<ModelNode> steps;
+
+        steps = prepareReadCompositeOperations(PathAddress.EMPTY_ADDRESS, emptyAddressChildrenTypes, skipServerDirectReads);
+        op = createComposite(steps);
         DomainTestUtils.executeForResult(op, masterClient);
 
-        // assert we are also able to read the Domain model recursively
-        op = Util.createEmptyOperation("read-children-resources", CORE_SERVICE_MANAGEMENT);
-        op.get("child-type").set("access");
-        op.get("recursive-depth").set("1");
-        op.get("include-runtime").set("true");
+        steps.clear();
+        steps = prepareReadCompositeOperations(SLAVE_ADDR, slaveChildrenTypes, skipServerDirectReads);
+
+        op = createComposite(steps);
         DomainTestUtils.executeForResult(op, masterClient);
 
+        steps = prepareReadCompositeOperations(PathAddress.EMPTY_ADDRESS, emptyAddressChildrenTypes, skipServerDirectReads);
+        steps.addAll(prepareReadCompositeOperations(SLAVE_ADDR, slaveChildrenTypes, skipServerDirectReads));
+
+        op = createComposite(steps);
+        DomainTestUtils.executeForResult(op, masterClient);
+
+        // check if we can read the server status
         op = Util.getReadAttributeOperation(SLAVE_ADDR.append(SERVER_CONFIG_MAIN_THREE), "status");
         DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private ModelNode createComposite(List<ModelNode> steps) {
+        ModelNode composite = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        ModelNode stepsNode = composite.get(STEPS);
+        for (ModelNode step : steps) {
+            stepsNode.add(step);
+        }
+        return composite;
+    }
+
+    private void addCommonReadOperationAttributes(ModelNode op, boolean skipServerDirectReads) {
+        String operation = op.get(OP).asString();
+        switch (operation) {
+            case READ_RESOURCE_OPERATION: {
+                op.get("include-aliases").set(true);
+                op.get("include-undefined-metric-values").set(true);
+            }
+            case READ_CHILDREN_RESOURCES_OPERATION: {
+                op.get("include-runtime").set(true);
+                op.get("recursive").set(true);
+                op.get("include-defaults").set(true);
+                op.get("proxies").set(!skipServerDirectReads);
+            }
+        }
+    }
+
+    private List<ModelNode> prepareReadCompositeOperations(PathAddress address, List<String> childTypes, boolean skipServerDirectReads) {
+        final List<ModelNode> steps = new ArrayList<>();
+        ModelNode step;
+
+        step = Util.createEmptyOperation(READ_RESOURCE_OPERATION, address);
+        addCommonReadOperationAttributes(step, skipServerDirectReads);
+        steps.add(step);
+
+        for(String childType : childTypes) {
+            if (skipServerDirectReads && childType.equals("server")) continue;
+            step = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
+            addCommonReadOperationAttributes(step, skipServerDirectReads);
+            step.get("child-type").set(childType);
+            steps.add(step);
+        }
+
+        return steps;
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/SlowServiceActivator.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/SlowServiceActivator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceRegistryException;
+
+/**
+ * Simple service activator that delays the activation some seconds.
+ *
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+public class SlowServiceActivator implements ServiceActivator {
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        try {
+            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(20)*1000;
+            while (System.currentTimeMillis() - timeout < 0) {
+                TimeUnit.SECONDS.sleep(1);
+            }
+        } catch (InterruptedException e) {
+            throw new ServiceRegistryException(e);
+        }
+    }
+}


### PR DESCRIPTION
Currently, when a composite operation that is targetted to a single host is being routed via two-phase operation handler, the write lock is acquired in the Domain Controller, even if we also return the routing as a non-multiphase.

In order to facilitate the tasks of the web console reading resources under this scenario, this patch removes the lock acquisition for these operations.

My understanding:
The write lock is acquired to prevent changes in the topology. Under the scenario for this patch, an operation targeting a single slave host, only a change removing the slave could affect to the results if we are not acquiring the write lock. Removing a slave could be as a cause of:

1. User action, the user has requested a host shutdown or reload.
2. The host process crashed and was removed from the list of available servers.

My argument to allow this change is, in both cases, if there is a read operation in the middle and a host is removed, it could be expected an error.

Notice that write operations should not be affected by this case since a write operation could have acquired the write lock on the slave, and then a manual host reloading done by the user will be blocked in the slave until the write ends. The shutdown doesn't acquire the lock, so it is always executed independently of this patch.

Jira issue: https://issues.redhat.com/browse/WFCORE-4809