### PR TITLE
[WFCORE-4954] Add legacy controller for EAP 7.3

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -67,6 +67,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
         data.add(new TransformersTestParameter(ModelVersion.create(4, 1, 0), ModelTestControllerVersion.EAP_7_0_0));
         data.add(new TransformersTestParameter(ModelVersion.create(5, 0, 0), ModelTestControllerVersion.EAP_7_1_0));
         data.add(new TransformersTestParameter(ModelVersion.create(8, 0, 0), ModelTestControllerVersion.EAP_7_2_0));
+        data.add(new TransformersTestParameter(ModelVersion.create(10, 0, 0), ModelTestControllerVersion.EAP_7_3_0));
 
         return data;
     }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -47,6 +47,7 @@ public enum ModelTestControllerVersion {
 
     // WildFly legacy test will need to rename the *-wf14.dmr files to *-7.2.0.dmr
     EAP_7_2_0("7.2.0.GA-redhat-00005", true, "14.0.0", "6.0.11.Final-redhat-00001", "7.2.0"),
+    EAP_7_3_0("7.3.0.GA-redhat-00004", true, "18.0.0", "10.1.2.Final-redhat-00001", "7.3.0"),
     ;
 
     private final String mavenGavVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.legacy.test>4.0.1.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>1.0.10.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>


### PR DESCRIPTION
Add EAP 7.3.0 controllers for EAP 7.3.0 transforming tests.

Jira issue: https://issues.redhat.com/browse/WFCORE-4954
