### PR TITLE
[WFCORE-5207] Add missing enums to host-release type

### DIFF
--- a/server/src/main/resources/schema/wildfly-config_15_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_15_0.xsd
@@ -5029,6 +5029,24 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="WildFly20.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 13.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly21.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 14.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                     <xs:enumeration value="EAP7.3">
                         <xs:annotation>
                             <xs:documentation>


### PR DESCRIPTION
The 15.0 XSD is missing the WildFly20.0 and WildFly21.0 values in the
host-release enums while they were properly set in the Java
HostExcludeResourceDefinition.KnownRelease enum.

JIRA: https://issues.redhat.com/browse/WFCORE-5207
