### PR TITLE
[WFCORE-5262] Add a timestamp at the beginning of image startup in EAP images

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/domain.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.bat
@@ -1,4 +1,7 @@
 @echo off
+
+echo %date:~-4%-%date:~3,2%-%date:~0,2% %time:~0,2%:%time:~3,2%:%time:~6,2% Starting the domain server
+
 rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------

--- a/core-feature-pack/common/src/main/resources/content/bin/domain.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.ps1
@@ -1,3 +1,5 @@
+"$((Get-Date).ToString('yyyy-MM-dd hh:mm:ss')) Starting the domain server"
+
 #############################################################################
 #                                                                          ##
 #    WildFly Startup Script for starting the domain server                 ##

--- a/core-feature-pack/common/src/main/resources/content/bin/domain.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo "`date "+%Y-%m-%d %H:%M:%S"` Starting the domain server"
+
 DIRNAME=`dirname "$0"`
 PROGNAME=`basename "$0"`
 GREP="grep"

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
@@ -1,4 +1,7 @@
 @echo off
+
+echo %date:~-4%-%date:~3,2%-%date:~0,2% %time:~0,2%:%time:~3,2%:%time:~6,2% Starting the standalone server
+
 rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.ps1
@@ -1,3 +1,5 @@
+"$((Get-Date).ToString('yyyy-MM-dd hh:mm:ss')) Starting the standalone server"
+
 #############################################################################
 #                                                                          ##
 #    WildFly Startup Script for starting the standalone server             ##

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -5,6 +5,9 @@
 #         standalone.sh --debug 9797
 
 # By default debug mode is disabled.
+
+echo "`date "+%Y-%m-%d %H:%M:%S"` Starting the standalone server"
+
 DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"
 GC_LOG="$GC_LOG"


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5262

related (cloned) issue: https://issues.redhat.com/browse/JBEAP-18005