### PR TITLE
[WFCORE-5204] Upgrade jakarta.inject-api from 1.0.1 to 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
         <version.io.undertow>2.2.2.Final</version.io.undertow>
-        <version.jakarta.inject.jakarta.inject-api>1.0.1</version.jakarta.inject.jakarta.inject-api>
+        <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>
         <version.junit>4.13.1</version.junit>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-5204

Tag: https://github.com/eclipse-ee4j/injection-api/releases/tag/1.0.3
Diff to previous integrated release: https://github.com/eclipse-ee4j/injection-api/compare/1.0.1...1.0.3

The main reason is to properly set the Automatic-Module-Name to java.inject, instead of jakarta.inject
