### PR TITLE
[WFCORE-4988] Upgrade Undertow to 2.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <version.com.jcraft.jzlib>1.1.1</version.com.jcraft.jzlib>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.1.1.Final</version.io.undertow>
+        <version.io.undertow>2.1.2.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-4988


        Release Notes - Undertow - Version 2.1.2.Final
                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1713'>UNDERTOW-1713</a>] -         Calling isReady may start async IO too early
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1716'>UNDERTOW-1716</a>] -         Allow colon in the request cookie value regardless of setting ALLOW_HTTP_SEPARATORS_IN_V0
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1717'>UNDERTOW-1717</a>] -         Return 416 Range Not Satisfiable when first-byte-pos of Range request header is equal to the content-length
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1719'>UNDERTOW-1719</a>] -         Handling of path parameters can set incorrect requestURI/requestPath
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1720'>UNDERTOW-1720</a>] -         Race in Sender implementations
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1722'>UNDERTOW-1722</a>] -         Memory leak involving request attributes
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-467'>UNDERTOW-467</a>] -         Deprecate existing authenticationComplete method on SecurityContext and overload with a method that does not have the cachingRequired parameter.
</li>
</ul>
                                    