### PR TITLE
WFCORE-4949 Expose the original task in RequestController.QueuedTask

### DIFF
--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ControlPointTask.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ControlPointTask.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.requestcontroller;
+
+/**
+ * An implementation of {@code java.lang.Runnable} that wraps the original task
+ * with control point operations, and exposes the original task.
+ */
+public final class ControlPointTask implements Runnable {
+    private final Runnable originalTask;
+    private final ControlPoint controlPoint;
+
+    public ControlPointTask(final Runnable originalTask, final ControlPoint controlPoint) {
+        this.originalTask = originalTask;
+        this.controlPoint = controlPoint;
+    }
+
+    public Runnable getOriginalTask() {
+        return originalTask;
+    }
+
+    @Override
+    public void run() {
+        try {
+            controlPoint.beginExistingRequest();
+            originalTask.run();
+        } finally {
+            controlPoint.requestComplete();
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFCORE-4949

The proposed fix allows the caller of request controller to have access to the original task submitted to the request controller, in order to gain more context data that is otherwise hidden by the wrapper Runnable used in request controller `QueuedTask`.

This change is needed for fixing
WFLY-13357 Execution of concurrent batch jobs containg partitioned steps causes deadlock