### PR TITLE
Revert "[WFCORE-5241] In jboss-cli.sh,  convert JAVA_OPTS into array …

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/jboss-cli.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/jboss-cli.sh
@@ -84,14 +84,9 @@ JAVA_OPTS="$JAVA_OPTS -Dcom.ibm.jsse2.overrideDefaultTLS=true"
 JBOSS_MODULEPATH=$(eval echo \"${JBOSS_MODULEPATH}\")
 
 LOG_CONF=`echo $JAVA_OPTS | grep "logging.configuration"`
-
-# WFCORE-5241 convert $JAVA_OPTS into array and quote each element to allow exec them with whitespace inside.
-java_opts_array=()
-eval 'for arg in '$JAVA_OPTS'; do java_opts_array+=("$arg"); done'
-
 if [ "x$LOG_CONF" = "x" ]; then
-    exec "$JAVA" "${java_opts_array[@]}" -Dlogging.configuration=file:"$JBOSS_HOME"/bin/jboss-cli-logging.properties -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.as.cli "$@"
+    exec "$JAVA" $JAVA_OPTS -Dlogging.configuration=file:"$JBOSS_HOME"/bin/jboss-cli-logging.properties -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.as.cli "$@"
 else
     echo "logging.configuration already set in JAVA_OPTS"
-    exec "$JAVA" "${java_opts_array[@]}" -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.as.cli "$@"
+    exec "$JAVA" $JAVA_OPTS -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.as.cli "$@"
 fi

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/CliScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/CliScriptTestCase.java
@@ -45,14 +45,6 @@ public class CliScriptTestCase extends ScriptTestCase {
         if (!TestSuiteEnvironment.isWindows()) {
             // WFCORE-5216
             env.put("JBOSS_MODULEPATH", "$JBOSS_HOME/modules:$HOME");
-
-            // WFCORE-5241 For jboss-cli.sh, test with JAVA_OPTS parameter including whitespace
-            String javaOpts = env.get("JAVA_OPTS");
-            if (javaOpts != null) {
-                env.put("JAVA_OPTS", javaOpts + " -Dtestparameter=\"something with space\"");
-            } else {
-                env.put("JAVA_OPTS", "-Dtestparameter=\"something with space\"");
-            }
         }
         // Read an attribute
         script.start(env, "--commands=embed-server,:read-attribute(name=server-state),exit");


### PR DESCRIPTION
…and quote each element to allow exec them with whitespace inside"

This reverts commit db82190b4b2191638c699eeaced3898cd1f4c60e.

Issue: https://issues.redhat.com/browse/WFCORE-5333 revert fix which breaks script with `dash`
