### PR TITLE
[WFCORE-4864] Bump jackson-databind from 2.9.10.1 to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
             For example: <version.org.jboss.hal.release-stream>
          -->
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-        <version.com.fasterxml.jackson.core.jackson-databind>2.9.10.1</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.com.fasterxml.jackson.core.jackson-databind>2.10.1</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.googlecode.javaewah>1.1.6</version.com.googlecode.javaewah>
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>
         <version.com.google.guava>25.0-jre</version.com.google.guava>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4864

This is preferred to #4090 if it passes CI.