### PR TITLE
[WFCORE-5057] Upgrade jboss-threads to 2.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>2.0.1.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
-        <version.org.jboss.threads>2.3.6.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.8.1.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5057

Tag: https://github.com/jbossas/jboss-threads/releases/tag/2.4.0.Final
Diff: https://github.com/jbossas/jboss-threads/compare/2.3.6.Final...2.4.0.Final