### PR TITLE
[WFCORE-5090] Upgrade WildFly Elytron to 1.13.0.CR4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.13.0.CR3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.0.CR4</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5090


        Release Notes - WildFly Elytron - Version 1.13.0.CR4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2013'>ELY-2013</a>] -         Upgrade to JBoss Threads 2.4.0.Final
</li>
</ul>
                                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1902'>ELY-1902</a>] -         Support for multiple security realms - Failover
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1949'>ELY-1949</a>] -         Adjust Security Manager behaviour when alternative Security Manager installed.
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2015'>ELY-2015</a>] -         Release WildFly Elytron 1.13.0.CR4
</li>
</ul>