### PR TITLE
[WFCORE-4965] Error loading a PKCS12 keystore inside a security-realm when using a credential-reference

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -729,10 +729,10 @@ public class SecurityRealmAddHandler extends AbstractAddStepHandler {
             ExceptionSupplier<CredentialSource, Exception> keystoreCredentialSourceSupplier = null;
             final String keySuffix = SERVER_IDENTITY + KEY_DELIMITER + SSL;
             if (ssl.hasDefined(KeystoreAttributes.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE_NAME)) {
-                keyCredentialSourceSupplier = CredentialReference.getCredentialSourceSupplier(context, KeystoreAttributes.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE, ssl, serviceBuilder, keySuffix);
+                keystoreCredentialSourceSupplier = CredentialReference.getCredentialSourceSupplier(context, KeystoreAttributes.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE, ssl, serviceBuilder, keySuffix);
             }
             if (ssl.hasDefined(KeystoreAttributes.KEY_PASSWORD_CREDENTIAL_REFERENCE_NAME)) {
-                keystoreCredentialSourceSupplier = CredentialReference.getCredentialSourceSupplier(context, KeystoreAttributes.KEY_PASSWORD_CREDENTIAL_REFERENCE, ssl, serviceBuilder, keySuffix);
+                keyCredentialSourceSupplier = CredentialReference.getCredentialSourceSupplier(context, KeystoreAttributes.KEY_PASSWORD_CREDENTIAL_REFERENCE, ssl, serviceBuilder, keySuffix);
             }
             serviceBuilder.setInstance(new FileKeyManagerService(kmsConsumer, pathManagerSupplier, keyCredentialSourceSupplier, keystoreCredentialSourceSupplier, provider, path, relativeTo, keystorePassword, keyPassword, alias, autoGenerateCertHostName));
         }

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfacePKCS12TestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfacePKCS12TestCase.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.core.test.standalone.mgmt;
+
+import org.jboss.as.test.categories.CommonCriteria;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Same test than HTTPSManagementInterfaceTestCase but using PKCS12 certificates
+ * instead of JKS.
+ *
+ * @author rmartinc
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+@Category(CommonCriteria.class)
+public class HTTPSManagementInterfacePKCS12TestCase extends HTTPSManagementInterfaceTestCase {
+
+    @BeforeClass
+    public static void startAndSetupContainer() throws Exception {
+        HTTPSManagementInterfaceTestCase.startAndSetupContainer("PKCS12");
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
@@ -156,6 +156,14 @@ public abstract class AbstractBaseSecurityRealmsServerSetupTask implements Serve
                         sslModuleNode.get(Constants.KEY_PASSWORD_CREDENTIAL_REFERENCE).set(getCredentialReferenceModelNode(ssl.getKeyPasswordCredentialReference()));
                     }
 
+                    if (StringUtils.isNotEmpty(ssl.getAlias())) {
+                        sslModuleNode.get(Constants.ALIAS).set(ssl.getAlias());
+                    }
+
+                    if (StringUtils.isNotEmpty(ssl.getProvider())) {
+                        sslModuleNode.get(Constants.PROVIDER).set(ssl.getProvider());
+                    }
+
                     sslModuleNode.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
                     steps.add(sslModuleNode);
                 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/config/realm/RealmKeystore.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/config/realm/RealmKeystore.java
@@ -37,6 +37,8 @@ public class RealmKeystore {
     private final String keyPassword;
     private final CredentialReference keystorePasswordCredentialReference;
     private final CredentialReference keyPasswordCredentialReference;
+    private final String alias;
+    private final String provider;
 
     // Constructors ----------------------------------------------------------
 
@@ -51,6 +53,8 @@ public class RealmKeystore {
         this.keyPassword = builder.keyPassword;
         this.keystorePasswordCredentialReference = builder.keystorePasswordCredentialReference;
         this.keyPasswordCredentialReference = builder.keyPasswordCredentialReference;
+        this.alias = builder.alias;
+        this.provider = builder.provider;
     }
 
     // Public methods --------------------------------------------------------
@@ -100,6 +104,24 @@ public class RealmKeystore {
         return keyPasswordCredentialReference;
     }
 
+    /**
+     * Getter for the alias.
+     *
+     * @return the alias
+     */
+    public String getAlias() {
+        return alias;
+    }
+
+    /**
+     * Getter for the provider.
+     *
+     * @return the alias
+     */
+    public String getProvider() {
+        return provider;
+    }
+
     @Override
     public String toString() {
         return "RealmKeystore [keystorePath=" + keystorePath + ", keystorePassword=" + keystorePassword + ", keystorePasswordCredentialReference=" + keystorePasswordCredentialReference + ", keyPassword=" + keyPassword + ", keyPasswordCredentialReference=" + keyPasswordCredentialReference + "]";
@@ -113,6 +135,8 @@ public class RealmKeystore {
         private String keyPassword;
         private CredentialReference keystorePasswordCredentialReference;
         private CredentialReference keyPasswordCredentialReference;
+        private String alias;
+        private String provider;
 
         public Builder keystorePath(String keystorePath) {
             this.keystorePath = keystorePath;
@@ -136,6 +160,16 @@ public class RealmKeystore {
 
         public Builder keyPasswordCredentialReference(CredentialReference keyPasswordCredentialReference) {
             this.keyPasswordCredentialReference = keyPasswordCredentialReference;
+            return this;
+        }
+
+        public Builder alias(String alias) {
+            this.alias = alias;
+            return this;
+        }
+
+        public Builder provider(String provider) {
+            this.provider = provider;
             return this;
         }
 


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/WFCORE-4965.

Just setting the correct references but duplicating a test to check a ssl security-realm configuration with PKCS12 certificates too.
