### PR TITLE
[WFCORE-4962] / [WFCORE-4963] / [WFCORE-4981] DUP Refactoring to share service name of resolved SecurityDomain.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -511,6 +511,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
                     @Override
                     protected void execute(DeploymentProcessorTarget processorTarget) {
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.STRUCTURE,  Phase.STRUCTURE_SECURITY_METADATA, new SecurityMetaDataProcessor());
+                        processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_DEFINE_VIRTUAL_DOMAIN_NAME, new VirtualSecurityDomainNameProcessor());
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_ELYTRON, new DependencyProcessor());
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_ELYTRON_EE_SECURITY, new EESecurityDependencyProcessor());
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.CONFIGURE_MODULE, Phase.CONFIGURE_AUTHENTICATION_CONTEXT, AUTHENITCATION_CONTEXT_PROCESSOR);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -510,6 +510,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
                 context.addStep(new AbstractDeploymentChainStep() {
                     @Override
                     protected void execute(DeploymentProcessorTarget processorTarget) {
+                        processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.STRUCTURE,  Phase.STRUCTURE_SECURITY_METADATA, new SecurityMetaDataProcessor());
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_ELYTRON, new DependencyProcessor());
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_ELYTRON_EE_SECURITY, new EESecurityDependencyProcessor());
                         processorTarget.addDeploymentProcessor(ElytronExtension.SUBSYSTEM_NAME, Phase.CONFIGURE_MODULE, Phase.CONFIGURE_AUTHENTICATION_CONTEXT, AUTHENITCATION_CONTEXT_PROCESSOR);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SecurityMetaDataProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SecurityMetaDataProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import static org.jboss.as.server.security.SecurityMetaData.ATTACHMENT_KEY;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.security.SecurityMetaData;
+
+/**
+ * A {@code DeploymentUnitProcessor} to associate a {@code SecurityMetaData} instance with each {@code DeploymentUnit}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class SecurityMetaDataProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        /*
+         * The SecurityMetaData is pro-actively attached to the deployment early to allow other processors
+         * to update it to build a security policy, also references can be cached to receive subsequent updates.
+         */
+        phaseContext.getDeploymentUnit().putAttachment(ATTACHMENT_KEY, new SecurityMetaData());
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit deploymentUnit) {
+        deploymentUnit.removeAttachment(ATTACHMENT_KEY);
+    }
+
+}

--- a/elytron/src/main/java/org/wildfly/extension/elytron/VirtualSecurityDomainNameProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/VirtualSecurityDomainNameProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import static org.jboss.as.server.security.SecurityMetaData.ATTACHMENT_KEY;
+import static org.jboss.as.server.security.VirtualDomainMarkerUtility.isVirtualDomainRequired;
+import static org.jboss.as.server.security.VirtualDomainMarkerUtility.virtualDomainName;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.security.SecurityMetaData;
+
+/**
+ * A {@code DeploymentUnitProcessor} to set the {@code ServiceName} of any virtual security domain to be used
+ * by the deployment.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class VirtualSecurityDomainNameProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        SecurityMetaData securityMetaData = deploymentUnit.getAttachment(ATTACHMENT_KEY);
+        if (securityMetaData != null && isVirtualDomainRequired(deploymentUnit)) {
+            securityMetaData.setSecurityDomain(virtualDomainName(deploymentUnit));
+        }
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {}
+
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -670,7 +670,8 @@ public enum Phase {
     public static final int INSTALL_WS_UNIVERSAL_META_DATA_MODEL        = 0x1C10;
     public static final int INSTALL_WS_DEPLOYMENT_ASPECTS               = 0x1C11;
     // IMPORTANT: WS integration installs deployment aspects dynamically
-    // so consider INSTALL 0x1C10 - 0x1CFF reserved for WS subsystem!
+    // so consider INSTALL 0x1C10 - 0x1CFE reserved for WS subsystem!
+    public static final int INSTALL_WEB_RESOLVE_SECURITY_DOMAIN         = 0x1CFF;
     public static final int INSTALL_WAR_DEPLOYMENT                      = 0x1D00;
     /**
      * @deprecated there is no phase processing associated with this constant - it was used for OSGi integration

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -272,6 +272,7 @@ public enum Phase {
     public static final int STRUCTURE_GLOBAL_REQUEST_CONTROLLER         = 0x2000;
     public static final int STRUCTURE_WS_SERVICES_DEPS                  = 0x2100;
     public static final int STRUCTURE_DEPENDENCIES_MANIFEST             = 0x2200;
+    public static final int STRUCTURE_SECURITY_METADATA                 = 0x2300;
     public static final int STRUCTURE_DEFERRED_DEPLOYMENT_OVERLAY       = 0xF000; //needs to run after all structure processors
 
     // PARSE

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -403,6 +403,7 @@ public enum Phase {
     public static final int PARSE_CASSANDRA_DRIVER                      = 0x4C02;
     public static final int PARSE_MONGO_DRIVER                          = 0x4C03;
     public static final int PARSE_MICROPROFILE_JWT_DETECTION            = 0x4C0D;
+    public static final int PARSE_DEFINE_VIRTUAL_DOMAIN_NAME            = 0x4C17;
 
     // REGISTER
     /**

--- a/server/src/main/java/org/jboss/as/server/security/SecurityMetaData.java
+++ b/server/src/main/java/org/jboss/as/server/security/SecurityMetaData.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server.security;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Meta Data to be attached to a {@link DeploymentUnit} to contain information about the active
+ * security policy.
+ *
+ * Note: This applies to security backed by WildFly Elytron only not legacy security.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SecurityMetaData {
+
+    public static final AttachmentKey<SecurityMetaData> ATTACHMENT_KEY = AttachmentKey.create(SecurityMetaData.class);
+
+    private volatile ServiceName securityDomain;
+
+    /**
+     * Get the {@code ServiceName} of the {@code SecurityDomain} selected for use with this deployment.
+     *
+     * @return the {@code ServiceName} of the {@code SecurityDomain} selected for use with this deployment.
+     */
+    public ServiceName getSecurityDomain() {
+        return securityDomain;
+    }
+
+    /**
+     * Get the {@code ServiceName} of the {@code SecurityDomain} selected for use with this deployment.
+     *
+     * @return the {@code ServiceName} of the {@code SecurityDomain} selected for use with this deployment.
+     */
+    public void setSecurityDomain(ServiceName securityDomain) {
+        this.securityDomain = securityDomain;
+    }
+
+}


### PR DESCRIPTION
A WildFly PR will follow for the WildFly side of the changes but this initial change is required within WildFly Core first.

https://issues.redhat.com/browse/WFCORE-4962
https://issues.redhat.com/browse/WFCORE-4963
https://issues.redhat.com/browse/WFCORE-4981

Overall the intent is to transition to a point a complete security policy is defined before entering Phase.INSTALL so all DUP installation activities can refer to a common policy that has been collaboratively established without repeating resolution activities (possibly with different results) in different subsystems.

One remaining issue is the web services deployment unit processors don't convert the deployment to a web application until later in the INSTALL phase, other than for web services Phase.INSTALL_WEB_RESOLVE_SECURITY_DOMAIN could likely come all the way back to Phase.CONFIGURE_MODULE.
