### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (manualmode)

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/TestEnvironment.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/TestEnvironment.java
@@ -46,7 +46,7 @@ class TestEnvironment {
                     .build());
             CLEANUP_MODULES.add(ModuleBuilder.of(TestEnvironment.IMPL_MODULE_NAME, "logging-impl.jar")
                     .addPackage(AppendingFileHandler.class.getPackage())
-                    .addDependencies(ModuleDependency.of("java.logging"), ModuleDependency.of("org.jboss.logmanager"),
+                    .addDependencies(ModuleDependency.of("org.wildfly.common"), ModuleDependency.of("java.logging"), ModuleDependency.of("org.jboss.logmanager"),
                             ModuleDependency.of(TestEnvironment.API_MODULE_NAME), ModuleDependency.of("org.apache.log4j", true))
                     .addServiceProvider(PropertyResolver.class, SystemPropertyResolver.class)
                     .build());

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/impl/AppendingAppender.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/impl/AppendingAppender.java
@@ -19,6 +19,8 @@
 
 package org.jboss.as.test.manualmode.logging.module.impl;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -26,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.helpers.LogLog;
@@ -63,7 +64,7 @@ public class AppendingAppender extends AppenderSkeleton {
     protected void append(final LoggingEvent event) {
         if (isAsSevereAsThreshold(event.getLevel())) {
             synchronized (lock) {
-                final String text = Objects.requireNonNull(resolver).resolve(PROPERTY_KEY);
+                final String text = checkNotNullParamWithNullPointerException("resolver", resolver).resolve(PROPERTY_KEY);
                 final LoggingEvent changed = new LoggingEvent(event.getFQNOfLoggerClass(), event.getLogger(),
                         event.getTimeStamp(), event.getLevel(), event.getMessage() + text, event.getThreadName(),
                         event.getThrowableInformation(), event.getNDC(), event.getLocationInformation(), event.getProperties());

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/impl/AppendingFileHandler.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/impl/AppendingFileHandler.java
@@ -19,6 +19,8 @@
 
 package org.jboss.as.test.manualmode.logging.module.impl;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -26,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 import java.util.logging.ErrorManager;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
@@ -50,7 +51,7 @@ public class AppendingFileHandler extends Handler {
     public void publish(final LogRecord record) {
         if (isLoggable(record)) {
             synchronized (lock) {
-                final String text = Objects.requireNonNull(resolver).resolve(PROPERTY_KEY);
+                final String text = checkNotNullParamWithNullPointerException("resolver cannot be null", resolver).resolve(PROPERTY_KEY);
                 record.setMessage(record.getMessage() + text);
                 final String line = getFormatter().format(record);
                 try {


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: testsuite-manualmode