### PR TITLE
[WFCORE-5213] Add 'org.bouncycastle:bcmail-jdk15on' to dependency management to ensure alignment with the other BouncyCastle dependencies defined in WildFly Core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1262,6 +1262,11 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
+                <artifactId>bcmail-jdk15on</artifactId>
+                <version>${version.org.bouncycastle}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpg-jdk15on</artifactId>
                 <version>${version.org.bouncycastle}</version>
             </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5213
