### PR TITLE
[WFCORE-5151] dir-contexts referral-mode attribute upper/lower case discrepancy

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -106,8 +106,8 @@ class DirContextDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition REFERRAL_MODE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REFERRAL_MODE, ModelType.STRING, true)
-            .setDefaultValue(new ModelNode(ReferralMode.IGNORE.name()))
-            .setAllowedValues(ReferralMode.FOLLOW.name(), ReferralMode.IGNORE.name(), ReferralMode.THROW.name())
+            .setDefaultValue(new ModelNode(ReferralMode.IGNORE.toString()))
+            .setAllowedValues(ReferralMode.FOLLOW.toString(), ReferralMode.IGNORE.toString(), ReferralMode.THROW.toString())
             .setValidator(EnumValidator.create(ReferralMode.class, true, true))
             .setAllowExpression(true)
             .setRestartAllServices()


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5151

In [ELY-1637](https://issues.redhat.com/browse/ELY-1637)/[WFCORE-3971](https://issues.redhat.com/browse/WFCORE-3971) the values for the `referral-mode` were changed to be in lower case to match the documentation and XSD. This PR is just to also change the allowed values and the default value (they now keep using `name()` instead `toString()` and are upper case). QA team filed the issue to be consistent. The real value for the attribute is case insensitive since the beginning so I think nothing more is needed (no transformer) and the change is just cosmetic.