### PR TITLE
WFCORE-5302 Update Google guava 30.1-jre

### DIFF
--- a/model-test/pom.xml
+++ b/model-test/pom.xml
@@ -55,7 +55,22 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-resolver-provider</artifactId>
+            <exclusions>
+               <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+               </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,8 @@
         <version.com.fasterxml.jackson.core.jackson-databind>2.11.3</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.googlecode.javaewah>1.1.7</version.com.googlecode.javaewah>
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>
-        <version.com.google.guava>25.0-jre</version.com.google.guava>
+        <version.com.google.guava>30.1-jre</version.com.google.guava>
+        <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
         <version.commons-io>2.5</version.commons-io>
@@ -681,7 +682,39 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${version.com.google.guava}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>failureaccess</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
+            <dependency>
+                <!-- This is a transitive dep of com.google.guava -->
+                <groupId>com.google.guava</groupId>
+                <artifactId>failureaccess</artifactId>
+                <version>${version.com.google.guava.failureaccess}</version>
+             </dependency>
             <dependency>
                 <groupId>com.io7m.xom</groupId>
                 <artifactId>xom</artifactId>


### PR DESCRIPTION
Fixing [WFCORE-5302](https://issues.redhat.com/browse/WFCORE-5203) Updates Google Guava to 30.1-jre.
This patch will fail in integration tests, please find analysis and discussion under [https://github.com/wildfly/wildfly/pull/13788](https://github.com/wildfly/wildfly/pull/13788). This pull request supersedes 4406.

@jamezp Could you please review this PR as precondition of 13788.