### PR TITLE
[WFCORE-5266] Upgrade WildFly OpenSSL to 2.1.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>2.1.2.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.1.3.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5266

https://github.com/wildfly-security/wildfly-openssl/compare/2.1.2.Final...2.1.3.Final


        Release Notes - WildFly OpenSSL - Version 2.1.3.Final
                                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-63'>WFSSL-63</a>] -         Unable to build WildFly SSL on Fedora 33
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-65'>WFSSL-65</a>] -         Issues with wildfly openssl and client certificates when used on the client side with Jetty
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-66'>WFSSL-66</a>] -         Add a new GitHub workflow to trigger CI for pull requests
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-67'>WFSSL-67</a>] -         Refactor some tests in ClientSessionTestBase to make use of the EchoRunnable test class and ensure that tests wait for threads to finish to avoid hangs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-68'>WFSSL-68</a>] -         Release WildFly OpenSSL 2.1.3.Final
</li>
</ul>
