### PR TITLE
[WFCORE-5075] Upgrade WildFly OpenSSL to 1.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>1.1.1.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>1.1.2.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5075


        Release Notes - WildFly OpenSSL - Version 1.1.2.Final
                                                                                                                                                    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-39'>WFSSL-39</a>] -         Update the OS-version-specific category that&#39;s added to the native search path to match the format used by JBoss Modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-40'>WFSSL-40</a>] -         Update the directory names that are used for the RHEL natives
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-41'>WFSSL-41</a>] -         Release WildFly OpenSSL 1.1.2.Final
</li>
</ul>