### PR TITLE
Add workflow action for closing stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+# see: https://github.com/actions/stale
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'wildfly'
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'There has been no activity on this PR for 30 days. It will be auto-closed after 90 days.'
+        close-pr-message: 'There has been no activity on this PR for 90 days and it has been closed automatically.'
+        days-before-stale: 30
+        days-before-close: 90


### PR DESCRIPTION
This is a test workflow for closing stale PRs. A comment is left after 30 days indicating there has been no activity, and the PR is closed after 90 with no activity. It is based on the github supplied action here: https://github.com/actions/starter-workflows/blob/main/automation/stale.yml

(No JIRA, yet, this is more for discussion.)
