### PR TITLE
[WFCORE-4653] Upgrade picketbox to 5.0.3.Final-redhat-00005

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
             For example: <version.org.jboss.hal.release-stream>
          -->
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-        <version.com.fasterxml.jackson.core.jackson-databind>2.9.10.1</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.com.fasterxml.jackson.core.jackson-databind>2.10.1</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.googlecode.javaewah>1.1.6</version.com.googlecode.javaewah>
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>
         <version.com.google.guava>25.0-jre</version.com.google.guava>
@@ -207,7 +207,7 @@
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>2.18.0</version.org.mockito>
         <version.org.mock-server.mockserver-netty>5.9.0</version.org.mock-server.mockserver-netty>
-        <version.org.picketbox>5.0.3.Final</version.org.picketbox>
+        <version.org.picketbox>5.0.3.Final-redhat-00005</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4653

I don't think this is urgent. The lib is available in MRRC so I filed this.