### PR TITLE
[WFCORE-4966] / [WFCORE-4730] Upgrade WildFly OpenSSL to 1.1.0.Final and include the linux-s390x binding

### DIFF
--- a/core-feature-pack/feature-pack-build.xml
+++ b/core-feature-pack/feature-pack-build.xml
@@ -39,6 +39,9 @@
         <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-i386" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
             <filter pattern="META-INF*" include="false" />
         </copy-artifact>
+        <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-s390x" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
+            <filter pattern="META-INF*" include="false" />
+        </copy-artifact>
         <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-macosx-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
             <filter pattern="META-INF*" include="false" />
         </copy-artifact>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -546,6 +546,11 @@
 
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
+            <artifactId>wildfly-openssl-linux-s390x</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
         </dependency>
 

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -1147,6 +1147,17 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.openssl</groupId>
+      <artifactId>wildfly-openssl-linux-s390x</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.openssl</groupId>
       <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
       <licenses>
         <license>

--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -376,6 +376,12 @@
 
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
+            <artifactId>wildfly-openssl-linux-s390x</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/core-galleon-pack/src/main/resources/packages/org.wildfly.openssl/pm/wildfly/tasks.xml
+++ b/core-galleon-pack/src/main/resources/packages/org.wildfly.openssl/pm/wildfly/tasks.xml
@@ -7,6 +7,9 @@
     <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-i386" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
         <filter pattern="META-INF*" include="false" />
     </copy-artifact>
+    <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-s390x" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
+        <filter pattern="META-INF*" include="false" />
+    </copy-artifact>
     <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-macosx-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true" optional="true">
         <filter pattern="META-INF*" include="false" />
     </copy-artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>1.0.10.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>1.1.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
@@ -1513,6 +1514,11 @@
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-linux-x86_64</artifactId>
                 <version>${version.org.wildfly.openssl.wildfly-openssl-linux-x86_64}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.openssl</groupId>
+                <artifactId>wildfly-openssl-linux-s390x</artifactId>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-linux-s390x}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4966
https://issues.redhat.com/browse/WFCORE-4730

Note the minor version bump just indicates the evolution of the wildfly-openssl build process.

        Release Notes - WildFly OpenSSL - Version 1.1.0.Final
                                                                                                                                        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-31'>WFSSL-31</a>] -         Add the ability to make use of the &#39;jboss.modules.os-name&#39; property when building on RHEL platforms
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-33'>WFSSL-33</a>] -         Release WildFly OpenSSL 1.1.0.Final
</li>
</ul>
                                    
