### PR TITLE
[WFCORE-5206] Remove workaround for ModuleLoader.installMBeanServer() method invocation

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -385,15 +384,7 @@ public final class BootableJar implements ShutdownHandler {
         }
 
         // Register JBoss Modules MBean
-        // MODULES-401 makes this method public
-        // Remove this workaround when upgrading to JBoss modules 1.11
-        try {
-            Method m = ModuleLoader.class.getDeclaredMethod("installMBeanServer");
-            m.setAccessible(true);
-            m.invoke(null);
-        } catch (NoSuchMethodException ex) {
-            log.cantRegisterModuleMBeans(ex);
-        }
+        ModuleLoader.installMBeanServer();
     }
 
     private static String getServiceName(ClassLoader classLoader, String className) throws IOException {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5206