### PR TITLE
[WFCORE-5118] Cannot get resources from ContextClassLoader with Server Lifecycle Events

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management/main/module.xml
@@ -43,5 +43,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.wildfly.extension.core-management-client"/>
+        <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/testsuite/shared/src/main/java/org/wildfly/test/events/provider/TestListener.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/events/provider/TestListener.java
@@ -57,8 +57,21 @@ public class TestListener implements ProcessStateListener {
     private FileWriter fileRunningWriter;
     private ProcessStateListenerInitParameters parameters;
 
+    private static void checkTccl() {
+        // search for this same class as a resource, finding it means the TCCL is assigned to our module
+        String classFile = TestListener.class.getName().replaceAll("\\.", "/") + ".class";
+        if (Thread.currentThread().getContextClassLoader().getResource(classFile) == null) {
+            throw new ListenerFailureException("Incorrect TCCL assigned to the listener: " + Thread.currentThread().getContextClassLoader());
+        }
+    }
+
+    public TestListener() {
+        checkTccl();
+    }
+
     @Override
     public void init(ProcessStateListenerInitParameters parameters) {
+        checkTccl();
         this.parameters = parameters;
         Path dataDir = Paths.get(parameters.getInitProperties().get("file"));
 
@@ -85,6 +98,7 @@ public class TestListener implements ProcessStateListener {
 
     @Override
     public void cleanup() {
+        checkTccl();
         try {
             fileRuntimeWriter.close();
         } catch (IOException e) {
@@ -103,6 +117,7 @@ public class TestListener implements ProcessStateListener {
 
     @Override
     public void runtimeConfigurationStateChanged(RuntimeConfigurationStateChangeEvent evt) {
+        checkTccl();
         if (parameters.getInitProperties().containsKey(FAIL_RUNTIME_CONFIGURATION_STATE_CHANGED)) {
             throw new ListenerFailureException(FAIL_RUNTIME_CONFIGURATION_STATE_CHANGED);
         }
@@ -124,6 +139,7 @@ public class TestListener implements ProcessStateListener {
 
     @Override
     public void runningStateChanged(RunningStateChangeEvent evt) {
+        checkTccl();
         if (parameters.getInitProperties().containsKey(FAIL_RUNNING_STATE_CHANGED)) {
             throw new ListenerFailureException(FAIL_RUNNING_STATE_CHANGED);
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5118

I have added just a try/finally to add the TCCL to the one in the module specified. I have used the `WildFlySecurityManager` class to do that which needs to add that dependency in the `module.xml`. If you prefer to add a helper class or something different just let me know (I think that it's better to not repeat the code).
