### PR TITLE
[WFCORE-4943] Remove duplicate dependency to controller-client in wildfly-elytron-integration

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -148,11 +148,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
org.wildfly.core:wildfly-controller-client is a dependency of
wildfly-elytron-integration. There is no need to duplicate it with a
test scope.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>