### PR TITLE
[WFCORE-5143]: Bouncycastle - Failing tests in RESTEasy TS.

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
@@ -28,4 +28,8 @@
     <resources>
         <artifact name="${org.bouncycastle:bcpkix-jdk15on}"/>
     </resources>
+    
+    <dependencies>
+        <module name="org.bouncycastle.bcprov" services="import"/>
+    </dependencies>
 </module>


### PR DESCRIPTION
* Adding missing dependency in bcpkix module.

Jira: https://issues.redhat.com/browse/WFCORE-5143
      https://issues.redhat.com/browse/WFLY-13903