### PR TITLE
[WFCORE-4829] Ensure the pattern-formatter is always marshalled to th…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/formatters/PatternFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/formatters/PatternFormatterResourceDefinition.java
@@ -78,21 +78,22 @@ public class PatternFormatterResourceDefinition extends TransformerResourceDefin
             .setAttributeMarshaller(new DefaultAttributeMarshaller() {
                 @Override
                 public void marshallAsElement(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
-                    if (isMarshallable(attribute, resourceModel, marshallDefault)) {
-                        writer.writeStartElement(attribute.getXmlName());
-                        final String pattern = resourceModel.get(PATTERN.getName()).asString();
-                        writer.writeAttribute(PATTERN.getXmlName(), pattern);
-                        if (resourceModel.hasDefined(COLOR_MAP.getName())) {
-                            final String colorMap = resourceModel.get(COLOR_MAP.getName()).asString();
-                            writer.writeAttribute(COLOR_MAP.getXmlName(), colorMap);
-                        }
-                        writer.writeEndElement();
+                    // We always want to marshal the element
+                    writer.writeStartElement(attribute.getXmlName());
+                    // We also need to always marshal the pattern has it's a required attribute in the XML.
+                    final String pattern;
+                    if (resourceModel.hasDefined(PATTERN.getName())) {
+                        pattern = resourceModel.get(PATTERN.getName()).asString();
+                    } else {
+                        pattern = PATTERN.getDefaultValue().asString();
                     }
-                }
-
-                @Override
-                public boolean isMarshallable(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault) {
-                    return resourceModel.hasDefined(PATTERN.getName());
+                    writer.writeAttribute(PATTERN.getXmlName(), pattern);
+                    // Only marshal the color-map if defined as this is a newer attribute.
+                    if (resourceModel.hasDefined(COLOR_MAP.getName())) {
+                        final String colorMap = resourceModel.get(COLOR_MAP.getName()).asString();
+                        writer.writeAttribute(COLOR_MAP.getXmlName(), colorMap);
+                    }
+                    writer.writeEndElement();
                 }
             })
             .build();


### PR DESCRIPTION
…e XML configuration correctly. The pattern-formatter element should always be written as should the pattern attribute on the pattern-formatter attribute.

https://issues.redhat.com/browse/WFCORE-4829