### PR TITLE
[WFCORE-4748] Allow the MODULE_OPTS to be set

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/parsing/Element.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Element.java
@@ -138,6 +138,7 @@ public enum Element {
     MANAGEMENT_CLIENT_CONTENT("management-client-content"),
     MANAGEMENT_INTERFACES("management-interfaces"),
     MEMBERSHIP_FILTER("membership-filter"),
+    MODULE_OPTIONS("module-options"),
     MULTICAST("multicast"),
 
     NAME("name"),

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
@@ -270,10 +270,18 @@ if not "%PRESERVE_JAVA_OPT%" == "true" (
 
 
 rem Set the module options
-set "MODULE_OPTS="
+set "MODULE_OPTS=%MODULE_OPTS%"
 if "%SECMGR%" == "true" (
-    set "MODULE_OPTS=-secmgr"
+    set "MODULE_OPTS=%MODULE_OPTS% -secmgr"
 )
+setlocal EnableDelayedExpansion
+rem Add -client to the JVM options, if supported (32 bit VM), and not overridden
+echo "!MODULE_OPTS!" | findstr /I \-javaagent: > nul
+if not errorlevel == 1 (
+    set AGENT_PARAM=-javaagent:"!JBOSS_HOME!\jboss-modules.jar"
+    set "JAVA_OPTS=!AGENT_PARAM! !JAVA_OPTS!"
+)
+setlocal DisableDelayedExpansion
 
 echo ===============================================================================
 echo.

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.conf
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.conf
@@ -84,3 +84,7 @@ fi
 
 # Uncomment and edit to use a custom java.security file to override all the Java security properties
 #JAVA_OPTS="$JAVA_OPTS -Djava.security.properties==/path/to/custom/java.security"
+
+# Uncomment to add a Java agent. If an agent is added to the module options, then jboss-modules.jar is added as an agent
+# on the JVM. This allows things like the log manager or security manager to be configured before the agent is invoked.
+# MODULE_OPTS="-javaagent:agent.jar"

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.bat
@@ -82,3 +82,7 @@ rem # Uncomment and edit to use a custom java.security file to override all the 
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djava.security.properties==C:\path\to\custom\java.security"
 
 :JAVA_OPTS_SET
+
+rem # Uncomment to add a Java agent. If an agent is added to the module options, then jboss-modules.jar is added as an agent
+rem # on the JVM. This allows things like the log manager or security manager to be configured before the agent is invoked.
+rem set "MODULE_OPTS=-javaagent:agent.jar"

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.ps1
@@ -82,3 +82,7 @@ if (-Not $JAVA_OPTS) {
 
 # Uncomment this out to control garbage collection logging
 # $GC_LOG=$true
+
+# Uncomment to add a Java agent. If an agent is added to the module options, then jboss-modules.jar is added as an agent
+# on the JVM. This allows things like the log manager or security manager to be configured before the agent is invoked.
+# $MODULE_OPTS="-javaagent:agent.jar"

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.ps1
@@ -18,6 +18,11 @@ Write-Debug "debug is: $global:DEBUG_MODE"
 Write-Debug "debug port: $global:DEBUG_PORT"
 Write-Debug "sec mgr: $SECMGR"
 
+$MODULE_OPTS = Get-Env MODULE_OPTS $null
+if ($MODULE_OPTS -like "*-javaagent:*") {
+    $JAVA_OPTS += "-javaagent:$JBOSS_HOME\jboss-modules.jar"
+}
+Write-Debug "MODULE_OPTS: $MODULE_OPTS"
 if ($SECMGR) {
     $MODULE_OPTS +="-secmgr";
 }

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -309,9 +309,13 @@ if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
 fi
 
 # Set up the module arguments
-MODULE_OPTS=""
+MODULE_OPTS="$MODULE_OPTS"
 if [ "$SECMGR" = "true" ]; then
     MODULE_OPTS="$MODULE_OPTS -secmgr";
+fi
+AGENT_SET=$(echo "$MODULE_OPTS" | $GREP "\-javaagent:")
+if [ "x$AGENT_SET" != "x" ]; then
+  JAVA_OPTS="-javaagent:\"${JBOSS_HOME}/jboss-modules.jar\" ${JAVA_OPTS}"
 fi
 
 # Display our environment

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTransformersTestCase.java
@@ -32,6 +32,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TIM
 import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.MANAGEMENT_SUBSYSTEM_ENDPOINT;
 import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MODULE_OPTIONS;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -123,7 +124,8 @@ public class DomainServerGroupTransformersTestCase extends AbstractCoreModelTest
                         FailedOperationTransformationConfig.ChainedConfig.createBuilder(MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE)
                                 .addConfig(new FailedOperationTransformationConfig.RejectExpressionsConfig(MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET))
                                 .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(SOCKET_BINDING_DEFAULT_INTERFACE))
-                                .build().setReadOnly(MANAGEMENT_SUBSYSTEM_ENDPOINT)));
+                                .build().setReadOnly(MANAGEMENT_SUBSYSTEM_ENDPOINT))
+                .addFailedAttribute(serverGroupAddress.append("jvm", "full"), new FailedOperationTransformationConfig.NewAttributesConfig(MODULE_OPTIONS)));
 
         //check that we reject /server-group=main-server-group:suspend-servers(timeout=?)
         OperationTransformer.TransformedOperation transOp = mainServices.transformOperation(modelVersion, Util.createOperation("suspend-servers", serverGroupAddress));

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-full.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-full.xml
@@ -20,6 +20,9 @@
                <variable name="name2" value="value2"/>
             </environment-variables>
             <launch-command prefix="command-prefix"/>
+            <module-options>
+               <option value="-javaagent:jboss-modules.jar"/>
+            </module-options>
          </jvm>
          <!-- Needed for the add operation -->
          <socket-binding-group ref="test-sockets"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
@@ -20,6 +20,9 @@
                     <variable name="name2" value="${mytest.value2:value2}"/>
                 </environment-variables>
                 <launch-command prefix="${mytest.value:command-prefix}"/>
+                <module-options>
+                    <option value="${mytest.agent.value:-javaagent:jboss-modules.jar}"/>
+                </module-options>
              </jvm>
              <!-- Needed for the add operation -->
              <socket-binding-group ref="test-sockets"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
@@ -31,6 +31,9 @@
                      <variable name="name1" value="value1"/>
                      <variable name="name2" value="value2"/>
                  </environment-variables>
+                 <module-options>
+                     <option value="-javaagent:jboss-modules.jar"/>
+                 </module-options>
             </jvm>
 
             <socket-binding-group ref="test-sockets" port-offset="10" default-interface="public-two"/>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.domain.controller.transformers;
 
+import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_10_0;
+import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_13_0;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_1_7;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_1_8;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_2_0;
@@ -146,7 +148,7 @@ public class DomainTransformers {
 
     private static void registerChainedServerGroupTransformers(TransformerRegistry registry) {
         ChainedTransformationDescriptionBuilder builder = ServerGroupTransformers.buildTransformerChain();
-        registerChainedTransformer(registry, builder, VERSION_8_0, VERSION_7_0, VERSION_6_0, VERSION_5_0, VERSION_4_1, VERSION_4_0, VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8, VERSION_1_7);
+        registerChainedTransformer(registry, builder, VERSION_13_0, VERSION_10_0, VERSION_8_0, VERSION_7_0, VERSION_6_0, VERSION_5_0, VERSION_4_1, VERSION_4_0, VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8, VERSION_1_7);
     }
 
     private static void registerProfileTransformers(TransformerRegistry registry) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JvmTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JvmTransformers.java
@@ -26,6 +26,7 @@ import static org.jboss.as.host.controller.model.jvm.JvmAttributes.LAUNCH_COMMAN
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.host.controller.model.jvm.JvmAttributes;
 import org.jboss.as.host.controller.model.jvm.JvmResourceDefinition;
 
 /**
@@ -43,5 +44,19 @@ class JvmTransformers {
             .setDiscard(DiscardAttributeChecker.UNDEFINED, LAUNCH_COMMAND)
             .addRejectCheck(RejectAttributeChecker.DEFINED, LAUNCH_COMMAND)
         .end();
+    }
+
+
+    public static void registerTransformers13_AndBelow(ResourceTransformationDescriptionBuilder parent) {
+        parent.addChildResource(JvmResourceDefinition.GLOBAL.getPathElement())
+                .getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, JvmAttributes.MODULE_OPTIONS)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, JvmAttributes.MODULE_OPTIONS)
+                .end();
+        parent.addChildResource(JvmResourceDefinition.SERVER.getPathElement())
+                .getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, JvmAttributes.MODULE_OPTIONS)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, JvmAttributes.MODULE_OPTIONS)
+                .end();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
@@ -47,9 +47,13 @@ class ServerGroupTransformers {
         //////////////////////////////////
         //The EAP/AS 7.x chains
 
+        // module-options was introduced in 13, WildFly 20
+        ResourceTransformationDescriptionBuilder currentTo13 = createBuilderFromCurrent(chainedBuilder, KernelAPIVersion.VERSION_13_0);
+        JvmTransformers.registerTransformers13_AndBelow(currentTo13);
+
         //timeout attribute renamed to suspend-timeout in Version 9.0. Must be renamed for 8.0 and below
-        ResourceTransformationDescriptionBuilder currentTo80 = createBuilderFromCurrent(chainedBuilder, KernelAPIVersion.VERSION_8_0);
-        DomainServerLifecycleHandlers.registerTimeoutToSuspendTimeoutRename(currentTo80);
+        ResourceTransformationDescriptionBuilder builder10to8 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_10_0, KernelAPIVersion.VERSION_8_0);
+        DomainServerLifecycleHandlers.registerTimeoutToSuspendTimeoutRename(builder10to8);
 
         // kill-servers and destroy-servers are rejected since 5.0 and below
         ResourceTransformationDescriptionBuilder builder60to50 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_6_0, KernelAPIVersion.VERSION_5_0);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
-
 import javax.security.sasl.SaslException;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
@@ -1451,5 +1450,15 @@ public interface HostControllerLogger extends BasicLogger {
      */
     @Message(id = 215, value = "Could not find java executable under %s.")
     IllegalStateException cannotFindJavaExe(String binDir);
+
+    /**
+     * Creates an exception inidcating the module options is not allowed.
+     *
+     * @param option the option that is not allowed
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 216, value = "The module option %s is not allowed.")
+    OperationFailedException moduleOptionNotAllowed(String option);
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmElement.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmElement.java
@@ -63,6 +63,7 @@ public class JvmElement {
     private String stack;
     private String launchCommand;
     private final JvmOptionsElement jvmOptionsElement = new JvmOptionsElement();
+    private final JvmOptionsElement moduleOptionsElement = new JvmOptionsElement();
     private Map<String, String> environmentVariables = new HashMap<String, String>();
 
     public JvmElement(final String name) {
@@ -103,6 +104,11 @@ public class JvmElement {
             }
             if(node.hasDefined(JvmAttributes.JVM_LAUNCH_COMMAND)) {
                 launchCommand = node.get(JvmAttributes.JVM_LAUNCH_COMMAND).asString();
+            }
+            if(node.hasDefined(JvmAttributes.MODULE_OPTIONS.getName())) {
+                for(final ModelNode option : node.get(JvmAttributes.MODULE_OPTIONS.getName()).asList()) {
+                    moduleOptionsElement.addOption(option.asString());
+                }
             }
             if(node.hasDefined(JvmAttributes.JVM_HEAP)) {
                 heapSize = node.get(JvmAttributes.JVM_HEAP).asString();
@@ -220,6 +226,10 @@ public class JvmElement {
 
     public JvmOptionsElement getJvmOptions() {
         return jvmOptionsElement;
+    }
+
+    public JvmOptionsElement getModuleOptions() {
+        return moduleOptionsElement;
     }
 
     public Map<String, String> getEnvironmentVariables() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmOptionsElement.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmOptionsElement.java
@@ -24,6 +24,7 @@ package org.jboss.as.host.controller.model.jvm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.wildfly.common.Assert;
 
@@ -66,6 +67,25 @@ public final class JvmOptionsElement {
      */
     public List<String> getOptions() {
         return new ArrayList<String>(options);
+    }
+
+    /**
+     * Uses regex on each option to check if the option matches the pattern.
+     *
+     * @param regex the regex pattern
+     *
+     * @return {@code true} if one of the options matches the patter, otherwise {@code false}
+     */
+    public boolean contains(final String regex) {
+        final Pattern pattern = Pattern.compile(regex);
+        synchronized (options) {
+            for (String opt : options) {
+                if (pattern.matcher(opt).matches()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
@@ -22,6 +22,7 @@
 package org.jboss.as.host.controller.operations;
 
 import static org.jboss.as.host.controller.resources.ServerConfigResourceDefinition.GROUP;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MODULE_OPTIONS;
 import static org.jboss.as.host.controller.resources.ServerConfigResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.host.controller.resources.ServerConfigResourceDefinition.SOCKET_BINDING_GROUP;
 import static org.jboss.as.host.controller.resources.ServerConfigResourceDefinition.SOCKET_BINDING_PORT_OFFSET;
@@ -45,7 +46,7 @@ public class ServerRestartRequiredServerConfigWriteAttributeHandler extends Mode
     public static OperationStepHandler INSTANCE = new ServerRestartRequiredServerConfigWriteAttributeHandler();
 
     protected ServerRestartRequiredServerConfigWriteAttributeHandler() {
-        super(GROUP, SOCKET_BINDING_GROUP, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE);
+        super(GROUP, MODULE_OPTIONS, SOCKET_BINDING_GROUP, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE);
     }
 
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
@@ -274,6 +274,10 @@ public class JvmXml {
                     parseLaunchCommand(reader, addOp);
                     break;
                 }
+                case MODULE_OPTIONS: {
+                    parseModuleOptions(reader, addOp);
+                    break;
+                }
                 default:
                     throw unexpectedElement(reader);
             }
@@ -575,6 +579,48 @@ public class JvmXml {
         addOp.get(JvmAttributes.JVM_OPTIONS).set(options);
     }
 
+    static void parseModuleOptions(final XMLExtendedStreamReader reader, final ModelNode addOp) throws XMLStreamException {
+
+        final ModelNode options = new ModelNode();
+        // Handle attributes
+        ParseUtils.requireNoAttributes(reader);
+        // Handle elements
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element moduleOptionElement = Element.forName(reader.getLocalName());
+            if (moduleOptionElement == Element.OPTION) {
+                // Handle attributes
+                ModelNode option = null;
+                final int count = reader.getAttributeCount();
+                for (int i = 0; i < count; i++) {
+                    final String attrValue = reader.getAttributeValue(i);
+                    if (!isNoNamespaceAttribute(reader, i)) {
+                        throw ParseUtils.unexpectedAttribute(reader, i);
+                    } else {
+                        final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+                        if (attribute == Attribute.VALUE) {
+                            option = ParseUtils.parsePossibleExpression(attrValue);
+                        } else {
+                            throw ParseUtils.unexpectedAttribute(reader, i);
+                        }
+                    }
+                }
+                if (option == null) {
+                    throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.VALUE));
+                }
+
+                options.add(option);
+                // Handle elements
+                requireNoContent(reader);
+            } else {
+                throw unexpectedElement(reader);
+            }
+        }
+        if (!options.isDefined()) {
+            throw missingRequiredElement(reader, Collections.singleton(Element.OPTION));
+        }
+        addOp.get(JvmAttributes.MODULE_OPTIONS.getName()).set(options);
+    }
+
     public static void writeJVMElement(final XMLExtendedStreamWriter writer, final String jvmName, final ModelNode jvmElement)
             throws XMLStreamException {
         writer.writeStartElement(Element.JVM.getLocalName());
@@ -625,6 +671,10 @@ public class JvmXml {
         if (JvmAttributes.LAUNCH_COMMAND.isMarshallable(jvmElement)) {
             writer.writeEmptyElement(Element.LAUNCH_COMMAND.getLocalName());
             JvmAttributes.PREFIX.marshallAsAttribute(jvmElement, writer);
+        }
+
+        if (JvmAttributes.MODULE_OPTIONS.isMarshallable(jvmElement)) {
+            JvmAttributes.MODULE_OPTIONS.marshallAsElement(jvmElement, writer);
         }
 
         writer.writeEndElement();

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -224,6 +224,8 @@ jvm.remove-jvm-option=Remove a jvm option.
 jvm.remove-jvm-option.jvm-option=A JVM option.
 jvm.environment-variables=The JVM environment variables.
 jvm.launch-command=Command prefixed to JVM at launch.
+jvm.module-options=The options passed to JBoss Modules during the boot of the server. Note that if a -javaent: is \
+  defined in the module options the jboss-modules.jar will be automatically added as a Java agent.
 #jvm.system.properties=The JVM system properties.
 jvm.java-home=The java home
 jvm.type=The JVM type can be either SUN or IBM

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -26,6 +26,7 @@ import static org.wildfly.core.launcher.logger.LauncherMessages.MESSAGES;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,7 @@ import org.wildfly.core.launcher.Arguments.Argument;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "MagicNumber", "UnusedReturnValue"})
 public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneCommandBuilder> implements CommandBuilder {
 
     // JPDA remote socket debugging
@@ -55,6 +56,8 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     private String modulesLocklessArg;
     private String modulesMetricsArg;
     private final Map<String, String> securityProperties;
+    private boolean addModuleAgent;
+    private final Collection<String> moduleOpts;
 
     /**
      * Creates a new command builder for a standalone instance.
@@ -69,6 +72,8 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         javaOpts = new Arguments();
         javaOpts.addAll(DEFAULT_VM_ARGUMENTS);
         securityProperties = new LinkedHashMap<>();
+        moduleOpts = new ArrayList<>();
+        addModuleAgent = false;
     }
 
     /**
@@ -200,6 +205,105 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
      */
     public List<String> getJavaOptions() {
         return javaOpts.asList();
+    }
+
+    /**
+     * Adds an option which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDir(String)} to add a module
+     * directory.
+     * </p>
+     *
+     * @param arg the argument to add
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder addModuleOption(final String arg) {
+        if (arg != null) {
+            if (arg.startsWith("-javaagent:")) {
+                addModuleAgent = true;
+            } else if ("-mp".equals(arg) || "--modulepath".equals(arg)) {
+                throw MESSAGES.invalidArgument(arg, "addModuleOption");
+            } else if ("-secmgr".equals(arg)) {
+                throw MESSAGES.invalidArgument(arg, "setUseSecurityManager");
+            }
+            moduleOpts.add(arg);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(String...)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to add
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder addModuleOptions(final String... args) {
+        if (args != null) {
+            for (String arg : args) {
+                addModuleOption(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(Iterable)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to add
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder addModuleOptions(final Iterable<String> args) {
+        if (args != null) {
+            for (String arg : args) {
+                addModuleOption(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Clears the current module options and adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(String...)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to use
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder setModuleOptions(final String... args) {
+        moduleOpts.clear();
+        addModuleOptions(args);
+        return this;
+    }
+
+    /**
+     * Clears the current module options and adds the options which will be passed to JBoss Modules.
+     * <p>
+     * Note that {@code -mp} or {@code --modulepath} is not supported. Use {@link #addModuleDirs(Iterable)} to add a
+     * module directory.
+     * </p>
+     *
+     * @param args the argument to use
+     *
+     * @return the builder
+     */
+    public StandaloneCommandBuilder setModuleOptions(final Iterable<String> args) {
+        moduleOpts.clear();
+        addModuleOptions(args);
+        return this;
     }
 
     /**
@@ -405,7 +509,7 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     }
 
     public StandaloneCommandBuilder setGitRepository(final String gitRepository, final String gitBranch, final String gitAuthentication) {
-        if(gitRepository == null) {
+        if (gitRepository == null) {
             throw MESSAGES.nullParam("git-repo");
         }
         addServerArg("--git-repo", gitRepository);
@@ -423,10 +527,19 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     public List<String> buildArguments() {
         final List<String> cmd = new ArrayList<>();
         cmd.add("-D[Standalone]");
+        // Check to see if an agent was added as a module option, if so we want to add JBoss Modules as an agent.
+        if (addModuleAgent) {
+            cmd.add("-javaagent:" + getModulesJarName());
+        }
         cmd.addAll(getJavaOptions());
         if (environment.getJvm().isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        // Add these to JVM level system properties
+        addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());
+        addSystemPropertyArg(cmd, SERVER_BASE_DIR, getBaseDirectory());
+        addSystemPropertyArg(cmd, SERVER_LOG_DIR, getLogDirectory());
+        addSystemPropertyArg(cmd, SERVER_CONFIG_DIR, getConfigurationDirectory());
         if (modulesLocklessArg != null) {
             cmd.add(modulesLocklessArg);
         }
@@ -443,13 +556,11 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         if (useSecurityManager()) {
             cmd.add(SECURITY_MANAGER_ARG);
         }
+        // Add the agent argument for jboss-modules
+        cmd.addAll(moduleOpts);
         cmd.add("-mp");
         cmd.add(getModulePaths());
         cmd.add("org.jboss.as.standalone");
-        addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());
-        addSystemPropertyArg(cmd, SERVER_BASE_DIR, getBaseDirectory());
-        addSystemPropertyArg(cmd, SERVER_LOG_DIR, getLogDirectory());
-        addSystemPropertyArg(cmd, SERVER_CONFIG_DIR, getConfigurationDirectory());
 
         // Add the security properties
         StringBuilder sb = new StringBuilder(64);

--- a/launcher/src/main/java/org/wildfly/core/launcher/logger/LauncherMessages.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/logger/LauncherMessages.java
@@ -59,4 +59,7 @@ public interface LauncherMessages {
 
     @Message(id = 6, value = "Invalid hostname: %s")
     IllegalArgumentException invalidHostname(CharSequence hostname);
+
+    @Message(id = 7, value = "The argument %s is not allowed for %s.")
+    IllegalArgumentException invalidArgument(String argument, String methodName);
 }

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -67,6 +67,7 @@ public class CommandBuilderTest {
                 .addJavaOption("-Djava.security.manager")
                 .addJavaOption("-Djava.net.preferIPv4Stack=true")
                 .addJavaOption("-Djava.net.preferIPv4Stack=false")
+                .addModuleOption("-javaagent:test-agent1.jar")
                 .setBindAddressHint("management", "0.0.0.0");
 
         // Get all the commands
@@ -83,6 +84,9 @@ public class CommandBuilderTest {
         Assert.assertTrue("Missing server configuration file override", commands.contains("-c=standalone-full.xml"));
 
         Assert.assertTrue("Missing -secmgr option", commands.contains("-secmgr"));
+
+        Assert.assertTrue("Missing jboss-modules.jar", commands.stream().anyMatch(entry -> entry.matches("-javaagent:.*jboss-modules.jar$")));
+        Assert.assertTrue("Missing test-agent1.jar", commands.contains("-javaagent:test-agent1.jar"));
 
         // If we're using Java 9+ ensure the modular JDK options were added
         testModularJvmArguments(commands, 1);

--- a/server/src/main/resources/schema/wildfly-config_14_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_14_0.xsd
@@ -4038,6 +4038,7 @@
             <xs:element name="jvm-options" type="jvm-optionsType" minOccurs="0"/>
             <xs:element name="environment-variables" type="environmentVariablesType" minOccurs="0"/>
             <xs:element name="launch-command" type="launch-commandType" minOccurs="0"/>
+            <xs:element name="module-options" type="moduleOptionsType" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="java-home" type="xs:string"/>
         <xs:attribute name="type" default="SUN">
@@ -4123,6 +4124,20 @@
         <xs:attribute name="value" use="required">
             <xs:annotation>
                 <xs:documentation>JVM javaagent value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="moduleOptionsType">
+        <xs:sequence>
+            <xs:element name="option" type="moduleOptionType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="moduleOptionType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JBoss Modules option value</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -40,14 +40,43 @@
         <wildfly.home>${project.basedir}${file.separator}target${file.separator}${server.name}</wildfly.home>
         <test.log.level>INFO</test.log.level>
         <test.log.file>${project.build.directory}${file.separator}test.log</test.log.file>
+        <maven.test.skip>false</maven.test.skip>
+        <skipTests>${maven.test.skip}</skipTests>
     </properties>
 
     <build>
         <plugins>
+            <!-- Create a test agent for the BootWithAgentTestCase -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-agent</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <finalName>logging-agent</finalName>
+                            <includes>
+                                <include>**/LoggingAgent.class</include>
+                            </includes>
+                            <archive>
+                                <manifestEntries>
+                                    <Premain-Class>org.wildfly.common.test.LoggingAgent</Premain-Class>
+                                </manifestEntries>
+                            </archive>
+                            <outputDirectory>${wildfly.home}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skip>${skipTests}</skip>
                     <failIfNoTests>false</failIfNoTests>
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/LoggingAgent.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/LoggingAgent.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.test;
+
+import java.lang.instrument.Instrumentation;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingAgent {
+    public static final String LOGGER_NAME = LoggingAgent.class.getName();
+    public static final String MSG = "This is a message from the agent";
+    public static final String DEBUG_ARG = "debug";
+
+    public static void premain(final String args, final Instrumentation instrumentation) throws ClassNotFoundException {
+        assert "org.jboss.logmanager.LogManager".equals(System.getProperty("java.util.logging.manager"));
+        assert Logger.class.isAssignableFrom(Class.forName("org.jboss.logmanager.Logger"));
+        final Logger logger = Logger.getLogger(LOGGER_NAME);
+        if (args != null && args.equals(DEBUG_ARG)) {
+            logger.fine(MSG);
+        }
+        logger.info(MSG);
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerConfigurator.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerConfigurator.java
@@ -1,0 +1,347 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.test;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.wildfly.core.launcher.DomainCommandBuilder;
+import org.wildfly.core.launcher.Launcher;
+import org.wildfly.core.launcher.ProcessHelper;
+import org.wildfly.core.launcher.StandaloneCommandBuilder;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ServerConfigurator {
+    private static final AtomicBoolean CONFIGURED = new AtomicBoolean(false);
+    public static final Set<Path> PATHS = new LinkedHashSet<>(16);
+
+    public static void configure() throws IOException, InterruptedException {
+        if (CONFIGURED.compareAndSet(false, true)) {
+            configureStandalone();
+            configureDomain();
+
+            // Always update the JBOSS_HOME/bin/*.conf.* files
+            try {
+                appendConf(ServerHelper.JBOSS_HOME, "domain", "PROCESS_CONTROLLER_JAVA_OPTS");
+                appendConf(ServerHelper.JBOSS_HOME, "domain", "HOST_CONTROLLER_JAVA_OPTS");
+                appendConf(ServerHelper.JBOSS_HOME, "standalone", "JAVA_OPTS");
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to update the script config files.", e);
+            }
+
+            // Always add the default path
+            PATHS.add(ServerHelper.JBOSS_HOME);
+
+            final String serverName = System.getProperty("server.name");
+
+            // Create special characters in paths to test with assuming the -Dserver.name was not used
+            if (serverName == null || serverName.isEmpty()) {
+                PATHS.add(copy("wildfly core"));
+                PATHS.add(copy("wildfly (core)"));
+            }
+        }
+    }
+
+    private static void configureStandalone() throws InterruptedException, IOException {
+        final Path stdout = Paths.get(TestSuiteEnvironment.getTmpDir(), "config-standalone-stdout.txt");
+        final StandaloneCommandBuilder builder = StandaloneCommandBuilder.of(ServerHelper.JBOSS_HOME)
+                .addJavaOptions(ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
+
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            builder.addJavaOption("-Dmaven.repo.local=" + localRepo);
+        }
+
+        Process process = null;
+        try {
+            process = Launcher.of(builder)
+                    .setRedirectErrorStream(true)
+                    .redirectOutput(stdout)
+                    .launch();
+            ServerHelper.waitForStandalone(process, () -> readStdout(stdout));
+
+            try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+                final CompositeOperationBuilder opBuilder = CompositeOperationBuilder.create();
+                ModelNode address = Operations.createAddress("subsystem", "logging", "custom-formatter", "json");
+                ModelNode op = Operations.createAddOperation(address);
+                op.get("class").set("org.jboss.logmanager.formatters.JsonFormatter");
+                op.get("module").set("org.jboss.logmanager");
+                final ModelNode properties = op.get("properties").setEmptyObject();
+                properties.get("exceptionOutputType").set("FORMATTED");
+                properties.get("prettyPrint").set(false);
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("subsystem", "logging", "file-handler", "json");
+                op = Operations.createAddOperation(address);
+                op.get("append").set(false);
+                op.get("level").set("DEBUG");
+                op.get("autoflush").set(true);
+                op.get("named-formatter").set("json");
+                final ModelNode file = op.get("file");
+                file.get("relative-to").set("jboss.server.log.dir");
+                file.get("path").set("json.log");
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("subsystem", "logging", "logger", "org.wildfly.common.test.LoggingAgent");
+                op = Operations.createAddOperation(address);
+                op.get("handlers").setEmptyList().add("json");
+                op.get("level").set("DEBUG");
+                opBuilder.addStep(op);
+
+                executeOperation(client, opBuilder.build());
+                ServerHelper.shutdownStandalone(client);
+            }
+
+            if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+                Assert.fail(readStdout(stdout));
+            }
+
+            if (process.exitValue() != 0) {
+                Assert.fail(readStdout(stdout));
+            }
+
+        } finally {
+            ProcessHelper.destroyProcess(process);
+        }
+    }
+
+    private static void configureDomain() throws IOException, InterruptedException {
+        final Path stdout = Paths.get(TestSuiteEnvironment.getTmpDir(), "config-domain-stdout.txt");
+        final DomainCommandBuilder builder = DomainCommandBuilder.of(ServerHelper.JBOSS_HOME)
+                .addHostControllerJavaOptions(ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
+
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            builder.addHostControllerJavaOption("-Dmaven.repo.local=" + localRepo)
+                    .addProcessControllerJavaOption("-Dmaven.repo.local=" + localRepo);
+        }
+
+        Process process = null;
+        try {
+            process = Launcher.of(builder)
+                    .setRedirectErrorStream(true)
+                    .redirectOutput(stdout)
+                    .launch();
+            ServerHelper.waitForDomain(process, () -> readStdout(stdout));
+
+            // Start server-three, configure it, then stop it
+            try (DomainClient client = DomainClient.Factory.create(TestSuiteEnvironment.getModelControllerClient())) {
+                final String hostName = ServerHelper.determineHostName(client);
+                // Configure server-three to launch with an agent
+                final CompositeOperationBuilder opBuilder = CompositeOperationBuilder.create();
+                ModelNode address = Operations.createAddress("profile", "default");
+                ModelNode op = Operations.createOperation("clone", address);
+                op.get("to-profile").set("test");
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("server-group", "other-server-group");
+                op = Operations.createWriteAttributeOperation(address, "profile", "test");
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("host", hostName, "server-config", "server-three", "jvm", "default");
+                op = Operations.createAddOperation(address);
+                op.get("module-options").setEmptyList().add("-javaagent:" + ServerHelper.JBOSS_HOME.resolve("logging-agent-tests.jar") + "=" + LoggingAgent.DEBUG_ARG);
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("profile", "test", "subsystem", "logging", "custom-formatter", "json");
+                op = Operations.createAddOperation(address);
+                op.get("class").set("org.jboss.logmanager.formatters.JsonFormatter");
+                op.get("module").set("org.jboss.logmanager");
+                final ModelNode properties = op.get("properties").setEmptyObject();
+                properties.get("exceptionOutputType").set("FORMATTED");
+                properties.get("prettyPrint").set(false);
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("profile", "test", "subsystem", "logging", "file-handler", "json");
+                op = Operations.createAddOperation(address);
+                op.get("append").set(false);
+                op.get("level").set("DEBUG");
+                op.get("autoflush").set(true);
+                op.get("named-formatter").set("json");
+                final ModelNode file = op.get("file");
+                file.get("relative-to").set("jboss.server.log.dir");
+                file.get("path").set("json.log");
+                opBuilder.addStep(op);
+
+                address = Operations.createAddress("profile", "test", "subsystem", "logging", "logger", "org.wildfly.common.test.LoggingAgent");
+                op = Operations.createAddOperation(address);
+                op.get("handlers").setEmptyList().add("json");
+                op.get("level").set("DEBUG");
+                opBuilder.addStep(op);
+
+                executeOperation(client, opBuilder.build());
+
+
+                client.startServer(hostName, "server-three");
+                ServerHelper.waitForManagedServer(client, "server-three", () -> readStdout(stdout));
+                ServerHelper.shutdownDomain(client);
+            }
+            if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+                Assert.fail(readStdout(stdout));
+            }
+
+            if (process.exitValue() != 0) {
+                Assert.fail(readStdout(stdout));
+            }
+        } finally {
+            ProcessHelper.destroyProcess(process);
+        }
+    }
+
+    private static void executeOperation(final ModelControllerClient client, final Operation op) throws IOException {
+        final ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    private static String readStdout(final Path stdout) {
+        final StringBuilder error = new StringBuilder(10240)
+                .append("Failed to boot the server: ").append(System.lineSeparator());
+        try {
+            for (String line : Files.readAllLines(stdout)) {
+                error.append(line).append(System.lineSeparator());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return error.toString();
+    }
+
+    private static void appendConf(final Path containerHome, final String baseName, final String envName) throws IOException {
+        // Add the local maven repository to the conf file
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            final Path binDir = containerHome.resolve("bin");
+            if (TestSuiteEnvironment.isWindows()) {
+                // Batch conf
+                Path conf = binDir.resolve(baseName + ".conf.bat");
+                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
+                    writer.newLine();
+                    writer.write("set \"");
+                    writer.write(envName);
+                    writer.write("=-Dmaven.repo.local=");
+                    writer.write(localRepo);
+                    writer.write(" %");
+                    writer.write(envName);
+                    writer.write("%\"");
+                    writer.newLine();
+                }
+                // Powershell conf
+                conf = binDir.resolve(baseName + ".conf.ps1");
+                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
+                    writer.newLine();
+                    writer.write('$');
+                    writer.write(envName);
+                    writer.write(" += '-Dmaven.repo.local=");
+                    writer.write(localRepo);
+                    writer.write("'");
+                    writer.newLine();
+                }
+            } else {
+                final Path conf = binDir.resolve(baseName + ".conf");
+                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
+                    writer.newLine();
+                    writer.write(envName);
+                    writer.write("=\"-Dmaven.repo.local=");
+                    writer.write(localRepo);
+                    writer.write(" $");
+                    writer.write(envName);
+                    writer.write('"');
+                    writer.newLine();
+                }
+            }
+        }
+    }
+
+    private static Path copy(final String targetName) {
+        final Path source = ServerHelper.JBOSS_HOME;
+        try {
+            final Path target = source.getParent().resolve(targetName);
+            deleteDirectory(target);
+            copyDirectory(source, target);
+            // Likely not needed in the PC, but also won't hurt
+            appendConf(target, "domain", "PROCESS_CONTROLLER_JAVA_OPTS");
+            appendConf(target, "domain", "HOST_CONTROLLER_JAVA_OPTS");
+            appendConf(target, "standalone", "JAVA_OPTS");
+            return target;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void copyDirectory(final Path source, final Path target) throws IOException {
+        Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                final Path targetFile = target.resolve(source.relativize(file));
+                Files.copy(file, targetFile);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {
+                final Path targetDir = target.resolve(source.relativize(dir));
+                Files.copy(dir, targetDir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void deleteDirectory(final Path dir) throws IOException {
+        if (Files.exists(dir) && Files.isDirectory(dir)) {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerHelper.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerHelper.java
@@ -1,0 +1,334 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.common.test;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STARTING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.client.helpers.domain.ServerIdentity;
+import org.jboss.as.controller.client.helpers.domain.ServerStatus;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ServerHelper {
+    public static final ModelNode EMPTY_ADDRESS = new ModelNode().setEmptyList();
+    public static final int TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(System.getProperty("jboss.test.start.timeout", "15")));
+    public static final Path JBOSS_HOME;
+    public static final String[] DEFAULT_SERVER_JAVA_OPTS = {
+            "-Djboss.management.http.port=" + TestSuiteEnvironment.getServerPort(),
+            "-Djboss.bind.address.management=" + TestSuiteEnvironment.getServerAddress(),
+    };
+
+    static {
+        EMPTY_ADDRESS.protect();
+        final String jbossHome = System.getProperty("jboss.home");
+
+        if (isNullOrEmpty(jbossHome)) {
+            throw new RuntimeException("Failed to configure environment. No jboss.home system property or JBOSS_HOME " +
+                    "environment variable set.");
+        }
+        JBOSS_HOME = Paths.get(jbossHome).toAbsolutePath();
+    }
+
+    /**
+     * Shuts down a standalone server.
+     *
+     * @throws IOException if an error occurs communicating with the server
+     */
+    public static void shutdownStandalone(final ModelControllerClient client) throws IOException {
+        final ModelNode op = Operations.createOperation("shutdown");
+        op.get("timeout").set(0);
+        final ModelNode response = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(response)) {
+            Assert.fail("Failed to shutdown server: " + Operations.getFailureDescription(response).asString());
+        }
+    }
+
+    /**
+     * Checks to see if a standalone server is running.
+     *
+     * @param client the client used to communicate with the server
+     *
+     * @return {@code true} if the server is running, otherwise {@code false}
+     */
+    public static boolean isStandaloneRunning(final ModelControllerClient client) {
+        try {
+            final ModelNode response = client.execute(Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state"));
+            if (Operations.isSuccessfulOutcome(response)) {
+                final String state = Operations.readResult(response).asString();
+                return !CONTROLLER_PROCESS_STATE_STARTING.equals(state)
+                        && !CONTROLLER_PROCESS_STATE_STOPPING.equals(state);
+            }
+        } catch (RuntimeException | IOException ignore) {
+        }
+        return false;
+    }
+
+    /**
+     * Waits the given amount of time in seconds for a standalone server to start.
+     * <p>
+     * If the {@code process} is not {@code null} and a timeout occurs the process will be
+     * {@linkplain Process#destroy() destroyed}.
+     * </p>
+     *
+     * @param process the Java process can be {@code null} if no process is available
+     *
+     * @throws InterruptedException if interrupted while waiting for the server to start
+     * @throws RuntimeException     if the process has died
+     */
+    public static void waitForStandalone(final Process process, final Supplier<String> failureDescription)
+            throws InterruptedException, IOException {
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+            waitForStart(process, failureDescription, () -> ServerHelper.isStandaloneRunning(client));
+        }
+    }
+
+    /**
+     * Checks to see if a domain server is running.
+     *
+     * @param client the client used to communicate with the server
+     *
+     * @return {@code true} if the server, and it's auto-start servers, are running, otherwise {@code false}
+     */
+    public static boolean isDomainRunning(final ModelControllerClient client) {
+        return isDomainRunning(client, false);
+    }
+
+    /**
+     * Checks to see if a domain server is running.
+     *
+     * @param client      the client used to communicate with the server
+     * @param forShutdown if this is checking for a shutdown
+     *
+     * @return {@code true} if the server, and it's auto-start servers, are running, otherwise {@code false}
+     */
+    public static boolean isDomainRunning(final ModelControllerClient client, final boolean forShutdown) {
+
+        final DomainClient domainClient = (client instanceof DomainClient ? (DomainClient) client : DomainClient.Factory.create(client));
+        try {
+            // Check for admin-only
+            final ModelNode hostAddress = determineHostAddress(domainClient);
+            final Operations.CompositeOperationBuilder builder = Operations.CompositeOperationBuilder.create()
+                    .addStep(Operations.createReadAttributeOperation(hostAddress, "running-mode"))
+                    .addStep(Operations.createReadAttributeOperation(hostAddress, "host-state"));
+            ModelNode response = domainClient.execute(builder.build());
+            if (Operations.isSuccessfulOutcome(response)) {
+                response = Operations.readResult(response);
+                if ("ADMIN_ONLY".equals(Operations.readResult(response.get("step-1")).asString())) {
+                    if (Operations.isSuccessfulOutcome(response.get("step-2"))) {
+                        final String state = Operations.readResult(response).asString();
+                        return !CONTROLLER_PROCESS_STATE_STARTING.equals(state)
+                                && !CONTROLLER_PROCESS_STATE_STOPPING.equals(state);
+                    }
+                }
+            }
+            final Map<ServerIdentity, ServerStatus> servers = new HashMap<>();
+            final Map<ServerIdentity, ServerStatus> statuses = domainClient.getServerStatuses();
+            for (ServerIdentity id : statuses.keySet()) {
+                final ServerStatus status = statuses.get(id);
+                switch (status) {
+                    case DISABLED:
+                    case STARTED: {
+                        servers.put(id, status);
+                        break;
+                    }
+                }
+            }
+            if (forShutdown) {
+                return statuses.isEmpty();
+            }
+            return statuses.size() == servers.size();
+        } catch (IllegalStateException | IOException ignore) {
+        }
+        return false;
+    }
+
+    /**
+     * Shuts down a domain server.
+     *
+     * @throws IOException if an error occurs communicating with the server
+     */
+    public static void shutdownDomain(final DomainClient client) throws IOException {
+        // Now shutdown the host
+        final ModelNode address = ServerHelper.determineHostAddress(client);
+        final ModelNode shutdownOp = Operations.createOperation("shutdown", address);
+        final ModelNode response = client.execute(shutdownOp);
+        if (!Operations.isSuccessfulOutcome(response)) {
+            Assert.fail("Failed to stop servers: " + response);
+        }
+    }
+
+    /**
+     * Waits the given amount of time in seconds for a domain server to start.
+     * <p>
+     * If the {@code process} is not {@code null} and a timeout occurs the process will be
+     * {@linkplain Process#destroy() destroyed}.
+     * </p>
+     *
+     * @param process the Java process can be {@code null} if no process is available
+     *
+     * @throws InterruptedException if interrupted while waiting for the server to start
+     * @throws RuntimeException     if the process has died
+     */
+    public static void waitForDomain(final Process process, final Supplier<String> failureDescription)
+            throws InterruptedException, IOException {
+        try (DomainClient client = DomainClient.Factory.create(TestSuiteEnvironment.getModelControllerClient())) {
+            waitForStart(process, failureDescription, () -> ServerHelper.isDomainRunning(client));
+        }
+    }
+
+    public static void waitForManagedServer(final DomainClient client, final String serverName, final Supplier<String> failureDescription) throws InterruptedException {
+            waitForStart(null, failureDescription, () -> {
+                // Wait for the server to start
+                ServerStatus serverStatus = null;
+                final Map<ServerIdentity, ServerStatus> statuses = client.getServerStatuses();
+                for (Map.Entry<ServerIdentity, ServerStatus> entry : statuses.entrySet()) {
+                    if (serverName.equals(entry.getKey().getServerName())) {
+                        serverStatus = entry.getValue();
+                        break;
+                    }
+                }
+                return serverStatus == ServerStatus.STARTED;
+            });
+    }
+
+    public static List<JsonObject> readLogFileFromModel(final String logFileName, final String... addressPrefix) throws IOException {
+        final Collection<String> addr = new ArrayList<>();
+        if (addressPrefix != null) {
+            Collections.addAll(addr, addressPrefix);
+        }
+        addr.add("subsystem");
+        addr.add("logging");
+        addr.add("log-file");
+        addr.add(logFileName);
+        final ModelNode address = Operations.createAddress(addr);
+        final ModelNode op = Operations.createReadAttributeOperation(address, "stream");
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+            final OperationResponse response = client.executeOperation(Operation.Factory.create(op), OperationMessageHandler.logging);
+            final ModelNode result = response.getResponseNode();
+            if (Operations.isSuccessfulOutcome(result)) {
+                final OperationResponse.StreamEntry entry = response.getInputStream(Operations.readResult(result).asString());
+                if (entry == null) {
+                    throw new RuntimeException(String.format("Failed to find entry with UUID %s for log file %s",
+                            Operations.readResult(result).asString(), logFileName));
+                }
+                final List<JsonObject> lines = new ArrayList<>();
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(entry.getStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        try (JsonReader jsonReader = Json.createReader(new StringReader(line))) {
+                            lines.add(jsonReader.readObject());
+                        }
+                    }
+                }
+                return lines;
+            }
+            throw new RuntimeException(String.format("Failed to read log file %s: %s", logFileName, Operations.getFailureDescription(result).asString()));
+        }
+    }
+
+    /**
+     * Attempts to determine the address for a domain server.
+     *
+     * @param client the client used to communicate with the server
+     *
+     * @return the host address
+     *
+     * @throws IOException if an error occurs determining the host name
+     */
+    public static ModelNode determineHostAddress(final ModelControllerClient client) throws IOException {
+        return Operations.createAddress("host", determineHostName(client));
+    }
+
+    /**
+     * Attempts to determine the name for a domain server.
+     *
+     * @param client the client used to communicate with the server
+     *
+     * @return the host name
+     *
+     * @throws IOException if an error occurs determining the host name
+     */
+    public static String determineHostName(final ModelControllerClient client) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "local-host-name");
+        ModelNode response = client.execute(op);
+        if (Operations.isSuccessfulOutcome(response)) {
+            return Operations.readResult(response).asString();
+        }
+        throw new IOException("Failed to determine host name: " + Operations.readResult(response).asString());
+    }
+
+    private static boolean isNullOrEmpty(final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static void waitForStart(final Process process, final Supplier<String> failureDescription, final BooleanSupplier check) throws InterruptedException {
+        long timeout = ServerHelper.TIMEOUT * 1000;
+        final long sleep = 100L;
+        while (timeout > 0) {
+            long before = System.currentTimeMillis();
+            if (check.getAsBoolean())
+                break;
+            timeout -= (System.currentTimeMillis() - before);
+            if (process != null && !process.isAlive()) {
+                Assert.fail(failureDescription.get());
+            }
+            TimeUnit.MILLISECONDS.sleep(sleep);
+            timeout -= sleep;
+        }
+        if (timeout <= 0) {
+            if (process != null) {
+                process.destroy();
+            }
+            Assert.fail(String.format("The server did not start within %s seconds: %s", ServerHelper.TIMEOUT, failureDescription.get()));
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/launcher/test/LauncherTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/launcher/test/LauncherTestCase.java
@@ -1,0 +1,163 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.launcher.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.json.JsonObject;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.common.test.LoggingAgent;
+import org.wildfly.common.test.ServerConfigurator;
+import org.wildfly.common.test.ServerHelper;
+import org.wildfly.core.launcher.DomainCommandBuilder;
+import org.wildfly.core.launcher.Launcher;
+import org.wildfly.core.launcher.ProcessHelper;
+import org.wildfly.core.launcher.StandaloneCommandBuilder;
+
+/**
+ * This tests launching WildFly with JBoss Modules as an agent. For details see
+ * <a href="https://issues.jboss.org/browse/WFCORE-4674">WFCORE-4677</a>.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LauncherTestCase {
+    private static final Path STDOUT_PATH = Paths.get(TestSuiteEnvironment.getTmpDir(), "stdout.txt");
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ServerConfigurator.configure();
+    }
+
+    @Test
+    public void testStandaloneWithAgent() throws Exception {
+        final StandaloneCommandBuilder builder = StandaloneCommandBuilder.of(ServerHelper.JBOSS_HOME)
+                .addJavaOptions(ServerHelper.DEFAULT_SERVER_JAVA_OPTS)
+                .setUseSecurityManager(parseProperty("security.manager"))
+                // Add the test logging agent to the jboss-modules arguments
+                .addModuleOption("-javaagent:" + ServerHelper.JBOSS_HOME.resolve("logging-agent-tests.jar") + "=" + LoggingAgent.DEBUG_ARG);
+
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            builder.addJavaOption("-Dmaven.repo.local=" + localRepo);
+        }
+
+        Process process = null;
+        try {
+            process = Launcher.of(builder)
+                    .setRedirectErrorStream(true)
+                    .redirectOutput(STDOUT_PATH)
+                    .launch();
+            ServerHelper.waitForStandalone(process, LauncherTestCase::readStdout);
+            final List<JsonObject> lines = ServerHelper.readLogFileFromModel("json.log");
+            Assert.assertEquals("Expected 2 lines found " + lines.size(), 2, lines.size());
+            JsonObject msg = lines.get(0);
+            Assert.assertEquals(LoggingAgent.MSG, msg.getString("message"));
+            Assert.assertEquals("FINE", msg.getString("level"));
+            msg = lines.get(1);
+            Assert.assertEquals(LoggingAgent.MSG, msg.getString("message"));
+            Assert.assertEquals("INFO", msg.getString("level"));
+            try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+                ServerHelper.shutdownStandalone(client);
+            }
+            process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS);
+            if (process.exitValue() != 0) {
+                Assert.fail(readStdout());
+            }
+        } finally {
+            ProcessHelper.destroyProcess(process);
+        }
+    }
+
+    @Test
+    public void testDomainServerWithAgent() throws Exception {
+        final DomainCommandBuilder builder = DomainCommandBuilder.of(ServerHelper.JBOSS_HOME)
+                .addHostControllerJavaOptions(ServerHelper.DEFAULT_SERVER_JAVA_OPTS)
+                .setUseSecurityManager(parseProperty("security.manager"));
+
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            builder.addHostControllerJavaOption("-Dmaven.repo.local=" + localRepo)
+                    .addProcessControllerJavaOption("-Dmaven.repo.local=" + localRepo);
+        }
+
+        Process process = null;
+        try {
+            process = Launcher.of(builder)
+                    .setRedirectErrorStream(true)
+                    .redirectOutput(STDOUT_PATH)
+                    .launch();
+            ServerHelper.waitForDomain(process, LauncherTestCase::readStdout);
+
+            // Start server-three, configure it, then stop it
+            try (DomainClient client = DomainClient.Factory.create(TestSuiteEnvironment.getModelControllerClient())) {
+                final String hostName = ServerHelper.determineHostName(client);
+
+
+                client.startServer(hostName, "server-three");
+                ServerHelper.waitForManagedServer(client, "server-three", LauncherTestCase::readStdout);
+                final List<JsonObject> lines = ServerHelper.readLogFileFromModel("json.log", "host", hostName, "server", "server-three");
+                Assert.assertEquals("Expected 2 lines found " + lines.size(), 2, lines.size());
+                JsonObject msg = lines.get(0);
+                Assert.assertEquals(LoggingAgent.MSG, msg.getString("message"));
+                Assert.assertEquals("FINE", msg.getString("level"));
+                msg = lines.get(1);
+                Assert.assertEquals(LoggingAgent.MSG, msg.getString("message"));
+                Assert.assertEquals("INFO", msg.getString("level"));
+
+                ServerHelper.shutdownDomain(client);
+            }
+            process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS);
+            if (process.exitValue() != 0) {
+                Assert.fail(readStdout());
+            }
+        } finally {
+            ProcessHelper.destroyProcess(process);
+        }
+    }
+
+    private static String readStdout() {
+        final StringBuilder error = new StringBuilder(10240)
+                .append("Failed to boot the server: ").append(System.lineSeparator());
+        try {
+            for (String line : Files.readAllLines(STDOUT_PATH)) {
+                error.append(line).append(System.lineSeparator());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return error.toString();
+    }
+
+    private static boolean parseProperty(@SuppressWarnings("SameParameterValue") final String key) {
+        final String value = System.getProperty(key);
+        return value != null && (value.isEmpty() || Boolean.parseBoolean(value));
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
@@ -19,70 +19,24 @@
 
 package org.wildfly.scripts.test;
 
-import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STARTING;
-import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
-
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.Operations;
-import org.jboss.as.controller.client.helpers.domain.DomainClient;
-import org.jboss.as.controller.client.helpers.domain.ServerIdentity;
-import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
+import org.wildfly.common.test.ServerHelper;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class DomainScriptTestCase extends ScriptTestCase {
 
-    @SuppressWarnings("Convert2Lambda")
-    private static final Function<ModelControllerClient, Boolean> HOST_CONTROLLER_CHECK = new Function<ModelControllerClient, Boolean>() {
-        @Override
-        public Boolean apply(final ModelControllerClient client) {
-            final DomainClient domainClient = (client instanceof DomainClient ? (DomainClient) client : DomainClient.Factory.create(client));
-            try {
-                // Check for admin-only
-                final ModelNode hostAddress = determineHostAddress(domainClient);
-                final Operations.CompositeOperationBuilder builder = Operations.CompositeOperationBuilder.create()
-                        .addStep(Operations.createReadAttributeOperation(hostAddress, "running-mode"))
-                        .addStep(Operations.createReadAttributeOperation(hostAddress, "host-state"));
-                ModelNode response = domainClient.execute(builder.build());
-                if (Operations.isSuccessfulOutcome(response)) {
-                    response = Operations.readResult(response);
-                    if ("ADMIN_ONLY".equals(Operations.readResult(response.get("step-1")).asString())) {
-                        if (Operations.isSuccessfulOutcome(response.get("step-2"))) {
-                            final String state = Operations.readResult(response).asString();
-                            return !CONTROLLER_PROCESS_STATE_STARTING.equals(state)
-                                    && !CONTROLLER_PROCESS_STATE_STOPPING.equals(state);
-                        }
-                    }
-                }
-                final Map<ServerIdentity, ServerStatus> servers = new HashMap<>();
-                final Map<ServerIdentity, ServerStatus> statuses = domainClient.getServerStatuses();
-                for (ServerIdentity id : statuses.keySet()) {
-                    final ServerStatus status = statuses.get(id);
-                    switch (status) {
-                        case DISABLED:
-                        case STARTED: {
-                            servers.put(id, status);
-                            break;
-                        }
-                    }
-                }
-                return statuses.size() == servers.size();
-            } catch (IllegalStateException | IOException ignore) {
-            }
-            return false;
-        }
-    };
+    private static final Function<ModelControllerClient, Boolean> HOST_CONTROLLER_CHECK = ServerHelper::isDomainRunning;
 
     public DomainScriptTestCase() {
         super("domain", HOST_CONTROLLER_CHECK);
@@ -90,7 +44,7 @@ public class DomainScriptTestCase extends ScriptTestCase {
 
     @Override
     void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
-        script.start(DEFAULT_SERVER_JAVA_OPTS);
+        script.start(ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
 
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());
@@ -101,7 +55,7 @@ public class DomainScriptTestCase extends ScriptTestCase {
             @Override
             public ModelNode call() throws Exception {
                 try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
-                    return executeOperation(client, Operations.createOperation("shutdown", determineHostAddress(client)));
+                    return executeOperation(client, Operations.createOperation("shutdown", ServerHelper.determineHostAddress(client)));
                 }
             }
         };
@@ -109,12 +63,4 @@ public class DomainScriptTestCase extends ScriptTestCase {
         validateProcess(script);
     }
 
-    private static ModelNode determineHostAddress(final ModelControllerClient client) throws IOException {
-        final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "local-host-name");
-        ModelNode response = client.execute(op);
-        if (Operations.isSuccessfulOutcome(response)) {
-            return Operations.createAddress("host", Operations.readResult(response).asString());
-        }
-        throw new IOException("Failed to determine host name: " + Operations.readResult(response).asString());
-    }
 }

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -19,24 +19,14 @@
 
 package org.wildfly.scripts.test;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,7 +40,6 @@ import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
@@ -58,17 +47,13 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.wildfly.common.test.ServerConfigurator;
+import org.wildfly.common.test.ServerHelper;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public abstract class ScriptTestCase {
-
-    static final ModelNode EMPTY_ADDRESS = new ModelNode().addEmptyList();
-    static final String[] DEFAULT_SERVER_JAVA_OPTS = {
-            "-Djboss.management.http.port=" + TestSuiteEnvironment.getServerPort(),
-            "-Djboss.bind.address.management=" + TestSuiteEnvironment.getServerAddress(),
-    };
 
     static final Map<String, String> MAVEN_JAVA_OPTS = new LinkedHashMap<>();
 
@@ -79,46 +64,6 @@ public abstract class ScriptTestCase {
             "-NonInteractive",
             "-File"
     };
-    private static final Path JBOSS_HOME;
-
-    private static final Collection<Path> PATHS;
-    private static final long TIMEOUT;
-
-    static {
-        EMPTY_ADDRESS.protect();
-        final String jbossHome = System.getProperty("jboss.home");
-
-        if (isNullOrEmpty(jbossHome)) {
-            throw new RuntimeException("Failed to configure environment. No jboss.home system property or JBOSS_HOME " +
-                    "environment variable set.");
-        }
-        JBOSS_HOME = Paths.get(jbossHome).toAbsolutePath();
-        final String timeoutString = System.getProperty("jboss.test.start.timeout", "120");
-        TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
-
-        // Always update the JBOSS_HOME/bin/*.conf.* files
-        try {
-            appendConf(JBOSS_HOME, "domain", "PROCESS_CONTROLLER_JAVA_OPTS");
-            appendConf(JBOSS_HOME, "domain", "HOST_CONTROLLER_JAVA_OPTS");
-            appendConf(JBOSS_HOME, "standalone", "JAVA_OPTS");
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to update the script config files.", e);
-        }
-
-        // Always add the default path
-        final Set<Path> paths = new LinkedHashSet<>(16);
-        paths.add(JBOSS_HOME);
-
-        final String serverName = System.getProperty("server.name");
-
-        // Create special characters in paths to test with assuming the -Dserver.name was not used
-        if (serverName == null || serverName.isEmpty()) {
-            paths.add(copy("wildfly core"));
-            paths.add(copy("wildfly (core)"));
-        }
-
-        PATHS = paths;
-    }
 
     private final String scriptBaseName;
     private final Function<ModelControllerClient, Boolean> check;
@@ -135,11 +80,12 @@ public abstract class ScriptTestCase {
     }
 
     @BeforeClass
-    public static void configureEnvironment() {
+    public static void configureEnvironment() throws Exception {
         final String localRepo = System.getProperty("maven.repo.local");
         if (localRepo != null) {
             MAVEN_JAVA_OPTS.put("JAVA_OPTS", "-Dmaven.repo.local=" + localRepo);
         }
+        ServerConfigurator.configure();
     }
 
     @Before
@@ -190,60 +136,14 @@ public abstract class ScriptTestCase {
     }
 
     void validateProcess(final ScriptProcess script) throws InterruptedException {
-        if (script.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+        if (script.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
             // The script has exited, validate the exit code is valid
             final int exitValue = script.exitValue();
             if (exitValue != 0) {
                 Assert.fail(script.getErrorMessage(String.format("Expected an exit value 0f 0 got %d", exitValue)));
             }
         } else {
-            Assert.fail(script.getErrorMessage("The script process did not exit within " + TIMEOUT + " seconds."));
-        }
-    }
-
-    private static void appendConf(final Path containerHome, final String baseName, final String envName) throws IOException {
-        // Add the local maven repository to the conf file
-        final String localRepo = System.getProperty("maven.repo.local");
-        if (localRepo != null) {
-            final Path binDir = containerHome.resolve("bin");
-            if (TestSuiteEnvironment.isWindows()) {
-                // Batch conf
-                Path conf = binDir.resolve(baseName + ".conf.bat");
-                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
-                    writer.newLine();
-                    writer.write("set \"");
-                    writer.write(envName);
-                    writer.write("=-Dmaven.repo.local=");
-                    writer.write(localRepo);
-                    writer.write(" %");
-                    writer.write(envName);
-                    writer.write("%\"");
-                    writer.newLine();
-                }
-                // Powershell conf
-                conf = binDir.resolve(baseName + ".conf.ps1");
-                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
-                    writer.newLine();
-                    writer.write('$');
-                    writer.write(envName);
-                    writer.write(" += '-Dmaven.repo.local=");
-                    writer.write(localRepo);
-                    writer.write("'");
-                    writer.newLine();
-                }
-            } else {
-                final Path conf = binDir.resolve(baseName + ".conf");
-                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
-                    writer.newLine();
-                    writer.write(envName);
-                    writer.write("=\"-Dmaven.repo.local=");
-                    writer.write(localRepo);
-                    writer.write(" $");
-                    writer.write(envName);
-                    writer.write('"');
-                    writer.newLine();
-                }
-            }
+            Assert.fail(script.getErrorMessage("The script process did not exit within " + ServerHelper.TIMEOUT + " seconds."));
         }
     }
 
@@ -252,8 +152,8 @@ public abstract class ScriptTestCase {
     }
 
     private void executeTests(final String scriptExtension, final String... prefixCmds) throws InterruptedException, IOException, TimeoutException {
-        for (Path path : PATHS) {
-            try (ScriptProcess script = new ScriptProcess(path, scriptBaseName + scriptExtension, TIMEOUT, check, prefixCmds)) {
+        for (Path path : ServerConfigurator.PATHS) {
+            try (ScriptProcess script = new ScriptProcess(path, scriptBaseName + scriptExtension, ServerHelper.TIMEOUT, check, prefixCmds)) {
                 testScript(script);
             }
         }
@@ -280,7 +180,7 @@ public abstract class ScriptTestCase {
         Process process = null;
         try {
             process = builder.start();
-            if (!process.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
                 return false;
             }
             return process.exitValue() == 0;
@@ -292,61 +192,5 @@ public abstract class ScriptTestCase {
             }
             Files.deleteIfExists(stdout);
         }
-    }
-
-    private static Path copy(final String targetName) {
-        final Path source = JBOSS_HOME;
-        try {
-            final Path target = source.getParent().resolve(targetName);
-            deleteDirectory(target);
-            copyDirectory(source, target);
-            // Likely not needed in the PC, but also won't hurt
-            appendConf(target, "domain", "PROCESS_CONTROLLER_JAVA_OPTS");
-            appendConf(target, "domain", "HOST_CONTROLLER_JAVA_OPTS");
-            appendConf(target, "standalone", "JAVA_OPTS");
-            return target;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private static void copyDirectory(final Path source, final Path target) throws IOException {
-        Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
-                final Path targetFile = target.resolve(source.relativize(file));
-                Files.copy(file, targetFile);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {
-                final Path targetDir = target.resolve(source.relativize(dir));
-                Files.copy(dir, targetDir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
-    }
-
-    private static void deleteDirectory(final Path dir) throws IOException {
-        if (Files.exists(dir) && Files.isDirectory(dir)) {
-            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
-                    Files.delete(file);
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
-                    Files.delete(dir);
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        }
-    }
-
-    private static boolean isNullOrEmpty(final String value) {
-        return value == null || value.trim().isEmpty();
     }
 }


### PR DESCRIPTION
**NOTE:** This is not yet complete, but I wanted to get a CI run to test the different environments.

The first commit just upgrades the wildfly-maven-plugin and changes the property name is it was rather confusing with the `version.org.wildfly.plugins` property.

The second commit exposes the `MODULE_OPTS` environment variable and adds `jboss-modules.jar` as an agent if there is an agent defined in the options. A documentation PR will be required upstream before this can be merged.

https://issues.redhat.com/browse/WFCORE-4748
https://issues.redhat.com/browse/WFCORE-4897