### PR TITLE
Fix for WFCORE-5362, Upgrade galleon-plugins to 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>5.1.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.1.2.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <version.org.wildfly.jar.plugin>4.0.0.Final</version.org.wildfly.jar.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5362
Diff: https://github.com/wildfly/galleon-plugins/compare/5.1.1.Final...5.1.2.Final
