### PR TITLE
[WFCORE-5251] Upgrade Undertow to 2.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.3.Final</version.io.undertow>
+        <version.io.undertow>2.2.4.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5251


        Release Notes - Undertow - Version 2.2.4.Final
                                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1406'>UNDERTOW-1406</a>] -         WebSocketClient13TestCase gets stuck with JDK-11 early build 28
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1824'>UNDERTOW-1824</a>] -         CVE-2020-27782 AJP handler must send AJP responses for bad requests &amp; internal server errors
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1827'>UNDERTOW-1827</a>] -         InMemorySessionManager must bump session timeout on requestStarted
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1828'>UNDERTOW-1828</a>] -         NullPointerException occurred if a servlet calls HttpServletRequest#getContextPath() while EAP was shutting down
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1833'>UNDERTOW-1833</a>] -         Unnecessary code removal from Http2EndExchangeTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1838'>UNDERTOW-1838</a>] -         CVE-2020-10687 wildfly-undertow: Undertow: Incomplete fix for CVE-2017-2666 due to permitting invalid characters in HTTP requests
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1839'>UNDERTOW-1839</a>] -         Undertow SSLConduit write is not synchronized
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1841'>UNDERTOW-1841</a>] -         Undertow fails to mvn install twice
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1744'>UNDERTOW-1744</a>] -         Port Undertow to new Jakarta EE9
</li>
</ul>
                                                
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1757'>UNDERTOW-1757</a>] -         Release Undertow for Jakarta EE9
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1785'>UNDERTOW-1785</a>] -         Merge Jakarta EE9 Code (depends on Batavia)
</li>
</ul>
        