### PR TITLE
[WFCORE-5329] Upgrade Undertow to 2.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.4.Final</version.io.undertow>
+        <version.io.undertow>2.2.5.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5329
(adds OSGi support to Undertow)

**
        Release Notes - Undertow - Version 2.2.5.Final
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1845'>UNDERTOW-1845</a>] -         AbstractFramedChannel.FrameReadListener contains incomplete log when invoking listener
</li>
</ul>
                                                                                                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1846'>UNDERTOW-1846</a>] -         Load shedding excessive handshakes
</li>
</ul>
                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1847'>UNDERTOW-1847</a>] -         Add script to deploy jakarta EE9 transformed artifacts
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1852'>UNDERTOW-1852</a>] -         Add OSGi support
</li>
</ul>
                                                        **