### PR TITLE
[WFCORE-4135] Support for read only server configuration directory

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
@@ -54,8 +54,10 @@ public class ConfigurationFilePersistenceResource extends AbstractFilePersistenc
 
         if ( FilePersistenceUtils.isParentFolderWritable(fileName) ){
             tempFileName = FilePersistenceUtils.createTempFile(fileName);
-        }else{
+        } else if (configurationFile.getConfigurationDir().canWrite()) {
             tempFileName = FilePersistenceUtils.createTempFile(configurationFile.getConfigurationDir(), fileName.getName());
+        } else {
+            tempFileName = FilePersistenceUtils.createTempFile(configurationFile.getConfigurationTmpDir(), fileName.getName());
         }
 
         try {

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationPersister.java
@@ -132,7 +132,7 @@ public interface ConfigurationPersister {
     /**
      * Publish the current configuration
      * @param target the target destination of the publication.
-     * @return the location of the published configuraiotn
+     * @return the location of the published configuration
      * @throws ConfigurationPersistenceException if a problem happened when publishing
      */
     default String publish(String target) throws ConfigurationPersistenceException {

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -533,7 +533,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             } else {
                 repository = null;
             }
-            serverConfigurationFile = standalone ? new ConfigurationFile(serverConfigurationDir, defaultServerConfig, serverConfig, configInteractionPolicy, repository != null) : null;
+            serverConfigurationFile = standalone ? new ConfigurationFile(serverConfigurationDir, defaultServerConfig, serverConfig, configInteractionPolicy, repository != null, serverTempDir) : null;
             // Adds a system property to indicate whether or not the server configuration should be persisted
             @SuppressWarnings("deprecation")
             final String propertyKey = JBOSS_PERSIST_SERVER_CONFIG;

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/ReadOnlyModeTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/ReadOnlyModeTestCase.java
@@ -16,15 +16,30 @@
 package org.jboss.as.test.manualmode.management;
 
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.inject.Inject;
+
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.repository.PathUtil;
 import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
@@ -42,14 +57,10 @@ public class ReadOnlyModeTestCase {
     @Inject
     private ServerController container;
 
-    @Before
-    public void startContainer() throws Exception {
-        // Start the server
-        container.startReadOnly();
-    }
-
     @Test
     public void testConfigurationNotUpdated() throws Exception {
+        container.startReadOnly();
+
         ModelNode address = PathAddress.pathAddress("system-property", "read-only").toModelNode();
         try (ModelControllerClient client = container.getClient().getControllerClient()) {
             ModelNode op = Operations.createAddOperation(address);
@@ -59,6 +70,7 @@ public class ReadOnlyModeTestCase {
             container.reload();
             Assert.assertTrue(Operations.readResult(client.execute(Operations.createReadAttributeOperation(address, "value"))).asBoolean());
         }
+
         container.stop();
         container.startReadOnly();
         try (ModelControllerClient client = container.getClient().getControllerClient()) {
@@ -66,9 +78,71 @@ public class ReadOnlyModeTestCase {
         }
     }
 
-    @After
-    public void stopContainer() throws Exception {
-            // Stop the container
+    @Test
+    public void testReadOnlyConfigurationDirectory() throws Exception {
+        // We ignore the test on Windows to prevent in case of errors the pollution of %TMPDIR% with read only directories
+        // On unix machines, the /tmp dir is always deleted on each server boot by root user.
+        Assume.assumeFalse(TestSuiteEnvironment.isWindows());
+
+        final Path jbossHome = Paths.get(System.getProperty("jboss.home"));
+        final Path configDir = jbossHome.resolve("standalone").resolve("configuration");
+        final Path standaloneTmpDir = jbossHome.resolve("standalone").resolve("tmp");
+        final Path osTmpDir =  Paths.get("/tmp");
+        final Path roConfigDir = Files.createTempDirectory(osTmpDir, "wildfly-test-suite-");
+
+        PathUtil.copyRecursively(configDir, roConfigDir, true);
+
+        Set<PosixFilePermission> perms = new HashSet<>();
+
+        perms.add(PosixFilePermission.OWNER_READ);
+        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        perms.add(PosixFilePermission.GROUP_READ);
+        perms.add(PosixFilePermission.GROUP_EXECUTE);
+        perms.add(PosixFilePermission.OTHERS_READ);
+        perms.add(PosixFilePermission.OTHERS_EXECUTE);
+
+        Files.getFileAttributeView(roConfigDir, PosixFileAttributeView.class).setPermissions(perms);
+
+        assertFalse(roConfigDir.toString() + " is writeable", Files.isWritable(roConfigDir));
+
+        try {
+            container.startReadOnly(roConfigDir);
+            assertTrue("standalone_xml_history not found in " + standaloneTmpDir.toString(), Files.exists(standaloneTmpDir.resolve("standalone_xml_history")));
+
+            ModelNode result;
+            PathAddress address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "elytron")).append("security-domain", "ApplicationDomain");
+            try (ModelControllerClient client = container.getClient().getControllerClient()) {
+                ModelNode op = Operations.createWriteAttributeOperation(address.toModelNode(), "security-event-listener", "local-audit");
+                result = client.execute(op);
+
+                Assert.assertTrue("Operation " + op.toString() + " failed with result " + result.toString(), Operations.isSuccessfulOutcome(result));
+                Assert.assertTrue("Server it is expected to be in reload-required.", result.get("response-headers").get("process-state").asString().equals("reload-required"));
+
+                container.reload();
+                result = Operations.readResult(client.execute(Operations.createReadAttributeOperation(address.toModelNode(), "security-event-listener")));
+                Assert.assertTrue("'security-event-listener' is expected to be 'local-audit'", result.asString().equals("local-audit"));
+            }
+
             container.stop();
+            container.startReadOnly(roConfigDir);
+            try (ModelControllerClient client = container.getClient().getControllerClient()) {
+                result = Operations.readResult(client.execute(Operations.createReadAttributeOperation(address.toModelNode(), "security-event-listener")));
+                Assert.assertTrue("'security-event-listener' is expected to be 'undefined'", result.asString().equals("undefined"));
+            }
+
+        } finally {
+            perms.add(PosixFilePermission.OWNER_WRITE);
+            perms.add(PosixFilePermission.GROUP_WRITE);
+            perms.add(PosixFilePermission.OTHERS_WRITE);
+
+            Files.getFileAttributeView(roConfigDir, PosixFileAttributeView.class).setPermissions(perms);
+
+            PathUtil.deleteRecursively(roConfigDir);
+        }
+    }
+
+    @After
+    public void stopContainer() {
+        container.stop();
     }
 }

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -95,6 +95,7 @@ public class Server {
     private String gitRepository;
     private String gitBranch;
     private String gitAuthConfiguration;
+    private Path configDir;
 
     public Server() {
         this(null, false);
@@ -165,6 +166,10 @@ public class Server {
         this.gitAuthConfiguration = gitAuthConfig;
     }
 
+    public void setConfigDir(Path configDir) {
+        this.configDir = configDir;
+    }
+
     protected void start() {
         start(System.out);
     }
@@ -231,6 +236,10 @@ public class Server {
 
                 if (gitRepository != null) {
                     commandBuilder.setGitRepository(gitRepository, gitBranch, gitAuthConfiguration);
+                }
+
+                if (configDir != null) {
+                    commandBuilder.addJavaOption("-Djboss.server.config.dir="+configDir.toString());
                 }
 
                 //we are testing, of course we want assertions and set-up some other defaults

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
@@ -71,7 +71,7 @@ public class ServerController {
      * @param readOnly
      */
     public void start(final String serverConfig, final URI authConfigUri, Server.StartMode startMode, PrintStream out, boolean readOnly) {
-     start(serverConfig, authConfigUri, startMode, out, readOnly, null, null, null);
+     start(serverConfig, authConfigUri, startMode, out, readOnly, null, null, null, null);
     }
 
     /**
@@ -92,6 +92,28 @@ public class ServerController {
      */
     public void start(final String serverConfig, final URI authConfigUri, Server.StartMode startMode, PrintStream out,
                       boolean readOnly, final String gitRepository, final String gitBranch, final String gitAuthConfig) {
+        start(serverConfig, authConfigUri, startMode, out, readOnly, gitRepository, gitBranch, gitAuthConfig, null);
+    }
+
+    /**
+     * Stats the server.
+     * <p>
+     * If the {@code authConfigUri} is not {@code null} the resource will be used for authentication of the
+     * {@link org.jboss.as.controller.client.ModelControllerClient}.
+     * </p>
+     *
+     * @param serverConfig  the configuration file to use or {@code null} to use the default
+     * @param authConfigUri the path to the {@code wildfly-config.xml} or {@code null}
+     * @param startMode     the mode to start the server in
+     * @param out           the print stream used to consume the {@code stdout} and {@code stderr} streams
+     * @param readOnly
+     * @param gitRepository the git repository to clone to get the server configuration.
+     * @param gitBranch     the git branch to use to get the server configuration
+     * @param gitAuthConfig the path
+     * @param configDir     Server configuration directory
+     */
+    public void start(final String serverConfig, final URI authConfigUri, Server.StartMode startMode, PrintStream out,
+                      boolean readOnly, final String gitRepository, final String gitBranch, final String gitAuthConfig, Path configDir) {
         if (started.compareAndSet(false, true)) {
             server = new Server(authConfigUri, readOnly);
             if (serverConfig != null) {
@@ -99,6 +121,9 @@ public class ServerController {
             }
             if (gitRepository != null) {
                 server.setGitRepository(gitRepository, gitBranch, gitAuthConfig);
+            }
+            if (configDir != null) {
+                server.setConfigDir(configDir);
             }
             server.setStartMode(startMode);
             try {
@@ -126,6 +151,10 @@ public class ServerController {
 
     public void startReadOnly(){
         start(null, null, Server.StartMode.NORMAL, System.out, true);
+    }
+
+    public void startReadOnly(Path configDir){
+        start(null, null, Server.StartMode.NORMAL, System.out, true, null, null, null, configDir);
     }
 
     public void startSuspended() {


### PR DESCRIPTION
This PR supersedes https://github.com/wildfly/wildfly-core/pull/4104

WildFly proposal can be found here: wildfly/wildfly-proposals#304. It allows to start the server if we are using --read-only-server-config and the server configuration directory is a read-only directory. Only in that case, the history root directory falls back to the server temporal directory.

Jira issue: https://issues.redhat.com/browse/WFCORE-4135
