### PR TITLE
[WFCORE-4863] Upgrade PicketBox from 5.0.3.Final-redhat-00005 to 5.0.3.Final-redhat-00006

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>2.18.0</version.org.mockito>
         <version.org.mock-server.mockserver-netty>5.9.0</version.org.mock-server.mockserver-netty>
-        <version.org.picketbox>5.0.3.Final-redhat-00005</version.org.picketbox>
+        <version.org.picketbox>5.0.3.Final-redhat-00006</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.30</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4863

Branch: https://github.com/jbossas/redhat-picketbox/tree/5.0.x
Diff: https://github.com/jbossas/redhat-picketbox/compare/5.0.3.Final-16-g4e49f86c...5.0.3.Final-18-g76744137