### PR TITLE
Fix for WFCORE-5139, Upgrade Bootable JAR Maven plugin to 2.0.0.Beta8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.org.wildfly.galleon-plugins>4.2.8.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
-        <version.org.wildfly.jar.plugin>2.0.0.Beta4</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>2.0.0.Beta8</version.org.wildfly.jar.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.2.0.Final</version.org.wildfly.plugins>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -365,7 +365,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -484,7 +484,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -425,6 +425,17 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.wildfly.plugins</groupId>
+                            <artifactId>wildfly-jar-maven-plugin</artifactId>
+                            <version>${version.org.wildfly.jar.plugin}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
             <modules>
                 <module>rbac</module>
                 <module>manualmode</module>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -479,7 +479,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -325,7 +325,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5139

Changes since last upgrade: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/2.0.0.Beta4...2.0.0.Beta8

In addition to the upgrade, the plugin version has been removed from parent pom.xml and moved in ts.bootable profile defined in testsuite/pom.xml.

