### PR TITLE
[WFCORE-1313] User with slash or backslash char in LDAP name cannot log in through security-realm

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapUserSearcherFactory.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapUserSearcherFactory.java
@@ -205,7 +205,7 @@ class LdapUserSearcherFactory {
                     /*
                      * If this was a referral it would have been handled above.
                      */
-                    distinguishedUserDN = result.getName() + ("".equals(baseDn) ? "" : "," + baseDn);
+                    distinguishedUserDN = result.getNameInNamespace();
                 }
 
                 if (username == null) {

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/realms/LdapAuthenticationSuiteTest.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/realms/LdapAuthenticationSuiteTest.java
@@ -111,6 +111,25 @@ public class LdapAuthenticationSuiteTest extends BaseLdapSuiteTest {
         assertTrue("Supports Digest", supportedMechs.contains(AuthMechanism.PLAIN));
     }
 
+    @Test
+    public void testVerifyGoodPasswordUserNameWithSlash() throws Exception {
+        AuthorizingCallbackHandler cbh = securityRealm.getAuthorizingCallbackHandler(AuthMechanism.PLAIN);
+        NameCallback ncb = new NameCallback("Username", "User/Name");
+        RealmCallback rcb = new RealmCallback("Realm", TEST_REALM);
+        EvidenceVerifyCallback evc = new EvidenceVerifyCallback(new PasswordGuessEvidence("user_/password".toCharArray()));
+        cbh.handle(new Callback[] { ncb, rcb, evc });
+        assertTrue("Password Verified", evc.isVerified());
+    }
+
+    @Test
+    public void testVerifyGoodPasswordUserNameWithBackSlash() throws Exception {
+        AuthorizingCallbackHandler cbh = securityRealm.getAuthorizingCallbackHandler(AuthMechanism.PLAIN);
+        NameCallback ncb = new NameCallback("Username", "User\\Name");
+        RealmCallback rcb = new RealmCallback("Realm", TEST_REALM);
+        EvidenceVerifyCallback evc = new EvidenceVerifyCallback(new PasswordGuessEvidence("user_\\password".toCharArray()));
+        cbh.handle(new Callback[] { ncb, rcb, evc });
+        assertTrue("Password Verified", evc.isVerified());
+    }
 
     @Test
     public void testVerifyGoodPassword() throws Exception {

--- a/domain-management/src/test/resources/org/jboss/as/domain/management/security/realms/simple-partition.ldif
+++ b/domain-management/src/test/resources/org/jboss/as/domain/management/security/realms/simple-partition.ldif
@@ -47,6 +47,30 @@ uid: user_two
 departmentNumber: 2
 userPassword: two_password
 
+dn: uid=User/Name,dc=simple,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: uidObject
+objectClass: person
+objectClass: organizationalPerson
+cn: User Name With Slash
+sn: User Name With Slash
+uid: User/Name
+departmentNumber: 1
+userPassword: user_/password
+
+dn: uid=User\\Name,dc=simple,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: uidObject
+objectClass: person
+objectClass: organizationalPerson
+cn: User Name With Back Slash
+sn: User Name With Back Slash
+uid: User\\Name
+departmentNumber: 1
+userPassword: user_\password
+
 dn: uid=ReferralUserThree,dc=simple,dc=wildfly,dc=org
 objectClass: top
 objectClass: referral


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-1313

Changed to use `SearchResult.getNameInNamespace()` to retrieve the distinguish name instead of manipulate it using the `SearchResult.getName()`.