### PR TITLE
[WFCORE-4810] Upgrade WildFly Elytron to 1.11.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.11.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4810


        Release Notes - WildFly Elytron - Version 1.11.1.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1920'>ELY-1920</a>] -         Upgrade Smallrye JWT to 2.0.12
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1922'>ELY-1922</a>] -         Upgrade BouncyCastle to 1.64
</li>
</ul>
                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1923'>ELY-1923</a>] -         NPE in AuthenticationConfiguration.toString()
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1924'>ELY-1924</a>] -         EntityTest Failing on OpenJ9
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1925'>ELY-1925</a>] -         Release WildFly Elytron 1.11.1.Final
</li>
</ul>