### PR TITLE
WFCORE-2252: remove default value

### DIFF
--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -159,7 +159,6 @@ public class DeploymentAttributes {
                     ModelDescriptionConstants.HASH, ModelDescriptionConstants.INPUT_STREAM_INDEX,
                     ModelDescriptionConstants.BYTES, ModelDescriptionConstants.URL,
                     ModelDescriptionConstants.PATH, ModelDescriptionConstants.RELATIVE_TO)
-            .setDefaultValue(ModelNode.FALSE)
             .build();
 
     public static final SimpleAttributeDefinition CONTENT_INPUT_STREAM_INDEX =


### PR DESCRIPTION
Issue: [WFCORE-2252](https://issues.jboss.org/browse/WFCORE-2252)

Blocks #3773

The `empty` attribute is set as required but also has a default value, this seems like an oversight but if it's supposed to be required we can remove the default value instead.