### PR TITLE
[WFCORE-4955] Create a wildfly-network OutboundConnection interface f…

### DIFF
--- a/network/src/main/java/org/jboss/as/network/OutboundConnection.java
+++ b/network/src/main/java/org/jboss/as/network/OutboundConnection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.network;
+
+import java.net.URI;
+
+import javax.net.ssl.SSLContext;
+
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+
+/**
+ * Allows callers to get information of an outbound connection.
+ *
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+public interface OutboundConnection {
+
+    /**
+     * Get the destination URI for the connection.
+     *
+     * @return the destination URI
+     */
+    URI getDestinationUri();
+
+    /**
+     * Get the connection authentication configuration.  This is derived either from the authentication information
+     * defined on the resource, or the linked authentication configuration named on the resource.
+     *
+     * @return the authentication configuration
+     */
+    AuthenticationConfiguration getAuthenticationConfiguration();
+
+    /**
+     * Get the connection SSL Context.
+     *
+     * @return the SSL context
+     */
+    SSLContext getSSLContext();
+
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionResourceDefinition.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.network.OutboundConnection;
 
 /**
  * @author Jaikiran Pai
@@ -36,9 +37,9 @@ abstract class AbstractOutboundConnectionResourceDefinition extends SimpleResour
     static final String OUTBOUND_CONNECTION_CAPABILITY_NAME = "org.wildfly.remoting.outbound-connection";
     static final String OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.outbound-socket-binding";
     static final RuntimeCapability<Void> OUTBOUND_CONNECTION_CAPABILITY =
-            RuntimeCapability.Builder.of(OUTBOUND_CONNECTION_CAPABILITY_NAME, true, AbstractOutboundConnectionService.class)
+            RuntimeCapability.Builder.of(OUTBOUND_CONNECTION_CAPABILITY_NAME, true, OutboundConnection.class)
+                    .addRequirements(Capabilities.REMOTING_ENDPOINT_CAPABILITY_NAME)
                     .build();
-
 
     protected AbstractOutboundConnectionResourceDefinition(final Parameters parameters) {
         super(parameters.addCapabilities(OUTBOUND_CONNECTION_CAPABILITY));

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionService.java
@@ -22,43 +22,20 @@
 
 package org.jboss.as.remoting;
 
-import java.net.URI;
-
-import javax.net.ssl.SSLContext;
-
+import org.jboss.as.network.OutboundConnection;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.security.auth.client.AuthenticationConfiguration;
 
 /**
  * @author Jaikiran Pai
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-public abstract class AbstractOutboundConnectionService {
+public abstract class AbstractOutboundConnectionService implements OutboundConnection {
 
+    /**
+     * @deprecated Use {@code AbstractOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY}
+     * capability to get the base service name for an OutboundConnection.
+     */
+    @Deprecated
     public static final ServiceName OUTBOUND_CONNECTION_BASE_SERVICE_NAME = RemotingServices.SUBSYSTEM_ENDPOINT.append("outbound-connection");
 
-    protected AbstractOutboundConnectionService() {
-    }
-
-    /**
-     * Get the destination URI for the connection.
-     *
-     * @return the destination URI
-     */
-    public abstract URI getDestinationUri();
-
-    /**
-     * Get the connection authentication configuration.  This is derived either from the authentication information
-     * defined on the resource, or the linked authentication configuration named on the resource.
-     *
-     * @return the authentication configuration
-     */
-    public abstract AuthenticationConfiguration getAuthenticationConfiguration();
-
-    /**
-     * Get the connection SSL Context.
-     *
-     * @return the SSL context
-     */
-    public abstract SSLContext getSSLContext();
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
@@ -23,6 +23,7 @@
 package org.jboss.as.remoting;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.remoting.AbstractOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -81,12 +82,15 @@ class GenericOutboundConnectionAdd extends AbstractAddStepHandler {
 
         // Get the destination URI
         final URI uri = getDestinationURI(context, operation);
+
         // create the service
-        final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName serviceName = OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(connectionName);
         // also add an alias service name to easily distinguish between a generic, remote and local type of connection services
         final ServiceName aliasServiceName = GenericOutboundConnectionService.GENERIC_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName deprecatedServiceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+
         final ServiceBuilder<?> builder = context.getServiceTarget().addService(serviceName);
-        final Consumer<GenericOutboundConnectionService> serviceConsumer = builder.provides(serviceName, aliasServiceName);
+        final Consumer<GenericOutboundConnectionService> serviceConsumer = builder.provides(deprecatedServiceName, aliasServiceName);
         builder.setInstance(new GenericOutboundConnectionService(serviceConsumer, uri));
         builder.requires(RemotingServices.SUBSYSTEM_ENDPOINT);
         builder.install();

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionResourceDefinition.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.remoting;
 
-import static org.jboss.as.remoting.AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationStepHandler;
@@ -51,7 +49,7 @@ class GenericOutboundConnectionResourceDefinition extends AbstractOutboundConnec
     GenericOutboundConnectionResourceDefinition() {
         super(new Parameters(ADDRESS, RemotingExtension.getResourceDescriptionResolver(CommonAttributes.OUTBOUND_CONNECTION))
                 .setAddHandler(GenericOutboundConnectionAdd.INSTANCE)
-                .setRemoveHandler(new ServiceRemoveStepHandler(OUTBOUND_CONNECTION_BASE_SERVICE_NAME,  GenericOutboundConnectionAdd.INSTANCE))
+                .setRemoveHandler(new ServiceRemoveStepHandler(OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(), GenericOutboundConnectionAdd.INSTANCE))
                 .setDeprecatedSince(ModelVersion.create(4))
         );
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionWriteHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionWriteHandler.java
@@ -63,7 +63,7 @@ class GenericOutboundConnectionWriteHandler extends AbstractWriteAttributeHandle
     private void applyModelToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode fullModel) throws OperationFailedException {
 
         final String connectionName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
-        final ServiceName serviceName = GenericOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName serviceName = GenericOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(connectionName);
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController sc = registry.getService(serviceName);
         if (sc != null && sc.getState() == ServiceController.State.UP) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.AbstractOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY;
 import static org.jboss.as.remoting.AbstractOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME;
 
 import java.util.function.Consumer;
@@ -60,10 +61,13 @@ class LocalOutboundConnectionAdd extends AbstractAddStepHandler {
         final String connectionName = address.getLastElement().getValue();
         final String outboundSocketBindingRef = LocalOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, operation).asString();
         final ServiceName outboundSocketBindingDependency = context.getCapabilityServiceName(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME, outboundSocketBindingRef, OutboundSocketBinding.class);
-        final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+
+        final ServiceName serviceName = OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(connectionName);
         final ServiceName aliasServiceName = LocalOutboundConnectionService.LOCAL_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName deprecatedServiceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+
         final ServiceBuilder<?> builder = context.getServiceTarget().addService(serviceName);
-        final Consumer<LocalOutboundConnectionService> serviceConsumer = builder.provides(serviceName, aliasServiceName);
+        final Consumer<LocalOutboundConnectionService> serviceConsumer = builder.provides(deprecatedServiceName, aliasServiceName);
         final Supplier<OutboundSocketBinding> osbSupplier = builder.requires(outboundSocketBindingDependency);
         builder.requires(RemotingServices.SUBSYSTEM_ENDPOINT);
         builder.setInstance(new LocalOutboundConnectionService(serviceConsumer, osbSupplier));

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionResourceDefinition.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.remoting;
 
-import static org.jboss.as.remoting.AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationStepHandler;
@@ -55,7 +53,7 @@ class LocalOutboundConnectionResourceDefinition extends AbstractOutboundConnecti
     private LocalOutboundConnectionResourceDefinition() {
         super(new Parameters(ADDRESS, RemotingExtension.getResourceDescriptionResolver(CommonAttributes.LOCAL_OUTBOUND_CONNECTION))
                 .setAddHandler(LocalOutboundConnectionAdd.INSTANCE)
-                .setRemoveHandler(new ServiceRemoveStepHandler(OUTBOUND_CONNECTION_BASE_SERVICE_NAME, LocalOutboundConnectionAdd.INSTANCE))
+                .setRemoveHandler(new ServiceRemoveStepHandler(OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(), LocalOutboundConnectionAdd.INSTANCE))
                 .setDeprecatedSince(ModelVersion.create(4))
         );
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionWriteHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionWriteHandler.java
@@ -63,7 +63,7 @@ class LocalOutboundConnectionWriteHandler extends AbstractWriteAttributeHandler<
     private boolean applyModelToRuntime(OperationContext context, ModelNode operation) throws OperationFailedException {
         boolean reloadRequired = false;
         final String connectionName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
-        final ServiceName serviceName = LocalOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName serviceName = LocalOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(connectionName);
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController sc = registry.getService(serviceName);
         if (sc != null && sc.getState() == ServiceController.State.UP) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.AbstractOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY;
 import static org.jboss.as.remoting.AbstractOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME;
 import static org.jboss.as.remoting.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 
@@ -48,6 +49,7 @@ import org.xnio.OptionMap;
  */
 class RemoteOutboundConnectionAdd extends AbstractAddStepHandler {
 
+
     static final RemoteOutboundConnectionAdd INSTANCE = new RemoteOutboundConnectionAdd();
 
     private RemoteOutboundConnectionAdd() {
@@ -72,10 +74,12 @@ class RemoteOutboundConnectionAdd extends AbstractAddStepHandler {
         final String protocol = authenticationContext != null ? null : RemoteOutboundConnectionResourceDefinition.PROTOCOL.resolveModelAttribute(context, operation).asString();
 
         // create the service
-        final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName serviceName = OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(connectionName);
         final ServiceName aliasServiceName = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName deprecatedName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+
         final ServiceBuilder<?> builder = context.getServiceTarget().addService(serviceName);
-        final Consumer<RemoteOutboundConnectionService> serviceConsumer = builder.provides(serviceName, aliasServiceName);
+        final Consumer<RemoteOutboundConnectionService> serviceConsumer = builder.provides(deprecatedName, aliasServiceName);
         final Supplier<OutboundSocketBinding> osbSupplier = builder.requires(outboundSocketBindingDependency);
         final Supplier<SecurityRealm> srSupplier = securityRealm != null ? SecurityRealm.ServiceUtil.requires(builder, securityRealm) : null;
         final Supplier<AuthenticationContext> acSupplier = authenticationContext != null ? builder.requires(context.getCapabilityServiceName(AUTHENTICATION_CONTEXT_CAPABILITY, authenticationContext, AuthenticationContext.class)) : null;

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.remoting;
 
-import static org.jboss.as.remoting.AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME;
 import static org.jboss.as.remoting.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -96,7 +95,7 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
     private RemoteOutboundConnectionResourceDefinition() {
         super(new Parameters(ADDRESS, RemotingExtension.getResourceDescriptionResolver(CommonAttributes.REMOTE_OUTBOUND_CONNECTION))
                 .setAddHandler(RemoteOutboundConnectionAdd.INSTANCE)
-                .setRemoveHandler(new ServiceRemoveStepHandler(OUTBOUND_CONNECTION_BASE_SERVICE_NAME, RemoteOutboundConnectionAdd.INSTANCE))
+                .setRemoveHandler(new ServiceRemoveStepHandler(OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(), RemoteOutboundConnectionAdd.INSTANCE))
         );
     }
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionWriteHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionWriteHandler.java
@@ -66,7 +66,7 @@ class RemoteOutboundConnectionWriteHandler extends AbstractWriteAttributeHandler
 
         boolean reloadRequired = false;
         final String connectionName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
-        final ServiceName serviceName = RemoteOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName serviceName = RemoteOutboundConnectionResourceDefinition.OUTBOUND_CONNECTION_CAPABILITY.getCapabilityServiceName(connectionName);
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController sc = registry.getService(serviceName);
         if (sc != null && sc.getState() == ServiceController.State.UP) {


### PR DESCRIPTION
…rom AbstractOutboundConnectionService and expose via capabilities

Exposes a new interface `OutboundConnection` on `org.jboss.as.network` via capabilities to helping out to make `org.jboss.as.remoting` optional on `org.jboss.as.ejb3`. It deprecates the existing service name in favor of the one generated from the capability.

Jira issue: https://issues.redhat.com/browse/WFCORE-4955