### PR TITLE
[WFCORE-4860] If no deployments are defined with their own log contex…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/deployments/LoggingConfigDeploymentProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/LoggingConfigDeploymentProcessor.java
@@ -66,7 +66,6 @@ public class LoggingConfigDeploymentProcessor extends AbstractLoggingDeploymentP
     private static final String JBOSS_LOG4J_XML = "jboss-log4j.xml";
     private static final String DEFAULT_PROPERTIES = "logging.properties";
     private static final String JBOSS_PROPERTIES = "jboss-logging.properties";
-    private static final Object CONTEXT_LOCK = new Object();
 
     private final String attributeName;
     private final boolean process;
@@ -229,7 +228,7 @@ public class LoggingConfigDeploymentProcessor extends AbstractLoggingDeploymentP
             // Check the type of the configuration file
             if (isLog4jConfiguration(fileName)) {
                 final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-                final LogContext old = logContextSelector.getAndSet(CONTEXT_LOCK, logContext);
+                final LogContext old = logContextSelector.setLocalContext(logContext);
                 try {
                     WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
                     if (LOG4J_XML.equals(fileName) || JBOSS_LOG4J_XML.equals(fileName)) {
@@ -240,7 +239,7 @@ public class LoggingConfigDeploymentProcessor extends AbstractLoggingDeploymentP
                         new org.apache.log4j.PropertyConfigurator().doConfigure(properties, org.apache.log4j.JBossLogManagerFacade.getLoggerRepository(logContext));
                     }
                 } finally {
-                    logContextSelector.getAndSet(CONTEXT_LOCK, old);
+                    logContextSelector.setLocalContext(old);
                     WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
                 }
                 return new LoggingConfigurationService(null, resolveRelativePath(root, configFile));

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelector.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelector.java
@@ -44,14 +44,13 @@ public interface WildFlyLogContextSelector extends LogContextSelector {
     /**
      * Get and set the log context.
      *
-     * @param securityKey the security key to check (ignored if none was set on construction)
-     * @param newValue    the new log context value, or {@code null} to clear
+     * @param newValue the new log context value, or {@code null} to clear
      *
      * @return the previous log context value, or {@code null} if none was set
      *
      * @see org.jboss.logmanager.ThreadLocalLogContextSelector#getAndSet(Object, org.jboss.logmanager.LogContext)
      */
-    LogContext getAndSet(Object securityKey, LogContext newValue);
+    LogContext setLocalContext(LogContext newValue);
 
     /**
      * Register a class loader with a log context.


### PR DESCRIPTION
…t use the default log context selector. This will avoid the call stack being walked when determining the log context to use.

https://issues.redhat.com/browse/WFCORE-4860