### PR TITLE
[WFCORE-5087] Add support for the -secmgr command line argument,

### DIFF
--- a/bootable-jar/boot/src/main/java/org/wildfly/core/jar/boot/BootablePolicy.java
+++ b/bootable-jar/boot/src/main/java/org/wildfly/core/jar/boot/BootablePolicy.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This is a direct copy of org.jboss.modules.ModulesPolicy from jboss-modules as the bootstrap of
+ * bootable jar is very similar to a jboss-modules bootstrap.
+ */
+
+package org.wildfly.core.jar.boot;
+
+import java.security.AllPermission;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.security.Provider;
+
+final class BootablePolicy extends Policy {
+
+    private static final AllPermission ALL_PERMISSION = new AllPermission();
+
+    static final Permissions DEFAULT_PERMISSION_COLLECTION = getAllPermission();
+
+    private static final CodeSource ourCodeSource = BootablePolicy.class.getProtectionDomain().getCodeSource();
+
+    private final Policy policy;
+
+    private static Permissions getAllPermission() {
+        final Permissions permissions = new Permissions();
+        permissions.add(ALL_PERMISSION);
+        return permissions;
+    }
+
+    BootablePolicy(final Policy policy) {
+        this.policy = policy;
+    }
+
+    public Provider getProvider() {
+        return policy.getProvider();
+    }
+
+    public String getType() {
+        return policy.getType();
+    }
+
+    public Parameters getParameters() {
+        return policy.getParameters();
+    }
+
+    public PermissionCollection getPermissions(final CodeSource codesource) {
+        return codesource != null && codesource.equals(ourCodeSource) ? getAllPermission() : policy.getPermissions(codesource);
+    }
+
+    public PermissionCollection getPermissions(final ProtectionDomain domain) {
+        final CodeSource codeSource = domain.getCodeSource();
+        return codeSource != null && codeSource.equals(ourCodeSource) ? getAllPermission() : policy.getPermissions(domain);
+    }
+
+    public boolean implies(final ProtectionDomain domain, final Permission permission) {
+        final CodeSource codeSource = domain.getCodeSource();
+        return codeSource != null && codeSource.equals(ourCodeSource) || policy.implies(domain, permission);
+    }
+
+    public void refresh() {
+        policy.refresh();
+    }
+}

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
@@ -50,6 +50,9 @@ final class CmdUsage extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.PROPERTIES + "=<url>");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argProperties());
 
+        addArguments(CommandLineConstants.SECMGR);
+        instructions.add(BootableJarLogger.ROOT_LOGGER.argSecurityManager());
+
         addArguments(CommandLineConstants.SECURITY_PROP + "<name>[=<value>]");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argSecurityProperty());
 

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
@@ -133,6 +133,9 @@ public interface BootableJarLogger extends BasicLogger {
     @Message(id = Message.NONE, value = "Print version and exit")
     String argVersion();
 
+    @Message(id = Message.NONE, value = "Activate the SecurityManager")
+    String argSecurityManager();
+
     @Message(id = Message.NONE, value = "Set a security property")
     String argSecurityProperty();
 

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
@@ -47,6 +47,7 @@
         <module name="org.jboss.threads"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.as.process-controller"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>


### PR DESCRIPTION
This approach is borrowed from JBoss Modules which follows a similar pattern of being started from a "java -jar" command before performing the rest of the bootstrap process.

https://issues.redhat.com/browse/WFCORE-5087

Unlike JBoss Modules this does not support alternative security managers as we only support WildFlySecurityManager with the running server.

The following example update makes use of the new -secmgr command line argument:
  https://github.com/wildfly-extras/wildfly-jar-maven-plugin/pull/46