### PR TITLE
[WFCORE-5091] / [WFCORE-5127] / [WFCORE-5128] Elytron Component Upgrades

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -342,6 +342,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-external</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-form</artifactId>
         </dependency>
         <dependency>

--- a/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
@@ -1381,6 +1381,17 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-http-external</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-http-form</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -58,6 +58,7 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-http-cert}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-digest}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-external}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-form}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-spnego}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-sso}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1766,6 +1766,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-http-external</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http-form</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.13.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.8.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.13.0.CR4</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.7.1.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
@@ -949,7 +949,7 @@ public class CliCompletionTestCase {
                 ctx.getDefaultCommandCompleter().complete(ctx,
                         cmd, cmd.length(), candidates);
                 List<String> res = Arrays.asList("BASIC", "CLIENT_CERT",
-                        "DIGEST", "DIGEST-SHA-256", "FORM");
+                        "DIGEST", "DIGEST-SHA-256", "EXTERNAL", "FORM");
                 assertEquals(candidates.toString(), res, candidates);
                 candidates = complete(ctx, cmd, null);
                 assertEquals(candidates.toString(), res, candidates);


### PR DESCRIPTION
Note that this PR depends on the upcoming Undertow component upgrade PR.

https://issues.redhat.com/browse/WFCORE-5091 
https://issues.redhat.com/browse/WFCORE-5127
https://issues.redhat.com/browse/WFCORE-5128


        Release Notes - WildFly Elytron - Version 1.13.0.Final
                                                                                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1921'>ELY-1921</a>] -         HTTP External Security Not Supported by Elytron
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1851'>ELY-1851</a>] -         Elytron ldaps realm fails if a referral is returned inside a search
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-1995'>ELY-1995</a>] -         AggregateRealm is failing in authentication with token-realm
</li>
</ul>

<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2021'>ELY-2021</a>] -         Release WildFly Elytron 1.13.0.Final
</li>
</ul>

        Release Notes - Elytron Web - Version 1.8.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-92'>ELYWEB-92</a>] -         Upgrade WildFly Common to 1.5.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-93'>ELYWEB-93</a>] -         Upgrade WildFly Elytron to 1.11.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-100'>ELYWEB-100</a>] -         Upgrade Undertow to 2.0.30.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-101'>ELYWEB-101</a>] -         Upgrade HttpComponents:HttpClient to 4.5.12
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-102'>ELYWEB-102</a>] -         Upgrade WildFly Elytron 1.11.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-108'>ELYWEB-108</a>] -         Upgrade Infinispan Core to 9.3.9.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-113'>ELYWEB-113</a>] -         Upgrade WildFly Elytron to 1.13.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-115'>ELYWEB-115</a>] -         Upgrade Undertow to 2.1.4.Final
</li>
</ul>
                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-99'>ELYWEB-99</a>] -         HTTP External Security Not Supported by Elytron
</li>
</ul>
                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-114'>ELYWEB-114</a>] -         Release Elytron Web 1.8.0.Final
</li>
</ul>
                                        
