### PR TITLE
[WFCORE-5069] Automatically add the -Djboss.modules.os-name property if it has not already been specified when running on RHEL 6, RHEL 7, or RHEL 8 to ensure the correct WildFly OpenSSL native library will be used

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/domain.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.sh
@@ -161,6 +161,15 @@ if $linux; then
              ;;
       esac
     done
+    # determine if we are running on RHEL 6, RHEL 7, or RHEL 8
+    RHEL_VERSION=$(uname -r | sed 's/.*\.\(el[678]\)\..*/\1/')
+    if [[ $RHEL_VERSION =~ ^el[678]$ ]]; then
+        # set the -Djboss.modules.os-name property if not already set
+        JBOSS_MODULES_OS_NAME_OPTION=`echo $SERVER_OPTS | $GREP "\-Djboss.modules.os-name"`
+        if [ "x$JBOSS_MODULES_OS_NAME_OPTION" = "x" ]; then
+            SERVER_OPTS="${SERVER_OPTS} -Djboss.modules.os-name=${RHEL_VERSION}"
+        fi
+    fi
 fi
 
 if $solaris; then

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -153,6 +153,15 @@ if $linux; then
               ;;
        esac
     done
+    # determine if we are running on RHEL 6, RHEL 7, or RHEL 8
+    RHEL_VERSION=$(uname -r | sed 's/.*\.\(el[678]\)\..*/\1/')
+    if [[ $RHEL_VERSION =~ ^el[678]$ ]]; then
+        # set the -Djboss.modules.os-name property if not already set
+        JBOSS_MODULES_OS_NAME_OPTION=`echo $SERVER_OPTS | $GREP "\-Djboss.modules.os-name"`
+        if [ "x$JBOSS_MODULES_OS_NAME_OPTION" = "x" ]; then
+            SERVER_OPTS="${SERVER_OPTS} -Djboss.modules.os-name=${RHEL_VERSION}"
+        fi
+    fi
 fi
 
 if $solaris; then

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -750,6 +750,11 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
         addSystemPropertyArg(cmd, DOMAIN_LOG_DIR, getLogDirectory());
         addSystemPropertyArg(cmd, DOMAIN_CONFIG_DIR, getConfigurationDirectory());
 
+        String jbossModulesOSName = getJBossModulesOSName();
+        if (jbossModulesOSName != null) {
+            addSystemPropertyArg(cmd, JBOSS_MODULES_OS_NAME, jbossModulesOSName);
+        }
+
         cmd.addAll(getServerArguments());
         return cmd;
     }

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -540,6 +540,12 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         addSystemPropertyArg(cmd, SERVER_BASE_DIR, getBaseDirectory());
         addSystemPropertyArg(cmd, SERVER_LOG_DIR, getLogDirectory());
         addSystemPropertyArg(cmd, SERVER_CONFIG_DIR, getConfigurationDirectory());
+
+        String jbossModulesOSName = getJBossModulesOSName();
+        if (jbossModulesOSName != null) {
+            addSystemPropertyArg(cmd, JBOSS_MODULES_OS_NAME, jbossModulesOSName);
+        }
+
         if (modulesLocklessArg != null) {
             cmd.add(modulesLocklessArg);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5069
