### PR TITLE
[WFCORE-5076] The "remoting-http-upgrade-service" should be ACTIVE.

### DIFF
--- a/core-feature-pack/galleon-common/src/main/resources/layers/standalone/remoting/layer-spec.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/layers/standalone/remoting/layer-spec.xml
@@ -2,6 +2,14 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="remoting">
     <dependencies>
         <layer name="io"/>
+        <layer name="elytron"/>
     </dependencies>
     <feature-group name="remoting"/>
+
+    <feature spec="subsystem.remoting.http-connector">
+        <param name="http-connector" value="http-remoting-connector"/>
+        <param name="connector-ref" value="default"/>
+        <unset param="security-realm"/>
+        <param name="sasl-authentication-factory" value="application-sasl-authentication"/>
+    </feature>
 </layer-spec>

--- a/core-feature-pack/galleon-feature-pack/src/main/resources/layers/standalone/legacy-remoting/layer-spec.xml
+++ b/core-feature-pack/galleon-feature-pack/src/main/resources/layers/standalone/legacy-remoting/layer-spec.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="legacy-remoting">
+    <dependencies>
+        <layer name="io"/>
+        <layer name="application-security-realm"/>
+    </dependencies>
+
+    <feature-group name="remoting"/>
+</layer-spec>

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
@@ -134,7 +134,7 @@ public class RemotingHttpUpgradeService implements Service {
         final Supplier<org.jboss.as.domain.management.SecurityRealm> srSupplier = securityRealm != null ? sb.requires(org.jboss.as.domain.management.SecurityRealm.ServiceUtil.createServiceName(securityRealm)) : null;
         final Supplier<SaslAuthenticationFactory> safSupplier = saslAuthenticationFactory != null ? sb.requires(context.getCapabilityServiceName(SASL_AUTHENTICATION_FACTORY_CAPABILITY, saslAuthenticationFactory, SaslAuthenticationFactory.class)) : null;
         sb.setInstance(new RemotingHttpUpgradeService(serviceConsumer, urSupplier, lrSupplier, eSupplier, srSupplier, safSupplier, httpConnectorName, endpointName.getSimpleName(), connectorPropertiesOptionMap));
-        sb.setInitialMode(ServiceController.Mode.PASSIVE);
+        sb.setInitialMode(ServiceController.Mode.ACTIVE);
         sb.install();
     }
 

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -660,42 +660,6 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>remoting-provisioning</id>
-                                <goals>
-                                    <goal>provision</goal>
-                                </goals>
-                                <phase>compile</phase>
-                                <configuration>
-                                    <install-dir>${project.build.directory}/layers-results/remoting</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>true</offline>
-                                    <plugin-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                        <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
-                                    <feature-packs>
-                                        <feature-pack>
-                                            <groupId>org.wildfly.core</groupId>
-                                            <artifactId>wildfly-core-galleon-pack</artifactId>
-                                            <version>${project.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
-                                        </feature-pack>
-                                    </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>remoting</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>request-controller-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
@@ -848,7 +812,6 @@
                                                 <layer>logging</layer>
                                                 <layer>management</layer>
                                                 <layer>management-security-realm</layer>
-                                                <layer>remoting</layer>
                                                 <layer>request-controller</layer>
                                                 <layer>secure-management</layer>
                                                 <layer>security-manager</layer>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5076

This is the simplest fix for the issue, a missing dependencies error is now reported:

```
17:02:54,850 ERROR [org.jboss.as.controller.management-operation] (Controller Boot Thread) WFLYCTL0013: Operation ("add") failed - address: ([
    ("subsystem" => "remoting"),
    ("http-connector" => "http-remoting-connector")
]) - failure description: {
    "WFLYCTL0412: Required services that are not installed:" => ["org.wildfly.core.management.security.realm.OtherRealm"],
    "WFLYCTL0180: Services with missing/unavailable dependencies" => ["jboss.remoting.remoting-http-upgrade-service.http-remoting-connector is missing [org.wildfly.core.management.security.realm.OtherRealm]"]
}
```

This service does not have it's own dependants so I don't really see a justification for a resource defined in the remoting subsystem to come up if it can, if not wait for a client to connect with an obscure error message.

We could handle this with capabilities if we wanted as an alternative we have just been trying to avoid spending time converting legacy security realms to capabilities as they are deprecated but if that is seen as the more correct fix that may be required.

_Note: Once legacy security is removed the Elytron sasl-authentication-factory attribute is capability based so does not suffer the same issue here._

This PR also contains the following fixes to adjust the remoting layer(s):

https://issues.redhat.com/browse/WFCORE-5078
https://issues.redhat.com/browse/WFCORE-5082

The end result of the two layers can be seen in the following gist, in each case the gist was populated with files from a server provisioned with "web-server" only then either "remoting" or "legacy-remoting" were added so the effect of the change can be seen:

https://gist.github.com/darranl/5503feaf0ab547fdde5622bd31de8dad/revisions
