### PR TITLE
Updating mockserver. Exclusion of dependency from xom.io7m

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -164,6 +164,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>2.18.0</version.org.mockito>
-        <version.org.mock-server.mockserver-netty>5.6.1</version.org.mock-server.mockserver-netty>
+        <version.org.mock-server.mockserver-netty>5.9.0</version.org.mock-server.mockserver-netty>
         <version.org.picketbox>5.0.3.Final</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22.jbossorg-1</version.org.slf4j>
@@ -714,6 +714,10 @@
                     <exclusion>
                         <groupId>xml-apis</groupId>
                         <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.mock-server</groupId>
+                        <artifactId>mockserver-netty</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
[WFCORE-4850] : https://issues.redhat.com/browse/WFCORE-4850

Updating mockserver. Exclusion of a dependency from xom.io7m .