### PR TITLE
[WFCORE-5286] Remove deprecated javax.api usage from modules

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/core/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/core/main/module.xml
@@ -34,7 +34,8 @@
 
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
         <module name="org.apache.commons.logging"/>
         <!-- Following module is available in WildFly full -->
         <module name="org.apache.commons.codec" optional="true"/>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/jgit/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/jgit/main/module.xml
@@ -33,9 +33,12 @@
     </resources>
 
     <dependencies>
-        <module name="org.slf4j" />
-        <module name="org.slf4j.impl" />
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.security.jgss"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <module name="org.slf4j"/>
+        <module name="org.slf4j.impl"/>
         <module name="org.apache.sshd"/>
         <module name="com.googlecode.javaewah"/>
         <module name="org.apache.httpcomponents.core"/>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -36,6 +36,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
         <module name="java.security.jgss"/>
         <module name="java.security.sasl"/>
         <module name="io.undertow.core"/>
@@ -51,7 +52,6 @@
         <module name="org.wildfly.common" />
         <module name="org.wildfly.security.elytron-web.undertow-server" />
         <module name="org.jboss.msc"/>
-        <module name="javax.api"/>
     </dependencies>
 
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFCORE-5286

