### PR TITLE
[WFCORE-4942] Upgrade Undertow to 2.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <version.com.jcraft.jzlib>1.1.1</version.com.jcraft.jzlib>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.1.0.Final</version.io.undertow>
+        <version.io.undertow>2.1.1.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-4942
(fixes CVE-2020-10719)

        Release Notes - Undertow - Version 2.1.1.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1710'>UNDERTOW-1710</a>] -         Upgrade Netty to 4.1.50.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1706'>UNDERTOW-1706</a>] -         Maven Enforcer Rule Dependency Convergency fails for Undertow 2.1.0.Final
</li>
</ul>
                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1197'>UNDERTOW-1197</a>] -         Response not reused when processing async request
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1419'>UNDERTOW-1419</a>] -         bumpTimeout method usage in InMemorySessionManager
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1702'>UNDERTOW-1702</a>] -         SameSiteCookieHandler can throw NPE if request doesn&#39;t contain user-agent header
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1703'>UNDERTOW-1703</a>] -         Checking isSymbolicLink should be in doPrivileged block
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1708'>UNDERTOW-1708</a>] -         Invalid HTTP request with large chunk size
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1709'>UNDERTOW-1709</a>] -         NullPointerException when calling the AJP port
</li>
</ul>
                                            