### PR TITLE
[WFCORE-5256] fix console-enabled attribute in http interface

### DIFF
--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_16.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_16.java
@@ -971,11 +971,7 @@ final class StandaloneXml_16 extends CommonXml implements ManagementXmlDelegate 
         HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
         HttpManagementResourceDefinition.SASL_PROTOCOL.marshallAsAttribute(protocol, writer);
         HttpManagementResourceDefinition.SERVER_NAME.marshallAsAttribute(protocol, writer);
-
-        boolean consoleEnabled = protocol.get(ModelDescriptionConstants.CONSOLE_ENABLED).asBoolean(true);
-        if (!consoleEnabled) {
-            HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
-        }
+        HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
 
         HttpManagementResourceDefinition.ALLOWED_ORIGINS.getMarshaller().marshallAsAttribute(
                 HttpManagementResourceDefinition.ALLOWED_ORIGINS, protocol, true, writer);


### PR DESCRIPTION
fix console-enabled attribute in http interface so it is resolved as expression

https://issues.redhat.com/browse/WFCORE-5256
