### PR TITLE
[WFCORE-4968] Upgrade to WildFly Elytron 1.12.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.12.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.12.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4968

https://github.com/wildfly-security/wildfly-elytron/compare/1.12.0.CR1...1.12.0.CR2

        Release Notes - WildFly Elytron - Version 1.12.0.CR2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1961'>ELY-1961</a>] -         Upgrade jboss-logmanager to 2.1.15.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1962'>ELY-1962</a>] -         Upgrade JBoss Threads to 2.3.4.Final
</li>
</ul>
                                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1952'>ELY-1952</a>] -         SSLConfigurator ignores some of the SSLParameters passed in via setSSLParameters method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1953'>ELY-1953</a>] -         Elytron tool command execution fails with java.nio.file.NoSuchFileException 
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1960'>ELY-1960</a>] -         Fix javadoc generation warnings
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1965'>ELY-1965</a>] -         Release WildFly Elytron 1.12.0.CR2
</li>
</ul>
                    