### PR TITLE
[WFCORE-944] truststore path is ignored if provider is not JKS

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -750,8 +750,9 @@ public class SecurityRealmAddHandler extends AbstractAddStepHandler {
         char[] keystorePassword = keystorePasswordNode.isDefined() ? keystorePasswordNode.asString().toCharArray() : null;
         final String provider = KeystoreAttributes.KEYSTORE_PROVIDER.resolveModelAttribute(context, ssl).asString();
         String keySuffix = AUTHENTICATION + KEY_DELIMITER + TRUSTSTORE;
+        ModelNode pathNode = KeystoreAttributes.KEYSTORE_PATH.resolveModelAttribute(context, ssl);
 
-        if (!JKS.equalsIgnoreCase(provider)) {
+        if (!pathNode.isDefined()) {
             serviceBuilder = serviceTarget.addService(serviceName);
             final Consumer<TrustManager[]> trustManagersConsumer = serviceBuilder.provides(serviceName);
             ExceptionSupplier<CredentialSource, Exception> credentialSourceSupplier = null;
@@ -760,7 +761,7 @@ public class SecurityRealmAddHandler extends AbstractAddStepHandler {
             }
             serviceBuilder.setInstance(new ProviderTrustManagerService(trustManagersConsumer, credentialSourceSupplier, provider, keystorePassword));
         } else {
-            String path = KeystoreAttributes.KEYSTORE_PATH.resolveModelAttribute(context, ssl).asString();
+            String path = pathNode.asString();
             ModelNode relativeToNode = KeystoreAttributes.KEYSTORE_RELATIVE_TO.resolveModelAttribute(context, ssl);
             String relativeTo = relativeToNode.isDefined() ? relativeToNode.asString() : null;
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
@@ -161,7 +161,7 @@ public abstract class AbstractBaseSecurityRealmsServerSetupTask implements Serve
                     }
 
                     if (StringUtils.isNotEmpty(ssl.getProvider())) {
-                        sslModuleNode.get(Constants.PROVIDER).set(ssl.getProvider());
+                        sslModuleNode.get(Constants.KEYSTORE_PROVIDER).set(ssl.getProvider());
                     }
 
                     sslModuleNode.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
@@ -178,6 +178,9 @@ public abstract class AbstractBaseSecurityRealmsServerSetupTask implements Serve
                         sslModuleNode.get(Constants.KEYSTORE_PASSWORD).set(truststore.getKeystorePassword());
                     } else {
                         sslModuleNode.get(Constants.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE).set(getCredentialReferenceModelNode(truststore.getKeystorePasswordCredentialReference()));
+                    }
+                    if (StringUtils.isNotEmpty(truststore.getProvider())) {
+                        sslModuleNode.get(Constants.KEYSTORE_PROVIDER).set(truststore.getProvider());
                     }
                     sslModuleNode.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
                     steps.add(sslModuleNode);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-944

I just used @darranl 's fix (https://github.com/wildfly/wildfly-core/pull/3841) but a manual test that used PKCS12 was modified to include this use-case. Indeed the test is better now. Previously the provider was not specified in the configuration (server-identity/ssl or authentication/truststore) and that seems to work in openjdk but fails in other implementations (IBM for example). So we are killing two birds with one stone.