### PR TITLE
[WFCORE-5102] Upgrade Undertow to 2.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.1.3.Final</version.io.undertow>
+        <version.io.undertow>2.2.0.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/projects/WFCORE/issues/WFCORE-5102


        Release Notes - Undertow - Version 2.1.4.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1755'>UNDERTOW-1755</a>] -         Doubled definition of :path and other HttpStrings
</li>
</ul>
                                                                                                                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1662'>UNDERTOW-1662</a>] -         [GSS][7.2.2] HTTP External Security Not Supported by Elytron
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1762'>UNDERTOW-1762</a>] -         Error page for custom exception-type is not is not displayed in jsp development mode
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1774'>UNDERTOW-1774</a>] -         Header field-name is not parsed in accordance to RFC7230 CVE-2020-1710
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1759'>UNDERTOW-1759</a>] -         Move CI to GH Actions
</li>
</ul>
                                                
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1711'>UNDERTOW-1711</a>] -         HttpContinueAcceptingHandlerTestCase fails with proxy http2 upgrade
</li>
</ul>
        


        Release Notes - Undertow - Version 2.2.0.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1676'>UNDERTOW-1676</a>] -         All cookies do not get passed across
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1712'>UNDERTOW-1712</a>] -         HttpContinueReadHandler can use a single ResponseCommitListener instance
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1753'>UNDERTOW-1753</a>] -         Improve logging for Predicates
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1770'>UNDERTOW-1770</a>] -         HttpString uses obsolete String Constructor
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1783'>UNDERTOW-1783</a>] -         Add support to multipart handling of specific charsets
</li>
</ul>
                                                                                                                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1622'>UNDERTOW-1622</a>] -         Option to enable read and write timeouts only for undertow blocking operations
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1747'>UNDERTOW-1747</a>] -         Provide a mechanism for a predicate in return a servlet error page
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1664'>UNDERTOW-1664</a>] -         http/2 canceled requests cause UT005085: Connection was not closed cleanly, forcibly closing connection
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1746'>UNDERTOW-1746</a>] -         Max and Min content size predicates are implemented backwards
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1763'>UNDERTOW-1763</a>] -         DefaultAccessLogReceiver may throw &quot;IOException: Stream closed&quot; or NullPointerException due to a concurrency issue
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1766'>UNDERTOW-1766</a>] -         Renegotiation broken on JDK14
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1772'>UNDERTOW-1772</a>] -         Delay listener initialization so that it happens after execution of servlet container initializers
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1773'>UNDERTOW-1773</a>] -         SessionListeners skips notification if a listener throws an exception
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1779'>UNDERTOW-1779</a>] -         Make some fields of Http2Channel final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1780'>UNDERTOW-1780</a>] -         CVE-2020-10687Incomplete fix for CVE-2017-2666 due to permitting invalid characters in HTTP requests
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1782'>UNDERTOW-1782</a>] -         UndertowXnioSsl handleEvent throws IllegalArgumentException &quot;Contains non-LDH ASCII&quot;  
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1732'>UNDERTOW-1732</a>] -         NPE calling isUserInRole if no SecurityContext established.
</li>
</ul>
                                                
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1724'>UNDERTOW-1724</a>] -         SameSiteCookieHandlerTestCase fails on CI
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1764'>UNDERTOW-1764</a>] -         Test suite calls Netty handshake method outside IO thread
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1765'>UNDERTOW-1765</a>] -         SPNEGO tests fail on windows JDK11
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1767'>UNDERTOW-1767</a>] -         TestResourceLoader hack causes intermittent failures
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1784'>UNDERTOW-1784</a>] -         Make Jakarta EE9 Jars Available
</li>
</ul>
        
