### PR TITLE
Fix for WFCORE-5137, Bootable JAR - Security manager is not found

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
@@ -72,6 +72,7 @@
         <module name="org.jboss.threads"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.as.process-controller"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5137

Revert of https://issues.redhat.com/browse/WFCORE-5119