### PR TITLE
[WFCORE-5193] Make IS_J9_JVM variable in TS more robust

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -27,7 +27,8 @@ public class TestSuiteEnvironment {
         final String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
         IS_WINDOWS = os.contains("win");
         IS_IBM_JVM = System.getProperty("java.vendor").startsWith("IBM");
-        IS_J9_JVM = System.getProperty("java.vendor").contains("OpenJ9") || IS_IBM_JVM;
+        IS_J9_JVM = System.getProperty("java.vendor").contains("OpenJ9")
+                    || System.getProperty("java.vm.vendor").contains("OpenJ9") || IS_IBM_JVM;
     }
 
     public static ModelControllerClient getModelControllerClient() {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5193

Details from the description of the jira:

So far, this IS_J9_JVM variable is defined by "java.vendor" system property:
```java
IS_J9_JVM = System.getProperty("java.vendor").contains("OpenJ9") || IS_IBM_JVM;
```

But this detection fails on Eclipse OpenJ9 VM AdoptOpenJDK (where "java.vendor" is "AdoptOpenJDK"). Which leads to the fail of JmxControlledStateNotificationsTestCase testcase in domain module on this JDK.

I suggest to add "java.vm.vendor" property to the previous detection ("java.vm.vendor" property is "Eclipse OpenJ9" on Eclipse OpenJ9 VM AdoptOpenJDK)

You can also see some CI runs on WFCORE-5193 jira.

Originally, IS_J9_JVM was introduced in https://issues.redhat.com/browse/WFCORE-4690