### PR TITLE
[WFCORE-4905] Provide common capability for Remoting connectors.

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
@@ -53,6 +53,7 @@ public class ConnectorResource extends SimpleResourceDefinition {
     private static final String CONNECTOR_CAPABILITY_NAME = "org.wildfly.remoting.connector";
     static final RuntimeCapability<Void> CONNECTOR_CAPABILITY =
             RuntimeCapability.Builder.of(CONNECTOR_CAPABILITY_NAME, true)
+                    .setAllowMultipleRegistrations(true)
                     .build();
 
     //FIXME is this attribute still used?

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorResource.java
@@ -25,6 +25,7 @@ import static org.jboss.as.remoting.Capabilities.SASL_AUTHENTICATION_FACTORY_CAP
 import static org.jboss.as.remoting.CommonAttributes.HTTP_CONNECTOR;
 import static org.jboss.as.remoting.ConnectorCommon.SASL_PROTOCOL;
 import static org.jboss.as.remoting.ConnectorCommon.SERVER_NAME;
+import static org.jboss.as.remoting.ConnectorResource.CONNECTOR_CAPABILITY;
 
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
@@ -85,7 +86,8 @@ public class HttpConnectorResource extends SimpleResourceDefinition {
         super(new Parameters(PATH, RemotingExtension.getResourceDescriptionResolver(HTTP_CONNECTOR))
                 .setAddHandler(HttpConnectorAdd.INSTANCE)
                 .setRemoveHandler(HttpConnectorRemove.INSTANCE)
-                .setCapabilities(HTTP_CONNECTOR_CAPABILITY));
+                // expose a common connector capability (WFCORE-4875)
+                .setCapabilities(CONNECTOR_CAPABILITY, HTTP_CONNECTOR_CAPABILITY));
     }
 
     @Override


### PR DESCRIPTION
This PR allows Remoting subsystem connector elements to be referenced by a common capability reference.

For details, see: https://issues.redhat.com/browse/WFCORE-4905