### PR TITLE
[WFCORE-5138] Upgrade JBoss Remoting to 5.0.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.9.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.10.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.12.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.18.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.19.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.4.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5138


        Release Notes - JBoss Remoting (3+) - Version 5.0.19.Final
                                                                                                                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-370'>REM3-370</a>] -         ClientConnectionOpenListener can throw BufferOverflowException when sending sasl response
</li>
</ul>
                                                                