### PR TITLE
[WFCORE-5261] Add the ability to use a common script configuration file.

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/add-user.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/add-user.bat
@@ -21,6 +21,8 @@ pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
+call "%DIRNAME%common.bat" :commonConf
+
 if "x%JBOSS_HOME%" == "x" (
   set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )

--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -2,6 +2,19 @@
 call %*
 goto :eof
 
+:commonConf
+if "x%COMMON_CONF%" == "x" (
+   set "COMMON_CONF=%DIRNAME%common.conf.bat"
+) else (
+   if not exist "%COMMON_CONF%" (
+       echo Config file not found "%COMMON_CONF%"
+   )
+)
+if exist "%COMMON_CONF%" (
+   call "%COMMON_CONF%" %*
+)
+goto :eof
+
 :setModularJdk
     "%JAVA%" --add-modules=java.se -version >nul 2>&1 && (set MODULAR_JDK=true) || (set MODULAR_JDK=false)
 goto :eof

--- a/core-feature-pack/common/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.ps1
@@ -30,6 +30,16 @@ Function Get-Env-Boolean{
   return $args[1]
 }
 
+$COMMOM_CONF_FILE = $SCRIPTS_HOME + '\common.conf.ps1'
+$COMMOM_CONF_FILE = Get-Env COMMON_CONF $COMMOM_CONF_FILE
+if ([System.IO.File]::Exists($COMMOM_CONF_FILE)) {
+    . $COMMOM_CONF_FILE
+} else {
+    if (Test-Path env:COMMON_CONF) {
+        Write-Output "Config file not found $env:COMMON_CONF"
+    }
+}
+
 $global:SECMGR = Get-Env-Boolean SECMGR $false
 $global:DEBUG_MODE=Get-Env DEBUG $false
 $global:DEBUG_PORT=Get-Env DEBUG_PORT 8787

--- a/core-feature-pack/common/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.sh
@@ -1,5 +1,17 @@
 #!/bin/sh -x
 
+if [ "x$COMMON_CONF" = "x" ]; then
+  COMMON_CONF="$DIRNAME/common.conf"
+else
+  if [ ! -r "$COMMON_CONF" ]; then
+    echo "Config file not found $COMMON_CONF"
+  fi
+
+fi
+if [ -r "$COMMON_CONF" ]; then
+  . "$COMMON_CONF"
+fi
+
 setModularJdk() {
   "$JAVA" --add-modules=java.se -version > /dev/null 2>&1 && MODULAR_JDK=true || MODULAR_JDK=false
 }

--- a/core-feature-pack/common/src/main/resources/content/bin/domain.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.bat
@@ -20,7 +20,7 @@ pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-
+call "%DIRNAME%common.bat" :commonConf
 
 setlocal EnableDelayedExpansion
 rem check for the security manager system property

--- a/core-feature-pack/common/src/main/resources/content/bin/elytron-tool.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/elytron-tool.bat
@@ -18,6 +18,8 @@ pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
+call "%DIRNAME%common.bat" :commonConf
+
 if "x%JBOSS_HOME%" == "x" (
   set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )

--- a/core-feature-pack/common/src/main/resources/content/bin/elytron-tool.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/elytron-tool.sh
@@ -7,6 +7,8 @@ GREP="grep"
 # Use the maximum available, or set MAX_FD != -1 to use that
 MAX_FD="maximum"
 
+. "$DIRNAME/common.sh"
+
 #
 # Helper to complain.
 #

--- a/core-feature-pack/common/src/main/resources/content/bin/jboss-cli.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/jboss-cli.bat
@@ -25,6 +25,8 @@ pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
+call "%DIRNAME%common.bat" :commonConf
+
 if "x%JBOSS_HOME%" == "x" (
   set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
@@ -16,7 +16,6 @@ set DEBUG_PORT_VAR=8787
 rem Set to all parameters by default
 set "SERVER_OPTS=%*"
 
-
 if NOT "x%DEBUG%" == "x" (
   set "DEBUG_MODE=%DEBUG%
 )
@@ -34,6 +33,7 @@ if "%OS%" == "Windows_NT" (
   set DIRNAME=.\
 )
 setlocal EnableDelayedExpansion
+call "!DIRNAME!common.bat" :commonConf
 rem check for the security manager system property
 echo(!SERVER_OPTS! | findstr /r /c:"-Djava.security.manager" > nul
 if not errorlevel == 1 (

--- a/core-feature-pack/common/src/main/resources/content/bin/vault.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/vault.bat
@@ -18,6 +18,8 @@ pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
+call "%DIRNAME%common.bat" :commonConf
+
 if "x%JBOSS_HOME%" == "x" (
   set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/CliScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/CliScriptTestCase.java
@@ -19,10 +19,7 @@
 
 package org.wildfly.scripts.test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -58,19 +55,12 @@ public class CliScriptTestCase extends ScriptTestCase {
 
         StringBuilder builder = new StringBuilder();
         // Read the output lines which should be valid DMR
-        try (BufferedReader reader = Files.newBufferedReader(script.getStdout(), StandardCharsets.UTF_8)) {
-            String line = reader.readLine();
+        for (String line : script.getStdout()) {
             // Skip lines like: "Picked up _JAVA_OPTIONS: ..."
-            while (line.startsWith("Picked up _JAVA_")) {
-                line = reader.readLine();
+            if (line.startsWith("Picked up _JAVA_") || line.startsWith("WARNING")) {
+                continue;
             }
-            while (line.startsWith("WARNING")) {
-                line = reader.readLine();
-            }
-            while (line != null) {
-                builder.append(line);
-                line = reader.readLine();
-            }
+            builder.append(line);
         }
         final ModelNode result = ModelNode.fromString(builder.toString());
         if (!Operations.isSuccessfulOutcome(result)) {

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
@@ -39,12 +39,12 @@ public class DomainScriptTestCase extends ScriptTestCase {
     private static final Function<ModelControllerClient, Boolean> HOST_CONTROLLER_CHECK = ServerHelper::isDomainRunning;
 
     public DomainScriptTestCase() {
-        super("domain", HOST_CONTROLLER_CHECK);
+        super("domain");
     }
 
     @Override
     void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
-        script.start(ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
+        script.start(HOST_CONTROLLER_CHECK, ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
 
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ElytronToolScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ElytronToolScriptTestCase.java
@@ -19,10 +19,7 @@
 
 package org.wildfly.scripts.test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Assert;
@@ -47,15 +44,12 @@ public class ElytronToolScriptTestCase extends ScriptTestCase {
             validateProcess(script);
 
             // Get the output and test the masked password
-            try (BufferedReader reader = Files.newBufferedReader(script.getStdout(), StandardCharsets.UTF_8)) {
-                String line = reader.readLine();
+            for (String line : script.getStdout()) {
                 // Skip lines like: "Picked up _JAVA_OPTIONS: ..."
-                while (line.startsWith("Picked up _JAVA_")) {
-                    line = reader.readLine();
+                if (line.startsWith("Picked up _JAVA_")) {
+                    continue;
                 }
                 Assert.assertEquals("MASK-8VzWsSNwBaR676g8ujiIDdFKwSjOBHCHgnKf17nun3v;12345678;123", line);
-                // We should only have one line
-                Assert.assertNull(reader.readLine());
             }
         } finally {
             script.close();

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -19,11 +19,13 @@
 
 package org.wildfly.scripts.test;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +35,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
@@ -57,26 +58,12 @@ public abstract class ScriptTestCase {
 
     static final Map<String, String> MAVEN_JAVA_OPTS = new LinkedHashMap<>();
 
-    private static final String[] POWER_SHELL_PREFIX = {
-            "powershell",
-            "-ExecutionPolicy",
-            "Unrestricted",
-            "-NonInteractive",
-            "-File"
-    };
-
     private final String scriptBaseName;
-    private final Function<ModelControllerClient, Boolean> check;
     private ExecutorService service;
 
 
     ScriptTestCase(final String scriptBaseName) {
-        this(scriptBaseName, null);
-    }
-
-    ScriptTestCase(final String scriptBaseName, final Function<ModelControllerClient, Boolean> check) {
         this.scriptBaseName = scriptBaseName;
-        this.check = check;
     }
 
     @BeforeClass
@@ -100,32 +87,32 @@ public abstract class ScriptTestCase {
 
     @Test
     public void testBatchScript() throws Exception {
-        Assume.assumeTrue(TestSuiteEnvironment.isWindows());
-        executeTests(".bat");
+        Assume.assumeTrue(Shell.BATCH.isSupported());
+        executeTests(Shell.BATCH);
     }
 
     @Test
     public void testPowerShellScript() throws Exception {
-        Assume.assumeTrue(TestSuiteEnvironment.isWindows() && isShellSupported("powershell", "-Help"));
-        executeTests(".ps1", POWER_SHELL_PREFIX);
+        Assume.assumeTrue(TestSuiteEnvironment.isWindows() && Shell.POWERSHELL.isSupported());
+        executeTests(Shell.POWERSHELL);
     }
 
     @Test
     public void testBashScript() throws Exception {
-        Assume.assumeTrue(!TestSuiteEnvironment.isWindows() && isShellSupported("bash", "-c", "echo", "test"));
-        executeTests(".sh");
+        Assume.assumeTrue(!TestSuiteEnvironment.isWindows() && Shell.BASH.isSupported());
+        executeTests(Shell.BASH);
     }
 
     @Test
     public void testDashScript() throws Exception {
-        Assume.assumeTrue(!TestSuiteEnvironment.isWindows() && isShellSupported("dash", "-c", "echo", "test"));
-        executeTests(".sh", "dash");
+        Assume.assumeTrue(!TestSuiteEnvironment.isWindows() && Shell.DASH.isSupported());
+        executeTests(Shell.DASH);
     }
 
     @Test
     public void testKshScript() throws Exception {
-        Assume.assumeTrue(!TestSuiteEnvironment.isWindows() && isShellSupported("ksh", "-c", "echo", "test"));
-        executeTests(".sh", "ksh");
+        Assume.assumeTrue(!TestSuiteEnvironment.isWindows() && Shell.KSH.isSupported());
+        executeTests(Shell.KSH);
     }
 
     abstract void testScript(ScriptProcess script) throws InterruptedException, TimeoutException, IOException;
@@ -151,11 +138,62 @@ public abstract class ScriptTestCase {
         return executeOperation(client, OperationBuilder.create(op).build());
     }
 
-    private void executeTests(final String scriptExtension, final String... prefixCmds) throws InterruptedException, IOException, TimeoutException {
+    private void executeTests(final Shell shell) throws InterruptedException, IOException, TimeoutException {
         for (Path path : ServerConfigurator.PATHS) {
-            try (ScriptProcess script = new ScriptProcess(path, scriptBaseName + scriptExtension, ServerHelper.TIMEOUT, check, prefixCmds)) {
+            try (ScriptProcess script = new ScriptProcess(path, scriptBaseName, shell, ServerHelper.TIMEOUT)) {
                 testScript(script);
+                script.close();
+                testCommonConf(script, shell);
             }
+        }
+    }
+
+    private void testCommonConf(final ScriptProcess script, final Shell shell) throws InterruptedException, IOException, TimeoutException {
+        testCommonConf(script, true, shell);
+        testCommonConf(script, false, shell);
+    }
+
+    private void testCommonConf(final ScriptProcess script, final boolean useEnvVar, final Shell shell) throws InterruptedException, IOException, TimeoutException {
+        final Map<String, String> env = new HashMap<>();
+        final Path confFile;
+        if (useEnvVar) {
+            confFile = Paths.get(TestSuiteEnvironment.getTmpDir(), "test-common" + shell.getConfExtension());
+            env.put("COMMON_CONF", confFile.toString());
+        } else {
+            confFile = script.getContainerHome().resolve("bin").resolve("common" + shell.getConfExtension());
+        }
+        // Create the common conf file which will simply echo some text and then exit the script
+        final String text = "Test from common configuration to " + confFile.getFileName().toString();
+        try (BufferedWriter writer = Files.newBufferedWriter(confFile, StandardCharsets.UTF_8)) {
+            if (shell == Shell.POWERSHELL) {
+                writer.write("Write-Output \"");
+                writer.write(text);
+                writer.write('"');
+                writer.newLine();
+                writer.write("break");
+            } else {
+                writer.write("echo \"");
+                writer.write(text);
+                writer.write('"');
+                writer.newLine();
+                writer.write("exit");
+            }
+            writer.newLine();
+        }
+        try {
+            script.start(env);
+            if (!script.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+                Assert.fail(script.getErrorMessage("Failed to exit script from " + confFile));
+            }
+            // Batch scripts print the quotes around the text
+            final String expectedText = (shell == Shell.BATCH ? "\"" + text + "\"" : text);
+            final List<String> lines = script.getStdout();
+            Assert.assertEquals(script.getErrorMessage("There should only be one line logged before the script exited"),
+                    1, lines.size());
+            Assert.assertEquals(expectedText, lines.get(0));
+        } finally {
+            script.close();
+            Files.delete(confFile);
         }
     }
 
@@ -165,32 +203,5 @@ public abstract class ScriptTestCase {
             Assert.fail(String.format("Failed to execute op: %s%nFailure Description: %s", op, Operations.getFailureDescription(result)));
         }
         return Operations.readResult(result);
-    }
-
-    private static boolean isShellSupported(final String name, final String... args) throws IOException, InterruptedException {
-        final List<String> cmd = new ArrayList<>();
-        cmd.add(name);
-        if (args != null && args.length > 0) {
-            cmd.addAll(Arrays.asList(args));
-        }
-        final Path stdout = Files.createTempFile(name + "-supported", ".log");
-        final ProcessBuilder builder = new ProcessBuilder(cmd)
-                .redirectErrorStream(true)
-                .redirectOutput(stdout.toFile());
-        Process process = null;
-        try {
-            process = builder.start();
-            if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
-                return false;
-            }
-            return process.exitValue() == 0;
-        } catch (IOException e) {
-            return false;
-        } finally {
-            if (process != null) {
-                process.destroyForcibly();
-            }
-            Files.deleteIfExists(stdout);
-        }
     }
 }

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Shell.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Shell.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.wildfly.common.test.ServerHelper;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public enum Shell {
+    BASH(".sh", ".conf", () -> isShellSupported("bash", "-c", "echo", "test")),
+    BATCH(".bat", ".conf.bat", TestSuiteEnvironment::isWindows),
+    DASH(".sh", ".conf", () -> isShellSupported("dash", "-c", "echo", "test"), "dash"),
+    KSH(".sh", ".conf", () -> isShellSupported("ksh", "-c", "echo", "test"), "ksh"),
+    POWERSHELL(".ps1", ".conf.ps1", () -> isShellSupported("powershell", "-Help"),
+            "powershell",
+            "-ExecutionPolicy",
+            "Unrestricted",
+            "-NonInteractive",
+            "-File"),
+    ;
+    private final String extension;
+    private final String confExtension;
+    private final BooleanSupplier supported;
+    private final String[] prefix;
+
+    Shell(final String extension, final String confExtension, final BooleanSupplier supported, final String... prefix) {
+        this.extension = extension;
+        this.confExtension = confExtension;
+        this.supported = supported;
+        this.prefix = prefix;
+    }
+
+    public String[] getPrefix() {
+        return prefix;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public String getConfExtension() {
+        return confExtension;
+    }
+
+    public boolean isSupported() {
+        return supported.getAsBoolean();
+    }
+
+    private static boolean isShellSupported(final String name, final String... args) {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(name);
+        if (args != null && args.length > 0) {
+            cmd.addAll(Arrays.asList(args));
+        }
+        try {
+            final Path stdout = Files.createTempFile(name + "-supported", ".log");
+            final ProcessBuilder builder = new ProcessBuilder(cmd)
+                    .redirectErrorStream(true)
+                    .redirectOutput(stdout.toFile());
+            Process process = null;
+            try {
+                process = builder.start();
+                if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+                    return false;
+                }
+                return process.exitValue() == 0;
+            } catch (IOException e) {
+                return false;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } finally {
+                if (process != null) {
+                    process.destroyForcibly();
+                }
+                Files.deleteIfExists(stdout);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -74,7 +74,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
     private static final Function<ModelControllerClient, Boolean> STANDALONE_CHECK = ServerHelper::isStandaloneRunning;
 
     public StandaloneScriptTestCase() {
-        super("standalone", STANDALONE_CHECK);
+        super("standalone");
     }
 
     @Parameters
@@ -94,7 +94,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         // seem to work when a directory has a space. An error indicating the trailing quote cannot be found. Removing
         // the `\ parts and just keeping quotes ends in the error shown in JDK-8215398.
         Assume.assumeFalse(TestSuiteEnvironment.isWindows() && MODULAR_JVM && env.containsKey("GC_LOG") && script.getScript().toString().contains(" "));
-        script.start(env, ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
+        script.start(STANDALONE_CHECK, env, ServerHelper.DEFAULT_SERVER_JAVA_OPTS);
         Assert.assertNotNull("The process is null and may have failed to start.", script);
         Assert.assertTrue("The process is not running and should be", script.isAlive());
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5261

This adds an import for a `common.conf` file in each `common.xx` script. A placeholder file was not created as I see no need to clutter the `bin` directory. A documentation PR will be required for the WildFly docs.

Analysis Doc: https://github.com/wildfly/wildfly-proposals/pull/369
Docs and Full PR: https://github.com/wildfly/wildfly/pull/13989