### PR TITLE
WFCORE-2252: remove default value

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/OutboundBindAddressResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/OutboundBindAddressResourceDefinition.java
@@ -35,7 +35,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.operations.validation.InetAddressValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.MaskedAddressValidator;
-import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -53,7 +52,6 @@ public class OutboundBindAddressResourceDefinition extends PersistentResourceDef
         .setRequired(true)
         .setAllowExpression(true)
         .setValidator(new InetAddressValidator(false, true))
-        .setDefaultValue(ModelNode.ZERO)
         .setRestartAllServices()
         .build();
 


### PR DESCRIPTION
Issue: [WFCORE-2252](https://issues.jboss.org/browse/WFCORE-2252)

Blocks #3773

The `bind-address` attribute is set as required but also has a default value, I set it as optional but if it's supposed to be required we can remove the default value instead.