### PR TITLE
[WFLY-10879] Adding new EE deployment phase constant

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -613,6 +613,7 @@ public enum Phase {
     public static final int POST_MODULE_UNDERTOW_SERVLET_CONTAINER_DEPENDENCY       = 0x2F1A;
 
     public static final int POST_MODULE_EE_CONCURRENT_CONTEXT           = 0x3000;
+    public static final int POST_MODULE_EE_STARTUP_COUNTDOWN            = 0x3080;
     public static final int POST_MODULE_BATCH_ENVIRONMENT               = 0x3100;
     public static final int POST_MODULE_RAR_SERVICES_DEPS               = 0x3300;
     public static final int POST_MODULE_UNDERTOW_MODCLUSTER             = 0x3400;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-10879 

This adds a new phase constant required by wildfly/wildfly#11711.

Is it OK to use the WFLY issue for this or should I create a separate WFCORE ticket?