### PR TITLE
WFCORE-5220 ibm.jdk module misses jsse and jsse2 paths

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
@@ -36,6 +36,8 @@
                 <path name="com/ibm/crypto"/>
                 <path name="com/ibm/crypto/provider"/>
                 <path name="com/ibm/dataaccess"/>
+                <path name="com/ibm/jsse"/>
+                <path name="com/ibm/jsse2"/>
                 <path name="com/ibm/jvm"/>
                 <path name="com/ibm/jvm/io"/>
                 <path name="com/ibm/jvm/util"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5220

IBM JDK has classes in com.ibm.jsse and com.ibm.jsse2 that are not included in the ibm.jdk module.

This cause ClassNotFoundException if someone refer to JSSE socket factory provider in IBM JDK.