### PR TITLE
[WFCORE-4749] Bump domain management version to 11.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -64,6 +64,7 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         EAP70("EAP7.0", KernelAPIVersion.VERSION_4_1),
         EAP71("EAP7.1", KernelAPIVersion.VERSION_5_0),
         EAP72("EAP7.2", KernelAPIVersion.VERSION_8_0),
+        EAP73("EAP7.3", KernelAPIVersion.VERSION_10_0),
         WILDFLY10("WildFly10.0", KernelAPIVersion.VERSION_4_0),
         WILDFLY10_1("WildFly10.1", KernelAPIVersion.VERSION_4_2),
         WILDFLY11("WildFly11.0", KernelAPIVersion.VERSION_5_0),

--- a/server/src/main/resources/schema/wildfly-config_11_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_11_0.xsd
@@ -4978,6 +4978,33 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="WildFly16.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 10.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly17.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 10.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly18.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 10.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -35,7 +35,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 10;
+    public static final int MANAGEMENT_MAJOR_VERSION = 11;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
- Add KnownRelease.EAP73 as known release
- Add missing host-release types to wildlfy-config_11_0.xsd

Jira issue: https://issues.redhat.com/browse/WFCORE-4749