### PR TITLE
[WFCORE-5071] Extra spaces in DeploymentTransformer.java produces error at build

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/transformation/DeploymentTransformer.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/transformation/DeploymentTransformer.java
@@ -48,7 +48,6 @@ public interface DeploymentTransformer {
      *               in which it should be written. If the latter the name of the written file will be the same as
      *               the name of the {@code src} file. Note also that {@code target} can be the same path as
      *               {@code src}, in which case the file at {@code src} will be replaced.
-     *               
      * @throws IOException if a problem occurs reading or writing the content
      */
     void transform(Path src, Path target) throws IOException ;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5071

@wildfly/mergers-full Issue with WFCORE-5065 make the build fail because of the check-style. Just removing that line.