### PR TITLE
[WFCORE-4818] Upgrade WildFly Elytron to 1.11.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.11.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4818


        Release Notes - WildFly Elytron - Version 1.11.2.Final
                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1926'>ELY-1926</a>] -         Move wildfly-elytron-password-impl dependency in client from test scope to compile scope
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1927'>ELY-1927</a>] -         Release WildFly Elytron 1.11.2.Final
</li>
</ul>