### PR TITLE
[WFCORE-5001] Upgrade WildFly Elytron to 1.13.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.12.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5001


        Release Notes - WildFly Elytron - Version 1.13.0.CR1
                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1970'>ELY-1970</a>] -         The service descriptors in the wildfly-elytron module do not correctly combine the other modules.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1974'>ELY-1974</a>] -         Correct class names in ProviderFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1976'>ELY-1976</a>] -         Elytron provider not being used with credential store and SASL authentication on the Client Side
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1975'>ELY-1975</a>] -         Update AcmeClientSpi#obtainCertificate so that it obtains the order URL from the response to newOrder
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1993'>ELY-1993</a>] -         Release WildFly Elytron 1.13.0.CR1
</li>
</ul>
                    