### PR TITLE
Fix for WFCORE-5059, Upgrade bootable testsuite to use 2.0.0.Alpha6 maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.org.wildfly.galleon-plugins>4.2.8.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
-        <version.org.wildfly.jar.plugin>2.0.0.Alpha3</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>2.0.0.Alpha6</version.org.wildfly.jar.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.2.0.Final</version.org.wildfly.plugins>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -384,9 +384,13 @@
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>
-                                    <cli-script-files>
-                                        <script>${ts.config.elytron.cli.no.embedded}</script>
-                                    </cli-script-files>
+                                    <cli-sessions>
+                                        <cli-session>
+                                            <script-files>
+                                                <script>${ts.config.elytron.cli.no.embedded}</script>
+                                            </script-files>
+                                        </cli-session>
+                                    </cli-sessions>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>org.wildfly.core</groupId>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -494,9 +494,13 @@
                                     <record-state>false</record-state>
                                     <log-time>${galleon.log.time}</log-time>
                                     <offline>true</offline>
-                                    <cli-script-files>
-                                        <script>${project.basedir}/enable-rbac.cli</script>
-                                    </cli-script-files>
+                                    <cli-sessions>
+                                        <cli-session>
+                                            <script-files>
+                                                <script>${project.basedir}/enable-rbac.cli</script>
+                                            </script-files>
+                                        </cli-session>
+                                    </cli-sessions>
                                     <extra-server-content-dirs>
                                         <dir>${project.basedir}/src/test/resources/wildfly</dir>
                                     </extra-server-content-dirs>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5059
Upgraded plugin release, updated tests plugin configuration to use cli-sessions.