### PR TITLE
[WFCORE-5148] Upgrade Bouncy Castle to 1.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.4.0</version.org.apache.sshd>
         <version.org.apache.xerces>2.12.0.SP03</version.org.apache.xerces>
-        <version.org.bouncycastle>1.65</version.org.bouncycastle>
+        <version.org.bouncycastle>1.66</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>6.0.3</version.org.codehaus.woodstox.woodstox-core>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5148

Release notes: https://www.bouncycastle.org/releasenotes.html