### PR TITLE
[WFCORE-4895] Fix bootable jar maven module versions

### DIFF
--- a/bootable-jar/boot/pom.xml
+++ b/bootable-jar/boot/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-jar-parent</artifactId>
-        <version>12.0.0.Beta2-SNAPSHOT</version>
+        <version>12.0.0.Beta3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wildfly-jar-boot</artifactId>

--- a/bootable-jar/pom.xml
+++ b/bootable-jar/pom.xml
@@ -23,7 +23,7 @@
    <parent>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-core-parent</artifactId>
-        <version>12.0.0.Beta2-SNAPSHOT</version>
+        <version>12.0.0.Beta3-SNAPSHOT</version>
     </parent>
 
   <artifactId>wildfly-jar-parent</artifactId>

--- a/bootable-jar/runtime/pom.xml
+++ b/bootable-jar/runtime/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-jar-parent</artifactId>
-        <version>12.0.0.Beta2-SNAPSHOT</version>
+        <version>12.0.0.Beta3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wildfly-jar-runtime</artifactId>


### PR DESCRIPTION
Versions got state after merging. This throws an error building wildfly-core.

Jira issue: https://issues.redhat.com/browse/WFCORE-4895

FYI @jmesnil 