### PR TITLE
[WFCORE-4893] Expose the process state from the embedded server and controller

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -227,7 +227,7 @@ public class EmbeddedHostControllerFactory {
         private final ModuleLoader moduleLoader;
         private final ClassLoader embeddedModuleCL;
         private ServiceContainer serviceContainer;
-        private ControlledProcessState.State currentProcessState;
+        private volatile ControlledProcessState.State currentProcessState;
         private ModelControllerClient modelControllerClient;
         private ExecutorService executorService;
         private ProcessStateNotifier processStateNotifier;
@@ -370,6 +370,14 @@ public class EmbeddedHostControllerFactory {
             }
         }
 
+        @Override
+        public String getProcessState() {
+            if (currentProcessState == null) {
+                return null;
+            }
+            return currentProcessState.toString();
+        }
+
         private void exit() {
 
             if (serviceContainer != null) {
@@ -437,6 +445,8 @@ public class EmbeddedHostControllerFactory {
             }
             return Main.determineEnvironment(cmds.toArray(new String[cmds.size()]), startTime, ProcessType.EMBEDDED_HOST_CONTROLLER).getHostControllerEnvironment();
         }
+
+
     }
 }
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcess.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcess.java
@@ -48,6 +48,15 @@ public interface EmbeddedManagedProcess {
      */
     void stop();
 
+    /**
+     * Returns the current process state of this managed process.
+     * <p>
+     * The returned value is a String representation of one of the possible {@code ControlledProcessState.State} values.
+     *
+     * @return The current process state, or {@code null} if currently the process state is unknown.
+     */
+    String getProcessState();
+
     static ClassLoader getTccl() {
         if (System.getSecurityManager() == null) {
             return Thread.currentThread().getContextClassLoader();

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcessImpl.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcessImpl.java
@@ -37,6 +37,7 @@ class EmbeddedManagedProcessImpl implements EmbeddedManagedProcess, StandaloneSe
     private final Method methodStart;
     private final Method methodStop;
     private final Method methodGetModelControllerClient;
+    private final Method methodGetCurrentProcessState;
     private final Context context;
 
     EmbeddedManagedProcessImpl(Class<?> processClass, Object managedProcess, Context context) {
@@ -46,6 +47,7 @@ class EmbeddedManagedProcessImpl implements EmbeddedManagedProcess, StandaloneSe
             methodStart = processClass.getMethod("start");
             methodStop = processClass.getMethod("stop");
             methodGetModelControllerClient = processClass.getMethod("getModelControllerClient");
+            methodGetCurrentProcessState = processClass.getMethod("getProcessState");
         } catch (final NoSuchMethodException nsme) {
             throw EmbeddedLogger.ROOT_LOGGER.cannotGetReflectiveMethod(nsme, nsme.getMessage(), processClass.getName());
         }
@@ -65,6 +67,11 @@ class EmbeddedManagedProcessImpl implements EmbeddedManagedProcess, StandaloneSe
         } finally {
             context.restore();
         }
+    }
+
+    @Override
+    public String getProcessState() {
+        return (String) safeInvokeOnServer(methodGetCurrentProcessState);
     }
 
     @Override

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedServerReference.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedServerReference.java
@@ -55,6 +55,11 @@ public final class EmbeddedServerReference implements StandaloneServer, HostCont
     }
 
     @Override
+    public String getProcessState() {
+        return delegate.getProcessState();
+    }
+
+    @Override
     public ModelControllerClient getModelControllerClient()  {
         return delegate.getModelControllerClient();
     }

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -215,7 +215,7 @@ public class EmbeddedStandaloneServerFactory {
         private final ModuleLoader moduleLoader;
         private final ClassLoader embeddedModuleCL;
         private ServiceContainer serviceContainer;
-        private ControlledProcessState.State currentProcessState;
+        private volatile ControlledProcessState.State currentProcessState;
         private ModelControllerClient modelControllerClient;
         private ExecutorService executorService;
         private ProcessStateNotifier processStateNotifier;
@@ -232,7 +232,7 @@ public class EmbeddedStandaloneServerFactory {
                 public void propertyChange(PropertyChangeEvent evt) {
                     if ("currentState".equals(evt.getPropertyName())) {
                         ControlledProcessState.State newState = (ControlledProcessState.State) evt.getNewValue();
-                        establishModelControllerClient(newState, false);
+                        establishModelControllerClient(newState, true);
                     }
                 }
             };
@@ -337,6 +337,14 @@ public class EmbeddedStandaloneServerFactory {
             } finally {
                 EmbeddedManagedProcess.setTccl(tccl);
             }
+        }
+
+        @Override
+        public String getProcessState() {
+            if (currentProcessState == null) {
+                return null;
+            }
+            return currentProcessState.toString();
         }
 
         private void exit() {


### PR DESCRIPTION
Expose the current process state to the client and instead of polling for the process state by using management operations, use the exposed value to return when the process state is not starting.

Jira issue: https://issues.redhat.com/browse/WFCORE-4893