### PR TITLE
[WFCORE-5147] Adjusting git integration logging and stability of RemoteSshGitRepositoryTestCase

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
-import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -52,7 +51,6 @@ import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
-import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.common.cpu.ProcessorInfo;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -528,9 +526,8 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             if (gitConfiguration != null ) {
                 try {
                     repository = new GitRepository(gitConfiguration);
-                } catch(IllegalArgumentException | IOException | ConfigXMLParseException | GeneralSecurityException ex) {
-                    repository = null;
-                    ServerLogger.ROOT_LOGGER.errorUsingGit(ex, ex.getMessage());
+                } catch(Exception ex) {
+                    throw ServerLogger.ROOT_LOGGER.unableToInitialiseGitRepository(ex);
                 }
             } else {
                 repository = null;

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -527,6 +527,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                 try {
                     repository = new GitRepository(gitConfiguration);
                 } catch(Exception ex) {
+                    ServerLogger.ROOT_LOGGER.errorUsingGit(ex, ex.getMessage());
                     throw ServerLogger.ROOT_LOGGER.unableToInitialiseGitRepository(ex);
                 }
             } else {

--- a/server/src/main/java/org/jboss/as/server/controller/git/ElytronClientCredentialsProvider.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/ElytronClientCredentialsProvider.java
@@ -39,12 +39,12 @@ import org.wildfly.security.auth.client.ElytronXmlParser;
  * Currently only login/password is supported.
  * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
  */
-public class ElytronClientCredentialsProvider extends CredentialsProvider {
+class ElytronClientCredentialsProvider extends CredentialsProvider {
 
     private static AuthenticationContextConfigurationClient CLIENT = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
     private final AuthenticationContext context;
 
-    public ElytronClientCredentialsProvider(URI authenticationConfig) throws ConfigXMLParseException, GeneralSecurityException {
+    ElytronClientCredentialsProvider(URI authenticationConfig) throws ConfigXMLParseException, GeneralSecurityException {
         context =  ElytronXmlParser.parseAuthenticationClientConfiguration(authenticationConfig).create();
     }
 

--- a/server/src/main/java/org/jboss/as/server/controller/git/ElytronClientSshdSessionFactory.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/ElytronClientSshdSessionFactory.java
@@ -66,7 +66,7 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  *
  * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
  */
-public class ElytronClientSshdSessionFactory extends SshdSessionFactory {
+class ElytronClientSshdSessionFactory extends SshdSessionFactory {
 
     private static AuthenticationContextConfigurationClient CLIENT = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
     private final AuthenticationContext context;
@@ -77,7 +77,7 @@ public class ElytronClientSshdSessionFactory extends SshdSessionFactory {
     private URI uri;
     private String knownHostsFile;
 
-    public ElytronClientSshdSessionFactory(URI authenticationConfig) throws ConfigXMLParseException, GeneralSecurityException {
+    ElytronClientSshdSessionFactory(URI authenticationConfig) throws ConfigXMLParseException, GeneralSecurityException {
         if (authenticationConfig != null) {
             context = ElytronXmlParser.parseAuthenticationClientConfiguration(authenticationConfig).create();
         } else {

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
@@ -198,7 +198,7 @@ public class GitRepository implements Closeable {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     try {
-                        ServerLogger.ROOT_LOGGER.deletingFile(file);
+                        ServerLogger.ROOT_LOGGER.debugf("Deleting file %s", file);
                         Files.delete(file);
                     } catch (IOException ioex) {
                         ServerLogger.ROOT_LOGGER.debug(ioex.getMessage(), ioex);
@@ -220,7 +220,7 @@ public class GitRepository implements Closeable {
                         throw exc;
                     }
                     try {
-                        ServerLogger.ROOT_LOGGER.deletingFile(dir);
+                        ServerLogger.ROOT_LOGGER.debugf("Deleting file %s", dir);
                         Files.delete(dir);
                     } catch (IOException ioex) {
                         ServerLogger.ROOT_LOGGER.debug(ioex.getMessage(), ioex);

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
@@ -155,6 +155,20 @@ public class GitRepository implements Closeable {
         ServerLogger.ROOT_LOGGER.usingGit();
     }
 
+    public GitRepository(Repository repository) {
+        this.repository = repository;
+        this.ignored = Collections.emptySet();
+        this.defaultRemoteRepository = DEFAULT_REMOTE_NAME;
+        this.branch = MASTER;
+        if (repository.isBare()) {
+            this.basePath = repository.getDirectory().toPath();
+        } else {
+            this.basePath = repository.getDirectory().toPath().getParent();
+        }
+        ServerLogger.ROOT_LOGGER.usingGit();
+        sshdSessionFactory = null;
+    }
+
     private void checkoutToSelectedBranch(final Git git) throws IOException, GitAPIException {
         boolean createBranch = !ObjectId.isId(branch);
         if (createBranch) {
@@ -168,20 +182,6 @@ public class GitRepository implements Closeable {
         if (checkout.getResult().getStatus() == CheckoutResult.Status.ERROR) {
             throw ServerLogger.ROOT_LOGGER.failedToPullRepository(null, defaultRemoteRepository);
         }
-    }
-
-    public GitRepository(Repository repository) {
-        this.repository = repository;
-        this.ignored = Collections.emptySet();
-        this.defaultRemoteRepository = DEFAULT_REMOTE_NAME;
-        this.branch = MASTER;
-        if (repository.isBare()) {
-            this.basePath = repository.getDirectory().toPath();
-        } else {
-            this.basePath = repository.getDirectory().toPath().getParent();
-        }
-        ServerLogger.ROOT_LOGGER.usingGit();
-        sshdSessionFactory = null;
     }
 
     private void clearExistingFiles(Path root, String gitRepository) {

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1353,6 +1353,9 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 279, value = "Git initialized in %s")
     void gitRespositoryInitialized(String name);
 
+    @Message(id = 280, value = "Unable to initialise the git repository.")
+    IllegalArgumentException unableToInitialiseGitRepository(@Cause Throwable cause);
+
     ////////////////////////////////////////////////
     //Messages without IDs
 

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1345,6 +1345,14 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 277, value = "Failed to load SSH Credentials %s")
     RuntimeException failedToLoadSSHCredentials(@Cause Throwable cause, String message);
 
+    @LogMessage(level = INFO)
+    @Message(id = 278, value = "The configuration history is managed through Git")
+    void usingGit();
+
+    @LogMessage(level = INFO)
+    @Message(id = 279, value = "Git initialized in %s")
+    void gitRespositoryInitialized(String name);
+
     ////////////////////////////////////////////////
     //Messages without IDs
 
@@ -1354,23 +1362,10 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = Message.NONE, value = "The attribute '%s' has changed from '%s' to '%s'")
     String jmxAttributeChange(String name, String oldState, String stateString);
 
-    @LogMessage(level = INFO)
-    @Message(id = Message.NONE, value = "The configuration history is managed through Git")
-    void usingGit();
-
     @Message(id = Message.NONE, value = "Repository initialized")
     String repositoryInitialized();
 
     @Message(id = Message.NONE, value = "Adding .gitignore")
     String addingIgnored();
-
-    @LogMessage(level = INFO)
-    @Message(id = Message.NONE, value = "Git initialized in %s")
-    void gitRespositoryInitialized(String name);
-
-    @LogMessage(level = DEBUG)
-    @Message(id = Message.NONE, value = "Deleting file %s")
-    void deletingFile(Path name);
-
 
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
@@ -58,7 +58,7 @@ import org.wildfly.core.testrunner.UnsuccessfulOperationException;
  */
 public class AbstractGitRepositoryTestCase {
 
-    private final Path jbossServerBaseDir = new File(System.getProperty("jboss.home", System.getenv("JBOSS_HOME"))).toPath().resolve("standalone");
+    private static final Path JBOSS_SERVER_BASE_DIR = new File(System.getProperty("jboss.home", System.getenv("JBOSS_HOME"))).toPath().resolve("standalone");
     private static final String TEST_DEPLOYMENT_RUNTIME_NAME = "test.jar";
     private static final ModelNode TEST_SYSTEM_PROPERTY_ADDRESS = new ModelNode().add("system-property", "git-history-property");
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmssSSS");
@@ -262,15 +262,15 @@ public class AbstractGitRepositoryTestCase {
     }
 
     protected Path getDotGitDir() {
-        return jbossServerBaseDir.resolve(".git");
+        return JBOSS_SERVER_BASE_DIR.resolve(".git");
     }
 
     protected Path getDotGitIgnore() {
-        return jbossServerBaseDir.resolve(".gitignore");
+        return JBOSS_SERVER_BASE_DIR.resolve(".gitignore");
     }
 
-    protected Path getJbossServerBaseDir() {
-        return jbossServerBaseDir;
+    protected static Path getJbossServerBaseDir() {
+        return JBOSS_SERVER_BASE_DIR;
     }
 
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteSshGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteSshGitRepositoryTestCase.java
@@ -78,6 +78,7 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 @ServerControl(manual = true)
 public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
 
+    private static Path backupRoot;
     private static Path remoteRoot;
     private static Repository remoteRepository;
     private static SSHServer sshServer;
@@ -133,6 +134,8 @@ public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCas
 
     @BeforeClass
     public static void setUp() throws Exception {
+        backupConfiguration();
+
         Security.insertProviderAt(CREDENTIAL_STORE_PROVIDER, 1);
 
         cleanCredentialStores();
@@ -171,10 +174,19 @@ public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCas
 
     }
 
+    static void backupConfiguration() throws IOException {
+        Path backUpRoot = Files.createTempDirectory("BackUpConfigurationFiles").resolve("configuration");
+        Files.createDirectories(backUpRoot);
+        PathUtil.copyRecursively(getJbossServerBaseDir().resolve("configuration"), backUpRoot, true);
+
+        RemoteSshGitRepositoryTestCase.backupRoot = backUpRoot;
+    }
+
     @AfterClass
     public static void afterClass() throws IOException {
         Security.removeProvider(CREDENTIAL_STORE_PROVIDER.getName());
         FileUtils.delete(CS_PUBKEY.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+        PathUtil.deleteRecursively(backupRoot);
     }
 
     @Before
@@ -244,6 +256,16 @@ public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCas
         closeRepository();
         closeEmptyRemoteRepository();
         closeRemoteRepository();
+
+        restoreConfiguration();
+    }
+
+    void restoreConfiguration() throws IOException {
+        Path configuration = getJbossServerBaseDir().resolve("configuration");
+        PathUtil.deleteRecursively(configuration);
+        Files.createDirectories(configuration);
+
+        PathUtil.copyRecursively(backupRoot,  getJbossServerBaseDir().resolve("configuration"), true);
     }
 
     @Test
@@ -428,11 +450,6 @@ public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCas
 
     @Test
     public void startGitRepoRemoteSSHFailedAuthTest() throws Exception {
-        Path backUpRoot = Files.createTempDirectory("BackUpConfigurationFiles").resolve("remote");
-        Path backUpConfigDir = backUpRoot.resolve("configuration");
-        Files.createDirectories(backUpConfigDir);
-        PathUtil.copyRecursively(getJbossServerBaseDir().resolve("configuration"), backUpConfigDir, true);
-
         //add user to server
         sshServer.setTestUser(EC_USER);
         sshServer.setTestUserPublicKey(Paths.get(SSH_DIR +'/' + RSA_PUBKEY)); //incorrect public key
@@ -448,24 +465,10 @@ public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCas
         } catch (RuntimeException ex) {
             //
         }
-
-        //reset for next test
-        PathUtil.copyRecursively(backUpConfigDir, getJbossServerBaseDir().resolve("configuration"), true);
-        Path properties = getJbossServerBaseDir().resolve("configuration").resolve("logging.properties");
-        if(Files.exists(properties)) {
-            Files.delete(properties);
-        }
-        PathUtil.deleteRecursively(backUpRoot);
-
     }
 
     @Test
     public void startGitRepoRemoteUnknownHostTest() throws Exception {
-        Path backUpRoot = Files.createTempDirectory("BackUpConfigurationFiles").resolve("remote");
-        Path backUpConfigDir = backUpRoot.resolve("configuration");
-        Files.createDirectories(backUpConfigDir);
-        PathUtil.copyRecursively(getJbossServerBaseDir().resolve("configuration"), backUpConfigDir, true);
-
         //Create new empty known hosts file
         Path emptyHosts = new File(SSH_DIR, "empty_hosts").toPath();
         Files.write(emptyHosts, Collections.singleton("[localhost]:"));
@@ -487,16 +490,8 @@ public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCas
             assertLogContains(serverLog, "cannot be established", true);
         }
 
-        //reset for next test
-        PathUtil.copyRecursively(backUpConfigDir, getJbossServerBaseDir().resolve("configuration"), true);
-        Path properties = getJbossServerBaseDir().resolve("configuration").resolve("logging.properties");
-        if(Files.exists(properties)) {
-            Files.delete(properties);
-        }
-        PathUtil.deleteRecursively(backUpRoot);
         //Delete empty known_hosts file
         FileUtils.delete(emptyHosts.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
-
     }
 
     private static class SSHServer extends SshTestGitServer {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5147

The RemoteSshGitRepositoryTestCase test case was quite unstable on a resource constrained environment, the test was dependent on monitoring the server.log for an error message but it appears the git integration may log the error in a separate thread so I believe the process can be terminated before the message is logged.

Attempting to debug the issue I realised the test case was not properly restoring the default server configuration between test as attempts to add additional logging categories were being overridden.

Finally we were not logging useful information ourselves, although log and throw can be a bad practice at the moment the uncaught exception only made it's way to System.err - the problem with this was if you are reliant on the server.log the messages would be missing.
