### PR TITLE
[WFCORE-5042] Upgrade WildFly Elytron to 1.13.0.CR2

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -213,6 +213,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-common</artifactId>
+            <version>${version.org.apache.sshd}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
@@ -112,6 +112,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
       <licenses>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/sshd/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/sshd/main/module.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2020, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<module xmlns="urn:jboss:module:1.8" name="org.apache.sshd">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.apache.sshd:sshd-common}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.slf4j"/>
+        <module name="org.slf4j.impl"/>
+        <module name="java.logging"/>
+        <module name="java.rmi"/>
+        <module name="java.management"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -126,6 +126,7 @@
         <module name="org.wildfly.common"/>
         <module name="javax.xml.ws.api" optional="true"/>
         <module name="org.jboss.ws.spi" optional="true"/>
+        <module name="org.apache.sshd"/>
         <!--
         This is only exported because some of the ElytronXmlParser methods throw an exception in this module. If other
         modules use the parser, they need to have visibility to this module.

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
         <version.org.apache.httpcomponents.httpcore>4.4.13</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
+        <version.org.apache.sshd>2.3.0</version.org.apache.sshd>
         <version.org.apache.xerces>2.12.0.SP02</version.org.apache.xerces>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
@@ -1173,6 +1174,12 @@
                 <groupId>com.googlecode.javaewah</groupId>
                 <artifactId>JavaEWAH</artifactId>
                 <version>${version.com.googlecode.javaewah}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-common</artifactId>
+                <version>${version.org.apache.sshd}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.13.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5042
https://issues.redhat.com/browse/WFCORE-5044


        Release Notes - WildFly Elytron - Version 1.13.0.CR2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1997'>ELY-1997</a>] -         Upgrade jboss-logmanager to 2.1.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1999'>ELY-1999</a>] -         Upgrade JBoss Threads to 2.3.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2003'>ELY-2003</a>] -         Upgrading  jboss-logmanager to 2.1.17.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2000'>ELY-2000</a>] -         Add additional TRACE logging in GssapiClient when obtaining credential using Callback
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2006'>ELY-2006</a>] -         Add a &quot;Delegating&quot; PolicyContextHandler
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2007'>ELY-2007</a>] -         Bring SecurityIdentity PolicyContextHandler inline with WildFly Core implementation.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2008'>ELY-2008</a>] -         Move JACC tests into JACC module
</li>
</ul>
                                                                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1879'>ELY-1879</a>] -         Support SSH authentication for Git persistence
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1932'>ELY-1932</a>] -         Support for multiple security realms - Distributed Identities
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1982'>ELY-1982</a>] -         TLS with BCJSSE Provider does not work
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2004'>ELY-2004</a>] -         SPNEGO mechanism handles delegated credential twice.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2009'>ELY-2009</a>] -         Remove loadedIdentities from PrincipalDistributedIdentity since it is unused and correct PrincipalDistributedIdentity#dispose
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1951'>ELY-1951</a>] -         Add version 1.6 of the Elytron client schema
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1984'>ELY-1984</a>] -         Add a wrapper HttpServerAuthenticationMechanismFactory that sets the peer address using the current authentication request
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2005'>ELY-2005</a>] -         Support for &quot;Container Subject Policy Context Handler&quot; should be in Elytron
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2010'>ELY-2010</a>] -         Release WildFly Elytron 1.13.0.CR2
</li>
</ul>
                                        