### PR TITLE
[WFCORE-4853] Add support for External HTTP authentication mechanism …

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -337,6 +337,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-external</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-form</artifactId>
         </dependency>
         <dependency>

--- a/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
@@ -1358,6 +1358,17 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-http-external</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-http-form</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -58,6 +58,7 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-http-cert}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-digest}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-external}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-form}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-spnego}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-sso}"/>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -565,10 +565,12 @@ class AuthenticationFactoryDefinitions {
     private static int toPriorityHttp(String name) {
         switch (name) {
             case HttpConstants.CLIENT_CERT_NAME:
-                return 30;
+                return 40;
             case HttpConstants.SPNEGO_NAME:
-                return 20;
+                return 30;
             case HttpConstants.BEARER_TOKEN:
+                return 20;
+            case HttpConstants.EXTERNAL_NAME:
                 return 10;
             case HttpConstants.BASIC_NAME:
                 // i.e. Any hashed username / password mechs are preferred.

--- a/pom.xml
+++ b/pom.xml
@@ -1704,6 +1704,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-http-external</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http-form</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
@@ -949,7 +949,7 @@ public class CliCompletionTestCase {
                 ctx.getDefaultCommandCompleter().complete(ctx,
                         cmd, cmd.length(), candidates);
                 List<String> res = Arrays.asList("BASIC", "CLIENT_CERT",
-                        "DIGEST", "DIGEST-SHA-256", "FORM");
+                        "DIGEST", "DIGEST-SHA-256", "EXTERNAL", "FORM");
                 assertEquals(candidates.toString(), res, candidates);
                 candidates = complete(ctx, cmd, null);
                 assertEquals(candidates.toString(), res, candidates);


### PR DESCRIPTION
…with Elytron

https://issues.redhat.com/browse/WFCORE-4853
https://issues.redhat.com/browse/EAP7-1323

To pass CI, this will require an Elytron, Elytron Web, and Undertow upgrade but this is ready for the changes to be reviewed.
Depends on wildfly-security/wildfly-elytron#1386, wildfly-security/elytron-web#174, and undertow-io/undertow#881