### PR TITLE
[WFCORE-5340][WFCORE-5267] Create model test controller version to test transformers agains EAP 7.4.0 based on WF23

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -68,7 +68,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
         data.add(new TransformersTestParameter(ModelVersion.create(5, 0, 0), ModelTestControllerVersion.EAP_7_1_0));
         data.add(new TransformersTestParameter(ModelVersion.create(8, 0, 0), ModelTestControllerVersion.EAP_7_2_0));
         data.add(new TransformersTestParameter(ModelVersion.create(10, 0, 0), ModelTestControllerVersion.EAP_7_3_0));
-
+        data.add(new TransformersTestParameter(ModelVersion.create(16, 0, 0), ModelTestControllerVersion.EAP_7_4_0_TEMP));
         return data;
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -48,6 +48,10 @@ public enum ModelTestControllerVersion {
     // WildFly legacy test will need to rename the *-wf14.dmr files to *-7.2.0.dmr
     EAP_7_2_0("7.2.0.GA-redhat-00005", true, "14.0.0", "6.0.11.Final-redhat-00001", "7.2.0"),
     EAP_7_3_0("7.3.0.GA-redhat-00004", true, "18.0.0", "10.1.2.Final-redhat-00001", "7.3.0"),
+    // We use a 7.4.0_TEMP version which is based on WF23. Once we get 7.4.0.GA out, we will replace this by:
+    // EAP_7_4_0("7.4.0.GA-redhat-?????", true, "23.0.0", "15.0.0.Final-redhat-?????", "7.4.0"),
+    // See https://issues.redhat.com/browse/WFCORE-5347
+    EAP_7_4_0_TEMP("23.0.0.Final", false, "23.0.0", "15.0.0.Final", "wf23"),
     ;
 
     private final String mavenGavVersion;

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -305,6 +305,59 @@ public abstract class ModelTestModelControllerService extends AbstractController
     }
 
     /**
+     * This is the constructor to use for 23.0.x core model tests.
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition rootResourceDefinition, ControlledProcessState processState,
+                                              final ExpressionResolver expressionResolver, final CapabilityRegistry capabilityRegistry, final Controller23x version) {
+        super(processType,
+                runningModeControl,
+                persister,
+                processState == null ? new ControlledProcessState(true) : processState,
+                rootResourceDefinition,
+                null,
+                expressionResolver,
+                AuditLogger.NO_OP_LOGGER,
+                new DelegatingConfigurableAuthorizer(),
+                new ManagementSecurityIdentitySupplier(),
+                capabilityRegistry
+        );
+
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for 23.0.x subsystem tests.
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition resourceDefinition, final ControlledProcessState processState,
+                                              final CapabilityRegistry capabilityRegistry, final Controller23x version) {
+        super(processType,
+                runningModeControl,
+                persister,
+                processState == null ? new ControlledProcessState(true) : processState,
+                resourceDefinition,
+                null,
+                ExpressionResolver.TEST_RESOLVER,
+                AuditLogger.NO_OP_LOGGER,
+                new DelegatingConfigurableAuthorizer(),
+                new ManagementSecurityIdentitySupplier(),
+                capabilityRegistry
+        );
+
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+
+    /**
      * This is the constructor to use for current core model tests
      */
     protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
@@ -609,6 +662,12 @@ public abstract class ModelTestModelControllerService extends AbstractController
     public static class Controller18x {
         public static Controller18x INSTANCE = new Controller18x();
         private Controller18x() {
+        }
+    }
+
+    public static class Controller23x {
+        public static Controller23x INSTANCE = new Controller23x();
+        private Controller23x() {
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.legacy.test>5.0.0.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>6.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.1.3.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
Supersedes https://github.com/wildfly/wildfly-core/pull/4534

This PR combines two issues:
    Jira: https://issues.redhat.com/browse/WFCORE-5340
    Jira: https://issues.redhat.com/browse/WFCORE-5267

It adds a EAP_7_4_0_TEMP model controller version based on WF23. We use the _TEMP suffix to force us to review and replace any uses of it when we get real 7.4.0.GA out and available for this replacement. There are some more advanced subsystem tests that specify additional maven artifacts that could need an additional review once we move out of WF23. Having a _TEMP suffix will allow us to pay attention to them once we are removing this suffix.
