### PR TITLE
[WFCORE-4969] Upgrade XNIO to 3.8.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.0.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.1.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-4969


        Release Notes - XNIO - Version 3.8.1.Final
                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-372'>XNIO-372</a>] -         NPE happens on ByteBufferSlicePool.clean() for non-direct buffers
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-374'>XNIO-374</a>] -         ByteBufferSlicePool FREE_DIRECT_BUFFERS is always empty
</li>
</ul>
                                            