### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (securitymanager)

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
@@ -41,6 +41,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.manager"/>
     </dependencies>
 </module>

--- a/security-manager/pom.xml
+++ b/security-manager/pom.xml
@@ -50,6 +50,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
             <type>pom</type>

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/DeferredPermissionFactory.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/DeferredPermissionFactory.java
@@ -16,6 +16,8 @@
 
 package org.wildfly.extension.security.manager;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.security.Permission;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.security.LoadedPermissionFactory;
@@ -47,19 +49,10 @@ public class DeferredPermissionFactory implements PermissionFactory {
     };
 
     public DeferredPermissionFactory(Type type, ModuleLoader moduleLoader, String moduleName, String permissionClass, String permissionName, String permissionActions) {
-        if (type == null) {
-            throw new IllegalArgumentException("type argument is null");
-        }
-        if (moduleLoader == null) {
-            throw new IllegalArgumentException("moduleLoader argument is null");
-        }
-        if (permissionClass == null) {
-            throw new IllegalArgumentException("permissionClass argument is null");
-        }
-        this.type = type;
-        this.moduleLoader = moduleLoader;
+        this.type = checkNotNullParam("type", type);
+        this.moduleLoader = checkNotNullParam("moduleLoader", moduleLoader);
         this.moduleName = moduleName;
-        this.permissionClass = permissionClass;
+        this.permissionClass = checkNotNullParam("permissionClass", permissionClass);
         this.permissionName = permissionName;
         this.permissionActions = permissionActions;
         this.factory = null;


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: securitymanager