### PR TITLE
[WFCORE-5013] Remove the WildFly OpenSSL linux-i386, windows-i386, and solaris-x86_64 natives

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -549,11 +549,6 @@
 
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-linux-i386</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-linux-s390x</artifactId>
         </dependency>
 
@@ -564,17 +559,7 @@
 
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-windows-i386</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-windows-x86_64</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
         </dependency>
 
         <dependency>

--- a/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/license/core-feature-pack-common-licenses.xml
@@ -1084,17 +1084,6 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.openssl</groupId>
-      <artifactId>wildfly-openssl-linux-i386</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.openssl</groupId>
       <artifactId>wildfly-openssl-linux-x86_64</artifactId>
       <licenses>
         <license>
@@ -1107,28 +1096,6 @@
     <dependency>
       <groupId>org.wildfly.openssl</groupId>
       <artifactId>wildfly-openssl-linux-s390x</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.openssl</groupId>
-      <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.openssl</groupId>
-      <artifactId>wildfly-openssl-windows-i386</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/core-feature-pack/galleon-common/src/main/resources/packages/org.wildfly.openssl/pm/wildfly/tasks.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/packages/org.wildfly.openssl/pm/wildfly/tasks.xml
@@ -4,26 +4,15 @@
     <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
         <filter pattern="META-INF*" include="false" />
     </copy-artifact>
-    <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-i386" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
-        <filter pattern="META-INF*" include="false" />
-    </copy-artifact>
     <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-s390x" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
         <filter pattern="META-INF*" include="false" />
     </copy-artifact>
     <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-macosx-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true" optional="true">
         <filter pattern="META-INF*" include="false" />
     </copy-artifact>
-    <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-windows-i386" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
-        <filter pattern="*.dll" include="true"/>
-        <filter pattern="META-INF*" include="false" />
-        <filter pattern="*.*" include="false"/>
-    </copy-artifact>
     <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-windows-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
         <filter pattern="*.dll" include="true"/>
         <filter pattern="META-INF*" include="false" />
         <filter pattern="*.*" include="false"/>
-    </copy-artifact>
-    <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-solaris-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
-        <filter pattern="META-INF*" include="false" />
     </copy-artifact>
 </tasks>

--- a/core-feature-pack/legacy-feature-pack/feature-pack-build.xml
+++ b/core-feature-pack/legacy-feature-pack/feature-pack-build.xml
@@ -36,25 +36,15 @@
         <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true" >
             <filter pattern="META-INF*" include="false" />
         </copy-artifact>
-        <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-i386" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
-            <filter pattern="META-INF*" include="false" />
-        </copy-artifact>
         <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-linux-s390x" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
             <filter pattern="META-INF*" include="false" />
         </copy-artifact>
         <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-macosx-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
             <filter pattern="META-INF*" include="false" />
         </copy-artifact>
-        <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-windows-i386" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
-            <filter pattern="*.dll" include="true"/>
-            <filter pattern="*" include="false" />
-        </copy-artifact>
         <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-windows-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
             <filter pattern="*.dll" include="true"/>
             <filter pattern="*" include="false" />
-        </copy-artifact>
-        <copy-artifact artifact="org.wildfly.openssl:wildfly-openssl-solaris-x86_64" to-location="modules/system/layers/base/org/wildfly/openssl/main/lib" extract="true">
-            <filter pattern="META-INF*" include="false" />
         </copy-artifact>
     </copy-artifacts>
     <mkdirs>

--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -211,11 +211,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-linux-i386</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-linux-x86_64</artifactId>
             <scope>test</scope>
         </dependency>
@@ -227,16 +222,6 @@
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-windows-i386</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -219,12 +219,9 @@
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.1.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.openssl.wildfly-openssl-linux-i386>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
-        <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
-        <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.13.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.8.0.Final</version.org.wildfly.security.elytron-web>
@@ -1622,11 +1619,6 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
-                <artifactId>wildfly-openssl-linux-i386</artifactId>
-                <version>${version.org.wildfly.openssl.wildfly-openssl-linux-i386}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-linux-x86_64</artifactId>
                 <version>${version.org.wildfly.openssl.wildfly-openssl-linux-x86_64}</version>
             </dependency>
@@ -1639,16 +1631,6 @@
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
                 <version>${version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.openssl</groupId>
-                <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
-                <version>${version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.openssl</groupId>
-                <artifactId>wildfly-openssl-windows-i386</artifactId>
-                <version>${version.org.wildfly.openssl.wildfly-openssl-windows-i386}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5013

Note that a [proposal](https://lists.jboss.org/archives/list/wildfly-dev@lists.jboss.org/thread/7W5B2K4C2QXWBVVSZPHDBXDY3CW4JRA4/) for removing these natives was sent to the WildFly Dev mailing list a few weeks ago. We haven't received any concerns so we are going to proceed with removing them. Anyone running on these platforms who needs these natives will still be able to build and make use of them on their own. I've created a PR against WildFly that adds documentation on how to do this:

https://github.com/wildfly/wildfly/pull/13667