### PR TITLE
[WFCORE-5208] Upgrade WildFly OpenSSL to 2.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>2.1.1.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.1.2.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5208

https://github.com/wildfly-security/wildfly-openssl/compare/2.1.1.Final...2.1.2.Final

        Release Notes - WildFly OpenSSL - Version 2.1.2.Final
                                                                                                                                                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-60'>WFSSL-60</a>] -         Issues with wildfly openssl and client certificates when used on the client side
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-61'>WFSSL-61</a>] -         Avoid NPE if SSL_get_cipher returns &quot;(NONE)&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-62'>WFSSL-62</a>] -         Fix initial value for minProtocolIndex in OpenSSLEngine#setEnabledProtocols
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-64'>WFSSL-64</a>] -         Release WildFly OpenSSL 2.1.2.Final
</li>
</ul>
                                                        