### PR TITLE
[WFCORE-5034] Upgrade log4j to 2.13.3

### DIFF
--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -38,7 +38,7 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
-        <version.org.apache.logging.log4j>2.11.0</version.org.apache.logging.log4j>
+        <version.org.apache.logging.log4j>2.13.3</version.org.apache.logging.log4j>
         <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
     </properties>
 


### PR DESCRIPTION
This component is only used when the embedded test suite is run.

JIRA: https://issues.redhat.com/browse/WFCORE-5034

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
