### PR TITLE
Fix for WFCORE-5119, Bootable JAR - Remove dependency on elytron-private

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
@@ -72,7 +72,6 @@
         <module name="org.jboss.threads"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.as.process-controller"/>
-        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5119

Remove useless dependency on elytron-private.

@darranl FYI.