### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (domain-management)

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/password/simple/SimpleKeyboard.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/password/simple/SimpleKeyboard.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.domain.management.security.password.simple;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.Map;
@@ -89,9 +91,7 @@ public class SimpleKeyboard implements Keyboard {
     }
 
     public boolean siblings(String word, int index, int isSiblingIndex) {
-        if (word == null) {
-            throw new IllegalArgumentException();
-        }
+        checkNotNullParam("word", word);
         if (index >= isSiblingIndex) {
             throw new IllegalArgumentException();
         }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/password/simple/SimplePasswordStrengthChecker.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/password/simple/SimplePasswordStrengthChecker.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.domain.management.security.password.simple;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -83,10 +85,7 @@ public class SimplePasswordStrengthChecker implements PasswordStrengthChecker {
 
     public SimplePasswordStrengthChecker(final List<PasswordRestriction> initRestrictions, final Dictionary dictionary,
             final Keyboard keyboard) {
-        if (initRestrictions == null) {
-            throw new IllegalArgumentException("Initial restrictions must not be null.");
-        }
-        this.restrictionsInPlace = Collections.unmodifiableList(initRestrictions);
+        this.restrictionsInPlace = Collections.unmodifiableList(checkNotNullParam("initRestrictions", initRestrictions));
         this.dictionary = dictionary;
         this.keyboard = keyboard;
     }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/operations/CacheBuilder.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/operations/CacheBuilder.java
@@ -31,6 +31,7 @@ import static org.jboss.as.domain.management.ModelDescriptionConstants.CACHE;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.EVICTION_TIME;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.CACHE_FAILURES;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.MAX_CACHE_SIZE;
+import static org.wildfly.common.Assert.checkNotNullParam;
 
 import org.jboss.dmr.ModelNode;
 
@@ -58,10 +59,8 @@ public class CacheBuilder<T extends ParentBuilder<?>> extends Builder<T> {
 
     public CacheBuilder<T> setBy(final By by) {
         assertNotBuilt();
-        if (by == null) {
-            throw new IllegalArgumentException("By can not be null.");
-        }
-        this.by = by;
+
+        this.by = checkNotNullParam("by", by);
 
         return this;
     }


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: domainmanagement
