### PR TITLE
[WFCORE-4897] Upgrade the wildfly-maven-plugin to 2.0.2.Final and ren…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.galleon-plugins>4.2.4.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
-        <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
+        <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.0.0.Final</version.org.wildfly.plugins>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -287,7 +287,7 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.plugin}</version>
+                        <version>${version.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <phase>process-test-resources</phase>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -168,7 +168,7 @@
                      <plugin>
                          <groupId>org.wildfly.plugins</groupId>
                          <artifactId>wildfly-maven-plugin</artifactId>
-                         <version>${version.org.wildfly.plugin}</version>
+                         <version>${version.wildfly.plugin}</version>
                          <executions>
                              <execution>
                                  <phase>process-test-resources</phase>
@@ -209,7 +209,7 @@
                      <plugin>
                          <groupId>org.wildfly.plugins</groupId>
                          <artifactId>wildfly-maven-plugin</artifactId>
-                         <version>${version.org.wildfly.plugin}</version>
+                         <version>${version.wildfly.plugin}</version>
                          <configuration>
                              <!-- We turn off the ${ts.enable.elytron.cli}
                                   script as Galleon already enabled it-->

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -311,7 +311,7 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.plugin}</version>
+                        <version>${version.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <phase>process-test-resources</phase>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -307,7 +307,7 @@
                      <plugin>
                          <groupId>org.wildfly.plugins</groupId>
                          <artifactId>wildfly-maven-plugin</artifactId>
-                         <version>${version.org.wildfly.plugin}</version>
+                         <version>${version.wildfly.plugin}</version>
                          <executions>
                              <execution>
                                  <phase>process-test-resources</phase>


### PR DESCRIPTION
…ame the property as it's too closely named to another plugin version property.

https://issues.redhat.com/browse/WFCORE-4897

This is not really required, but I had done it as part of another commit and felt I may as well submit it. If we don't want to do it we can just close it.