### PR TITLE
[WFCORE-5064] Incorrect use of KeyManagerFactory.getDefaultAlgorithm instead of TrustManagerFactory

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileTrustManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileTrustManagerService.java
@@ -30,7 +30,6 @@ import java.security.cert.X509Certificate;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -108,7 +107,7 @@ class FileTrustManagerService extends AbstractTrustManagerService {
     @Override
     public void start(StartContext context) throws StartException {
         try {
-            trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         } catch (NoSuchAlgorithmException e) {
             throw DomainManagementLogger.ROOT_LOGGER.unableToStart(e);
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5064

Just changing to use the correct default trust-manager algorithm defined at JDK level (right now it's using the KeyManagerFactory default, the default value `SunX509` also exists for TrustManagerFactory and it's valid). I'm not adding any tests because the final https availability for the realm is tested for example in HTTPSManagementInterfaceTestCase. We can add a test similar to the steps I added to reproduce it in the JIRA if you really think it is needed.
