### PR TITLE
[WFCORE-5290] / [WFCORE-5291] / [WFCORE-4584] Elytron Component Upgrades

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -323,6 +323,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-encryption</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http</artifactId>
         </dependency>
         <dependency>

--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -1304,6 +1304,17 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-encryption</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-http</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -52,6 +52,7 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-credential-source-impl}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-credential-store}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-digest}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-encryption}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-basic}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-bearer}"/>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -43,4 +43,5 @@
         <module>legacy-feature-pack</module>
     </modules>
 
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.15.0.CR1</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.8.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.9.0.CR1</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1801,6 +1801,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-encryption</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.14.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.15.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.8.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5290
https://issues.redhat.com/browse/WFCORE-5291
https://issues.redhat.com/browse/WFCORE-4584


        Release Notes - WildFly Elytron - Version 1.15.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2068'>ELY-2068</a>] -         Upgrade to MicroProfile JWT 1.2
</li>
</ul>
                    
<h2>        Requirement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1842'>ELY-1842</a>] -         Update the tool to support generating and exporting / importing a secret key to the credential store
</li>
</ul>
                                                                                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2081'>ELY-2081</a>] -         Develop a simple properties based credential store for secret keys
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2086'>ELY-2086</a>] -         Update the WildFly Elytron tool to support encrypting clear text values
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1626'>ELY-1626</a>] -         Programmatic web authentication (HttpServletRequest.login()) does not trigger sso
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2076'>ELY-2076</a>] -         Some traces of &quot;programatic&quot; remain in code that should be converted to &quot;programmatic&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2077'>ELY-2077</a>] -         Due to mechanism wrapping calls to dispose() are not making it to the underlying mechamims,
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2087'>ELY-2087</a>] -         Error code 12000 has been duplicated
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2055'>ELY-2055</a>] -         Refactor CredentialStoreCommand to make development easier
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2089'>ELY-2089</a>] -         Release WildFly Elytron 1.15.0.CR1
</li>
</ul>
                                        

        Release Notes - Elytron Web - Version 1.9.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-120'>ELYWEB-120</a>] -         Update Undertow to 2.2.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-121'>ELYWEB-121</a>] -         Upgrade to org.apache.httpcomponents:httpcore:4.4.14
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-122'>ELYWEB-122</a>] -         Upgrade to org.apache.httpcomponents:httpclient:4.5.13
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-123'>ELYWEB-123</a>] -         Upgrade WildFly Elytron to 1.14.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-127'>ELYWEB-127</a>] -         Upgrade WildFly Elytron to 1.15.0.CR1
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-125'>ELYWEB-125</a>] -         Make it possible to pass through an alternative IdentityCache Supplier
</li>
</ul>
                                                                                                                                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-118'>ELYWEB-118</a>] -         Update Elytron Web to build on Fedora 33
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-126'>ELYWEB-126</a>] -         Programmatic authentication is misspelt as &quot;Programatic&quot; 
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-119'>ELYWEB-119</a>] -         Create GitHub CI Workflow
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-128'>ELYWEB-128</a>] -         Release Elytron Web 1.9.0.CR1
</li>
</ul>
                                        
