### PR TITLE
[WFCORE-5100] Add missing distribution repo in core-feature-pack-common-licenses.xml license file

### DIFF
--- a/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
@@ -96,6 +96,7 @@
         <license>
           <name>Apache License 2.0</name>
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
         </license>
       </licenses>
     </dependency>
@@ -106,6 +107,7 @@
         <license>
           <name>Apache License 2.0</name>
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
         </license>
       </licenses>
     </dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5100
