### PR TITLE
[WFCORE-5363] Upgrade JBoss Remoting to 5.0.21.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.11.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.11.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.12.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.20.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.21.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5363

Fixes:
 * [REM3-377] Use safeClose() in ClientServiceHandle.close()
