### PR TITLE
[WFCORE-5152] Upgrade WildFly Elytron to 1.13.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.13.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.8.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5152

        Release Notes - WildFly Elytron - Version 1.13.1.Final
                                                                                                                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2026'>ELY-2026</a>] -         UnsupportedOperationException in SSLEngine using jdk 251+
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2027'>ELY-2027</a>] -         Release WildFly Elytron 1.13.1.Final
</li>
</ul>
                                        