### PR TITLE
[WFCORE-5232] Use a new process to delete the install directory. JBos…

### DIFF
--- a/bootable-jar/boot/src/main/java/org/wildfly/core/jar/boot/CleanupProcessor.java
+++ b/bootable-jar/boot/src/main/java/org/wildfly/core/jar/boot/CleanupProcessor.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.jar.boot;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An entry point that expects a first parameter of an install directory and a second parameter of the number of retries
+ * used to delete the install directory.
+ * <p>
+ * The retries are used for cases where a process may still have files locked and this process is executed before the
+ * process has fully exited. A 0.5 second sleep will happen between each retry.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("MagicNumber")
+public class CleanupProcessor {
+
+    public static void main(final String[] args) throws Exception {
+        if (args == null || args.length != 2) {
+            throw new IllegalArgumentException("The path to the install directory and number of retires are required.");
+        }
+        final Path installDir = Paths.get(args[0]);
+        final int retries = Integer.parseInt(args[1]);
+        final Path cleanupMarker = installDir.resolve("wildfly-cleanup-marker");
+        int attempts = 1;
+        while (attempts <= retries) {
+            final boolean lastAttempt = attempts == retries;
+            try {
+                cleanup(installDir, cleanupMarker, lastAttempt);
+                break;
+            } catch (IOException e) {
+                if (lastAttempt) {
+                    throw e;
+                }
+                TimeUnit.MILLISECONDS.sleep(500L);
+                attempts++;
+            }
+        }
+    }
+
+    private static void cleanup(final Path installDir, final Path cleanupMarker, final boolean log) throws IOException {
+        Files.walkFileTree(installDir, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                try {
+                    // Don't delete the cleanup marker until we're ready to delete the directory
+                    if (!file.equals(cleanupMarker)) {
+                        Files.delete(file);
+                    }
+                } catch (IOException e) {
+                    if (log) {
+                        logError("Failed to delete file %s%n\t%s%n", file, e.getLocalizedMessage());
+                    } else {
+                        throw e;
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                try {
+                    if (dir.equals(installDir)) {
+                        // We have to delete the marker before we can delete the directory
+                        Files.deleteIfExists(cleanupMarker);
+                    }
+                    Files.delete(dir);
+                } catch (IOException e) {
+                    if (log) {
+                        logError("Failed to delete directory %s%n\t%s%n", dir, e.getLocalizedMessage());
+                    } else {
+                        throw e;
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @SuppressWarnings("UseOfSystemOutOrSystemErr")
+            private void logError(final String format, final Object... args) {
+                System.err.printf(format, args);
+            }
+        });
+    }
+}

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/InstallationCleaner.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/InstallationCleaner.java
@@ -1,0 +1,204 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.jar.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.TimeUnit;
+
+import org.wildfly.core.jar.runtime._private.BootableJarLogger;
+
+/**
+ * Allows for cleanup of a bootable JAR installation. The {@link #run()} method blocks until the
+ * {@linkplain BootableEnvironment#getPidFile() PID file} is deleted or a
+ * {@linkplain BootableEnvironment#getTimeout() timeout} is reached. Then there is an attempt to delete the install
+ * directory.
+ * <p>
+ * If the {@code org.wildfly.core.jar.cleanup.newProcess} system property is set to {@code true}, the default for Windows,
+ * a new process will be launched to delete the install directory.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class InstallationCleaner implements Runnable {
+    private final BootableEnvironment environment;
+    private final Path cleanupMarker;
+    private final BootableJarLogger logger;
+    private final boolean newProcess;
+    private final int retries;
+
+    InstallationCleaner(final BootableEnvironment environment, final BootableJarLogger logger) {
+        this.environment = environment;
+        cleanupMarker = environment.getJBossHome().resolve("wildfly-cleanup-marker");
+        this.logger = logger;
+        newProcess = getProperty("org.wildfly.core.jar.cleanup.newProcess", environment.isWindows());
+        retries = getProperty("org.wildfly.core.jar.cleanup.retries", 3);
+    }
+
+    @Override
+    public void run() {
+        // Clean up is not already in progress
+        if (Files.notExists(cleanupMarker)) {
+            try {
+                Files.createFile(cleanupMarker);
+                long timeout = environment.getTimeout() * 1000;
+                final Path pidFile = environment.getPidFile();
+                final long wait = 500L;
+                while (Files.exists(pidFile)) {
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(wait);
+                    } catch (InterruptedException ignore) {
+                        break;
+                    }
+                    timeout -= wait;
+                    if (timeout <= 0) {
+                        logger.cleanupTimeout(environment.getTimeout(), pidFile);
+                        break;
+                    }
+                }
+                cleanup();
+            } catch (IOException e) {
+                logger.failedToStartCleanupProcess(e, environment.getJBossHome());
+            }
+        }
+    }
+
+    /**
+     * Either starts a new process to delete the install directory or deletes the install directory in the current
+     * process.
+     * <p>
+     * By default Windows will launch a new cleanup process. This can be controlled by setting the
+     * {@code org.wildfly.core.jar.cleanup.newProcess} to {@code true} to launch or a new process or {@code false} to
+     * delete the install directory in the current process.
+     * </p>
+     *
+     * @throws IOException if an error occurs deleting the directory
+     */
+    void cleanup() throws IOException {
+        if (newProcess) {
+            try {
+                newProcess();
+            } catch (IOException e) {
+                IOException suppressed = null;
+                try {
+                    deleteDirectory();
+                } catch (IOException ex) {
+                    suppressed = ex;
+                }
+                if (suppressed != null) {
+                    e.addSuppressed(suppressed);
+                }
+                throw e;
+            }
+        } else {
+            deleteDirectory();
+        }
+    }
+
+    private void deleteDirectory() throws IOException {
+        final Path installDir = environment.getJBossHome();
+        Files.walkFileTree(installDir, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
+                try {
+                    // Don't delete the cleanup marker until we're ready to delete the directory
+                    if (!file.equals(cleanupMarker)) {
+                        Files.delete(file);
+                    }
+                } catch (IOException e) {
+                    logger.cantDelete(file.toString(), e);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) {
+                try {
+                    if (dir.equals(installDir)) {
+                        // We have to delete the marker before we can delete the directory
+                        Files.deleteIfExists(cleanupMarker);
+                    }
+                    Files.delete(dir);
+                } catch (IOException e) {
+                    logger.cantDelete(dir.toString(), e);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private void newProcess() throws IOException {
+        // Start a new process which will clean up the install directory. This is done in a new process in cases where
+        // this process may hold locks on to resources that need to be cleaned up.
+        final String[] cmd = {
+                getJavaCommand(),
+                "-cp",
+                // Use the current class path as it should just have the bootable JAR on it and this is where the
+                // CleanupProcess is located.
+                System.getProperty("java.class.path"),
+                "org.wildfly.core.jar.boot.CleanupProcessor",
+                environment.getJBossHome().toString(),
+                Integer.toString(retries)
+        };
+        final ProcessBuilder builder = new ProcessBuilder(cmd)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .directory(new File(System.getProperty("user.dir")));
+        builder.start();
+    }
+
+    private String getJavaCommand() {
+        final Path javaHome = Paths.get(System.getProperty("java.home"));
+        final Path java;
+        if (environment.isWindows()) {
+            java = javaHome.resolve("bin").resolve("java.exe");
+        } else {
+            java = javaHome.resolve("bin").resolve("java");
+        }
+        if (Files.exists(java)) {
+            return java.toString();
+        }
+        return "java";
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static boolean getProperty(final String key, final boolean dft) {
+        final String value = System.getProperty(key);
+        if (value == null) {
+            return dft;
+        }
+        return value.isEmpty() || Boolean.parseBoolean(value);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static int getProperty(final String key, final int dft) {
+        final String value = System.getProperty(key);
+        if (value == null) {
+            return dft;
+        }
+        return Integer.parseInt(value);
+    }
+}

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
@@ -116,6 +116,17 @@ public interface BootableJarLogger extends BasicLogger {
     @Message(id = 21, value = "Cannot register JBoss Modules MBeans, %s")
     void cantRegisterModuleMBeans(Exception ex);
 
+    @Message(id = 22, value = "The PID file %s already exists. This may result in the install directory \"%s\" not being properly deleted.")
+    IllegalStateException pidFileAlreadyExists(Path pidFile, Path installDir);
+
+    @LogMessage(level = WARN)
+    @Message(id = 23, value = "Failed to start the cleanup processor. This may result in the install directory \"%s\" not being properly deleted.")
+    void failedToStartCleanupProcess(@Cause Throwable cause, Path installDir);
+
+    @LogMessage(level = WARN)
+    @Message(id = 24, value = "The container has not properly shutdown within %ds. This may result in the install directory \"%s\" not being properly deleted.")
+    void cleanupTimeout(long timeout, Path installDir);
+
     @Message(id = Message.NONE, value = "Set system property jboss.bind.address to the given value")
     String argPublicBindAddress();
 

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
@@ -72,6 +72,7 @@
         <module name="org.jboss.threads"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.as.process-controller"/>
+        <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 


### PR DESCRIPTION
…s Modules holds locks on the JAR's which results in a failure to delete the install directory on Windows. By using a new process we wait until the main process has died and we delete the files in the new process avoiding the files being locked.

https://issues.redhat.com/browse/WFCORE-5232

@jfdenise This is my proposal to the issue with deleting the Windows install directory. What this will do is for Windows by default it will launch a new process which deletes the directory. For all other operating systems it will just delete the directory in the same process. Note this can be overridden with the `org.wildfly.core.jar.cleanup.newProcess` system property.

There is also a slight change to the extraction of the container from the bootable JAR. It simply checks for the existence of a `wildfly-cleanup-marker` file in the install directory and waits for a settable timeout before it just continues. This is to avoid possible issues where a directory is being deleted, but the restart of the bootable JAR happens too fast.