### PR TITLE
[WFCORE-5183] Ensure the Provider instance was loaded using a ModuleClassLoader.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ProviderDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ProviderDefinitions.java
@@ -68,6 +68,7 @@ import org.jboss.as.controller.services.path.PathManager.PathEventContext;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.modules.ModuleClassLoader;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.State;
@@ -218,10 +219,13 @@ class ProviderDefinitions {
                                     try {
                                         if (!(iterator.hasNext())) { break; }
                                         final Provider p = iterator.next();
-                                        if (configSupplier != null) {
-                                            deferred.add(p::load);
+                                        // We don't want to pick up JDK services resolved via JPMS definitions.
+                                        if (p.getClass().getClassLoader() instanceof ModuleClassLoader) {
+                                            if (configSupplier != null) {
+                                                deferred.add(p::load);
+                                            }
+                                            loadedProviders.add(p);
                                         }
-                                        loadedProviders.add(p);
                                     } catch (ServiceConfigurationError | RuntimeException e) {
                                         ROOT_LOGGER.tracef(e, "Failed to initialize a security provider");
                                     }


### PR DESCRIPTION
There may be a follow up PR as we are also discussing an API in JBoss Modules to optimise it but this covers the initial issue we have been seeing on some Java 11 installations:

https://issues.redhat.com/browse/WFCORE-5183