### PR TITLE
Fix for WFCORE-4912, Upgrade galleon to 4.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,10 +110,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>4.2.4.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.2.5.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>4.2.4.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.2.6.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-4912

Galleon changes since 4.2.4.Final: https://github.com/wildfly/galleon/compare/4.2.4.Final...wildfly:4.2.5.Final

Galleon plugins changes since 4.2.4.Final: https://github.com/wildfly/galleon-plugins/compare/wildfly-provisioning-parent-4.2.4.Final...wildfly:4.2.6.Final
