### PR TITLE
[WFCORE-4291] Add support for non-graceful startup

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -218,6 +218,7 @@ public class ModelDescriptionConstants {
     public static final String FULL_REPLACE_DEPLOYMENT = "full-replace-deployment";
     public static final String GENERATE_SELF_SIGNED_CERTIFICATE_HOST = "generate-self-signed-certificate-host";
     public static final String GRACEFUL_SHUTDOWN_TIMEOUT = "graceful-shutdown-timeout";
+    public static final String GRACEFUL_STARTUP = "graceful-startup";
     public static final String GROUP = "group";
     public static final String GROUP_ATTRIBUTE = "group-attribute";
     public static final String GROUP_DN_ATTRIBUTE = "group-dn-attribute";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -93,6 +93,7 @@ public enum Attribute {
     FORCE("force"),
     FORMATTER("formatter"),
     GENERATE_SELF_SIGNED_CERTIFICATE_HOST("generate-self-signed-certificate-host"),
+    GRACEFUL_STARTUP("graceful-startup"),
     GROUP("group"),
     GROUP_ATTRIBUTE("group-attribute"),
     GROUP_DN_ATTRIBUTE("group-dn-attribute"),

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTransformersTestCase.java
@@ -32,6 +32,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TIM
 import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.MANAGEMENT_SUBSYSTEM_ENDPOINT;
 import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET;
+import static org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition.GRACEFUL_STARTUP;
 import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MODULE_OPTIONS;
 
 import java.util.List;
@@ -102,7 +103,6 @@ public class DomainServerGroupTransformersTestCase extends AbstractCoreModelTest
 
     }
 
-
     @Test
     public void testRejectTransformersEAP() throws Exception {
         if (modelVersion.getMajor() > 1) {
@@ -121,9 +121,10 @@ public class DomainServerGroupTransformersTestCase extends AbstractCoreModelTest
         List<ModelNode> ops = builder.parseXmlResource("servergroup.xml");
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, new FailedOperationTransformationConfig()
                 .addFailedAttribute(serverGroupAddress,
-                        FailedOperationTransformationConfig.ChainedConfig.createBuilder(MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE)
+                        FailedOperationTransformationConfig.ChainedConfig.createBuilder(MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE, GRACEFUL_STARTUP)
                                 .addConfig(new FailedOperationTransformationConfig.RejectExpressionsConfig(MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET))
                                 .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(SOCKET_BINDING_DEFAULT_INTERFACE))
+                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(GRACEFUL_STARTUP))
                                 .build().setReadOnly(MANAGEMENT_SUBSYSTEM_ENDPOINT))
                 .addFailedAttribute(serverGroupAddress.append("jvm", "full"), new FailedOperationTransformationConfig.NewAttributesConfig(MODULE_OPTIONS)));
 
@@ -170,10 +171,11 @@ public class DomainServerGroupTransformersTestCase extends AbstractCoreModelTest
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, new FailedOperationTransformationConfig()
                 .addFailedAttribute(PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP)),
                         FailedOperationTransformationConfig.ChainedConfig.createBuilder(
-                                MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE)
+                                MANAGEMENT_SUBSYSTEM_ENDPOINT, SOCKET_BINDING_PORT_OFFSET, SOCKET_BINDING_DEFAULT_INTERFACE, GRACEFUL_STARTUP)
                                 .addConfig(new FailedOperationTransformationConfig.RejectExpressionsConfig(MANAGEMENT_SUBSYSTEM_ENDPOINT,
                                         SOCKET_BINDING_PORT_OFFSET))
                                 .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(SOCKET_BINDING_DEFAULT_INTERFACE))
+                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(GRACEFUL_STARTUP))
                                 .build().setReadOnly(MANAGEMENT_SUBSYSTEM_ENDPOINT)));
 
     }

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
@@ -13,7 +13,7 @@
     </deployment-overlays>
 
     <server-groups>
-        <server-group name="test" profile="test" management-subsystem-endpoint="true">
+        <server-group name="test" profile="test" management-subsystem-endpoint="true" graceful-startup="false">
 
             <jvm name="full" java-home="javaHome" type="SUN" env-classpath-ignored="true">
                  <heap size="heapSize" max-size="maxHeapSize"/>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
@@ -103,7 +103,13 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
             .build();
 
-    public static final AttributeDefinition[] ADD_ATTRIBUTES = new AttributeDefinition[] {PROFILE, SOCKET_BINDING_GROUP, SOCKET_BINDING_DEFAULT_INTERFACE, SOCKET_BINDING_PORT_OFFSET, MANAGEMENT_SUBSYSTEM_ENDPOINT};
+    public static final SimpleAttributeDefinition GRACEFUL_STARTUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.GRACEFUL_STARTUP, ModelType.BOOLEAN, true)
+                    .setAllowExpression(true)
+                    .setDefaultValue(ModelNode.TRUE)
+                    .build();
+
+    public static final AttributeDefinition[] ADD_ATTRIBUTES = new AttributeDefinition[] {PROFILE, SOCKET_BINDING_GROUP,
+            SOCKET_BINDING_DEFAULT_INTERFACE, SOCKET_BINDING_PORT_OFFSET, MANAGEMENT_SUBSYSTEM_ENDPOINT, GRACEFUL_STARTUP};
 
     private final HostFileRepository fileRepository;
     private final ContentRepository contentRepository;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -24,6 +24,7 @@ package org.jboss.as.domain.controller.transformers;
 
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_10_0;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_13_0;
+import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_15_0;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_1_7;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_1_8;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_2_0;
@@ -148,7 +149,9 @@ public class DomainTransformers {
 
     private static void registerChainedServerGroupTransformers(TransformerRegistry registry) {
         ChainedTransformationDescriptionBuilder builder = ServerGroupTransformers.buildTransformerChain();
-        registerChainedTransformer(registry, builder, VERSION_13_0, VERSION_10_0, VERSION_8_0, VERSION_7_0, VERSION_6_0, VERSION_5_0, VERSION_4_1, VERSION_4_0, VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8, VERSION_1_7);
+        registerChainedTransformer(registry, builder, VERSION_15_0, VERSION_13_0, VERSION_10_0, VERSION_8_0, VERSION_7_0,
+                VERSION_6_0, VERSION_5_0, VERSION_4_1, VERSION_4_0, VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8,
+                VERSION_1_7);
     }
 
     private static void registerProfileTransformers(TransformerRegistry registry) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
@@ -47,29 +47,36 @@ class ServerGroupTransformers {
         //////////////////////////////////
         //The EAP/AS 7.x chains
 
-        // module-options was introduced in 13, WildFly 20
-        ResourceTransformationDescriptionBuilder currentTo13 = createBuilderFromCurrent(chainedBuilder, KernelAPIVersion.VERSION_13_0);
-        JvmTransformers.registerTransformers13_AndBelow(currentTo13);
+        // graceful-startup attribute was introduced in Kernel 16 (Wildfly 23)
+        ResourceTransformationDescriptionBuilder currentTo15 = createBuilderFromCurrent(chainedBuilder, KernelAPIVersion.VERSION_15_0)
+                .getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, ServerGroupResourceDefinition.GRACEFUL_STARTUP)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ServerGroupResourceDefinition.GRACEFUL_STARTUP)
+                .end();
 
-        //timeout attribute renamed to suspend-timeout in Version 9.0. Must be renamed for 8.0 and below
+        // module-options was introduced in Kernel API 14 (WildFly Core 13, WildFly 21)
+        ResourceTransformationDescriptionBuilder builder15to13 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_15_0, KernelAPIVersion.VERSION_13_0);
+        JvmTransformers.registerTransformers13_AndBelow(builder15to13);
+
+        //timeout attribute renamed to suspend-timeout in Version Kernel 9.0 (WildFly Core 7, WildFly 15). Must be renamed for 8.0 and below
         ResourceTransformationDescriptionBuilder builder10to8 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_10_0, KernelAPIVersion.VERSION_8_0);
         DomainServerLifecycleHandlers.registerTimeoutToSuspendTimeoutRename(builder10to8);
 
-        // kill-servers and destroy-servers are rejected since 5.0 and below
+        // kill-servers and destroy-servers are rejected for Kernel 5.0 (WildFly Core 3, WildFly 11) and below
         ResourceTransformationDescriptionBuilder builder60to50 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_6_0, KernelAPIVersion.VERSION_5_0);
         DomainServerLifecycleHandlers.registerKillDestroyTransformers(builder60to50);
 
-        // The use of default-interface attribute in socket-binding-group is rejected since 1.8 and below
+        // The use of default-interface attribute in socket-binding-group is rejected for 1.8 and below
         ResourceTransformationDescriptionBuilder builder20to18 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_2_0, KernelAPIVersion.VERSION_1_8)
                 .getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.UNDEFINED, ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE)
                 .end();
 
-        //suspend and resume servers are rejected since 1.8 and below
+        //suspend and resume servers are rejected for Kernel 1.8 (EAP 6.4.0 CP07) and below
         DomainServerLifecycleHandlers.registerServerLifeCycleOperationsTransformers(builder20to18);
 
-        // The use of launch-command is rejected since 2.1 and below
+        // The use of launch-command is rejected since Kernel 2.1 (WildFly 8.1.0) and below
         ResourceTransformationDescriptionBuilder builder30To21 = createBuilder(chainedBuilder, KernelAPIVersion.VERSION_3_0, KernelAPIVersion.VERSION_2_1);
         JvmTransformers.registerTransformers2_1_AndBelow(builder30To21);
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -844,7 +844,9 @@ class ManagedServer {
             final ModelNode endpointConfig = bootConfiguration.getSubsystemEndpointConfiguration();
             // Send std.in
             final ServiceActivator hostControllerCommActivator = DomainServerCommunicationServices.create(endpointConfig, managementURI, serverName, serverProcessName, authKey, useSubsystemEndpoint, bootConfiguration.getSSLContextSupplier());
-            final ServerStartTask startTask = new ServerStartTask(hostControllerName, serverName, 0, operationID, Collections.<ServiceActivator>singletonList(hostControllerCommActivator), bootUpdates, launchProperties, bootConfiguration.isSuspended());
+            final ServerStartTask startTask = new ServerStartTask(hostControllerName, serverName, 0, operationID,
+                    Collections.<ServiceActivator>singletonList(hostControllerCommActivator), bootUpdates, launchProperties,
+                    bootConfiguration.isSuspended(), bootConfiguration.isGracefulStartup());
             final Marshaller marshaller = MARSHALLER_FACTORY.createMarshaller(CONFIG);
             final OutputStream os = processControllerClient.sendStdin(serverProcessName);
             marshaller.start(Marshalling.createByteOutput(os));

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootConfiguration.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootConfiguration.java
@@ -97,6 +97,8 @@ public interface ManagedServerBootConfiguration {
 
     boolean isSuspended();
 
+    boolean isGracefulStartup();
+
     /**
      * Gets a semi-unique id for the server process.
      * @return the id

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_16.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_16.java
@@ -484,6 +484,10 @@ final class DomainXml_16 extends CommonXml implements ManagementXmlDelegate {
                             ServerGroupResourceDefinition.PROFILE.parseAndSetParameter(value, groupAddOp, reader);
                             break;
                         }
+                        case GRACEFUL_STARTUP: {
+                            ServerGroupResourceDefinition.GRACEFUL_STARTUP.parseAndSetParameter(value, groupAddOp, reader);
+                            break;
+                        }
                         case MANAGEMENT_SUBSYSTEM_ENDPOINT: {
                             ServerGroupResourceDefinition.MANAGEMENT_SUBSYSTEM_ENDPOINT.parseAndSetParameter(value, groupAddOp, reader);
                             break;
@@ -747,6 +751,7 @@ final class DomainXml_16 extends CommonXml implements ManagementXmlDelegate {
         writer.writeAttribute(Attribute.NAME.getLocalName(), groupName);
 
         ServerGroupResourceDefinition.PROFILE.marshallAsAttribute(group, writer);
+        ServerGroupResourceDefinition.GRACEFUL_STARTUP.marshallAsAttribute(group, writer);
         ServerGroupResourceDefinition.MANAGEMENT_SUBSYSTEM_ENDPOINT.marshallAsAttribute(group, writer);
 
         // JVM

--- a/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
@@ -76,6 +76,7 @@ server-group.add.jvm=The jvm name.
 server-group.remove=Remove an existing new server group.
 server-group.profile=The profile name.
 server-group.jvm=The named jvm.
+server-group.graceful-startup=Start the servers gracefully, queuing or cleanly rejecting incoming requests until the server is fully started.
 server-group.socket-binding-group=The default socket binding group used for servers associated with this group.
 server-group.socket-binding-default-interface=The socket binding group default interface for this server.
 server-group.socket-binding-port-offset=The default offset to be added to the port values given by the socket binding group.

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -130,6 +130,7 @@ public class CommandLineConstants {
     public static final String NORMAL_MODE = "normal";
     public static final String SUSPEND_MODE = "suspend";
     public static final String ADMIN_ONLY_MODE = "admin-only";
+    public static final String GRACEFUL_STARTUP = "--graceful-startup";
 
 
     // java.net properties

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
@@ -77,6 +77,9 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.START_MODE);
         instructions.add(ServerLogger.ROOT_LOGGER.argStartMode());
 
+        addArguments(CommandLineConstants.GRACEFUL_STARTUP+"=<value>");
+        instructions.add(ServerLogger.ROOT_LOGGER.argGracefulStartup());
+
         addArguments(CommandLineConstants.GIT_REPO + " <repo_url>", CommandLineConstants.GIT_REPO + "=<repo_url>");
         instructions.add(ServerLogger.ROOT_LOGGER.argGitRepo());
 

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -325,6 +325,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
     private final UUID serverUUID;
     private final long startTime;
     private final boolean startSuspended;
+    private final boolean startGracefully;
     private GitRepository repository;
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
@@ -334,6 +335,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                 System.currentTimeMillis(), startSuspended, null, null, null);
     }
 
+    @Deprecated
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig) {
@@ -341,6 +343,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                 System.currentTimeMillis(), false, null, null, null);
     }
 
+    @Deprecated
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, String gitRepository, String gitBranch, String gitAuthConfiguration) {
@@ -348,12 +351,23 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                 startTime, false, gitRepository, gitBranch, gitAuthConfiguration);
     }
 
+    @Deprecated
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended,
                              String gitRepository, String gitBranch, String gitAuthConfiguration) {
-        this.startSuspended = startSuspended;
+        this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode,
+                productConfig, startTime, startSuspended, false, gitRepository, gitBranch, gitAuthConfiguration);
+    }
+
+    public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
+                             final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
+                             final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended,
+                             final boolean startGracefully, final String gitRepository, final String gitBranch, final String gitAuthConfiguration) {
         assert props != null;
+
+        this.startSuspended = startSuspended;
+        this.startGracefully = startGracefully;
 
         this.launchType = launchType;
         this.standalone = launchType != LaunchType.DOMAIN;
@@ -970,6 +984,15 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
      */
     public boolean isStartSuspended() {
         return startSuspended;
+    }
+
+    /**
+     * If this is true then the server will start with graceful startup disabled
+     *
+     * @return <code>true</code> if the server should start with graceful startup disabled
+     */
+    public boolean isStartGracefully() {
+        return startGracefully;
     }
 
     private File configureServerTempDir(String path, Properties providedProps) {

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironmentResourceDescription.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironmentResourceDescription.java
@@ -77,10 +77,12 @@ public class ServerEnvironmentResourceDescription extends SimpleResourceDefiniti
     static final AttributeDefinition QUALIFIED_HOST_NAME = SimpleAttributeDefinitionBuilder.create("qualified-host-name", ModelType.STRING).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
     public static final AttributeDefinition SERVER_NAME = SimpleAttributeDefinitionBuilder.create("server-name", ModelType.STRING).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
     static final AttributeDefinition TEMP_DIR = SimpleAttributeDefinitionBuilder.create("temp-dir", ModelType.STRING).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+    public static final AttributeDefinition START_SUSPENDED = SimpleAttributeDefinitionBuilder.create("start-suspended", ModelType.BOOLEAN).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+    public static final AttributeDefinition GRACEFUL_STARTUP = SimpleAttributeDefinitionBuilder.create("start-gracefully", ModelType.BOOLEAN).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
 
     private static final AttributeDefinition[] SERVER_ENV_ATTRIBUTES = {BASE_DIR, CONFIG_DIR, CONFIG_FILE, CONTENT_DIR, DATA_DIR,
             DEPLOY_DIR, EXT_DIRS, HOME_DIR, HOST_NAME, INITIAL_RUNNING_MODE, LAUNCH_TYPE, LOG_DIR, MODULES_DIR, NODE_NAME,
-            QUALIFIED_HOST_NAME, SERVER_NAME, TEMP_DIR};
+            QUALIFIED_HOST_NAME, SERVER_NAME, TEMP_DIR, START_SUSPENDED, GRACEFUL_STARTUP};
 
     private final ServerEnvironmentReadHandler osh;
 
@@ -194,6 +196,12 @@ public class ServerEnvironmentResourceDescription extends SimpleResourceDefiniti
             }
             if (equals(name, TEMP_DIR)) {
                 set(result, environment.getServerTempDir());
+            }
+            if (equals(name, START_SUSPENDED)) {
+                result.set(environment.isStartSuspended());
+            }
+            if (equals(name, GRACEFUL_STARTUP)) {
+                result.set(environment.isStartGracefully());
             }
         }
 

--- a/server/src/main/java/org/jboss/as/server/ServerStartTask.java
+++ b/server/src/main/java/org/jboss/as/server/ServerStartTask.java
@@ -84,10 +84,11 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
     private final int initialOperationID;
     private final Properties properties = new Properties();
     private final boolean suspend;
+    private final boolean gracefulStartup;
 
     public ServerStartTask(final String hostControllerName, final String serverName, final int portOffset, final int initialOperationID,
                            final List<ServiceActivator> startServices, final List<ModelNode> updates, final Map<String, String> launchProperties,
-                           boolean suspend) {
+                           boolean suspend, boolean gracefulStartup) {
         assert serverName != null && serverName.length() > 0  : "Server name \"" + serverName + "\" is invalid; cannot be null or blank";
         assert hostControllerName != null && hostControllerName.length() > 0 : "Host Controller name \"" + hostControllerName + "\" is invalid; cannot be null or blank";
 
@@ -98,6 +99,7 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         this.initialOperationID = initialOperationID;
         this.hostControllerName = hostControllerName;
         this.suspend = suspend;
+        this.gracefulStartup = gracefulStartup;
 
         this.home = WildFlySecurityManager.getPropertyPrivileged("jboss.home.dir", null);
         String serverBaseDir = WildFlySecurityManager.getPropertyPrivileged("jboss.domain.servers.dir", null) + File.separatorChar + serverName;
@@ -131,7 +133,7 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         // Create server environment on the server, so that the system properties are getting initialized on the right side
         final ServerEnvironment providedEnvironment = new ServerEnvironment(hostControllerName, properties,
                 WildFlySecurityManager.getSystemEnvironmentPrivileged(), null, null, ServerEnvironment.LaunchType.DOMAIN,
-                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend, null, null, null);
+                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend, gracefulStartup, null, null, null);
         DomainServerCommunicationServices.updateOperationID(initialOperationID);
 
         // TODO perhaps have ConfigurationPersisterFactory as a Service

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -573,6 +573,14 @@ public interface ServerLogger extends BasicLogger {
     String argStartMode();
 
     /**
+     * Instructions for the {@link CommandLineConstants#GRACEFUL_STARTUP} command line argument
+     *
+     * @return the message
+     */
+    @Message(id = Message.NONE, value ="Start the server gracefully, queuing or cleanly rejecting requests until the server is fully started")
+    String argGracefulStartup();
+
+    /**
      * Instructions for the {@link CommandLineConstants#GIT_REPO} command line argument.
      *
      * @return the message
@@ -1359,6 +1367,14 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 281, value = "System property %s is set. This should only be used for standalone clients. Setting this on the server will override your profile configuration.")
     void wildflyConfigUrlIsSet(String property);
+
+    @LogMessage(level = INFO)
+    @Message(id = 282, value = "Server is starting with graceful startup disabled; external requests may receive failure responses until startup completes.")
+    void startingNonGraceful();
+
+    @LogMessage(level = INFO)
+    @Message(id = 283, value = "A non-graceful startup was requested in conjunction with a suspended startup. The server will start suspended.")
+    void disregardingNonGraceful();
 
     ////////////////////////////////////////////////
     //Messages without IDs

--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -116,11 +116,24 @@ public class SuspendController implements Service<SuspendController> {
         }
     }
 
-    public synchronized void resume() {
+    public void nonGracefulStart() {
+        resume(false);
+    }
+
+    public void resume() {
+        resume(true);
+    }
+
+    private synchronized void resume(boolean gracefulStart) {
         if (state == State.RUNNING) {
             return;
         }
-        ServerLogger.ROOT_LOGGER.resumingServer();
+        if (!gracefulStart) {
+            ServerLogger.ROOT_LOGGER.startingNonGraceful();
+        } else {
+            ServerLogger.ROOT_LOGGER.resumingServer();
+        }
+
         if (timer != null) {
             timer.cancel();
             timer = null;

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -51,6 +51,8 @@ server.env.initial-running-mode=The initial running mode of the server, when the
 server.env.server-name=The name of the server.
 server.env.temp-dir=The temporary directory.
 server.suspend-state=The suspend state of the server
+server.env.start-suspended=Start the server suspended.
+server.env.start-gracefully=Start the server gracefully.
 
 # Lifecycle operations
 

--- a/server/src/main/resources/schema/wildfly-config_16_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_16_0.xsd
@@ -2923,6 +2923,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="graceful-startup" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Set to true to have servers in the group start gracefully, queuing or cleanly rejecting incoming
+                    requests until the server is fully started. If set to false, the server will pass the request to the
+                    appropriate subsystem for processing, irrespective of whether or not that system is ready.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="management-subsystem-endpoint" type="xs:boolean" default="false">
             <xs:annotation>
                 <xs:documentation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4291

Squashed commit of the following:
commit 874016e
Author: Brian Stansberry <brian.stansberry@redhat.com>
Date:   Mon Jul 29 13:50:48 2019 -0500

    [WFCORE-4291] Basic implementation of disabling initial boot-time suspension of a server.

Change name from "graceless" to "graceful-startup" and invert intention
Add support for '--graceful-startup' command line param for server startup
Modify schema to add graceful-startup attribute to server-group for domain mode support
Modify ManagedServerBootCmdFactory to pass arg as needed to managed servers