### PR TITLE
[WFCORE-5058] Upgrade WildFly Elytron to 1.13.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.13.0.CR2</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.0.CR3</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5058

        Release Notes - WildFly Elytron - Version 1.13.0.CR3
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2011'>ELY-2011</a>] -         Upgrade jboss-threads to 2.3.6.Final
</li>
</ul>
                                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1891'>ELY-1891</a>] -         Introduce RESTEasy integration with WildFly Elytron - AuthenticationClient for Authentication / SSL
</li>
</ul>
                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2012'>ELY-2012</a>] -         Release WildFly Elytron 1.13.0.CR3
</li>
</ul>
                                        
