### PR TITLE
[WFCORE-4934] Upgrade Undertow to 2.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.com.jcraft.jzlib>1.1.1</version.com.jcraft.jzlib>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.0.30.Final</version.io.undertow>
+        <version.io.undertow>2.1.0.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>
@@ -737,8 +737,16 @@
                 <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>io.undertow</groupId>
-                        <artifactId>undertow-build-config</artifactId>
+                        <groupId>org.jboss.threads</groupId>
+                        <artifactId>jboss-threads</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.common</groupId>
+                        <artifactId>wildfly-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.client</groupId>
+                        <artifactId>wildfly-client-config</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -748,8 +756,16 @@
                 <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>io.undertow</groupId>
-                        <artifactId>undertow-build-config</artifactId>
+                        <groupId>org.jboss.threads</groupId>
+                        <artifactId>jboss-threads</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.common</groupId>
+                        <artifactId>wildfly-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.client</groupId>
+                        <artifactId>wildfly-client-config</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
@@ -763,8 +779,16 @@
                 <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>io.undertow</groupId>
-                        <artifactId>undertow-build-config</artifactId>
+                        <groupId>org.jboss.threads</groupId>
+                        <artifactId>jboss-threads</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.common</groupId>
+                        <artifactId>wildfly-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.wildfly.client</groupId>
+                        <artifactId>wildfly-client-config</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-4934


        Release Notes - Undertow - Version 2.1.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1675'>UNDERTOW-1675</a>] -         Upgrade Undertow Dependencies
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-649'>UNDERTOW-649</a>] -         XNIO should only configure the SSLContext and Engine if configuration options are provided.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1672'>UNDERTOW-1672</a>] -         Unable to find the resource: /META-INF/BenchmarkList 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1699'>UNDERTOW-1699</a>] -         Http2ReceiverListener has unused fields
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1700'>UNDERTOW-1700</a>] -         Prevent resource leaks when Exchanges arent closed cleanly
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1701'>UNDERTOW-1701</a>] -         GracefulShutdownHandler has race condition that results in shutdownComplete not called
</li>
</ul>
    
<h2>        Library Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1636'>UNDERTOW-1636</a>] -         Upgrade XNIO
</li>
</ul>
                                                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1600'>UNDERTOW-1600</a>] -         Enhance SameSite Cookie support
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1464'>UNDERTOW-1464</a>] -         Matrix parameters are not properly handled
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1671'>UNDERTOW-1671</a>] -         URLUtils.parsePathParam uses &#39;&amp;&#39; as a separator
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1677'>UNDERTOW-1677</a>] -         WFLYCLWEBUT0002 error occurs in first cross-context request creating a shared session
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1678'>UNDERTOW-1678</a>] -         Some tests do not respect value of &#39;default.server.address&#39; property
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1683'>UNDERTOW-1683</a>] -         UT000146 is improperly thrown
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1685'>UNDERTOW-1685</a>] -         Slight test extension for SameSite cookie support
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1684'>UNDERTOW-1684</a>] -         Remove OSGi support
</li>
</ul>
                            
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1673'>UNDERTOW-1673</a>] -         Upgrade XNIO to 3.8.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1687'>UNDERTOW-1687</a>] -         Temporarily add JBoss Threads dependency to upgrade it to 3.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1688'>UNDERTOW-1688</a>] -         Upgrade H2 Database to 1.4.200
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1689'>UNDERTOW-1689</a>] -         Upgrade EasyMock to 4.2
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1690'>UNDERTOW-1690</a>] -         Upgrade JUnit to 4.13
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1691'>UNDERTOW-1691</a>] -         Upgrade Netty to 4.1.48.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1692'>UNDERTOW-1692</a>] -         Upgrade Apache HttpComponents to 4.5.12
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1693'>UNDERTOW-1693</a>] -         Upgrade JBoss Logging to 3.4.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1694'>UNDERTOW-1694</a>] -         Upgrade JBoss Logging Processor to 2.2.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1695'>UNDERTOW-1695</a>] -         Upgrade JBoss Log Manager to 2.1.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1696'>UNDERTOW-1696</a>] -         Upgrade JBoss Annotations API to 1.3 2.0.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1697'>UNDERTOW-1697</a>] -         Upgrade JBoss Servlet API to 2.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1698'>UNDERTOW-1698</a>] -         Upgrade JBoss WebSocket Spec to 2.0.0.Final
</li>
</ul>
        