### PR TITLE
Fix for WFCORE-5354, Upgrade galleon to 4.2.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>4.2.7.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.galleon-plugins>5.1.1.Final</version.org.wildfly.galleon-plugins>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5354
Diff: https://github.com/wildfly/galleon/compare/4.2.7.Final...4.2.8.Final
