### PR TITLE
[WFCORE-5349] Upgrade to WildFly Elytron 1.15.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.15.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.15.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-5</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5349

https://github.com/wildfly-security/wildfly-elytron/compare/1.15.1.Final...1.15.2.Final


        Release Notes - WildFly Elytron - Version 1.15.2.Final
                                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2104'>ELY-2104</a>] -         two calls to introspection endpoint for one request with JWT
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2106'>ELY-2106</a>] -         Release WildFly Elytron 1.15.2.Final
</li>
</ul>
                                        