### PR TITLE
Fix for WFCORE-4831, CLI boot, exception not thrown when error printed to error file

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/BootScriptInvoker.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/BootScriptInvoker.java
@@ -142,12 +142,12 @@ public class BootScriptInvoker implements AdditionalBootCliScriptInvoker {
         if (errorFile != null) {
             File errors = new File(errorFile);
             if (errors.exists()) {
-                ROOT_LOGGER.unexpectedErrors(file, errors);
                 StringBuilder errorBuilder = new StringBuilder();
                 for (String line : Files.readAllLines(errors.toPath())) {
                     errorBuilder.append(line).append("\n");
                 }
                 ROOT_LOGGER.error(errorBuilder.toString());
+                throw ROOT_LOGGER.unexpectedErrors(file, errors);
             }
 
         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/_private/BootScriptInvokerLogger.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/_private/BootScriptInvokerLogger.java
@@ -109,9 +109,9 @@ public interface BootScriptInvokerLogger extends BasicLogger {
      *
      * @param script CLI script
      * @param errors File that contains error messages
+     * @return Exception to throw
      */
-    @LogMessage(level = ERROR)
     @Message(id = 8, value = "Error processing CLI script %s. The Operations were executed but "
             + "there were unexpected values. See list of errors in %s")
-    void unexpectedErrors(File script, File errors);
+    IllegalStateException unexpectedErrors(File script, File errors);
 }

--- a/cli/src/test/java/org/jboss/as/cli/impl/BootScriptInvokerTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/impl/BootScriptInvokerTestCase.java
@@ -230,8 +230,17 @@ public class BootScriptInvokerTestCase {
         Files.write(file, builder.toString().getBytes());
         TestClient client = new TestClient();
         StringBuilder outContent = new StringBuilder();
+        boolean failure = false;
         try {
-            invoker.runCliScript(client, file.toFile());
+            try {
+                invoker.runCliScript(client, file.toFile());
+                failure = true;
+            } catch (Exception ex) {
+                // Expected.
+            }
+            if (failure) {
+                throw new Exception("Test should have failed");
+            }
         } finally {
             for (String l : Files.readAllLines(output)) {
                 outContent.append(l).append("\n");


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-4831
Exception must be thrown if an error has been written to the error file.