### PR TITLE
WFCORE-4882 correct minOccurts value for host element in XSD

### DIFF
--- a/server/src/main/resources/schema/wildfly-config_13_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_13_0.xsd
@@ -4610,7 +4610,7 @@
         <xs:complexContent>
             <xs:extension base="base-scoped-roleType">
                 <xs:choice>
-                    <xs:element name="host" type="namedType" minOccurs="1" maxOccurs="unbounded">
+                    <xs:element name="host" type="namedType" minOccurs="0" maxOccurs="unbounded">
                         <xs:annotation>
                             <xs:documentation>
                                 <![CDATA[


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-4882 
Broken 'domain.xml' after migration of <host-scoped-roles> leading to 'Boostrap error' in HAL. 

A broken domain configuration
```
           <host-scoped-roles>
                <role name="custom-role-name" base-role="Administrator">
                </role>
            </host-scoped-roles>
```

This broken configuration doesn't bother the old HAL, so user only see the issue from HAL after the migration.

The correct one should be:

```
            <host-scoped-roles>
                <role name="dbaish" base-role="Administrator">
                    <host name="master"/>
                </role>
            </host-scoped-roles>
```
https://github.com/wildfly/wildfly-core/blob/11.0.0.Final/server/src/main/resources/schema/wildfly-config_9_0.xsd#L4567 show minOccurs="1"

~~Attribute `host` list should be required, thus a server boot error can be logged during migration~~

This PR only corrects the minOccruts value in XSD for the host element.