### PR TITLE
Bootable JAR Logging Updates

### DIFF
--- a/bootable-jar/runtime/pom.xml
+++ b/bootable-jar/runtime/pom.xml
@@ -118,4 +118,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- This is only set for testing purposes and is not a real home directory -->
+                        <test.jboss.home>${project.build.directory}</test.jboss.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Arguments.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Arguments.java
@@ -16,51 +16,82 @@
  */
 package org.wildfly.core.jar.runtime;
 
+import static org.wildfly.core.jar.runtime.Constants.DEPLOYMENT_ARG;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
+
 import org.jboss.as.process.CommandLineConstants;
-import static org.wildfly.core.jar.runtime.Constants.DEPLOYMENT_ARG;
 import org.wildfly.core.jar.runtime._private.BootableJarLogger;
 
 /**
  *
  * @author jdenise
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 final class Arguments {
 
-    private Arguments() {
-
+    private Arguments(final BootableEnvironment environment) {
+        this.environment = environment;
     }
 
     private Boolean isHelp;
     private Boolean isVersion;
     private final List<String> serverArguments = new ArrayList<>();
+    private final BootableEnvironment environment;
     private Path deployment;
 
-    public static Arguments parseArguments(List<String> args) throws Exception {
+    static Arguments parseArguments(final List<String> args, final BootableEnvironment environment) throws Exception {
         Objects.requireNonNull(args);
-        Arguments arguments = new Arguments();
+        Arguments arguments = new Arguments(environment);
         arguments.handleArguments(args);
         return arguments;
     }
 
     private void handleArguments(List<String> args) throws Exception {
-        for (String a : args) {
+        final Map<String, String> systemProperties = new HashMap<>();
+        final Iterator<String> iter = args.iterator();
+        while (iter.hasNext()) {
+            final String a = iter.next();
             if (a.startsWith(DEPLOYMENT_ARG)) {
                 deployment = checkPath(getValue(a));
             } else if (a.startsWith(CommandLineConstants.PUBLIC_BIND_ADDRESS)) {
                 serverArguments.add(a);
             } else if (CommandLineConstants.PROPERTIES.equals(a)) {
                 serverArguments.add(a);
+                if (iter.hasNext()) {
+                    final String urlSpec = iter.next();
+                    serverArguments.add(urlSpec);
+                    addSystemProperties(makeUrl(urlSpec), systemProperties);
+                } else {
+                    throw BootableJarLogger.ROOT_LOGGER.invalidArgument(a);
+                }
+            } else if (a.startsWith(CommandLineConstants.PROPERTIES)) {
+                serverArguments.add(a);
+                // We need these set as system properties early so the log manager can use them
+                final String urlSpec = parseValue(a, CommandLineConstants.PROPERTIES);
+                addSystemProperties(makeUrl(urlSpec), systemProperties);
             } else if (a.startsWith(CommandLineConstants.SECURITY_PROP)) {
                 serverArguments.add(a);
             } else if (a.startsWith(CommandLineConstants.SYS_PROP)) {
+                // We want to set the server argument and add as a system property. The reason for this is when if the
+                // property already exists on the system-property resource a warning is logged alerting to that. However
+                // we also need to set it as a current system property for usage in the log manager.
                 serverArguments.add(a);
+                addSystemProperty(a, systemProperties);
             } else if (a.startsWith(CommandLineConstants.START_MODE)) {
                 serverArguments.add(a);
             } else if (a.startsWith(CommandLineConstants.DEFAULT_MULTICAST_ADDRESS)) {
@@ -74,6 +105,8 @@ final class Arguments {
                 throw BootableJarLogger.ROOT_LOGGER.unknownArgument(a);
             }
         }
+        // Add the system properties to the environment
+        environment.setSystemProperties(systemProperties);
     }
 
     private Path checkPath(String path) {
@@ -118,6 +151,69 @@ final class Arguments {
      */
     public Path getDeployment() {
         return deployment;
+    }
+
+    private static void addSystemProperty(final String arg, final Map<String, String> properties) {
+        final int i = arg.indexOf('=');
+        final String key;
+        final String value;
+        if (i > 2) {
+            key = arg.substring(2, i);
+        } else if (i == -1 && arg.length() > 2) {
+            key = arg.substring(2);
+        } else {
+            throw BootableJarLogger.ROOT_LOGGER.invalidArgument(arg);
+        }
+
+        // We shouldn't be actually setting these properties
+        if (i == -1 || (i + 1) == arg.length()) {
+            value = "";
+        } else {
+            value = arg.substring(i + 1);
+        }
+        properties.put(key ,value);
+    }
+
+    private static void addSystemProperties(final URL url, final Map<String, String> properties) throws IOException {
+        final Properties parsed = new Properties();
+        try (InputStream in = url.openConnection().getInputStream()) {
+            parsed.load(in);
+        }
+        for (String key : parsed.stringPropertyNames()) {
+            properties.put(key, parsed.getProperty(key));
+        }
+    }
+
+    private static String parseValue(final String arg, final String key) {
+        final String value;
+        int splitPos = key.length();
+        if (arg.length() <= splitPos + 1 || arg.charAt(splitPos) != '=') {
+            throw BootableJarLogger.ROOT_LOGGER.invalidArgument(arg);
+        } else {
+            value = arg.substring(splitPos + 1);
+        }
+        return value;
+    }
+
+    private static URL makeUrl(final String urlSpec) throws MalformedURLException {
+        final String trimmed = urlSpec.trim();
+        URL url;
+        try {
+            url = new URL(trimmed);
+            if ("file".equals(url.getProtocol())) {
+                // make sure the file is absolute & canonical file url
+                url = Paths.get(url.toURI()).toRealPath().toUri().toURL();
+            }
+        } catch (Exception e) {
+            // make sure we have an absolute & canonical file url
+            try {
+                url = Paths.get(trimmed).toRealPath().toUri().toURL();
+            } catch (Exception n) {
+                throw new MalformedURLException(n.toString());
+            }
+        }
+
+        return url;
     }
 
 }

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableEnvironment.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableEnvironment.java
@@ -1,0 +1,226 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.jar.runtime;
+
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Represents a bootable JAR environment.
+ * <p>
+ * The environment initializes required system properties. System properties should also be
+ * {@linkplain #setSystemProperty(String, String) set} via the environment and not directly.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class BootableEnvironment {
+
+    private static final AtomicBoolean DEBUG = new AtomicBoolean();
+    private final Path jbossHome;
+    private final Path serverDir;
+    private final Collection<String> ignoredProperties;
+    private final PropertyUpdater propertyUpdater;
+
+    private BootableEnvironment(final Path jbossHome, final Collection<String> ignoredProperties,
+                                final PropertyUpdater propertyUpdater) {
+        this.jbossHome = jbossHome;
+        serverDir = jbossHome.resolve("standalone");
+        this.ignoredProperties = ignoredProperties;
+        this.propertyUpdater = propertyUpdater;
+    }
+
+    /**
+     * Creates a new environment initializing required system properties based on the JBoss Home directory passed in.
+     *
+     * @param jbossHome the base JBoss Home directory
+     *
+     * @return the newly create environment
+     */
+    static BootableEnvironment of(final Path jbossHome) {
+        final PropertyUpdater propertyUpdater;
+        if (System.getSecurityManager() == null) {
+            propertyUpdater = System::setProperty;
+        } else {
+            propertyUpdater = (name, value) ->
+                    AccessController.doPrivileged((PrivilegedAction<String>) () -> System.setProperty(name, value));
+        }
+        return of(jbossHome, propertyUpdater);
+    }
+
+    /**
+     * Creates a new environment initializing required system properties based on the JBoss Home directory passed in.
+     *
+     * @param jbossHome       the base JBoss Home directory
+     * @param propertyUpdater the updater used to set system properties
+     *
+     * @return the newly create environment
+     */
+    static BootableEnvironment of(final Path jbossHome, final PropertyUpdater propertyUpdater) {
+        return new BootableEnvironment(jbossHome, init(jbossHome, propertyUpdater), propertyUpdater);
+    }
+
+    /**
+     * Returns the base JBoss Home directory.
+     *
+     * @return the JBoss Home directory
+     */
+    Path getJBossHome() {
+        return jbossHome;
+    }
+
+    /**
+     * Results the servers configuration directory appending any optional paths.
+     *
+     * @param paths the optional paths to append to the configuration directory
+     *
+     * @return the resolved path
+     */
+    Path resolveConfigurationDir(final String... paths) {
+        return resolvePath(serverDir, "configuration", paths);
+    }
+
+    /**
+     * Results the servers content directory appending any optional paths.
+     *
+     * @param paths the optional paths to append to the content directory
+     *
+     * @return the resolved path
+     */
+    Path resolveContentDir(final String... paths) {
+        return resolvePath(resolveDataDir(), "content", paths);
+    }
+
+    /**
+     * Results the servers data directory appending any optional paths.
+     *
+     * @param paths the optional paths to append to the data directory
+     *
+     * @return the resolved path
+     */
+    Path resolveDataDir(final String... paths) {
+        return resolvePath(serverDir, "data", paths);
+    }
+
+    /**
+     * Results the servers log directory appending any optional paths.
+     *
+     * @param paths the optional paths to append to the log directory
+     *
+     * @return the resolved path
+     */
+    Path resolveLogDir(final String... paths) {
+        return resolvePath(serverDir, "log", paths);
+    }
+
+    /**
+     * Sets the system properties represented by the properties.
+     * <p>
+     * Note there are a set of system properties that will not be set and are determined based on the JBoss Home
+     * directory.
+     * </p>
+     *
+     * @param properties the properties to set
+     */
+    void setSystemProperties(final Map<String, String> properties) {
+        final Map<String, String> local = new HashMap<>(properties);
+        final String debugValue = local.remove(Constants.DEBUG_PROPERTY);
+        if (debugValue != null) {
+            DEBUG.set(debugValue.isEmpty() || "true".equalsIgnoreCase(debugValue));
+        }
+        for (Map.Entry<String, String> entry : local.entrySet()) {
+            setSystemProperty(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Sets the system property.
+     * <p>
+     * Note there are a set of system properties that will not be set and are determined based on the JBoss Home
+     * directory.
+     * </p>
+     *
+     * @param key   the key for the property
+     * @param value the property value
+     */
+    void setSystemProperty(final String key, final String value) {
+        if (ignoredProperties.contains(key)) {
+            logDebug("Ignoring system property %s.", key);
+        } else {
+            propertyUpdater.setProperty(key, value);
+        }
+    }
+
+    private static Collection<String> init(final Path jbossHome, final PropertyUpdater propertyUpdater) {
+        final Collection<String> propertyNames = new ArrayList<>();
+        propertyNames.add("java.ext.dirs");
+        propertyNames.add("java.home");
+        propertyNames.add("java.io.tmpdir");
+        propertyNames.add("jboss.server.persist.config");
+        propertyNames.add("jboss.server.management.uuid");
+        propertyNames.add("modules.path");
+        propertyNames.add("user.dir");
+        propertyNames.add("user.home");
+
+        // Configure known paths
+        setSystemProperty(propertyUpdater, "jboss.home.dir", jbossHome, propertyNames);
+        final Path serverBaseDir = resolvePath(jbossHome, "standalone");
+        setSystemProperty(propertyUpdater, "jboss.server.base.dir", serverBaseDir, propertyNames);
+        setSystemProperty(propertyUpdater, "jboss.controller.temp.dir", resolvePath(serverBaseDir, "tmp"), propertyNames);
+        final Path dataDir = resolvePath(serverBaseDir, "data");
+        setSystemProperty(propertyUpdater, "jboss.server.data.dir", dataDir, propertyNames);
+        setSystemProperty(propertyUpdater, "jboss.server.config.dir", resolvePath(serverBaseDir, "configuration"), propertyNames);
+        setSystemProperty(propertyUpdater, "jboss.server.deploy.dir", resolvePath(dataDir, "content"), propertyNames);
+        setSystemProperty(propertyUpdater, "jboss.server.log.dir", resolvePath(serverBaseDir, "log"), propertyNames);
+        setSystemProperty(propertyUpdater, "jboss.server.temp.dir", resolvePath(serverBaseDir, "tmp"), propertyNames);
+        return propertyNames;
+    }
+
+    private static Path resolvePath(final Path base, final String path1, final String... paths) {
+        Path result = base.resolve(path1);
+        for (String path : paths) {
+            result = result.resolve(path);
+        }
+        return result.toAbsolutePath().normalize();
+    }
+
+    private static void setSystemProperty(final PropertyUpdater propertyUpdater, final String key, final Path path, final Collection<String> names) {
+        names.add(key);
+        final String previousValue = propertyUpdater.setProperty(key, path.toString());
+        if (previousValue == null) {
+            logDebug("Setting system property %s to %s", key, path);
+        } else {
+            logDebug("Replacing system property %s with a value of %s. The previous value was %s.", key, path, previousValue);
+        }
+    }
+
+    @SuppressWarnings("UseOfSystemOutOrSystemErr")
+    static void logDebug(final String format, final Object... args) {
+        if (DEBUG.get()) {
+            System.out.printf("[DEBUG] " + format, args);
+        }
+    }
+}

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
@@ -320,7 +320,7 @@ public final class BootableJar implements ShutdownHandler {
                         break;
                     }
                 } catch (Exception ex) {
-                    log.unexpectedExceptionWhileShuttingDown(ex);
+                    throw log.unexpectedExceptionWhileShuttingDown(ex);
                 }
             }
         } finally {

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
@@ -23,14 +23,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -55,12 +56,9 @@ import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.PropertyConfigurator;
 import org.jboss.modules.ModuleClassLoader;
 import org.jboss.modules.ModuleLoader;
-import static org.wildfly.core.jar.runtime.Constants.JBOSS_SERVER_CONFIG_DIR;
-import static org.wildfly.core.jar.runtime.Constants.JBOSS_SERVER_LOG_DIR;
 import static org.wildfly.core.jar.runtime.Constants.LOG_BOOT_FILE_PROP;
 import static org.wildfly.core.jar.runtime.Constants.LOG_MANAGER_CLASS;
 import static org.wildfly.core.jar.runtime.Constants.LOG_MANAGER_PROP;
-import static org.wildfly.core.jar.runtime.Constants.STANDALONE;
 import static org.wildfly.core.jar.runtime.Constants.STANDALONE_CONFIG;
 import org.wildfly.core.jar.runtime._private.BootableJarLogger;
 
@@ -68,10 +66,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import static org.wildfly.core.jar.runtime.Constants.CONFIGURATION;
-import static org.wildfly.core.jar.runtime.Constants.DATA;
 import static org.wildfly.core.jar.runtime.Constants.DEPLOYMENTS;
-import static org.wildfly.core.jar.runtime.Constants.LOG;
 import static org.wildfly.core.jar.runtime.Constants.LOGGING_PROPERTIES;
 import static org.wildfly.core.jar.runtime.Constants.SERVER_LOG;
 import static org.wildfly.core.jar.runtime.Constants.SERVER_STATE;
@@ -99,14 +94,14 @@ public final class BootableJar implements ShutdownHandler {
 
     private BootableJarLogger log;
 
-    private final Path jbossHome;
+    private final BootableEnvironment environment;
     private final List<String> startServerArgs = new ArrayList<>();
     private Server server;
     private final Arguments arguments;
     private final ModuleLoader loader;
 
-    private BootableJar(Path jbossHome, Arguments arguments, ModuleLoader loader, long unzipTime) throws Exception {
-        this.jbossHome = jbossHome;
+    private BootableJar(BootableEnvironment environment, Arguments arguments, ModuleLoader loader, long unzipTime) throws Exception {
+        this.environment = environment;
         this.arguments = arguments;
         this.loader = loader;
         startServerArgs.addAll(arguments.getServerArguments());
@@ -119,7 +114,7 @@ public final class BootableJar implements ShutdownHandler {
             setupDeployment(arguments.getDeployment());
         }
 
-        log.advertiseInstall(jbossHome, unzipTime + (System.currentTimeMillis() - t));
+        log.advertiseInstall(environment.getJBossHome(), unzipTime + (System.currentTimeMillis() - t));
     }
 
     @Override
@@ -131,13 +126,13 @@ public final class BootableJar implements ShutdownHandler {
     }
 
     private void setupDeployment(Path deployment) throws Exception {
-        Path deploymentDir = jbossHome.resolve(STANDALONE).resolve(DATA).resolve(CONTENT).resolve(DEP_1).resolve(DEP_2);
+        Path deploymentDir = environment.resolveContentDir(DEP_1, DEP_2);
 
         Path target = deploymentDir.resolve(CONTENT);
         Files.createDirectories(deploymentDir);
         // Exploded deployment
         boolean isExploded = Files.isDirectory(deployment);
-        updateConfig(jbossHome.resolve(STANDALONE).resolve(CONFIGURATION).resolve(STANDALONE_CONFIG),
+        updateConfig(environment.resolveConfigurationDir(STANDALONE_CONFIG),
                 deployment.getFileName().toString(), isExploded);
         if (isExploded) {
             copyDirectory(deployment, target);
@@ -203,13 +198,15 @@ public final class BootableJar implements ShutdownHandler {
     }
 
     private void configureLogger() throws IOException {
-        System.setProperty(LOG_MANAGER_PROP, LOG_MANAGER_CLASS);
+        environment.setSystemProperty(LOG_MANAGER_PROP, LOG_MANAGER_CLASS);
         configureLogging();
         log = BootableJarLogger.ROOT_LOGGER;
     }
 
     private void configureLogging() throws IOException {
         if (!arguments.isVersion()) {
+            // Load the boot configuration properties
+            loadBootConfigProperties();
             LogContext ctx = configureLogContext();
             // Use our own LogContextSelector which returns the configured context.
             LogContext.setLogContextSelector(() -> ctx);
@@ -217,21 +214,14 @@ public final class BootableJar implements ShutdownHandler {
     }
 
     private LogContext configureLogContext() throws IOException {
-        final Path baseDir = jbossHome.resolve(STANDALONE);
-        String serverLogDir = System.getProperty(JBOSS_SERVER_LOG_DIR, null);
-        if (serverLogDir == null) {
-            serverLogDir = baseDir.resolve(LOG).toString();
-            System.setProperty(JBOSS_SERVER_LOG_DIR, serverLogDir);
-        }
-        final String serverCfgDir = System.getProperty(JBOSS_SERVER_CONFIG_DIR, baseDir.resolve(CONFIGURATION).toString());
         // Create our own log context instead of using the default system log context. This is useful for cases when the
         // LogManager.readConfiguration() may be invoked it will not override the current configuration.
         final LogContext logContext = LogContext.create();
-        final Path bootLog = Paths.get(serverLogDir).resolve(SERVER_LOG);
-        final Path loggingProperties = Paths.get(serverCfgDir).resolve(Paths.get(LOGGING_PROPERTIES));
+        final Path bootLog = environment.resolveLogDir(SERVER_LOG);
+        final Path loggingProperties = environment.resolveConfigurationDir(LOGGING_PROPERTIES);
         if (Files.exists(loggingProperties)) {
             try (final InputStream in = Files.newInputStream(loggingProperties)) {
-                System.setProperty(LOG_BOOT_FILE_PROP, bootLog.toAbsolutePath().toString());
+                environment.setSystemProperty(LOG_BOOT_FILE_PROP, bootLog.toAbsolutePath().toString());
                 // The LogManager.readConfiguration() uses the LogContext.getSystemLogContext(). Since we create our
                 // own LogContext we need to configure the context and attach the configurator to the root logger. The
                 // logging subsystem will use this configurator to determine what resources may need to be reconfigured.
@@ -256,15 +246,15 @@ public final class BootableJar implements ShutdownHandler {
     }
 
     private void cleanup() {
-        log.deletingHome(jbossHome);
-        deleteDir(jbossHome);
+        log.deletingHome(environment.getJBossHome());
+        deleteDir(environment.getJBossHome());
 
     }
 
     private Server buildServer(List<String> args) throws IOException {
         String[] array = new String[args.size()];
         log.advertiseOptions(args);
-        return Server.newSever(jbossHome, args.toArray(array), loader, this);
+        return Server.newSever(args.toArray(array), loader, this);
     }
 
     private void deleteDir(Path root) {
@@ -334,6 +324,22 @@ public final class BootableJar implements ShutdownHandler {
         }
     }
 
+    private void loadBootConfigProperties() throws IOException {
+        final Path configFile = environment.resolveConfigurationDir( "boot-config.properties");
+        if (Files.exists(configFile)) {
+            try (BufferedReader reader = Files.newBufferedReader(configFile, StandardCharsets.UTF_8)) {
+                final Properties properties = new Properties();
+                properties.load(reader);
+                // Set the system properties if they are not already defined
+                for (String key : properties.stringPropertyNames()) {
+                    // Note this overrides any previously set system property. This is what the system-property resource
+                    // does and this should behave the same.
+                    environment.setSystemProperty(key, properties.getProperty(key));
+                }
+            }
+        }
+    }
+
     /**
      * Modular entry point.
      *
@@ -346,9 +352,11 @@ public final class BootableJar implements ShutdownHandler {
      */
     public static void run(Path jbossHome, List<String> args, ModuleLoader moduleLoader, ModuleClassLoader moduleClassLoader, Long unzipTime) throws Exception {
         setTccl(moduleClassLoader);
+        // Initialize the environment
+        final BootableEnvironment environment = BootableEnvironment.of(jbossHome);
         Arguments arguments;
         try {
-            arguments = Arguments.parseArguments(args);
+            arguments = Arguments.parseArguments(args, environment);
         } catch (Throwable ex) {
             System.err.println(ex);
             CmdUsage.printUsage(System.out);
@@ -360,7 +368,7 @@ public final class BootableJar implements ShutdownHandler {
         }
 
         // Side effect is to initialise Log Manager
-        BootableJar bootableJar = new BootableJar(jbossHome, arguments, moduleLoader, unzipTime);
+        BootableJar bootableJar = new BootableJar(environment, arguments, moduleLoader, unzipTime);
 
         // At this point we can configure JMX
         configureJMX(moduleClassLoader, bootableJar.log);

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Constants.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Constants.java
@@ -22,25 +22,16 @@ package org.wildfly.core.jar.runtime;
  */
 interface Constants {
 
-    static final String JBOSS_SERVER_CONFIG_DIR = "jboss.server.config.dir";
-    static final String JBOSS_SERVER_LOG_DIR = "jboss.server.log.dir";
-
     static final String DEPLOYMENT_ARG = "--deployment";
     static final String INSTALL_DIR_ARG = "--install-dir";
     static final String DISPLAY_GALLEON_CONFIG_ARG = "--display-galleon-config";
 
-    static final String CONFIGURATION = "configuration";
-    static final String DATA = "data";
-    static final String DEPLOYMENT = "deployment";
     static final String DEPLOYMENTS = "deployments";
     static final String STANDALONE_CONFIG = "standalone.xml";
-    static final String STANDALONE = "standalone";
-    static final String LOG = "log";
 
     static final String LOG_MANAGER_PROP = "java.util.logging.manager";
     static final String LOG_MANAGER_CLASS = "org.jboss.logmanager.LogManager";
     static final String LOG_BOOT_FILE_PROP = "org.jboss.boot.log.file";
-    static final String LOG_EMBEDDED_PROP = "org.wildfly.logging.embedded";
     static final String LOGGING_PROPERTIES = "logging.properties";
 
     static final String SERVER_LOG = "server.log";
@@ -48,4 +39,6 @@ interface Constants {
     static final String STOPPED = "stopped";
 
     static final String SHA1 = "sha1";
+
+    String DEBUG_PROPERTY = "org.wildfly.core.jar.debug";
 }

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/PropertyUpdater.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/PropertyUpdater.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.jar.runtime;
+
+/**
+ * A simple interface for setting properties.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@FunctionalInterface
+interface PropertyUpdater {
+
+    /**
+     * Sets the property.
+     *
+     * @param name  the name of the property
+     * @param value the value of the property
+     *
+     * @return the previous value if the property existed or {@code null} if the property did not already exist
+     */
+    String setProperty(String name, String value);
+}

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Server.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Server.java
@@ -19,10 +19,7 @@ package org.wildfly.core.jar.runtime;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import static java.lang.System.getProperties;
-import static java.lang.System.getSecurityManager;
 import static java.lang.System.getenv;
-import static java.lang.System.setProperty;
-import java.nio.file.Path;
 import static java.security.AccessController.doPrivileged;
 import java.security.PrivilegedAction;
 import java.util.Collections;
@@ -97,26 +94,11 @@ final class Server {
         };
     }
 
-    static Server newSever(Path jbossHome, String[] cmdargs, ModuleLoader moduleLoader, ShutdownHandler shutdownHandler) {
-        setPropertyPrivileged(ServerEnvironment.HOME_DIR, jbossHome.toString());
+    static Server newSever(String[] cmdargs, ModuleLoader moduleLoader, ShutdownHandler shutdownHandler) {
         setupVfsModule(moduleLoader);
         Properties sysprops = getSystemPropertiesPrivileged();
         Map<String, String> sysenv = getSystemEnvironmentPrivileged();
         return new Server(cmdargs, sysprops, sysenv, moduleLoader, shutdownHandler);
-    }
-
-    static String setPropertyPrivileged(final String name, final String value) {
-        final SecurityManager sm = getSecurityManager();
-        if (sm == null) {
-            return setProperty(name, value);
-        } else {
-            return doPrivileged(new PrivilegedAction<String>() {
-                @Override
-                public String run() {
-                    return setProperty(name, value);
-                }
-            });
-        }
     }
 
     private static void setupVfsModule(final ModuleLoader moduleLoader) {

--- a/bootable-jar/runtime/src/test/java/org/wildfly/core/jar/runtime/ArgumentsTestCase.java
+++ b/bootable-jar/runtime/src/test/java/org/wildfly/core/jar/runtime/ArgumentsTestCase.java
@@ -16,13 +16,22 @@
  */
 package org.wildfly.core.jar.runtime;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -31,11 +40,12 @@ import org.junit.Test;
  */
 public class ArgumentsTestCase {
 
+
     @Test
     public void test() throws Exception {
         {
             String[] args = {};
-            Arguments arguments = Arguments.parseArguments(Arrays.asList(args));
+            Arguments arguments = Arguments.parseArguments(Arrays.asList(args), createEnvironment());
             assertNull(arguments.getDeployment());
             assertTrue(arguments.getServerArguments().isEmpty());
             assertFalse(arguments.isHelp());
@@ -49,7 +59,7 @@ public class ArgumentsTestCase {
                 String[] args = {"--version", "--help",
                     "--deployment=" + deployment
                 };
-                Arguments arguments = Arguments.parseArguments(Arrays.asList(args));
+                Arguments arguments = Arguments.parseArguments(Arrays.asList(args), createEnvironment());
                 assertEquals(arguments.getDeployment(), deployment);
                 assertEquals(1, arguments.getServerArguments().size());
                 assertTrue(arguments.isHelp());
@@ -64,7 +74,7 @@ public class ArgumentsTestCase {
             boolean error = false;
             try {
                 String[] args = {"--foo"};
-                Arguments arguments = Arguments.parseArguments(Arrays.asList(args));
+                Arguments arguments = Arguments.parseArguments(Arrays.asList(args), createEnvironment());
                 error = true;
             } catch (Exception ex) {
                 // OK expected
@@ -78,7 +88,7 @@ public class ArgumentsTestCase {
             boolean error = false;
             try {
                 String[] args = {"--deployment=foo"};
-                Arguments arguments = Arguments.parseArguments(Arrays.asList(args));
+                Arguments arguments = Arguments.parseArguments(Arrays.asList(args), createEnvironment());
                 error = true;
             } catch (Exception ex) {
                 // OK expected
@@ -86,6 +96,59 @@ public class ArgumentsTestCase {
             if (error) {
                 throw new Exception("Should have failed");
             }
+        }
+    }
+
+    @Test
+    public void testSystemProperties() throws Exception {
+        final List<String> args = Collections.singletonList("-Dtest.name=value");
+        final TestPropertyUpdater propertyUpdater = new TestPropertyUpdater();
+        Arguments.parseArguments(args, createEnvironment(propertyUpdater));
+        Assert.assertTrue("Expected property test.name to exist: " + propertyUpdater, propertyUpdater.properties.containsKey("test.name"));
+        Assert.assertEquals("Expected the value \"value\" for property test.name: " + propertyUpdater,
+                "value", propertyUpdater.properties.get("test.name"));
+    }
+
+    @Test
+    public void testPropertiesWithSpace() throws Exception {
+        final URL resource = getClass().getResource("/test-system.properties");
+        Assert.assertNotNull("Could not locate test-system.properties", resource);
+        final List<String> args = Arrays.asList("--properties", resource.toString());
+        final TestPropertyUpdater propertyUpdater = new TestPropertyUpdater();
+        Arguments.parseArguments(args, createEnvironment(propertyUpdater));
+        Assert.assertTrue("Expected property org.wildfly.core.jar.test to exist: " + propertyUpdater, propertyUpdater.properties.containsKey("org.wildfly.core.jar.test"));
+    }
+
+    @Test
+    public void testPropertiesWithEquals() throws Exception {
+        final URL resource = getClass().getResource("/test-system.properties");
+        Assert.assertNotNull("Could not locate test-system.properties", resource);
+        final List<String> args = Collections.singletonList("--properties=" + resource.toString());
+        final TestPropertyUpdater propertyUpdater = new TestPropertyUpdater();
+        Arguments.parseArguments(args, createEnvironment(propertyUpdater));
+        Assert.assertTrue("Expected property org.wildfly.core.jar.test to exist: " + propertyUpdater, propertyUpdater.properties.containsKey("org.wildfly.core.jar.test"));
+    }
+
+    private static BootableEnvironment createEnvironment() {
+        return createEnvironment(new TestPropertyUpdater());
+    }
+
+    private static BootableEnvironment createEnvironment(final PropertyUpdater propertyUpdater) {
+        final Path fakeHome = Paths.get(System.getProperty("test.jboss.home"));
+        return BootableEnvironment.of(fakeHome, propertyUpdater);
+    }
+
+    private static class TestPropertyUpdater implements PropertyUpdater {
+        final Map<String, String> properties = new HashMap<>();
+
+        @Override
+        public String setProperty(final String name, final String value) {
+            return properties.put(name, value);
+        }
+
+        @Override
+        public String toString() {
+            return properties.toString();
         }
     }
 

--- a/bootable-jar/runtime/src/test/resources/test-system.properties
+++ b/bootable-jar/runtime/src/test/resources/test-system.properties
@@ -1,0 +1,20 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2020 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.wildfly.core.jar.test=Test value


### PR DESCRIPTION
# The following issues are fixed in this PR:

- https://issues.redhat.com/browse/WFCORE-5115
- https://issues.redhat.com/browse/WFCORE-5109

## [WFCORE-5115](https://issues.redhat.com/browse/WFCORE-5115) 
Use a hard-coded boot-config.properties to load system properties in the bootable JAR entry point. This properties file is generated by the wildfly-jar-maven-plugin. It's used at boot to configure properties required by the log manager during initialization.

## [WFCORE-4895](https://issues.redhat.com/browse/WFCORE-4895)
Minor follow up to the bootable JAR module. Actually throw the exception when a shutdown failure occurs.
    


## [WFCORE-5109](https://issues.redhat.com/browse/WFCORE-5109)
Ensure the configurator is attached to the root logger. This means the logging subsystem will not reconfigure resources that do not need to be reconfigured.
