### PR TITLE
[WFCORE-4881] Upgrade XNIO to 3.8.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.7.7.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.0.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-4881


        Release Notes - XNIO - Version 3.8.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-362'>XNIO-362</a>] -         Upgrade XNIO Dependencies
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-258'>XNIO-258</a>] -         No indication of &quot;too many open files&quot; problem in the logs / error messages
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-348'>XNIO-348</a>] -         Enhance XNIO error logging for notifier failure
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-357'>XNIO-357</a>] -         Channels.flushBlocking does not have an overload with a timeout
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-361'>XNIO-361</a>] -         JsseXnioSsl.openConnection could block future if a RuntimeException is thrown by engine
</li>
</ul>
                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-265'>XNIO-265</a>] -         Accept thread blocks forever on java.nio.channels.SelectableChannel.register
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-286'>XNIO-286</a>] -         QueuedNioTcpServer does not respond if accept fails
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-328'>XNIO-328</a>] -         Thread allocation hash can result in only allocating to 50% of IO threads
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-335'>XNIO-335</a>] -         XNIO I/O threads are taking high CPU (may be because its not closing CLOSE_WAIT TCP connections)
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-351'>XNIO-351</a>] -         Queued executor (v2) can accept into the wrong thread
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-356'>XNIO-356</a>] -         Channels.readBlocking with timeout overload may return spuriously
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-358'>XNIO-358</a>] -         ByteBufferSlicePool should add buffer to DIRECT_BUFFERS only on clean
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-360'>XNIO-360</a>] -         JsseSslConduitEngine does not handle BUFFER_OVERFLOW
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-341'>XNIO-341</a>] -         Upgrade jboss-parent pom version to 35
</li>
</ul>
                            
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-363'>XNIO-363</a>] -         Upgrade Byteman to 4.0.8
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-364'>XNIO-364</a>] -         Upgrade logging to 3.4.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-365'>XNIO-365</a>] -         Upgrade Logging Tools to 2.2.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-366'>XNIO-366</a>] -         Upgrade LogManager to 2.1.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-367'>XNIO-367</a>] -         Upgrade JBoss Threads to 2.3.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-368'>XNIO-368</a>] -         Upgrade WildFly Config to 1.0.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-369'>XNIO-369</a>] -         Upgrade JUnit to 4.12
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-370'>XNIO-370</a>] -         Upgrade JMock to 2.12.0
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-371'>XNIO-371</a>] -         Upgrade JBoss Bridger to 1.5.Final
</li>
</ul>
        