### PR TITLE
Revert "[WFCORE-4653] Upgrade picketbox to 5.0.3.Final-redhat-00005"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>2.18.0</version.org.mockito>
         <version.org.mock-server.mockserver-netty>5.9.0</version.org.mock-server.mockserver-netty>
-        <version.org.picketbox>5.0.3.Final-redhat-00005</version.org.picketbox>
+        <version.org.picketbox>5.0.3.Final</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>


### PR DESCRIPTION
Reverts wildfly/wildfly-core#4092

WildFly Core does not include MRRC in its repository list so we shouldn't use -redhat versions.