### PR TITLE
[WFCORE-5173] Upgrade Undertow to 2.2.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.2.Final</version.io.undertow>
+        <version.io.undertow>2.2.3.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5173


        Release Notes - Undertow - Version 2.2.3.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1792'>UNDERTOW-1792</a>] -         ServletPrintWriter.println uses LF instead of CRLF
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1802'>UNDERTOW-1802</a>] -         Improve FormEncodedDataDefinition to handle chars in configured encoding
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1810'>UNDERTOW-1810</a>] -         Provide valid Servlet major version responses if undertow-servlet has been transformed to use jakarta.* Servlet APIs
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1821'>UNDERTOW-1821</a>] -         Keep the order of matched parameters by PathTemplateMatcher
</li>
</ul>
                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1743'>UNDERTOW-1743</a>] -         Request attributes are lost when a client closes a connection while response is being written
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1745'>UNDERTOW-1745</a>] -         ExchangeCompletionListener is not invoked for HTTP/2 POST request on HTTP Upgrade based connection
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1787'>UNDERTOW-1787</a>] -         Issues when undertow is setup behind apache proxy
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1791'>UNDERTOW-1791</a>] -         Unable to run TLS-based Undertow proxy in Java 15
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1806'>UNDERTOW-1806</a>] -         HTTP/2 close behaviour is problematic on unclean close
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1807'>UNDERTOW-1807</a>] -         ForwardedHandlerTestCase fails on jdk14+
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1812'>UNDERTOW-1812</a>] -         Renegotiation always blocks 30 seconds and fails using TLSv1.3
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1813'>UNDERTOW-1813</a>] -         Undertow i.u.s.h.r.PathResourceManager catches SecurityException
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1816'>UNDERTOW-1816</a>] -         HTTPS connection abruptly closed by HttpServerConnection
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1817'>UNDERTOW-1817</a>] -         Enhance error page handling to be spec compliant
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1820'>UNDERTOW-1820</a>] -         SaveOriginalPostRequestTestCase fails NonDex check
</li>
</ul>
                                                                