### PR TITLE
[WFCORE-5324] Support for CLI script executing at boot for bootable JAR

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Arguments.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Arguments.java
@@ -53,6 +53,7 @@ final class Arguments {
     private final List<String> serverArguments = new ArrayList<>();
     private final BootableEnvironment environment;
     private Path deployment;
+    private Path cliScript;
 
     static Arguments parseArguments(final List<String> args, final BootableEnvironment environment) throws Exception {
         Objects.requireNonNull(args);
@@ -101,6 +102,11 @@ final class Arguments {
                 serverArguments.add(a);
             } else if (CommandLineConstants.HELP.equals(a)) {
                 isHelp = true;
+            } else if (a.startsWith("--cli-script")) {
+                cliScript = Paths.get(getValue(a));
+                if (!Files.exists(cliScript) || !Files.isReadable(cliScript)) {
+                    throw new Exception("File doesn't exist or is not readable: " + cliScript);
+                }
             } else {
                 throw BootableJarLogger.ROOT_LOGGER.unknownArgument(a);
             }
@@ -151,6 +157,10 @@ final class Arguments {
      */
     public Path getDeployment() {
         return deployment;
+    }
+
+    public Path getCLIScript() {
+        return cliScript;
     }
 
     private static void addSystemProperty(final String arg, final Map<String, String> properties) {

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableEnvironment.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableEnvironment.java
@@ -44,6 +44,7 @@ class BootableEnvironment {
     private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
     private final Path jbossHome;
     private final Path serverDir;
+    private final Path tmpDir;
     private final Collection<String> ignoredProperties;
     private final PropertyUpdater propertyUpdater;
     private final String pidFileName;
@@ -53,6 +54,7 @@ class BootableEnvironment {
                                 final PropertyUpdater propertyUpdater) {
         this.jbossHome = jbossHome;
         serverDir = jbossHome.resolve("standalone");
+        tmpDir = resolvePath(serverDir, "tmp");
         this.ignoredProperties = ignoredProperties;
         this.propertyUpdater = propertyUpdater;
         String pidFileName = System.getProperty("org.wildfly.core.bootable.jar.pidFile");
@@ -110,6 +112,15 @@ class BootableEnvironment {
      */
     Path getJBossHome() {
         return jbossHome;
+    }
+
+    /**
+     * Returns the server tmp dir.
+     *
+     * @return the server tmp dir.
+     */
+    Path getTmpDir() {
+        return tmpDir;
     }
 
     /**

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableEnvironment.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableEnvironment.java
@@ -199,6 +199,8 @@ class BootableEnvironment {
      * <p>
      * Note there are a set of system properties that will not be set and are determined based on the JBoss Home
      * directory.
+     * Special case for {@code jboss.server.log.dir} that can be set as an argument. If not set, then a value is  determined based on the JBoss Home
+     * directory.
      * </p>
      *
      * @param properties the properties to set
@@ -211,6 +213,11 @@ class BootableEnvironment {
         }
         for (Map.Entry<String, String> entry : local.entrySet()) {
             setSystemProperty(entry.getKey(), entry.getValue());
+        }
+        // Handle server log dir.
+        if (System.getProperty("jboss.server.log.dir") == null) {
+            Path p = resolvePath(serverDir, "log");
+            propertyUpdater.setProperty("jboss.server.log.dir", p.toString());
         }
     }
 
@@ -252,7 +259,6 @@ class BootableEnvironment {
         setSystemProperty(propertyUpdater, "jboss.server.data.dir", dataDir, propertyNames);
         setSystemProperty(propertyUpdater, "jboss.server.config.dir", resolvePath(serverBaseDir, "configuration"), propertyNames);
         setSystemProperty(propertyUpdater, "jboss.server.deploy.dir", resolvePath(dataDir, "content"), propertyNames);
-        setSystemProperty(propertyUpdater, "jboss.server.log.dir", resolvePath(serverBaseDir, "log"), propertyNames);
         setSystemProperty(propertyUpdater, "jboss.server.temp.dir", resolvePath(serverBaseDir, "tmp"), propertyNames);
         return propertyNames;
     }

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
@@ -230,6 +230,18 @@ public final class BootableJar implements ShutdownHandler {
     }
 
     public void run() throws Exception {
+        Path script = arguments.getCLIScript();
+        if (script != null) {
+            long id = System.currentTimeMillis();
+            Path markerDir = environment.getTmpDir().resolve(id + "-cli-boot-hook-dir");
+            Path outputFile = environment.getTmpDir().resolve(id + "-cli-boot-hook-output-file.txt");
+            Files.createDirectories(markerDir);
+            startServerArgs.add("--start-mode=admin-only");
+            startServerArgs.add("-Dorg.wildfly.internal.cli.boot.hook.script=" + script.toAbsolutePath().toString());
+            startServerArgs.add("-Dorg.wildfly.internal.cli.boot.hook.marker.dir=" + markerDir.toAbsolutePath().toString());
+            startServerArgs.add("-Dorg.wildfly.internal.cli.boot.hook.script.output.file=" + outputFile.toAbsolutePath().toString());
+        }
+
         Runtime.getRuntime().addShutdownHook(new ShutdownHook());
         server = buildServer(startServerArgs);
 

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
@@ -41,6 +41,9 @@ final class CmdUsage extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SYS_PROP + "<name>[=<value>]");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argSystem());
 
+        addArguments(Constants.CLI_SCRIPT_ARG);
+        instructions.add(BootableJarLogger.ROOT_LOGGER.argCliScript());
+
         addArguments(Constants.DISPLAY_GALLEON_CONFIG_ARG);
         instructions.add(BootableJarLogger.ROOT_LOGGER.argDisplayGalleonConfig());
 

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Constants.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Constants.java
@@ -25,6 +25,7 @@ interface Constants {
     static final String DEPLOYMENT_ARG = "--deployment";
     static final String INSTALL_DIR_ARG = "--install-dir";
     static final String DISPLAY_GALLEON_CONFIG_ARG = "--display-galleon-config";
+    static final String CLI_SCRIPT_ARG = "--cli-script";
 
     static final String DEPLOYMENTS = "deployments";
     static final String STANDALONE_CONFIG = "standalone.xml";

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
@@ -162,4 +162,7 @@ public interface BootableJarLogger extends BasicLogger {
 
     @Message(id = Message.NONE, value = "Display the content of the Galleon configuration used to build this bootable JAR")
     String argDisplayGalleonConfig();
+
+    @Message(id = Message.NONE, value = "Path to a CLI script to execute when starting the Bootable JAR")
+    String argCliScript();
 }

--- a/bootable-jar/runtime/src/test/java/org/wildfly/core/jar/runtime/ArgumentsTestCase.java
+++ b/bootable-jar/runtime/src/test/java/org/wildfly/core/jar/runtime/ArgumentsTestCase.java
@@ -97,6 +97,32 @@ public class ArgumentsTestCase {
                 throw new Exception("Should have failed");
             }
         }
+
+        {
+            Path script = Files.createTempFile(null, ".cli");
+            try {
+                String[] args = {"--cli-script=" + script };
+                Arguments arguments = Arguments.parseArguments(Arrays.asList(args), createEnvironment());
+                assertEquals(arguments.getCLIScript(), script);
+                assertEquals(0, arguments.getServerArguments().size());
+            } finally {
+                Files.delete(script);
+            }
+        }
+
+        {
+            boolean error = false;
+            try {
+                String[] args = {"--cli-script=foo.cli"};
+                Arguments arguments = Arguments.parseArguments(Arrays.asList(args), createEnvironment());
+                error = true;
+            } catch (Exception ex) {
+                // OK expected
+            }
+            if (error) {
+                throw new Exception("Should have failed");
+            }
+        }
     }
 
     @Test

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -91,9 +91,10 @@ class CliConfigImpl implements CliConfig {
 
     private static final Logger log = Logger.getLogger(CliConfig.class);
 
-    static CliConfig newBootConfig() throws CliInitializationException {
+    static CliConfig newBootConfig(boolean echoCommand) throws CliInitializationException {
         CliConfigImpl config = new CliConfigImpl();
         config.validateOperationRequests = false;
+        config.echoCommand = echoCommand;
         return config;
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -455,8 +455,17 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
      *
      */
     public CommandContextImpl(OutputStream output) throws CliInitializationException {
+        this(output, true);
+    }
+
+    /**
+     * Constructor called from Boot invoker, minimal configuration. Used by test.
+     * public for testing purpose.
+     *
+     */
+    public CommandContextImpl(OutputStream output, boolean enableEchoCommand) throws CliInitializationException {
         bootInvoker = true;
-        config = CliConfigImpl.newBootConfig();
+        config = CliConfigImpl.newBootConfig(enableEchoCommand);
         addressResolver = ControllerAddressResolver.newInstance(config, null);
 
         operationHandler = new OperationRequestHandler();

--- a/cli/src/main/java/org/jboss/as/cli/impl/_private/BootScriptInvokerLogger.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/_private/BootScriptInvokerLogger.java
@@ -114,4 +114,17 @@ public interface BootScriptInvokerLogger extends BasicLogger {
     @Message(id = 8, value = "Error processing CLI script %s. The Operations were executed but "
             + "there were unexpected values. See list of errors in %s")
     IllegalStateException unexpectedErrors(File script, File errors);
+
+    /**
+     * Logs an error message to advertise that an unexpected exception was
+     * thrown.
+     *
+     * @param cause
+     * @param cmd
+     * @param file CLI script file
+     * @return Exception to throw
+     */
+    @Message(id = 9, value = "Unexpected exception while processing CLI command %s from %s")
+    IllegalStateException unexpectedCommandException(@Cause Throwable cause, String cmd, File file);
+
 }

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/bootable-jar/main/module.xml
@@ -74,6 +74,7 @@
         <module name="org.jboss.as.process-controller"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private" services="import"/>
+        <module name="org.jboss.as.cli"/>
     </dependencies>
 
 </module>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -365,6 +365,37 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <configuration>
+                            <hollowJar>true</hollowJar>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </plugin-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-vault-test-galleon-pack</artifactId>
+                                    <!--<artifactId>wildfly-core-galleon-pack</artifactId>-->
+                                    <version>${project.version}</version>
+                                    <!-- Specifically include patching -->
+                                    <included-packages>
+                                        <name>org.jboss.as.patching.cli</name>
+                                        <name>org.picketbox</name>
+                                    </included-packages>
+                                    <excluded-packages>
+                                        <name>product.conf</name>
+                                    </excluded-packages>
+                                </feature-pack>
+                            </feature-packs>
+                            <layers>
+                                <layer>core-server</layer>
+                                <layer>core-tools</layer>
+                                <layer>deployment-scanner</layer>
+                            </layers>
+                        </configuration>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>
@@ -375,14 +406,6 @@
                                 <phase>compile</phase>
                                 <configuration>
                                     <output-file-name>test-wildfly.jar</output-file-name>
-                                    <hollowJar>true</hollowJar>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>true</offline>
-                                    <plugin-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                    </plugin-options>
                                     <cli-sessions>
                                         <cli-session>
                                             <script-files>
@@ -390,27 +413,18 @@
                                             </script-files>
                                         </cli-session>
                                     </cli-sessions>
-                                    <feature-packs>
-                                        <feature-pack>
-                                            <groupId>org.wildfly.core</groupId>
-                                            <artifactId>wildfly-core-vault-test-galleon-pack</artifactId>
-                                            <!--<artifactId>wildfly-core-galleon-pack</artifactId>-->
-                                            <version>${project.version}</version>
-                                            <!-- Specifically include patching -->
-                                            <included-packages>
-                                                <name>org.jboss.as.patching.cli</name>
-                                                <name>org.picketbox</name>
-                                            </included-packages>
-                                            <excluded-packages>
-                                                <name>product.conf</name>
-                                            </excluded-packages>
-                                        </feature-pack>
-                                    </feature-packs>
-                                    <layers>
-                                        <layer>core-server</layer>
-                                        <layer>core-tools</layer>
-                                        <layer>deployment-scanner</layer>
-                                    </layers>
+                                </configuration>
+                            </execution>
+                            <!-- execution with elytron configuration done at runtime -->
+                            <execution>
+                                <id>bootable-jar-packaging-runtime</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <bootable-jar-build-artifacts>bootable-jar-build-artifacts-runtime</bootable-jar-build-artifacts>
+                                    <output-file-name>test-wildfly-runtime.jar</output-file-name>
                                 </configuration>
                             </execution>
                         </executions>
@@ -433,7 +447,7 @@
                                             <name>wildfly.bootable.jar</name>
                                             <value>true</value>
                                         </property>
-                                        <property>
+                                         <property>
                                             <name>wildfly.bootable.jar.jar</name>
                                             <value>${project.build.directory}/test-wildfly.jar</value>
                                         </property>
@@ -442,6 +456,32 @@
                                             <value>${project.build.directory}/${server.output.dir.prefix}</value>
                                         </property>
                                     </systemProperties>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>default-test-runtime</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemProperties>
+                                        <property>
+                                            <name>wildfly.bootable.jar</name>
+                                            <value>true</value>
+                                        </property>
+                                        <property>
+                                            <name>wildfly.bootable.jar.jar</name>
+                                            <value>${project.build.directory}/test-wildfly-runtime.jar</value>
+                                        </property>
+                                        <property>
+                                            <name>wildfly.bootable.jar.install.dir</name>
+                                            <value>${project.build.directory}/${server.output.dir.prefix}-runtime</value>
+                                        </property>
+                                    </systemProperties>
+                                    <systemPropertyVariables>
+                                        <jboss.args>${jboss.args} --cli-script=${ts.config.elytron.cli.no.embedded}</jboss.args>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
@@ -77,7 +77,7 @@ public class BasicIfElseTestCase extends CLISystemPropertyTestBase {
     @Test
     public void testIfMatchComparisonBoot() throws Exception {
 
-        final CommandContext ctx = new CommandContextImpl(cliOut);
+        final CommandContext ctx = new CommandContextImpl(cliOut, false);
         try {
             ctx.bindClient(managementClient.getControllerClient());
             ctx.handle(this.getAddPropertyReq("match-test-values", "\"AAA BBB\""));

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ManagementClient.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ManagementClient.java
@@ -37,6 +37,7 @@ import java.util.List;
 import javax.management.remote.JMXServiceURL;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import static org.jboss.as.controller.client.helpers.ClientConstants.RUNNING_STATE_NORMAL;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -133,6 +134,22 @@ public class ManagementClient implements AutoCloseable, Closeable {
             return SUCCESS.equals(rsp.get(OUTCOME).asString())
                     && !CONTROLLER_PROCESS_STATE_STARTING.equals(rsp.get(RESULT).asString())
                     && !CONTROLLER_PROCESS_STATE_STOPPING.equals(rsp.get(RESULT).asString());
+        } catch (RuntimeException rte) {
+            throw rte;
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    public boolean isServerInNormalMode() {
+        try {
+            ModelNode op = new ModelNode();
+            op.get(OP).set(READ_ATTRIBUTE_OPERATION);
+            op.get(OP_ADDR).setEmptyList();
+            op.get(NAME).set("running-mode");
+            ModelNode rsp = client.execute(op);
+            return SUCCESS.equals(rsp.get(OUTCOME).asString())
+                    && RUNNING_STATE_NORMAL.toUpperCase().equals(rsp.get(RESULT).asString());
         } catch (RuntimeException rte) {
             throw rte;
         } catch (IOException ex) {


### PR DESCRIPTION
Issues:
https://issues.redhat.com/browse/WFCORE-5322
https://issues.redhat.com/browse/WFCORE-5323
https://issues.redhat.com/browse/WFCORE-5324

Community doc PR:
https://github.com/wildfly/wildfly/pull/14069

* Introduce --cli-script=[path to cli script]
* Fix output when error occur during CLI script execution
* Fix ability to set server log config directory
* Evolved ts.bootable profile of elytron tests with CLI configuration applied at runtime.