### PR TITLE
[WFCORE-4824] Upgrade JBoss Modules from 1.9.2.Final to 1.10.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>2.1.14.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.modules.jboss-modules>1.9.2.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.10.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.17.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4824

This update brings in the following fixes and enhancements:

* [MODULES-377] Getting 'IllegalArgumentException: moduleLoader is null' when iterating modules and module.xml contains a permissions markup
* [MODULES-378] Resource in modules.xml that references a directory link ignored when loading a resource bundle with ModuleClassLoader
* [MODULES-393] Make jboss-modules a Java agent and allow other agents to be set as module arguments
* [MODULES-397] Eliminate deprecated -addindex , -modify , -logmodule command line options
* [MODULES-398] Deprecate -jaxpmodule command line option