### PR TITLE
Fix for WFCORE-5097, Add an option to the bootable JAR to display the Galleon config

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
@@ -41,6 +41,9 @@ final class CmdUsage extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SYS_PROP + "<name>[=<value>]");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argSystem());
 
+        addArguments(Constants.DISPLAY_GALLEON_CONFIG_ARG);
+        instructions.add(BootableJarLogger.ROOT_LOGGER.argDisplayGalleonConfig());
+
         addArguments(CommandLineConstants.HELP);
         instructions.add(BootableJarLogger.ROOT_LOGGER.argHelp());
 

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Constants.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Constants.java
@@ -27,6 +27,7 @@ interface Constants {
 
     static final String DEPLOYMENT_ARG = "--deployment";
     static final String INSTALL_DIR_ARG = "--install-dir";
+    static final String DISPLAY_GALLEON_CONFIG_ARG = "--display-galleon-config";
 
     static final String CONFIGURATION = "configuration";
     static final String DATA = "data";

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
@@ -144,4 +144,7 @@ public interface BootableJarLogger extends BasicLogger {
 
     @Message(id = Message.NONE, value = "Path to directory in which the server is installed. By default the server is installed in TEMP directory.")
     String argInstallation();
+
+    @Message(id = Message.NONE, value = "Display the content of the Galleon configuration used to build this bootable JAR")
+    String argDisplayGalleonConfig();
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5097

Add a new option to bootable JAR runtime to display the galleon provisioning.xml that reflects the provisioned server. The provisioning.xml file is added by the maven plugin (starting 2.0.0.Beta2).