### PR TITLE
Fix for WFCORE-5223 and WFCORE-5227, Galleon upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,10 +112,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>4.2.6.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.2.7.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>4.2.8.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.0.0.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <version.org.wildfly.jar.plugin>2.0.1.Final</version.org.wildfly.jar.plugin>


### PR DESCRIPTION
Issues:
https://issues.redhat.com/browse/WFCORE-5223
https://issues.redhat.com/browse/WFCORE-5227

Galleon upgrade: 
https://github.com/wildfly/galleon/compare/galleon-parent-4.2.6.Final...4.2.7.Final

Galleon-plugin upgrade to latest master than incorporates support for EE9 transformation.
https://github.com/wildfly/galleon-plugins/compare/4.2.8.Final...5.0.0.Final
