### PR TITLE
Fix for WFCORE-5199, CLI, shaded jar can't start embedded when logging json formater configured

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -198,6 +198,10 @@
             <groupId>org.jboss.stdio</groupId>
             <artifactId>jboss-stdio</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.picketbox</groupId>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5199
Did manual testing with bootable JAR, cli fat jar (with both jakarta8 and jakarata9).

