### PR TITLE
[WFCORE-4899] Upgrade jboss-modules to 1.10.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>2.1.15.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.modules.jboss-modules>1.10.0.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.10.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.18.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>


### PR DESCRIPTION
Takes the component commit from https://github.com/wildfly/wildfly-core/pull/4131

@jamezp FYI I have just pulled out your component upgrade commit, this still keeps coming up on the components upgrade report.  For WildFly Core we are quite on top of that report.