### PR TITLE
[WFCORE-5191] Enforce reuseForks to true in Scripts module of TS

### DIFF
--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -79,6 +79,7 @@
                     <skip>${skipTests}</skip>
                     <failIfNoTests>false</failIfNoTests>
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                    <reuseForks>true</reuseForks>
 
                     <systemPropertyVariables>
                         <jboss.home>${wildfly.home}</jboss.home>
@@ -150,6 +151,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
+                            <reuseForks>true</reuseForks>
                             <systemPropertyVariables>
                                 <org.jboss.logging.provider>jboss</org.jboss.logging.provider>
                                 <test.log.level>${test.log.level}</test.log.level>


### PR DESCRIPTION
Jira with more details: https://issues.redhat.com/browse/WFCORE-5191

This PR enforce reuseForks to true in Scripts module of TS, because reuseForks=false doesn't work on Scripts module of TS
