### PR TITLE
[12.0.x] [WFCORE-5028] Don't make the CallbackHandler provided by the CLI preferred as it is only intended as a fallback if authentication can not be performed using the available configuration.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -164,6 +164,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient
             channelConfig.setConnectionTimeout(connectionTimeout);
         }
         channelConfig.setTimeoutHandler(timeoutHandler);
+        channelConfig.setCallbackHandlerPreferred(false);
     }
 
     @Override

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
@@ -52,6 +52,7 @@ public class ProtocolConnectionConfiguration {
     private ProtocolTimeoutHandler timeoutHandler;
     private boolean sslEnabled = true;
     private boolean useStartTLS = true;
+    private boolean callbackHandlerPreferred = true;
 
     protected ProtocolConnectionConfiguration() {
         // TODO AS7-6223 propagate clientBindAddress configuration up to end user level and get rid of this system property
@@ -169,6 +170,20 @@ public class ProtocolConnectionConfiguration {
         return useStartTLS;
     }
 
+    /**
+     * Where a {@code CallbackHandler} is provided should this be preferred over any resolved
+     * {@code AuthenticationConfiguration}, defaults to {@code true}.
+     *
+     * @return {@code true} if the referenced {@code CallbackHandler} should be preferred.
+     */
+    public boolean isCallbackHandlerPreferred() {
+        return callbackHandlerPreferred;
+    }
+
+    public void setCallbackHandlerPreferred(boolean callbackHandlerPreferred) {
+        this.callbackHandlerPreferred = callbackHandlerPreferred;
+    }
+
     public ProtocolConnectionConfiguration copy() {
         return copy(this);
     }
@@ -206,6 +221,7 @@ public class ProtocolConnectionConfiguration {
         target.timeoutHandler = old.timeoutHandler;
         target.sslEnabled = old.sslEnabled;
         target.useStartTLS = old.useStartTLS;
+        target.callbackHandlerPreferred = old.callbackHandlerPreferred;
         return target;
     }
 

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
@@ -160,10 +160,12 @@ public class ProtocolConnectionUtils {
         AuthenticationContext captured = AuthenticationContext.captureCurrent();
         AuthenticationConfiguration mergedConfiguration = AUTH_CONFIGURATION_CLIENT.getAuthenticationConfiguration(uri, captured);
         if (handler != null) {
-            // Clear the three values as the CallbackHandler will be used for these.
-            mergedConfiguration = mergedConfiguration.useAnonymous();
-            mergedConfiguration = mergedConfiguration.useCredentials(IdentityCredentials.NONE);
-            mergedConfiguration = mergedConfiguration.useRealm(null);
+            if (configuration.isCallbackHandlerPreferred()) {
+                // Clear the three values as the CallbackHandler will be used for these.
+                mergedConfiguration = mergedConfiguration.useAnonymous();
+                mergedConfiguration = mergedConfiguration.useCredentials(IdentityCredentials.NONE);
+                mergedConfiguration = mergedConfiguration.useRealm(null);
+            }
             mergedConfiguration = mergedConfiguration.useCallbackHandler(handler, DEFAULT_CALLBACK_KINDS);
         }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BasicOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BasicOpsTestCase.java
@@ -34,6 +34,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 
 /**
  *
@@ -54,6 +58,22 @@ public class BasicOpsTestCase {
 
         cli.quit();
     }
+
+    @Test
+    public void testConnect_AuthenticationConfig() throws Exception {
+        AuthenticationContext testContext = AuthenticationContext.empty().with(MatchRule.ALL,
+                AuthenticationConfiguration.empty().useDefaultProviders()
+                        .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("DIGEST-MD5")).useName("testSuite")
+                        .usePassword("testSuitePassword"));
+        AuthenticationContext original = AuthenticationContext.getContextManager().getGlobalDefault();
+        AuthenticationContext.getContextManager().setGlobalDefault(testContext);
+        try {
+            testConnect();
+        } finally {
+            AuthenticationContext.getContextManager().setGlobalDefault(original);
+        }
+    }
+
 
     @Test
     public void testConnectBind() throws Exception {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DefaultSaslConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DefaultSaslConfigTestCase.java
@@ -23,6 +23,12 @@ import java.io.IOException;
 import java.net.ConnectException;
 
 import javax.inject.Inject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
 
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -74,6 +80,21 @@ public class DefaultSaslConfigTestCase {
     }
 
     /**
+     * Tests that DIGEST-MD5 SASL mechanism can be used for authentication in default server configuration.
+     *
+     * The supplied CallbackHandler should take priority for the username and password over the values
+     * on the AuthenticationConfiguration.
+     */
+    @Test
+    public void testDigestAuthnCallbackHandler() throws Exception {
+        AuthenticationContext.empty()
+                .with(MatchRule.ALL, AuthenticationConfiguration.empty().useDefaultProviders()
+                        .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("DIGEST-MD5"))
+                        .useName("bad").usePassword("bad"))
+                .run(() -> assertWhoAmI("testSuite", callbackHandler("testSuite", "testSuitePassword", "ManagementRealm")));
+    }
+
+    /**
      * Tests that DIGEST-MD5 SASL mechanism fail if wrong password is used.
      */
     @Test
@@ -111,7 +132,7 @@ public class DefaultSaslConfigTestCase {
 
     private void assertAuthenticationFails() {
         try {
-            executeWhoAmI();
+            executeWhoAmI(null);
         } catch (IOException e) {
             Throwable cause = e.getCause();
             Assert.assertThat(cause, is(instanceOf(ConnectException.class)));
@@ -119,9 +140,9 @@ public class DefaultSaslConfigTestCase {
         }
     }
 
-    private ModelNode executeWhoAmI() throws IOException {
+    private ModelNode executeWhoAmI(final CallbackHandler callbackHandler) throws IOException {
         ModelControllerClient client = ModelControllerClient.Factory.create(new ModelControllerClientConfiguration.Builder()
-                .setHostName(managementClient.getMgmtAddress()).setPort(9990).setConnectionTimeout(10000).build());
+                .setHostName(managementClient.getMgmtAddress()).setPort(9990).setConnectionTimeout(10000).setHandler(callbackHandler).build());
 
         ModelNode operation = new ModelNode();
         operation.get("operation").set("whoami");
@@ -131,14 +152,42 @@ public class DefaultSaslConfigTestCase {
     }
 
     private void assertWhoAmI(String expected) {
+        assertWhoAmI(expected, null);
+    }
+
+    private void assertWhoAmI(String expected, CallbackHandler callbackHandler) {
         try {
-            ModelNode result = executeWhoAmI();
+            ModelNode result = executeWhoAmI(callbackHandler);
             Assert.assertTrue("The whoami operation should finish with success", Operations.isSuccessfulOutcome(result));
             Assert.assertEquals("The whoami operation returned unexpected value", expected,
                     Operations.readResult(result).get("identity").get("username").asString());
         } catch (IOException e) {
             Assert.fail("The whoami operation failed - " + e.getMessage());
         }
+    }
+
+    private static CallbackHandler callbackHandler(final String username, final String password, final String realm) {
+        return new CallbackHandler() {
+
+            @Override
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback current : callbacks) {
+                    if (current instanceof NameCallback) {
+                        NameCallback ncb = (NameCallback) current;
+                        ncb.setName(username);
+                    } else if (current instanceof PasswordCallback) {
+                        PasswordCallback pcb = (PasswordCallback) current;
+                        pcb.setPassword(password.toCharArray());
+                    } else if (current instanceof RealmCallback) {
+                        RealmCallback rcb = (RealmCallback) current;
+                        rcb.setText(realm != null ? realm : rcb.getDefaultText());
+                    } else {
+                        throw new UnsupportedCallbackException(current);
+                    }
+                }
+            }
+
+        };
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5028