### PR TITLE
[WFCORE-5197] Upgrade WildFly Elytron to 1.13.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.13.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.13.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.8.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5197

https://github.com/wildfly-security/wildfly-elytron/compare/1.13.1.Final...1.13.2.Final


        Release Notes - WildFly Elytron - Version 1.13.2.Final
                                                                                                                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2023'>ELY-2023</a>] -         Elytron ClientCertAuthenticationMechanism does not work when using a web proxy
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2025'>ELY-2025</a>] -         Resource leak in ElytronXmlParser.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2028'>ELY-2028</a>] -         Resource leak in JaspiAuthenticationContext
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2029'>ELY-2029</a>] -         Checking String equality using != in SimpleDirContextFactoryBuilder
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2030'>ELY-2030</a>] -         Possible NullPointerException in FileSystemRealmCommand
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2031'>ELY-2031</a>] -         NullPointerException when using  CachingSecurityRealm with SCRAM algorithms
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2036'>ELY-2036</a>] -         DigestSaslServer doesn&#39;t return negotiated QOP and STRENGTH properties
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2047'>ELY-2047</a>] -         Release WildFly Elytron 1.13.2.Final
</li>
</ul>
                                        