### PR TITLE
[WFCORE-5083] check invalid attribute in ObjectTypeValidator.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3646,5 +3646,7 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 481, value = "The runtime dependency package '%s' is already registered at location '%s'")
     void runtimePackageDependencyAlreadyRegistered(String pckg, String location);
 
-
+    @LogMessage(level = WARN)
+    @Message(id = 482, value = "Unknown attribute '%s' encountered. Valid attribute names are: '%s'")
+    void unknownAttribute(StringBuilder unexpectedAttr, StringBuilder possibleAttributes);
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5083

Adding a global-module with an invalid attribute doesn't give an error. The input ObjectTypeAttribute parameter should have been validated in ObjectTypeValidator.