### PR TITLE
[WFCORE-5123] / [WFCORE-5124] / [WFCORE-5125] WildFly OpenSSL Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,11 +218,11 @@
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.1.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-i386>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
-        <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
-        <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.13.0.CR4</version.org.wildfly.security.elytron>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.1.0.Final</version.org.wildfly.openssl>
-        <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
+        <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>1.1.2.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.1.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5123
https://issues.redhat.com/browse/WFCORE-5124
https://issues.redhat.com/browse/WFCORE-5125


        Release Notes - WildFly OpenSSL - Version 2.1.0.Final
                                                                                                                                                        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-36'>WFSSL-36</a>] -         Add jdk.min.version property and set it to JDK 11
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-47'>WFSSL-47</a>] -         Release WildFly OpenSSL 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-48'>WFSSL-48</a>] -         Update WildFly OpenSSL Natives to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-49'>WFSSL-49</a>] -         Update the pom.xml files to add version properties for the various binaries
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-50'>WFSSL-50</a>] -         Upgrade WildFly OpenSSL Linux i386, MacOS x86_64, and Solaris natives to 2.1.0.SP01 
</li>
</ul>
                    
<h2>        Improvement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-16'>WFSSL-16</a>] -         Add support for TLSv1.3
</li>
</ul>


        Release Notes - WildFly OpenSSL Natives - Version 2.1.0.Final
                        
<h2>        Tracker
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-2'>SSLNTV-2</a>] -         Add jdk.min.version property and set it to JDK 11
</li>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-3'>SSLNTV-3</a>] -         Add support for TLSv1.3
</li>
</ul>
                                                                                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-4'>SSLNTV-4</a>] -         Release WildFly OpenSSL Natives 2.1.0.Final
</li>
</ul>


        Release Notes - WildFly OpenSSL Natives - Version 2.1.0.SP01
                                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-5'>SSLNTV-5</a>] -         Ensure that protoVersion is initialized in ssl.c
</li>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-6'>SSLNTV-6</a>] -         Allow JDK 8 to be used for linux-i386, linux-rhel6-i386, solaris-sparcv9, and solaris-x86_64
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-7'>SSLNTV-7</a>] -         Release WildFly OpenSSL Natives 2.1.0.SP01
</li>
</ul>                                                                            
