### PR TITLE
[WFCORE-4865] Upgrade Remoting JMX to 3.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <version.org.jboss.modules.jboss-modules>1.10.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.17.Final</version.org.jboss.remoting>
-        <version.org.jboss.remotingjmx.remoting-jmx>3.0.3.Final</version.org.jboss.remotingjmx.remoting-jmx>
+        <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.4.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>2.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4865


        Release Notes - Remoting JMX - Version 3.0.4.Final
                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REMJMX-166'>REMJMX-166</a>] -         IllegalThreadStateException after idle jmx connection
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REMJMX-169'>REMJMX-169</a>] -         Release Remoting JMX 3.0.4.Final
</li>
</ul>
                    