### PR TITLE
[WFCORE-5153] Upgrade Undertow to 2.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.0.Final</version.io.undertow>
+        <version.io.undertow>2.2.2.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5153


        Release Notes - Undertow - Version 2.2.1.Final
                                                                                                                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1788'>UNDERTOW-1788</a>] -         %r and %U in access log still output forwarded URL if forwarded URL is then dispatched to error page
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1795'>UNDERTOW-1795</a>] -         Sort both request &amp; response cookies
</li>
</ul>
                    

        Release Notes - Undertow - Version 2.2.2.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1796'>UNDERTOW-1796</a>] -         Change the default value of the io.undertow.protocols.alpn.jdk8 to true
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1800'>UNDERTOW-1800</a>] -         Change the order of the ALPN providers to prefer the JDK provider
</li>
</ul>
                                                                                                                                                                                                                                                                                                                                