### PR TITLE
[WFCORE-5285] Utilize o.w.common.Assert for Null-Checks (protocol)

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>jboss-remoting</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
         </dependency>

--- a/protocol/src/test/java/org/jboss/as/protocol/mgmt/support/ChannelServer.java
+++ b/protocol/src/test/java/org/jboss/as/protocol/mgmt/support/ChannelServer.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.protocol.mgmt.support;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -65,10 +67,7 @@ public class ChannelServer implements Closeable {
     }
 
     public static ChannelServer create(final Configuration configuration) throws IOException {
-        if (configuration == null) {
-            throw new IllegalArgumentException("Null configuration");
-        }
-        configuration.validate();
+        checkNotNullParam("configuration", configuration).validate();
 
         // Hack WFCORE-3302/REM3-303 workaround
         if (firstCreate) {
@@ -150,15 +149,9 @@ public class ChannelServer implements Closeable {
         }
 
         void validate() {
-            if (endpointName == null) {
-                throw new IllegalArgumentException("Null endpoint name");
-            }
-            if (uriScheme == null) {
-                throw new IllegalArgumentException("Null protocol name");
-            }
-            if (bindAddress == null) {
-                throw new IllegalArgumentException("Null bind address");
-            }
+            checkNotNullParam("endpointName", endpointName);
+            checkNotNullParam("uriScheme", uriScheme);
+            checkNotNullParam("bindAddress", bindAddress);
         }
 
         public void setEndpointName(String endpointName) {


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFCORE-5285

Original PR was too big to verify. It has been splitted up, here: protocol