### PR TITLE
[WFCORE-5218] Upgrade JBoss Remoting to 5.0.20.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.10.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.11.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.12.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.19.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.20.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5218


        Release Notes - JBoss Remoting (3+) - Version 5.0.20.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-373'>REM3-373</a>] -         Upgrade JUnit to 4.13.1
</li>
</ul>
                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-371'>REM3-371</a>] -         Channel is not closed when one of the peers cancels the connection
</li>
</ul>
                                                                
