### PR TITLE
[WFCORE-5337] Use INFO level instead of WARN for loging traces when a…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -444,7 +444,7 @@ public interface ControllerLogger extends BasicLogger {
     void transformationWarnings(String hostName, Set<String> problems);
 
     @Message(id = 33, value = "Extension '%s' is deprecated and may not be supported in future versions")
-    @LogMessage(level = WARN)
+    @LogMessage(level = INFO)
     void extensionDeprecated(String extensionName);
 
     @Message(id = 34, value = "Subsystems %s provided by legacy extension '%s' are not supported on servers running this version. " +


### PR DESCRIPTION
… deprecated extension is in use

Jira issue: https://issues.redhat.com/browse/WFCORE-5337