### PR TITLE
[WFCORE-4946] / [WFCORE-4947] Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.11.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.11.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.11.4.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.7.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4946
https://issues.redhat.com/browse/WFCORE-4947


        Release Notes - WildFly Elytron - Version 1.11.4.Final
                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1945'>ELY-1945</a>] -         Authentication vulnerable to session fixation attacks
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1954'>ELY-1954</a>] -         Submission for &quot;j_security_check&quot; login does not work if URL has no trailing slash
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1957'>ELY-1957</a>] -         Release WildFly Elytron 1.11.4.Final
</li>
</ul>
                    

        Release Notes - Elytron Web - Version 1.7.1.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-89'>ELYWEB-89</a>] -         Update Infinispan to 9.3.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-90'>ELYWEB-90</a>] -         HTTP Components Component Upgrades
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-91'>ELYWEB-91</a>] -         Upgrade WildFly Elytron to 1.11.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-107'>ELYWEB-107</a>] -         Upgrade WildFly Elytron to 1.11.4.Final
</li>
</ul>
                                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-103'>ELYWEB-103</a>] -         Add support for scope ID changes.
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-106'>ELYWEB-106</a>] -         Release Elytron Web 1.7.1.Final
</li>
</ul>
                    

