### PR TITLE
Fix for WFCORE-5365, cli-script option help text is missing a placeholder

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
@@ -41,7 +41,7 @@ final class CmdUsage extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SYS_PROP + "<name>[=<value>]");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argSystem());
 
-        addArguments(Constants.CLI_SCRIPT_ARG);
+        addArguments(Constants.CLI_SCRIPT_ARG + "=<value>");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argCliScript());
 
         addArguments(Constants.DISPLAY_GALLEON_CONFIG_ARG);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5365
