### PR TITLE
[WFCORE-4833] Allow TrivialAddHandler and AuthenticationFactories sta…

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -59,7 +59,6 @@ import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
@@ -386,7 +385,7 @@ class AuthenticationFactoryDefinitions {
                 serviceBuilder.setInstance(httpAuthenticationFactoryService);
 
                 commonDependencies(serviceBuilder, true, true)
-                        .setInitialMode(context.getProcessType() == ProcessType.EMBEDDED_SERVER && context.getRunningMode() == RunningMode.ADMIN_ONLY ? ServiceController.Mode.LAZY : ServiceController.Mode.ACTIVE)
+                        .setInitialMode(context.getRunningMode() == RunningMode.ADMIN_ONLY ? ServiceController.Mode.PASSIVE : ServiceController.Mode.ACTIVE)
                         .install();
             }
 
@@ -472,7 +471,7 @@ class AuthenticationFactoryDefinitions {
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { securityDomainAttribute, SASL_SERVER_FACTORY, mechanismConfigurationAttribute };
 
-        AbstractAddStepHandler add = new TrivialAddHandler<SaslAuthenticationFactory>(SaslAuthenticationFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, SASL_AUTHENTICATION_FACTORY_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<SaslAuthenticationFactory>(SaslAuthenticationFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.PASSIVE, attributes, SASL_AUTHENTICATION_FACTORY_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<SaslAuthenticationFactory> getValueSupplier(

--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -216,7 +216,7 @@ class HttpServerDefinitions {
 
     static ResourceDefinition getServiceLoaderServerMechanismFactoryDefinition() {
         AttributeDefinition[] attributes = new AttributeDefinition[] { MODULE };
-        AbstractAddStepHandler add = new TrivialAddHandler<HttpServerAuthenticationMechanismFactory>(HttpServerAuthenticationMechanismFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, HTTP_SERVER_MECHANISM_FACTORY_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<HttpServerAuthenticationMechanismFactory>(HttpServerAuthenticationMechanismFactory.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.PASSIVE, attributes, HTTP_SERVER_MECHANISM_FACTORY_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<HttpServerAuthenticationMechanismFactory> getValueSupplier(

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -1111,7 +1111,7 @@ class SSLDefinitions {
                 PRE_REALM_PRINCIPAL_TRANSFORMER, POST_REALM_PRINCIPAL_TRANSFORMER, FINAL_PRINCIPAL_TRANSFORMER, REALM_MAPPER,
                 providersDefinition, PROVIDER_NAME};
 
-        AbstractAddStepHandler add = new TrivialAddHandler<SSLContext>(SSLContext.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.LAZY, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
+        AbstractAddStepHandler add = new TrivialAddHandler<SSLContext>(SSLContext.class, ServiceController.Mode.ACTIVE, ServiceController.Mode.PASSIVE, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
 
             @Override
             protected ValueSupplier<SSLContext> getValueSupplier(ServiceBuilder<SSLContext> serviceBuilder,

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TrivialAddHandler.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TrivialAddHandler.java
@@ -28,7 +28,6 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
@@ -48,7 +47,7 @@ abstract class TrivialAddHandler<T> extends BaseAddHandler {
 
     private final RuntimeCapability<?> runtimeCapability;
     private final Mode initialMode;
-    private final Mode embeddedInitialMode;
+    private final Mode adminOnlyInitialMode;
 
     TrivialAddHandler(Class<T> serviceType, AttributeDefinition[] attributes, RuntimeCapability<?> runtimeCapability) {
         this(serviceType, Mode.ACTIVE, attributes, runtimeCapability);
@@ -58,12 +57,12 @@ abstract class TrivialAddHandler<T> extends BaseAddHandler {
         this(serviceType, initialMode, initialMode, attributes, runtimeCapability);
     }
 
-    TrivialAddHandler(Class<T> serviceType, Mode initialMode, Mode embeddedInitialMode, AttributeDefinition[] attributes, RuntimeCapability<?> runtimeCapability) {
+    TrivialAddHandler(Class<T> serviceType, Mode initialMode, Mode adminOnlyInitialMode, AttributeDefinition[] attributes, RuntimeCapability<?> runtimeCapability) {
         super(new HashSet<>(Collections.singletonList(checkNotNullParam("runtimeCapabilities", runtimeCapability))), attributes);
         this.runtimeCapability = runtimeCapability;
         checkNotNullParam("serviceType", serviceType);
         this.initialMode = checkNotNullParam("initialMode", initialMode);
-        this.embeddedInitialMode = checkNotNullParam("embeddedInitialMode", embeddedInitialMode);
+        this.adminOnlyInitialMode = checkNotNullParam("adminOnlyInitialMode", adminOnlyInitialMode);
     }
 
     @SuppressWarnings("unchecked")
@@ -76,9 +75,8 @@ abstract class TrivialAddHandler<T> extends BaseAddHandler {
         serviceBuilder.setInstance(trivialService);
 
         trivialService.setValueSupplier(getValueSupplier(serviceBuilder, context, resource.getModel()));
-
         installedForResource(commonDependencies(serviceBuilder, dependOnProperties(), dependOnProviderRegistration())
-                .setInitialMode(context.getProcessType() == ProcessType.EMBEDDED_SERVER && context.getRunningMode() == RunningMode.ADMIN_ONLY ? embeddedInitialMode : initialMode)
+                .setInitialMode(context.getRunningMode() == RunningMode.ADMIN_ONLY ? adminOnlyInitialMode : initialMode)
                 .install(), resource);
     }
 


### PR DESCRIPTION
…rt services with a different initial mode for admin-only

This is basically a follow up on #3861 allowing the configuration of a different service initial mode not only for the embedded server process type. This patch allows the configuration of a legacy security domain integration in the standard admin-only mode as well.


Jira issue: https://issues.redhat.com/browse/WFCORE-4833

cc: @darranl 