### PR TITLE
[WFCORE-4950] Regression: Legacy Ldap Realm securing EJB with JDK8 not working

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/LdapConnectionManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/LdapConnectionManagerService.java
@@ -251,11 +251,10 @@ public class LdapConnectionManagerService implements Service<LdapConnectionManag
     }
 
     private DirContext getConnection(final Hashtable<String, String> properties, final SSLContext sslContext) throws NamingException {
-        ClassLoader old = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        ClassLoader old = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(LdapConnectionManagerService.class);
         try {
             if (sslContext != null) {
                 ThreadLocalSSLSocketFactory.setSSLSocketFactory(sslContext.getSocketFactory());
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(ThreadLocalSSLSocketFactory.class);
                 properties.put("java.naming.ldap.factory.socket", ThreadLocalSSLSocketFactory.class.getName());
             }
             if (SECURITY_LOGGER.isTraceEnabled()) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/UserLdapCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/UserLdapCallbackHandler.java
@@ -343,6 +343,7 @@ public class UserLdapCallbackHandler implements Service, CallbackHandlerService 
                 throw new RealmUnavailableException(e);
             } catch (IllegalStateException | NamingException e) {
                 safeClose(ldapConnectionHandler);
+                SECURITY_LOGGER.tracef(e, "Unable to lookup the principal '%s' in the LDAP.", name);
                 return RealmIdentity.NON_EXISTENT;
             }
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-4950
Test PR in wildfly: https://github.com/wildfly/wildfly/pull/13249

Fix for WFCORE-4950. The final problem is a ClassNotFoundException of the class "com.sun.jndi.ldap.LdapCtxFactory" from module "org.wildfly.extension.io". So I added "sun.jdk" to that module. If you see something better to do just let me know. 

Tested with ibm jdk -8 too (just in case).

Tests included in issue WFLY-13358, I'll attach the PR for wildfly asap.