### PR TITLE
Exclude commons-codec dep from httpclient.  WildFly Core doesn't ship…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -797,6 +797,10 @@
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
… commons-codec, but full WildFly does. I am seeing security scanner warns about bugs in the version transitively depended on by httpclient, which is older than the unaffected version full WildFly uses. I don't want to put commons-codec under WildFly Core's dependency management, as that just makes it a hassle when full WildFly wants to upgrade.  So let's see if just excluding it works.

Note that core has some test fixtures that use httpclient and those uses may need the transitive commons-code dep, in which case this commit will fail CI and we'll need a different solution.


Note: If this passes CI I'll file a JIRA and update the commit message and PR title.