### PR TITLE
[WFCORE-4989] Upgrade WildFly Elytron to 1.12.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.12.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.12.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4989

https://github.com/wildfly-security/wildfly-elytron/compare/1.12.0.Final...1.12.1.Final

        Release Notes - WildFly Elytron - Version 1.12.1.Final
                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1979'>ELY-1979</a>] -         Elytron needs to deal with JEPS 244 in the org.wildfly.security.ssl package
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1981'>ELY-1981</a>] -         SSL Module missing plugin configuration to assemble multi-version jar
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1980'>ELY-1980</a>] -         Release WildFly Elytron 1.12.1.Final
</li>
</ul>
                    