### PR TITLE
Fix for WFCORE-5244, Upgrade tests to bootable JAR 3.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.org.wildfly.galleon-plugins>5.0.0.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
-        <version.org.wildfly.jar.plugin>2.0.1.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>3.0.0.Final</version.org.wildfly.jar.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.2.0.Final</version.org.wildfly.plugins>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5244
Diff with previous release:
https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/2.0.1.Final...3.0.0.Final
