### PR TITLE
[WFCORE-5301] Use a descriptive error message if the secret key is not available from the credential store.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/expression/ElytronExpressionResolver.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/expression/ElytronExpressionResolver.java
@@ -136,6 +136,9 @@ public class ElytronExpressionResolver implements ExpressionResolver {
         SecretKey secretKey;
         try {
             SecretKeyCredential credential = credentialStore.retrieve(resolverConfiguration.getAlias(), SecretKeyCredential.class);
+            if (credential == null) {
+                throw ROOT_LOGGER.credentialDoesNotExist(resolverConfiguration.getAlias(), SecretKeyCredential.class.getSimpleName());
+            }
             secretKey = credential.getSecretKey();
         } catch (CredentialStoreException e) {
             throw ROOT_LOGGER.unableToLoadCredential(e);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5301