### PR TITLE
[WFCORE-4748] Allow the MODULE_OPTS to be set and if an -javaagent: is found in the options automatically add jboss-modules as an agent to the VM.

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.bat
@@ -247,7 +247,7 @@ if not "%PRESERVE_JAVA_OPT%" == "true" (
             ) else if "!MODULAR_JDK!" == "true" (
                 set TMP_PARAM=-Xlog:gc*:file="\"!JBOSS_LOG_DIR!\gc.log\"":time,uptimemillis:filecount=5,filesize=3M
             ) else (
-                set TMP_PARAM=-verbose:gc -Xloggc:"!JBOSS_LOG_DIR!\gc.log" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading
+                set TMP_PARAM=-verbose:gc -Xloggc:"\"!JBOSS_LOG_DIR!\gc.log\"" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading
             )
             "!JAVA!" !TMP_PARAM! -version > nul 2>&1
             if not errorlevel == 1 (
@@ -270,10 +270,18 @@ if not "%PRESERVE_JAVA_OPT%" == "true" (
 
 
 rem Set the module options
-set "MODULE_OPTS="
+set "MODULE_OPTS=%MODULE_OPTS%"
 if "%SECMGR%" == "true" (
-    set "MODULE_OPTS=-secmgr"
+    set "MODULE_OPTS=%MODULE_OPTS% -secmgr"
 )
+setlocal EnableDelayedExpansion
+rem Add -client to the JVM options, if supported (32 bit VM), and not overriden
+echo "!MODULE_OPTS!" | findstr /I \-javaagent: > nul
+if not errorlevel == 1 (
+    set TMP_PARAM=-javaagent:"!JBOSS_HOME!\jboss-modules.jar"
+    set "JAVA_OPTS=!TMP_PARAM! %JAVA_OPTS%"
+)
+setlocal DisableDelayedExpansion
 
 echo ===============================================================================
 echo.

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf
@@ -84,3 +84,6 @@ fi
 
 # Uncomment and edit to use a custom java.security file to override all the Java security properties
 #JAVA_OPTS="$JAVA_OPTS -Djava.security.properties==/path/to/custom/java.security"
+
+# Uncomment to add a Java agent
+# MODULE_OPTS="-javaagent:agent.jar"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
@@ -82,3 +82,6 @@ rem # Uncomment and edit to use a custom java.security file to override all the 
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djava.security.properties==C:\path\to\custom\java.security"
 
 :JAVA_OPTS_SET
+
+rem # Uncomment to add a Java agent
+rem set "MODULE_OPTS=-javaagent:agent.jar"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
@@ -82,3 +82,6 @@ if (-Not $JAVA_OPTS) {
 
 # Uncomment this out to control garbage collection logging
 # $GC_LOG=$true
+
+# Uncomment to add a Java agent
+# $MODULE_OPTS="-javaagent:agent.jar"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.ps1
@@ -17,7 +17,9 @@ $STANDALONE_CONF_FILE = Get-Env RUN_CONF $STANDALONE_CONF_FILE
 Write-Debug "debug is: $global:DEBUG_MODE"
 Write-Debug "debug port: $global:DEBUG_PORT"
 Write-Debug "sec mgr: $SECMGR"
-
+if ($MODULE_OPTS -contains "-javaagent:") {
+    $JAVA_OPTS += "-javaagent:`\`"$JBOSS_HOME\jboss-modules.jar`\`""
+}
 if ($SECMGR) {
     $MODULE_OPTS +="-secmgr";
 }

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -309,9 +309,13 @@ if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
 fi
 
 # Set up the module arguments
-MODULE_OPTS=""
+MODULE_OPTS="$MODULE_OPTS"
 if [ "$SECMGR" = "true" ]; then
     MODULE_OPTS="$MODULE_OPTS -secmgr";
+fi
+AGENT_SET=$(echo "$MODULE_OPTS" | $GREP "\-javaagent:")
+if [ "x$AGENT_SET" != "x" ]; then
+  JAVA_OPTS="-javaagent:\"${JBOSS_HOME}/jboss-modules.jar\" ${JAVA_OPTS}"
 fi
 
 # Display our environment

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -26,6 +26,7 @@ import static org.wildfly.core.launcher.logger.LauncherMessages.MESSAGES;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,7 @@ import org.wildfly.core.launcher.Arguments.Argument;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "MagicNumber", "UnusedReturnValue"})
 public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneCommandBuilder> implements CommandBuilder {
 
     // JPDA remote socket debugging
@@ -55,6 +56,8 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     private String modulesLocklessArg;
     private String modulesMetricsArg;
     private final Map<String, String> securityProperties;
+    private boolean addModuleAgent;
+    private final Collection<String> moduleOpts;
 
     /**
      * Creates a new command builder for a standalone instance.
@@ -69,6 +72,8 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         javaOpts = new Arguments();
         javaOpts.addAll(DEFAULT_VM_ARGUMENTS);
         securityProperties = new LinkedHashMap<>();
+        moduleOpts = new ArrayList<>();
+        addModuleAgent = false;
     }
 
     /**
@@ -200,6 +205,103 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
      */
     public List<String> getJavaOptions() {
         return javaOpts.asList();
+    }
+
+    /**
+     * Adds an option which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDir(String)} to add a module
+     * directory.
+     * </p>
+     *
+     * @param arg the argument to add
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder addModuleOption(final String arg) {
+        if (arg != null) {
+            if (arg.startsWith("-javaagent:")) {
+                addModuleAgent = true;
+            } else if ("-mp".equals(arg) || "--modulepath".equals(arg)) {
+                throw MESSAGES.invalidArgument(arg, "addModuleOption");
+            }
+            moduleOpts.add(arg);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(String...)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to add
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder addModuleOptions(final String... args) {
+        if (args != null) {
+            for (String arg : args) {
+                addModuleOption(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(Iterable)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to add
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder addModuleOptions(final Iterable<String> args) {
+        if (args != null) {
+            for (String arg : args) {
+                addModuleOption(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Clears the current module options and adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(String...)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to use
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder setModuleOptions(final String... args) {
+        moduleOpts.clear();
+        addModuleOptions(args);
+        return this;
+    }
+
+    /**
+     * Clears the current module options and adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(Iterable)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to use
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder setModuleOptions(final Iterable<String> args) {
+        moduleOpts.clear();
+        addModuleOptions(args);
+        return this;
     }
 
     /**
@@ -405,7 +507,7 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     }
 
     public StandaloneCommandBuilder setGitRepository(final String gitRepository, final String gitBranch, final String gitAuthentication) {
-        if(gitRepository == null) {
+        if (gitRepository == null) {
             throw MESSAGES.nullParam("git-repo");
         }
         addServerArg("--git-repo", gitRepository);
@@ -423,10 +525,19 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     public List<String> buildArguments() {
         final List<String> cmd = new ArrayList<>();
         cmd.add("-D[Standalone]");
+        // Check to see if an agent was added as a module option, if so we want to add JBoss Modules as an agent.
+        if (addModuleAgent) {
+            cmd.add("-javaagent:" + getModulesJarName());
+        }
         cmd.addAll(getJavaOptions());
         if (environment.getJvm().isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        // Add these to JVM level system properties
+        addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());
+        addSystemPropertyArg(cmd, SERVER_BASE_DIR, getBaseDirectory());
+        addSystemPropertyArg(cmd, SERVER_LOG_DIR, getLogDirectory());
+        addSystemPropertyArg(cmd, SERVER_CONFIG_DIR, getConfigurationDirectory());
         if (modulesLocklessArg != null) {
             cmd.add(modulesLocklessArg);
         }
@@ -443,13 +554,11 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         if (useSecurityManager()) {
             cmd.add(SECURITY_MANAGER_ARG);
         }
+        // Add the agent argument for jboss-modules
+        cmd.addAll(moduleOpts);
         cmd.add("-mp");
         cmd.add(getModulePaths());
         cmd.add("org.jboss.as.standalone");
-        addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());
-        addSystemPropertyArg(cmd, SERVER_BASE_DIR, getBaseDirectory());
-        addSystemPropertyArg(cmd, SERVER_LOG_DIR, getLogDirectory());
-        addSystemPropertyArg(cmd, SERVER_CONFIG_DIR, getConfigurationDirectory());
 
         // Add the security properties
         StringBuilder sb = new StringBuilder(64);

--- a/launcher/src/main/java/org/wildfly/core/launcher/logger/LauncherMessages.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/logger/LauncherMessages.java
@@ -59,4 +59,7 @@ public interface LauncherMessages {
 
     @Message(id = 6, value = "Invalid hostname: %s")
     IllegalArgumentException invalidHostname(CharSequence hostname);
+
+    @Message(id = 7, value = "The argument %s is not allowed for %s.")
+    IllegalArgumentException invalidArgument(String argument, String methodName);
 }

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -64,6 +64,7 @@ public class CommandBuilderTest {
                 .addJavaOption("-Djava.security.manager")
                 .addJavaOption("-Djava.net.preferIPv4Stack=true")
                 .addJavaOption("-Djava.net.preferIPv4Stack=false")
+                .addModuleOption("-javaagent:test-agent1.jar")
                 .setBindAddressHint("management", "0.0.0.0");
 
         // Get all the commands
@@ -80,6 +81,9 @@ public class CommandBuilderTest {
         Assert.assertTrue("Missing server configuration file override", commands.contains("-c=standalone-full.xml"));
 
         Assert.assertTrue("Missing -secmgr option", commands.contains("-secmgr"));
+
+        Assert.assertTrue("Missing jboss-modules.jar", commands.stream().anyMatch(entry -> entry.matches("-javaagent:.*jboss-modules.jar$")));
+        Assert.assertTrue("Missing test-agent1.jar", commands.contains("-javaagent:test-agent1.jar"));
 
         // If we're using Java 9+ ensure the modular JDK options were added
         testModularJvmArguments(commands, 1);

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.galleon-plugins>4.2.4.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
-        <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
+        <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.0.0.Final</version.org.wildfly.plugins>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -287,7 +287,7 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.plugin}</version>
+                        <version>${version.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <phase>process-test-resources</phase>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -168,7 +168,7 @@
                      <plugin>
                          <groupId>org.wildfly.plugins</groupId>
                          <artifactId>wildfly-maven-plugin</artifactId>
-                         <version>${version.org.wildfly.plugin}</version>
+                         <version>${version.wildfly.plugin}</version>
                          <executions>
                              <execution>
                                  <phase>process-test-resources</phase>
@@ -209,7 +209,7 @@
                      <plugin>
                          <groupId>org.wildfly.plugins</groupId>
                          <artifactId>wildfly-maven-plugin</artifactId>
-                         <version>${version.org.wildfly.plugin}</version>
+                         <version>${version.wildfly.plugin}</version>
                          <configuration>
                              <!-- We turn off the ${ts.enable.elytron.cli}
                                   script as Galleon already enabled it-->

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -311,7 +311,7 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.plugin}</version>
+                        <version>${version.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <phase>process-test-resources</phase>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -40,14 +40,43 @@
         <wildfly.home>${project.basedir}${file.separator}target${file.separator}${server.name}</wildfly.home>
         <test.log.level>INFO</test.log.level>
         <test.log.file>${project.build.directory}${file.separator}test.log</test.log.file>
+        <maven.test.skip>false</maven.test.skip>
+        <skipTests>${maven.test.skip}</skipTests>
     </properties>
 
     <build>
         <plugins>
+            <!-- Create a test agent for the BootWithAgentTestCase -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-agent</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <finalName>logging-agent</finalName>
+                            <includes>
+                                <include>**/LoggingAgent.class</include>
+                            </includes>
+                            <archive>
+                                <manifestEntries>
+                                    <Premain-Class>org.wildfly.common.test.LoggingAgent</Premain-Class>
+                                </manifestEntries>
+                            </archive>
+                            <outputDirectory>${wildfly.home}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <failIfNoTests>false</failIfNoTests>
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
@@ -76,6 +105,37 @@
                         <configuration>
                             <config-file>server-provisioning.xml</config-file>
                             <server-name>${server.name}</server-name>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.plugin}</version>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                    <jboss-home>${wildfly.home}</jboss-home>
+                    <system-properties>
+                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                    </system-properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>configure-standalone</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <stdout>${project.build.directory}${file.separator}standalone-config.log</stdout>
+                            <commands>
+                                <command>/subsystem=logging/custom-formatter=json-formatter:add(module=org.jboss.logmanager, class=org.jboss.logmanager.formatters.JsonFormatter, properties={exceptionOutputType=FORMATTED, prettyPrint=false})</command>
+                                <command>/subsystem=logging/file-handler=json:add(file={relative-to=jboss.server.log.dir, path=json.log}, append=false, level=DEBUG, autoflush=true, named-formatter=json-formatter)</command>
+                                <command>/subsystem=logging/logger=org.wildfly.common.test.LoggingAgent:add(handlers=[json], level=DEBUG)</command>
+                            </commands>
                         </configuration>
                     </execution>
                 </executions>

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/LoggingAgent.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/LoggingAgent.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.test;
+
+import java.lang.instrument.Instrumentation;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingAgent {
+    public static final String LOGGER_NAME = LoggingAgent.class.getName();
+    public static final String MSG = "This is a message from the agent";
+
+    public static void premain(final String args, final Instrumentation instrumentation) throws ClassNotFoundException {
+        assert "org.jboss.logmanager.LogManager".equals(System.getProperty("java.util.logging.manager"));
+        assert Logger.class.isAssignableFrom(Class.forName("org.jboss.logmanager.Logger"));
+        final Logger logger = Logger.getLogger(LOGGER_NAME);
+        logger.warning(MSG);
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerHelper.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerHelper.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.test;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STARTING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ServerHelper {
+    public static final ModelNode EMPTY_ADDRESS = new ModelNode().setEmptyList();
+    public static final int TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(System.getProperty("jboss.test.start.timeout", "15")));
+    public static final Path JBOSS_HOME;
+    public static final String[] DEFAULT_SERVER_JAVA_OPTS = {
+            "-Djboss.management.http.port=" + TestSuiteEnvironment.getServerPort(),
+            "-Djboss.bind.address.management=" + TestSuiteEnvironment.getServerAddress(),
+    };
+
+    static {
+        EMPTY_ADDRESS.protect();
+        final String jbossHome = System.getProperty("jboss.home");
+
+        if (isNullOrEmpty(jbossHome)) {
+            throw new RuntimeException("Failed to configure environment. No jboss.home system property or JBOSS_HOME " +
+                    "environment variable set.");
+        }
+        JBOSS_HOME = Paths.get(jbossHome).toAbsolutePath();
+    }
+
+    /**
+     * Checks to see if a standalone server is running.
+     *
+     * @param client the client used to communicate with the server
+     *
+     * @return {@code true} if the server is running, otherwise {@code false}
+     */
+    public static boolean isStandaloneRunning(final ModelControllerClient client) {
+        try {
+            final ModelNode response = client.execute(Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state"));
+            if (Operations.isSuccessfulOutcome(response)) {
+                final String state = Operations.readResult(response).asString();
+                return !CONTROLLER_PROCESS_STATE_STARTING.equals(state)
+                        && !CONTROLLER_PROCESS_STATE_STOPPING.equals(state);
+            }
+        } catch (RuntimeException | IOException ignore) {
+        }
+        return false;
+    }
+
+    public static List<JsonObject> readLogFileFromModel(final String logFileName) throws IOException {
+        final ModelNode address = Operations.createAddress("subsystem", "logging", "log-file", logFileName);
+        final ModelNode op = Operations.createReadAttributeOperation(address, "stream");
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+            final OperationResponse response = client.executeOperation(Operation.Factory.create(op), OperationMessageHandler.logging);
+            final ModelNode result = response.getResponseNode();
+            if (Operations.isSuccessfulOutcome(result)) {
+                final OperationResponse.StreamEntry entry = response.getInputStream(Operations.readResult(result).asString());
+                if (entry == null) {
+                    throw new RuntimeException(String.format("Failed to find entry with UUID %s for log file %s",
+                            Operations.readResult(result).asString(), logFileName));
+                }
+                final List<JsonObject> lines = new ArrayList<>();
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(entry.getStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        try (JsonReader jsonReader = Json.createReader(new StringReader(line))) {
+                            lines.add(jsonReader.readObject());
+                        }
+                    }
+                }
+                return lines;
+            }
+            throw new RuntimeException(String.format("Failed to read log file %s: %s", logFileName, Operations.getFailureDescription(result).asString()));
+        }
+    }
+
+    private static boolean isNullOrEmpty(final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/launcher/test/LauncherTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/launcher/test/LauncherTestCase.java
@@ -1,0 +1,164 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.launcher.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.json.JsonObject;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.common.test.LoggingAgent;
+import org.wildfly.common.test.ServerHelper;
+import org.wildfly.core.launcher.Launcher;
+import org.wildfly.core.launcher.ProcessHelper;
+import org.wildfly.core.launcher.StandaloneCommandBuilder;
+
+/**
+ * This tests launching WildFly with JBoss Modules as an agent. For details see
+ * <a href="https://issues.jboss.org/browse/WFCORE-4674">WFCORE-4677</a>.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LauncherTestCase {
+    private static final Path STDOUT_PATH = Paths.get(TestSuiteEnvironment.getTmpDir(), "stdout.txt");
+
+    @Test
+    public void testStandaloneWithAgent() throws Exception {
+        final StandaloneCommandBuilder builder = StandaloneCommandBuilder.of(ServerHelper.JBOSS_HOME)
+                .addJavaOptions(ServerHelper.DEFAULT_SERVER_JAVA_OPTS)
+                .setUseSecurityManager(parseProperty("security.manager"))
+                // TODO (jrp) maybe test with agent arguments too, however this won't work until the 1.10.1.Final jboss-modules upgrade
+                // Add the test logging agent to the jboss-modules arguments
+                .addModuleOption("-javaagent:" + ServerHelper.JBOSS_HOME.resolve("logging-agent-tests.jar").toString());
+
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            builder.addJavaOption("-Dmaven.repo.local=" + localRepo);
+        }
+
+        Process process = null;
+        try {
+            process = Launcher.of(builder)
+                    .setRedirectErrorStream(true)
+                    .redirectOutput(STDOUT_PATH)
+                    .launch();
+            waitForStandalone(process);
+            final List<JsonObject> lines = ServerHelper.readLogFileFromModel("json.log");
+            Assert.assertEquals("Expected 1 line found " + lines.size(), 1, lines.size());
+            final JsonObject msg = lines.get(0);
+            Assert.assertEquals(LoggingAgent.MSG, msg.getString("message"));
+            shutdownStandalone();
+            process.waitFor();
+            if (process.exitValue() != 0) {
+                Assert.fail(readStdout());
+            }
+        } finally {
+            ProcessHelper.destroyProcess(process);
+        }
+    }
+
+    /**
+     * Waits the given amount of time in seconds for a standalone server to start.
+     * <p>
+     * If the {@code process} is not {@code null} and a timeout occurs the process will be
+     * {@linkplain Process#destroy() destroyed}.
+     * </p>
+     *
+     * @param process the Java process can be {@code null} if no process is available
+     *
+     * @throws InterruptedException if interrupted while waiting for the server to start
+     * @throws RuntimeException     if the process has died
+     */
+    private static void waitForStandalone(final Process process)
+            throws InterruptedException, IOException {
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+            long timeout = ServerHelper.TIMEOUT * 1000;
+            final long sleep = 100L;
+            while (timeout > 0) {
+                long before = System.currentTimeMillis();
+                if (ServerHelper.isStandaloneRunning(client))
+                    break;
+                timeout -= (System.currentTimeMillis() - before);
+                if (process != null && !process.isAlive()) {
+                    Assert.fail(readStdout());
+                }
+                TimeUnit.MILLISECONDS.sleep(sleep);
+                timeout -= sleep;
+            }
+            if (timeout <= 0) {
+                if (process != null) {
+                    process.destroy();
+                }
+                Assert.fail(String.format("The server did not start within %s seconds: %s", ServerHelper.TIMEOUT, readStdout()));
+            }
+        }
+    }
+
+    /**
+     * Shuts down a standalone server.
+     *
+     * @throws IOException if an error occurs communicating with the server
+     */
+    @SuppressWarnings("MagicNumber")
+    private static void shutdownStandalone() throws IOException {
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+            final ModelNode op = Operations.createOperation("shutdown");
+            op.get("timeout").set(0);
+            final ModelNode response = client.execute(op);
+            if (Operations.isSuccessfulOutcome(response)) {
+                while (true) {
+                    if (ServerHelper.isStandaloneRunning(client)) {
+                        try {
+                            TimeUnit.MILLISECONDS.sleep(20L);
+                        } catch (InterruptedException ignore) {
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                Assert.fail("Failed to shutdown server: " + Operations.getFailureDescription(response).asString());
+            }
+        }
+    }
+
+    private static String readStdout() throws IOException {
+        final StringBuilder error = new StringBuilder(10240)
+                .append("Failed to boot the server: ").append(System.lineSeparator());
+        for (String line : Files.readAllLines(STDOUT_PATH)) {
+            error.append(line).append(System.lineSeparator());
+        }
+        return error.toString();
+    }
+
+    private static boolean parseProperty(@SuppressWarnings("SameParameterValue") final String key) {
+        final String value = System.getProperty(key);
+        return value != null && (value.isEmpty() || Boolean.parseBoolean(value));
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
+import org.wildfly.common.test.ServerHelper;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -90,7 +91,7 @@ public class DomainScriptTestCase extends ScriptTestCase {
 
     @Override
     void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
-        script.start(DEFAULT_SERVER_JAVA_OPTS);
+        script.start(ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
 
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());
@@ -110,7 +111,7 @@ public class DomainScriptTestCase extends ScriptTestCase {
     }
 
     private static ModelNode determineHostAddress(final ModelControllerClient client) throws IOException {
-        final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "local-host-name");
+        final ModelNode op = Operations.createReadAttributeOperation(ServerHelper.EMPTY_ADDRESS, "local-host-name");
         ModelNode response = client.execute(op);
         if (Operations.isSuccessfulOutcome(response)) {
             return Operations.createAddress("host", Operations.readResult(response).asString());

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
@@ -32,8 +33,9 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.json.JsonObject;
+
 import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
@@ -43,6 +45,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.wildfly.common.test.ServerHelper;
+import org.wildfly.common.test.LoggingAgent;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -67,23 +71,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
     @Parameter
     public Map<String, String> env;
 
-    private static final Function<ModelControllerClient, Boolean> STANDALONE_CHECK = new Function<ModelControllerClient, Boolean>() {
-        private final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state");
-
-        @Override
-        public Boolean apply(final ModelControllerClient client) {
-
-            try {
-                final ModelNode result = client.execute(op);
-                if (Operations.isSuccessfulOutcome(result) &&
-                        ClientConstants.CONTROLLER_PROCESS_STATE_RUNNING.equals(Operations.readResult(result).asString())) {
-                    return true;
-                }
-            } catch (IllegalStateException | IOException ignore) {
-            }
-            return false;
-        }
-    };
+    private static final Function<ModelControllerClient, Boolean> STANDALONE_CHECK = ServerHelper::isStandaloneRunning;
 
     public StandaloneScriptTestCase() {
         super("standalone", STANDALONE_CHECK);
@@ -94,6 +82,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         final Collection<Object> result = new ArrayList<>(2);
         result.add(Collections.emptyMap());
         result.add(Collections.singletonMap("GC_LOG", "true"));
+        result.add(Collections.singletonMap("MODULE_OPTS", "-javaagent:logging-agent-tests.jar"));
         return result;
     }
 
@@ -105,9 +94,16 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         // seem to work when a directory has a space. An error indicating the trailing quote cannot be found. Removing
         // the `\ parts and just keeping quotes ends in the error shown in JDK-8215398.
         Assume.assumeFalse(TestSuiteEnvironment.isWindows() && MODULAR_JVM && env.containsKey("GC_LOG") && script.getScript().toString().contains(" "));
-        script.start(env, DEFAULT_SERVER_JAVA_OPTS);
+        script.start(env, ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());
+
+        if (env.containsKey("MODULE_OPTS")) {
+            final List<JsonObject> lines = ServerHelper.readLogFileFromModel("json.log");
+            Assert.assertEquals("Expected 1 line found " + lines.size(), 1, lines.size());
+            final JsonObject msg = lines.get(0);
+            Assert.assertEquals(LoggingAgent.MSG, msg.getString("message"));
+        }
 
         // Shutdown the server
         @SuppressWarnings("Convert2Lambda")

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -307,7 +307,7 @@
                      <plugin>
                          <groupId>org.wildfly.plugins</groupId>
                          <artifactId>wildfly-maven-plugin</artifactId>
-                         <version>${version.org.wildfly.plugin}</version>
+                         <version>${version.wildfly.plugin}</version>
                          <executions>
                              <execution>
                                  <phase>process-test-resources</phase>


### PR DESCRIPTION
**NOTE:** This is not yet complete, but I wanted to get a CI run to test the different environments.

The first commit just upgrades the wildfly-maven-plugin and changes the property name is it was rather confusing with the `version.org.wildfly.plugins` property.

The second commit exposes the `MODULE_OPTS` environment variable and adds `jboss-modules.jar` as an agent if there is an agent defined in the options. A documentation PR will be required upstream before this can be merged.

https://issues.redhat.com/browse/WFCORE-4748
https://issues.redhat.com/browse/WFCORE-4897