### PR TITLE
[WFCORE-4986] Upgrade WildFly Elytron to 1.12.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.12.0.CR3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.12.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4986

https://github.com/wildfly-security/wildfly-elytron/compare/1.12.0.CR3...1.12.0.Final

        Release Notes - WildFly Elytron - Version 1.12.0.CR4
                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1968'>ELY-1968</a>] -         Update error message returned by AcmeClientSpi#getLocation
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1973'>ELY-1973</a>] -         Release WildFly Elytron 1.12.0.Final
</li>
</ul>
                    