### PR TITLE
[WFCORE-5327] Upgrade WildFly Elytron to 1.15.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.15.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.15.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-5</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5327


        Release Notes - WildFly Elytron - Version 1.15.1.Final
                                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2098'>ELY-2098</a>] -         Webservices client should use currently configured and not previously configured authentication context
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2100'>ELY-2100</a>] -         Release WildFly Elytron 1.15.1.Final
</li>
</ul>