### PR TITLE
WFCORE-4967 fix: RequestController drops queued tasks randomly during server start.

### DIFF
--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestController.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestController.java
@@ -396,7 +396,7 @@ public class RequestController implements Service<RequestController>, ServerActi
         }
     }
 
-    private QueuedTask findForcedTask() {
+    private synchronized QueuedTask findForcedTask() {
         QueuedTask task = null;
         List<QueuedTask> storage = new ArrayList<>();
         while (task == null && !taskQueue.isEmpty()) {

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestController.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestController.java
@@ -396,21 +396,21 @@ public class RequestController implements Service<RequestController>, ServerActi
         }
     }
 
-    private synchronized QueuedTask findForcedTask() {
-        QueuedTask task = null;
+    private QueuedTask findForcedTask() {
+        QueuedTask _ret = null;
+        QueuedTask task;
         List<QueuedTask> storage = new ArrayList<>();
-        while (task == null && !taskQueue.isEmpty()) {
-            QueuedTask tmp = taskQueue.poll();
-            if(tmp.forceRun) {
-                task = tmp;
+        while ((task = taskQueue.poll()) != null) {
+            if (task.forceRun) {
+                _ret = task;
             } else {
-                storage.add(tmp);
+                storage.add(task);
             }
         }
-        //this screws the order somewhat, but the container is suspending anyway, and the order
-        //was never guarenteed. if we push them back onto the front we will need to just go through them again
+        // this screws the order somewhat, but the container is suspending anyway, and the order
+        // was never guarenteed. if we push them back onto the front we will need to just go through them again
         taskQueue.addAll(storage);
-        return task;
+        return _ret;
     }
 
     private static final class ControlPointIdentifier {

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestController.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestController.java
@@ -397,12 +397,12 @@ public class RequestController implements Service<RequestController>, ServerActi
     }
 
     private QueuedTask findForcedTask() {
-        QueuedTask _ret = null;
+        QueuedTask forcedTask = null;
         QueuedTask task;
         List<QueuedTask> storage = new ArrayList<>();
-        while ((task = taskQueue.poll()) != null) {
+        while (forcedTask == null && (task = taskQueue.poll()) != null) {
             if (task.forceRun) {
-                _ret = task;
+                forcedTask = task;
             } else {
                 storage.add(task);
             }
@@ -410,7 +410,7 @@ public class RequestController implements Service<RequestController>, ServerActi
         // this screws the order somewhat, but the container is suspending anyway, and the order
         // was never guarenteed. if we push them back onto the front we will need to just go through them again
         taskQueue.addAll(storage);
-        return _ret;
+        return forcedTask;
     }
 
     private static final class ControlPointIdentifier {

--- a/request-controller/src/test/java/org/wildfly/extension/requestcontroller/WFCORE4967_TestCase.java
+++ b/request-controller/src/test/java/org/wildfly/extension/requestcontroller/WFCORE4967_TestCase.java
@@ -43,32 +43,33 @@ public class WFCORE4967_TestCase {
     }
 
     private RequestController suspendedRCWithQueuedTasks(int i, Runnable whenExecuted) {
-        RequestController _ret = new RequestController(false);
-        _ret.suspended(() -> {
+        RequestController requestController = new RequestController(false);
+        requestController.suspended(() -> {
         });
 
         for (int taskNo = 0; taskNo < TASKS_QTY; taskNo++) {
-            _ret.queueTask(null, null, task -> whenExecuted.run(), 0, null, false, false);
+            requestController.queueTask(null, null, task -> whenExecuted.run(), 0, null, false, false);
         }
-        return _ret;
+        return requestController;
     }
 
     private List<Thread> createSynchronisedThreads(CountDownLatch latch, Runnable action) {
         int threadsQty = (int) latch.getCount();
-        List<Thread> _ret = new ArrayList<>(threadsQty);
+        List<Thread> threads = new ArrayList<>(threadsQty);
         for (int threadNo = 0; threadNo < threadsQty; threadNo++) {
-            _ret.add(new Thread(() -> {
+            threads.add(new Thread(() -> {
                 // wait for all threads to initialise
                 try {
                     latch.countDown();
                     latch.await();
-                } catch (Exception e) {
-                    /* yummy */}
+                } catch (InterruptedException e) {
+                    return;
+                }
 
                 // run all of them simultaneously
                 action.run();
             }));
         }
-        return _ret;
+        return threads;
     }
 }

--- a/request-controller/src/test/java/org/wildfly/extension/requestcontroller/WFCORE4967_TestCase.java
+++ b/request-controller/src/test/java/org/wildfly/extension/requestcontroller/WFCORE4967_TestCase.java
@@ -1,0 +1,63 @@
+package org.wildfly.extension.requestcontroller;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+public class WFCORE4967_TestCase {
+    private static final int TASKS_QTY = 10;
+    private static final int THREADS_QTY = 20;
+
+    @Test
+    public void noQueuedTasksLossWhenRunningRequestCompleteOnSuspendedRC() throws InterruptedException {
+        final AtomicInteger executedTaskCount = new AtomicInteger();
+
+        RequestController rc = suspendedRCWithQueuedTasks(TASKS_QTY, () -> {
+            executedTaskCount.incrementAndGet();
+        });
+
+        CountDownLatch latch = new CountDownLatch(THREADS_QTY);
+        createSynchronisedThreads(latch, () -> {
+            rc.requestComplete();
+        }).forEach(Thread::start);
+        latch.await();
+
+        rc.resume();
+        assertEquals(TASKS_QTY, executedTaskCount.intValue());
+    }
+
+    private RequestController suspendedRCWithQueuedTasks(int i, Runnable whenExecuted) {
+        RequestController _ret = new RequestController(false);
+        _ret.suspended(() -> {
+        });
+
+        for (int taskNo = 0; taskNo < TASKS_QTY; taskNo++) {
+            _ret.queueTask(null, null, task -> whenExecuted.run(), 0, null, false, false);
+        }
+        return _ret;
+    }
+
+    private List<Thread> createSynchronisedThreads(CountDownLatch latch, Runnable action) {
+        int threadsQty = (int) latch.getCount();
+        List<Thread> _ret = new ArrayList<>(threadsQty);
+        for (int threadNo = 0; threadNo < threadsQty; threadNo++) {
+            _ret.add(new Thread(() -> {
+                // wait for all threads to initialise
+                try {
+                    latch.countDown();
+                    latch.await();
+                } catch (Exception e) {
+                    /* yummy */}
+
+                // run all of them simultaneously
+                action.run();
+            }));
+        }
+        return _ret;
+    }
+}


### PR DESCRIPTION
solves: https://issues.redhat.com/browse/WFCORE-4967

findForcedTask method implementation could be improved but synchronization is fine from my point of view when server is paused anyway.