### PR TITLE
[WFCORE-5050] Upgrade WildFly OpenSSL to 1.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>1.1.0.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>1.1.1.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5050


        Release Notes - WildFly OpenSSL - Version 1.1.1.Final
                                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-34'>WFSSL-34</a>] -         libwfssl is not detected by EAP automatically -&gt; cannot use OpenSSL security provider
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-35'>WFSSL-35</a>] -         Release WildFly OpenSSL 1.1.1.Final
</li>
</ul>
                                                        