### PR TITLE
[WFCORE-4862] Return ServerEnvironmentStatus.ERROR in case of incorrect git server start argument values

### DIFF
--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -336,7 +336,7 @@ public final class Main {
                         } else {
                             STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                             usage();
-                            return null;
+                            return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                         }
                     } else {
                         gitRepository = arg.substring(idx + 1, arg.length());
@@ -351,7 +351,7 @@ public final class Main {
                         } else {
                             STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                             usage();
-                            return null;
+                            return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                         }
                     } else {
                         gitAuthConfiguration = arg.substring(idx + 1, arg.length());
@@ -366,7 +366,7 @@ public final class Main {
                         } else {
                             STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                             usage();
-                            return null;
+                            return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                         }
                     } else {
                         gitBranch = arg.substring(idx + 1, arg.length());


### PR DESCRIPTION
This is just to avoid NPE traces printing the usage if git configuration values are incorrect.

Jira issue: https://issues.redhat.com/browse/WFCORE-4862