### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (testsuite-elytron)

### DIFF
--- a/testsuite/elytron/src/test/java/org/jboss/as/test/shared/CliUtils.java
+++ b/testsuite/elytron/src/test/java/org/jboss/as/test/shared/CliUtils.java
@@ -16,7 +16,7 @@
 
 package org.jboss.as.test.shared;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 /**
  * CLI helper methods.
@@ -32,6 +32,6 @@ public class CliUtils {
      * @return escaped path
      */
     public static String escapePath(String path) {
-        return Objects.requireNonNull(path, "Path to escape can't be null.").replace("\\", "\\\\");
+        return checkNotNullParamWithNullPointerException("path", path).replace("\\", "\\\\");
     }
 }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AbstractConfigurableElement.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AbstractConfigurableElement.java
@@ -16,7 +16,7 @@
 
 package org.wildfly.test.security.common.elytron;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 /**
  * Abstract parent for {@link ConfigurableElement} implementations. It just holds common fields and provides parent for
@@ -29,7 +29,8 @@ public abstract class AbstractConfigurableElement implements ConfigurableElement
     protected final String name;
 
     protected AbstractConfigurableElement(Builder<?> builder) {
-        this.name = Objects.requireNonNull(builder.name, "Configuration name must not be null");
+        checkNotNullParamWithNullPointerException("builder", builder);
+        this.name = checkNotNullParamWithNullPointerException("builder.name", builder.name);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AbstractConstantHelper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AbstractConstantHelper.java
@@ -15,7 +15,7 @@
  */
 package org.wildfly.test.security.common.elytron;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
@@ -31,7 +31,7 @@ public abstract class AbstractConstantHelper extends AbstractConfigurableElement
 
     protected AbstractConstantHelper(Builder<?> builder) {
         super(builder);
-        this.constant = Objects.requireNonNull(builder.constant, "Constant has to be provided");
+        this.constant = checkNotNullParamWithNullPointerException("builder.constant", builder.constant);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AbstractUserRolesCapableElement.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AbstractUserRolesCapableElement.java
@@ -16,10 +16,11 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Abstract parent for {@link ConfigurableElement} implementations which are able to configure (and provide) users and roles.
@@ -56,7 +57,7 @@ public abstract class AbstractUserRolesCapableElement extends AbstractConfigurab
          * @param userWithRoles not-null {@link UserWithRoles} instance
          */
         public final T withUser(UserWithRoles userWithRoles) {
-            this.usersWithRoles.add(Objects.requireNonNull(userWithRoles, "Provided user must not be null."));
+            this.usersWithRoles.add(checkNotNullParamWithNullPointerException("userWithRoles", userWithRoles));
             return self();
         }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ConstantRealmMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ConstantRealmMapper.java
@@ -16,7 +16,7 @@
 
 package org.wildfly.test.security.common.elytron;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -39,7 +39,7 @@ public class ConstantRealmMapper extends AbstractConfigurableElement {
 
     private ConstantRealmMapper(Builder builder) {
         super(builder);
-        this.realm = Objects.requireNonNull(builder.realm, "Realm name must be provided");
+        this.realm = checkNotNullParamWithNullPointerException("builder.realm", builder.realm);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ConstantRoleMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ConstantRoleMapper.java
@@ -16,7 +16,7 @@
 
 package org.wildfly.test.security.common.elytron;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -39,7 +39,7 @@ public class ConstantRoleMapper extends AbstractConfigurableElement {
 
     private ConstantRoleMapper(Builder builder) {
         super(builder);
-        this.roles = Objects.requireNonNull(builder.roles, "Roles must be provided");
+        this.roles = checkNotNullParamWithNullPointerException("builder.roles", builder.roles);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/DirContext.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/DirContext.java
@@ -16,11 +16,11 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -51,7 +51,7 @@ public class DirContext extends AbstractConfigurableElement {
 
     private DirContext(Builder builder) {
         super(builder);
-        this.url = Objects.requireNonNull(builder.url, "URL in Elytron dir-context configuration has to be provided.");
+        this.url = checkNotNullParamWithNullPointerException("builder.url", builder.url);
         this.authenticationContext = builder.authenticationContext;
         this.authenticationLevel = builder.authenticationLevel;
         this.connectionTimeout = builder.connectionTimeout;

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/IdentityMapping.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/IdentityMapping.java
@@ -16,11 +16,11 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.jboss.dmr.ModelNode;
 
@@ -45,7 +45,7 @@ public class IdentityMapping implements ModelNodeConvertable {
 
 
     private IdentityMapping(Builder builder) {
-        this.rdnIdentifier = Objects.requireNonNull(builder.rdnIdentifier, "The rdn-identifier has to be provided in identity-mapping.");
+        this.rdnIdentifier = checkNotNullParamWithNullPointerException("builder.rdnIdentifier", builder.rdnIdentifier);
         this.useRecursiveSearch = builder.useRecursiveSearch;
         this.searchBaseDn = builder.searchBaseDn;
         this.attributeMapping = builder.attributeMapping.toArray(new AttributeMapping[builder.attributeMapping.size()]);

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/KeyStoreRealm.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/KeyStoreRealm.java
@@ -16,7 +16,7 @@
 package org.wildfly.test.security.common.elytron;
 
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
@@ -32,7 +32,7 @@ public class KeyStoreRealm extends AbstractConfigurableElement {
 
     private KeyStoreRealm(Builder builder) {
         super(builder);
-        this.keyStore = Objects.requireNonNull(builder.keyStore, "Key-store name has to be provided");
+        this.keyStore = checkNotNullParamWithNullPointerException("builder.keyStore", builder.keyStore);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/LdapRealm.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/LdapRealm.java
@@ -16,9 +16,8 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
-
-import java.util.Objects;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -42,9 +41,9 @@ public class LdapRealm extends AbstractConfigurableElement {
     private LdapRealm(Builder builder) {
         super(builder);
         this.allowBlankPassword = builder.allowBlankPassword;
-        this.dirContext = Objects.requireNonNull(builder.dirContext, "The 'dir-context' has to be provided.");
+        this.dirContext = checkNotNullParamWithNullPointerException("builder.dirContext", builder.dirContext);
         this.directVerification = builder.directVerification;
-        this.identityMapping = Objects.requireNonNull(builder.identityMapping, "The 'identity-mapping' has to be provided.");
+        this.identityMapping = checkNotNullParamWithNullPointerException("builder.identityMapping", builder.identityMapping);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/MechanismRealmConfiguration.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/MechanismRealmConfiguration.java
@@ -16,9 +16,8 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
-
-import java.util.Objects;
 
 import org.jboss.dmr.ModelNode;
 
@@ -33,7 +32,7 @@ public class MechanismRealmConfiguration extends AbstractMechanismConfiguration 
 
     private MechanismRealmConfiguration(Builder builder) {
         super(builder);
-        this.realmName = Objects.requireNonNull(builder.realmName, "Realm name must not be null.");
+        this.realmName = checkNotNullParamWithNullPointerException("builder.realmName", builder.realmName);
     }
 
     public String getRealmName() {

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/NameValue.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/NameValue.java
@@ -16,7 +16,7 @@
 
 package org.wildfly.test.security.common.elytron;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import org.jboss.dmr.ModelNode;
 
@@ -31,8 +31,8 @@ public class NameValue implements ModelNodeConvertable {
     private final String value;
 
     private NameValue(Builder builder) {
-        this.name = Objects.requireNonNull(builder.name, "Value of 'name' attribute has to be provided.");
-        this.value = Objects.requireNonNull(builder.value, "Value of 'value' attribute has to be provided.");
+        this.name = checkNotNullParamWithNullPointerException("builder.name", builder.name);
+        this.value = checkNotNullParamWithNullPointerException("builder.value", builder.value);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/OtpCredentialMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/OtpCredentialMapper.java
@@ -16,9 +16,8 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
-
-import java.util.Objects;
 
 import org.jboss.dmr.ModelNode;
 
@@ -35,10 +34,10 @@ public class OtpCredentialMapper implements ModelNodeConvertable {
     private final String sequenceFrom;
 
     private OtpCredentialMapper(Builder builder) {
-        this.algorithmFrom = Objects.requireNonNull(builder.algorithmFrom);
-        this.hashFrom = Objects.requireNonNull(builder.hashFrom);
-        this.seedFrom = Objects.requireNonNull(builder.seedFrom);
-        this.sequenceFrom = Objects.requireNonNull(builder.sequenceFrom);
+        this.algorithmFrom = checkNotNullParamWithNullPointerException("builder.algorithmFrom", builder.algorithmFrom);
+        this.hashFrom = checkNotNullParamWithNullPointerException("builder.hashFrom", builder.hashFrom);
+        this.seedFrom = checkNotNullParamWithNullPointerException("builder.seedFrom", builder.seedFrom);
+        this.sequenceFrom = checkNotNullParamWithNullPointerException("builder.sequenceFrom", builder.sequenceFrom);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleConfigurableSaslServerFactory.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleConfigurableSaslServerFactory.java
@@ -16,13 +16,13 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -49,7 +49,7 @@ public class SimpleConfigurableSaslServerFactory extends AbstractConfigurableEle
         this.filters = builder.filters;
         this.properties = builder.properties;
         this.protocol = builder.protocol;
-        this.saslServerFactory = Objects.requireNonNull(builder.saslServerFactory, "saslServerFactory must not be null");
+        this.saslServerFactory = checkNotNullParamWithNullPointerException("builder.saslServerFactory", builder.saslServerFactory);
         this.serverName = builder.serverName;
     }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleKeyManager.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleKeyManager.java
@@ -15,9 +15,8 @@
  */
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
-
-import java.util.Objects;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -36,7 +35,7 @@ public class SimpleKeyManager extends AbstractConfigurableElement {
 
     private SimpleKeyManager(Builder builder) {
         super(builder);
-        this.keyStore = Objects.requireNonNull(builder.keyStore, "Key-store name has to be provided");
+        this.keyStore = checkNotNullParamWithNullPointerException("builder.keyStore", builder.keyStore);
         this.credentialReference = defaultIfNull(builder.credentialReference, CredentialReference.EMPTY);
     }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleSaslAuthenticationFactory.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleSaslAuthenticationFactory.java
@@ -16,11 +16,11 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -43,9 +43,9 @@ public class SimpleSaslAuthenticationFactory extends AbstractConfigurableElement
 
     private SimpleSaslAuthenticationFactory(Builder builder) {
         super(builder);
-        this.mechanismConfigurations = new ArrayList<>(builder.mechanismConfigurations);
-        this.saslServerFactory = Objects.requireNonNull(builder.saslServerFactory,"saslServerFactory must be not-null");
-        this.securityDomain = Objects.requireNonNull(builder.securityDomain,"securityDomain must be not-null");
+        this.mechanismConfigurations = new ArrayList<>(checkNotNullParamWithNullPointerException("builder.mechanismConfigurations", builder.mechanismConfigurations));
+        this.saslServerFactory = checkNotNullParamWithNullPointerException("builder.saslServerFactory", builder.saslServerFactory);
+        this.securityDomain = checkNotNullParamWithNullPointerException("builder.securityDomain", builder.securityDomain);
     }
 
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleTrustManager.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SimpleTrustManager.java
@@ -15,7 +15,7 @@
  */
 package org.wildfly.test.security.common.elytron;
 
-import java.util.Objects;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -33,7 +33,7 @@ public class SimpleTrustManager extends AbstractConfigurableElement {
 
     private SimpleTrustManager(Builder builder) {
         super(builder);
-        this.keyStore = Objects.requireNonNull(builder.keyStore, "Key-store name has to be provided");
+        this.keyStore = checkNotNullParamWithNullPointerException("builder.keyStore", builder.keyStore);
     }
 
     @Override

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/UserPasswordMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/UserPasswordMapper.java
@@ -16,9 +16,8 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
-
-import java.util.Objects;
 
 import org.jboss.dmr.ModelNode;
 
@@ -34,7 +33,7 @@ public class UserPasswordMapper implements ModelNodeConvertable {
     private final Boolean verifiable;
 
     private UserPasswordMapper(Builder builder) {
-        this.from = Objects.requireNonNull(builder.from, "The 'from' attribute has to be provided.");
+        this.from = checkNotNullParamWithNullPointerException("builder.from", builder.from);
         this.writable = builder.writable;
         this.verifiable = builder.verifiable;
     }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/UserWithRoles.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/UserWithRoles.java
@@ -16,9 +16,10 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -33,9 +34,9 @@ public class UserWithRoles {
     private final Set<String> roles;
 
     private UserWithRoles(Builder builder) {
-        this.name = Objects.requireNonNull(builder.name, "Username must be not-null");
+        this.name = checkNotNullParamWithNullPointerException("builder.name", builder.name);
         this.password = builder.password != null ? builder.password : builder.name;
-        this.roles = new HashSet<>(builder.roles);
+        this.roles = new HashSet<>(checkNotNullParamWithNullPointerException("builder.roles", builder.roles));
     }
 
     /**

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/ClientMapping.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/ClientMapping.java
@@ -16,9 +16,8 @@
 
 package org.wildfly.test.security.common.other;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
-
-import java.util.Objects;
 
 import org.jboss.dmr.ModelNode;
 
@@ -35,7 +34,7 @@ public class ClientMapping {
 
     private ClientMapping(Builder builder) {
         this.sourceNetwork = builder.sourceNetwork;
-        this.destinationAddress = Objects.requireNonNull(builder.destinationAddress, "Destination address has to be provided");
+        this.destinationAddress = checkNotNullParamWithNullPointerException("builder.destinationAddress", builder.destinationAddress);
         this.destinationPort = builder.destinationPort;
     }
 


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: testsuite-elytron