### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (testrunner)

### DIFF
--- a/testsuite/test-runner/pom.xml
+++ b/testsuite/test-runner/pom.xml
@@ -49,6 +49,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -6,6 +6,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.OP_ADDR;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SERVER_CONFIG;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -19,7 +20,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -159,9 +159,7 @@ public class Server {
      * @param gitAuthConfig
      */
     public void setGitRepository(final String gitRepository, final String gitBranch, final String gitAuthConfig) {
-        Objects.requireNonNull(gitRepository);
-
-        this.gitRepository = gitRepository;
+        this.gitRepository = checkNotNullParamWithNullPointerException("gitRepository", gitRepository);
         this.gitBranch = gitBranch;
         this.gitAuthConfiguration = gitAuthConfig;
     }


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: testsuite - testrunner
