### PR TITLE
[11.0.x] [WFCORE-4878] Upgrade WildFly OpenSSL to 1.0.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>4.0.1.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>1.0.9.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>1.0.10.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4878

master PR: https://github.com/wildfly/wildfly-core/pull/4098