### PR TITLE
[WFCORE-5121] Add ability to ignore excluded extensions to FetchMissi…

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/FetchMissingConfigurationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/FetchMissingConfigurationHandler.java
@@ -50,10 +50,12 @@ public class FetchMissingConfigurationHandler implements OperationStepHandler {
 
     private final Transformers transformers;
     private final ExtensionRegistry extensionRegistry;
+    private final Set<String> excludedExtensions;
 
-    public FetchMissingConfigurationHandler(final String hostName, final Transformers transformers, final ExtensionRegistry extensionRegistry) {
+    public FetchMissingConfigurationHandler(final String hostName, final Set<String> excludedExtensions, final Transformers transformers, final ExtensionRegistry extensionRegistry) {
         this.transformers = transformers;
         this.extensionRegistry = extensionRegistry;
+        this.excludedExtensions = excludedExtensions;
     }
 
     @Override
@@ -66,7 +68,7 @@ public class FetchMissingConfigurationHandler implements OperationStepHandler {
         for (final ServerConfigInfo serverConfig : serverConfigs) {
             ReadMasterDomainModelUtil.processServerConfig(context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS), rc, serverConfig, extensionRegistry);
         }
-        final Transformers.ResourceIgnoredTransformationRegistry manualExcludes = HostInfo.createIgnoredRegistry(operation);
+        final Transformers.ResourceIgnoredTransformationRegistry manualExcludes = HostInfo.createIgnoredRegistry(operation, excludedExtensions);
         final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry = ReadMasterDomainModelUtil.createServerIgnoredRegistry(rc, manualExcludes);
 
         final ReadDomainModelHandler handler = new ReadDomainModelHandler(ignoredTransformationRegistry, transformers, true);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -348,7 +348,7 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
                         ModelVersion.create(major, minor, micro), Collections.<PathAddress, ModelVersion>emptyMap(), hostInfo);
                 final Transformers transformers = Transformers.Factory.create(target);
                 try {
-                    SlaveChannelAttachments.attachSlaveInfo(handler.getChannel(), registrationContext.hostName, transformers);
+                    SlaveChannelAttachments.attachSlaveInfo(handler.getChannel(), registrationContext.hostName, transformers, hostInfo.getDomainIgnoredExtensions());
                 } catch (IOException e) {
                     throw new OperationFailedException(e.getLocalizedMessage());
                 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostInfo.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostInfo.java
@@ -280,6 +280,10 @@ public class HostInfo implements Transformers.ResourceIgnoredTransformationRegis
         return requiredConfigurationHolder;
     }
 
+    public Set<String> getDomainIgnoredExtensions() {
+        return domainIgnoredExtensions;
+    }
+
     private static class IgnoredType {
         private final boolean wildcard;
         private final Set<String> names;
@@ -321,7 +325,7 @@ public class HostInfo implements Transformers.ResourceIgnoredTransformationRegis
         return createIgnoredRegistry(modelNode, null);
     }
 
-    private static Transformers.ResourceIgnoredTransformationRegistry createIgnoredRegistry(final ModelNode modelNode,
+    public static Transformers.ResourceIgnoredTransformationRegistry createIgnoredRegistry(final ModelNode modelNode,
                                                                                             Set<String> domainIgnoredExtensions) {
         final Map<String, IgnoredType> ignoredResources = processIgnoredResource(modelNode, domainIgnoredExtensions);
         return new Transformers.ResourceIgnoredTransformationRegistry() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
@@ -137,6 +137,7 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
             final String operationName = operation.getOperation().require(OP).asString();
             if (operationName.equals(FetchMissingConfigurationHandler.OPERATION_NAME)) {
                 handler = new FetchMissingConfigurationHandler(SlaveChannelAttachments.getHostName(context.getChannel()),
+                        SlaveChannelAttachments.getDomainIgnoredExtensions(context.getChannel()),
                         SlaveChannelAttachments.getTransformers(context.getChannel()),
                         domainController.getExtensionRegistry());
             } else {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/SlaveChannelAttachments.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/SlaveChannelAttachments.java
@@ -25,6 +25,8 @@ import org.jboss.as.controller.transform.Transformers;
 import org.jboss.remoting3.Attachments;
 import org.jboss.remoting3.Channel;
 
+import java.util.Set;
+
 /**
  * Manages attachments on the domain controller for each slave host controller channel.
  *
@@ -34,8 +36,8 @@ class SlaveChannelAttachments {
 
     private static final Attachments.Key<HostChannelInfo> HOST_CHANNEL_INFO = new Attachments.Key<HostChannelInfo>(HostChannelInfo.class);
 
-    static void attachSlaveInfo(Channel channel, String hostName, Transformers transformers) {
-        channel.getAttachments().attach(HOST_CHANNEL_INFO, new HostChannelInfo(hostName, transformers));
+    static void attachSlaveInfo(Channel channel, String hostName, Transformers transformers, Set<String> domainIgnoredExtensions) {
+        channel.getAttachments().attach(HOST_CHANNEL_INFO, new HostChannelInfo(hostName, transformers, domainIgnoredExtensions));
     }
 
     static String getHostName(Channel channel) {
@@ -46,13 +48,19 @@ class SlaveChannelAttachments {
         return channel.getAttachments().getAttachment(HOST_CHANNEL_INFO).transformers;
     }
 
+    static Set<String> getDomainIgnoredExtensions(Channel channel) {
+        return channel.getAttachments().getAttachment(HOST_CHANNEL_INFO).domainIgnoredExtensions;
+    }
+
     private static class HostChannelInfo {
         final String hostName;
         final Transformers transformers;
+        final Set<String> domainIgnoredExtensions;
 
-        public HostChannelInfo(String hostName, Transformers transformers) {
+        public HostChannelInfo(String hostName, Transformers transformers, Set<String> domainIgnoredExtensions) {
             this.hostName = hostName;
             this.transformers = transformers;
+            this.domainIgnoredExtensions = domainIgnoredExtensions;
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFCORE-5121

Attempts to solve the issue by passing the domain exclude info used to generate initial sync to handler doing missing config sync. This requires changing visibility of some methods, I'm not sure if there's a better way. 
@jmesnil could you review please?