### PR TITLE
[15.x] [WFCORE-5355] Upgrade WildFly Elytron to 1.15.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.15.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.15.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.0.Final</version.org.wildfly.security.elytron-web>
         <version.xalan>2.7.1.jbossorg-5</version.xalan>
        


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5355

Upstream PR https://github.com/wildfly/wildfly-core/pull/4543

        Release Notes - WildFly Elytron - Version 1.15.3.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2109'>ELY-2109</a>] -         Upgrade jboss logmanager to 2.1.18.Final
</li>
</ul>
                                                                                                                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2108'>ELY-2108</a>] -         Subject private credentials have zeroes when passed to elytron-enabled datasource
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2110'>ELY-2110</a>] -         Release WildFly Elytron 1.15.3.Final
</li>
</ul>
                                        