### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (process-controller)

### DIFF
--- a/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecInputStream.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecInputStream.java
@@ -18,6 +18,7 @@
 package org.jboss.as.process.stdin;
 
 import static org.jboss.as.process.stdin.BaseNCodec.EOF;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -129,9 +130,8 @@ class BaseNCodecInputStream extends FilterInputStream {
      */
     @Override
     public int read(final byte[] b, final int offset, final int len) throws IOException {
-        if (b == null) {
-            throw new NullPointerException();
-        } else if (offset < 0 || len < 0) {
+        checkNotNullParamWithNullPointerException("b", b);
+        if (offset < 0 || len < 0) {
             throw new IndexOutOfBoundsException();
         } else if (offset > b.length || offset + len > b.length) {
             throw new IndexOutOfBoundsException();

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecOutputStream.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecOutputStream.java
@@ -18,6 +18,7 @@
 package org.jboss.as.process.stdin;
 
 import static org.jboss.as.process.stdin.BaseNCodec.EOF;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -87,9 +88,8 @@ class BaseNCodecOutputStream extends FilterOutputStream {
      */
     @Override
     public void write(final byte[] b, final int offset, final int len) throws IOException {
-        if (b == null) {
-            throw new NullPointerException();
-        } else if (offset < 0 || len < 0) {
+        checkNotNullParamWithNullPointerException("b", b);
+        if (offset < 0 || len < 0) {
             throw new IndexOutOfBoundsException();
         } else if (offset > b.length || offset + len > b.length) {
             throw new IndexOutOfBoundsException();


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: process-controller