### PR TITLE
[WFCORE-5011] Remove wildfly-jar-boot license

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -896,7 +896,7 @@
                                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                                     <licensesConfigFile>${project.basedir}/src/license/core-feature-pack-licenses.xml</licensesConfigFile>
                                     <licensesOutputFile>${license.directory}/core-feature-pack-licenses.xml</licensesOutputFile>
-                                    <excludedArtifacts>wildfly-core-model-test-framework|wildfly-elytron\z</excludedArtifacts>
+                                    <excludedArtifacts>wildfly-core-model-test-framework|wildfly-jar-boot|wildfly-elytron\z</excludedArtifacts>
                                     <excludedScopes>system,provided</excludedScopes>
                                 </configuration>
                             </execution>

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -831,22 +831,6 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
-      <artifactId>wildfly-jar-boot</artifactId>
-      <licenses>
-        <license>
-          <name>GNU Lesser General Public License v2.1 or later</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-          <distribution>repo</distribution>
-        </license>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-jar-runtime</artifactId>
       <licenses>
         <license>

--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -1059,7 +1059,7 @@
                             <licensesConfigFile>${feature-pack.license.directory}/core-feature-pack-licenses.xml</licensesConfigFile>
                             <licensesOutputFile>${license.directory}/core-feature-pack-licenses.xml</licensesOutputFile>
                             <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
-                            <excludedArtifacts>wildfly-core-model-test-framework|wildfly-elytron\z</excludedArtifacts>
+                            <excludedArtifacts>wildfly-core-model-test-framework|wildfly-jar-boot|wildfly-elytron\z</excludedArtifacts>
                             <excludedScopes>system</excludedScopes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
artifact wildfly-jar-boot jar is not present in WildFly distribution

JIRA: https://issues.redhat.com/browse/WFCORE-5011