### PR TITLE
[WFCORE-5074] Upgrade JBoss Modules to 1.10.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>2.1.17.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.modules.jboss-modules>1.10.1.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.10.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.18.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5074


        Release Notes - JBoss Modules - Version 1.10.2.Final
                                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/MODULES-400'>MODULES-400</a>] -         Automatically set the os.name if the -Djboss.modules.os-name property has not already been specified when running on RHEL platforms
</li>
</ul>
         