### PR TITLE
Fix for WFCORE-5110, Bootable JAR doesn't setup the JAXP factories at boot

### DIFF
--- a/bootable-jar/boot/src/main/java/org/wildfly/core/jar/boot/Main.java
+++ b/bootable-jar/boot/src/main/java/org/wildfly/core/jar/boot/Main.java
@@ -16,6 +16,7 @@
  */
 package org.wildfly.core.jar.boot;
 
+import __redirected.__JAXPRedirected;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -134,6 +135,9 @@ public final class Main {
     private static void runBootableJar(Path jbossHome, List<String> arguments, Long unzipTime, boolean securityManager) throws Exception {
         final String modulePath = jbossHome.resolve(JBOSS_MODULES_DIR_NAME).toAbsolutePath().toString();
         ModuleLoader moduleLoader = setupModuleLoader(modulePath);
+
+        __JAXPRedirected.changeAll(MODULE_ID_JAR_RUNTIME, moduleLoader);
+
         final Module bootableJarModule;
         try {
             bootableJarModule = moduleLoader.loadModule(MODULE_ID_JAR_RUNTIME);

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
@@ -36,6 +36,24 @@
     </exports>
 
     <dependencies>
+        <!-- JAXP default dependencies. DO NOT REMOVE!!!
+             These are loaded by the JAXP redirect facility in jboss-modules when this module is used
+             as a boot module. The purpose is to provide a common default JAXP implementation on all
+             JDKs. This is necessary since we have to override the JAXP APIs to fix incompatibilities
+             with modular class-loading. In the future we may be able to replace this construct if
+             JAXP APIs are fixed on all known JVMs *and* we implement a subsystem to provide a similar
+             default/fallback common parser behavior. Please discuss any design changes in this area
+             on the WildFly development mailing list before enacting.
+
+             Xalan is optional for deritives of wildfly-core that do not desire TransformerFactory
+             support, or wish to require that deployments bundle an xslt implementaiton to use it,
+             as it will break otherwise.
+        -->
+        <module name="org.apache.xalan" services="import" optional="true"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.codehaus.woodstox" services="import"/>
+        <!-- END JAXP default dependencies -->
+        
         <module name="java.xml"/>
         <module name="java.desktop"/>
         <module name="org.jboss.as.server"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5110

Replace JAXP factories with the proper implementations.
