### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (security)

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.jboss.as.core-security-api" export="true" />
+        <module name="org.jboss.as.core-security-api" export="true"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/core-security/implementation/pom.xml
+++ b/core-security/implementation/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/core-security/implementation/src/main/java/org/jboss/as/core/security/AbstractRealmPrincipal.java
+++ b/core-security/implementation/src/main/java/org/jboss/as/core/security/AbstractRealmPrincipal.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.core.security;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 /**
  * A base {@link Principal} where a realm is also associated.
  *
@@ -41,10 +43,7 @@ abstract class AbstractRealmPrincipal extends SecurityRealmPrincipal implements 
 
     public AbstractRealmPrincipal(final String realm, final String name) {
         super(name);
-        if (realm == null) {
-            throw new IllegalArgumentException("realm is null");
-        }
-        this.realm = realm;
+        this.realm = checkNotNullParam("realm", realm);
     }
 
     public String getRealm() {

--- a/core-security/implementation/src/main/java/org/jboss/as/core/security/SecurityRealmPrincipal.java
+++ b/core-security/implementation/src/main/java/org/jboss/as/core/security/SecurityRealmPrincipal.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.core.security;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.Serializable;
 import java.security.Principal;
 
@@ -37,10 +39,7 @@ public abstract class SecurityRealmPrincipal implements Principal, Serializable 
     private final String name;
 
     SecurityRealmPrincipal(final String name) {
-        if (name == null) {
-            throw new IllegalArgumentException("name is null");
-        }
-        this.name = name;
+        this.name = checkNotNullParam("name", name);
     }
 
     /**


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: security
