### PR TITLE
[WFCORE-5111] Upgrading JBoss MSC from 1.4.11.Final to 1.4.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.10.2.Final</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.4.11.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.4.12.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.18.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>

--- a/subsystem-test/framework/pom.xml
+++ b/subsystem-test/framework/pom.xml
@@ -84,6 +84,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-vfs</artifactId>
         </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5111 

This component upgrade brings in:
 * [MSC-252] Removing double word of service in the thrown exception ServiceNotFoundException
 * [MSC-255] Deprecating StabilityMonitor & StabilityStatistics
