### PR TITLE
Restore WFCORE-4653

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>2.18.0</version.org.mockito>
         <version.org.mock-server.mockserver-netty>5.9.0</version.org.mock-server.mockserver-netty>
-        <version.org.picketbox>5.0.3.Final</version.org.picketbox>
+        <version.org.picketbox>5.0.3.Final-redhat-00005</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.30</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
         <maven.repository.protocol>https</maven.repository.protocol>
         <!-- The full remote maven repo URL; can be overridden via -D for special use cases -->
         <maven.repository.url>${maven.repository.protocol}://repository.jboss.org/nexus/content/groups/public/</maven.repository.url>
+        <!-- https://access.redhat.com/maven-repository -->
+        <maven.redhat.repository.url>${maven.repository.protocol}://maven.repository.redhat.com/ga/</maven.redhat.repository.url>
 
         <!-- Surefire args -->
         <surefire.jpda.args></surefire.jpda.args>
@@ -2091,6 +2093,20 @@
             <url>${maven.repository.url}</url>
             <layout>default</layout>
         </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+            <id>jboss-enterprise-maven-repository</id>
+            <name>JBoss Enterprise Maven Repository</name>
+            <url>${maven.redhat.repository.url}</url>
+            <layout>default</layout>
+        </repository>
     </repositories>
 
 
@@ -2105,6 +2121,17 @@
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
             <url>${maven.repository.url}</url>
+        </pluginRepository>
+        <pluginRepository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>jboss-enterprise-maven-repository</id>
+            <name>JBoss Enterprise Maven Repository</name>
+            <url>${maven.redhat.repository.url}</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
This experimental PR reverts the revert of https://issues.redhat.com/browse/WFCORE-4653 and adds the necessary maven.repository.redhat.com repository needed to allow it to work.

This is just to test as avoiding the use of MRRC would be good.
