### PR TITLE
[WFCORE-4878] Upgrade WildFly OpenSSL to 1.0.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>4.0.1.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>1.0.9.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>1.0.10.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4878


        Release Notes - WildFly OpenSSL - Version 1.0.10.Final
                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-21'>WFSSL-21</a>] -         The &#39;enabled-protocols&#39; value in legacy security is not respected if OpenSSL security provider is in use
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-25'>WFSSL-25</a>] -         Don&#39;t use vsnprintf to format messages
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-27'>WFSSL-27</a>] -         Use memmove instead of memcpy
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-30'>WFSSL-30</a>] -         Release WildFly OpenSSL 1.0.10.Final
</li>
</ul>