### PR TITLE
[WFCORE-5372] Use absolute path in permissions.xml in JMX test

### DIFF
--- a/testsuite/shared/src/main/java/org/wildfly/test/jmx/ServiceActivatorDeploymentUtil.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/jmx/ServiceActivatorDeploymentUtil.java
@@ -114,6 +114,8 @@ public class ServiceActivatorDeploymentUtil {
                 new FilePermission(targetPath.toAbsolutePath().toString(), "read"),
                 new FilePermission(targetPath.resolve("notifications").toAbsolutePath().toString(), "read, write"),
                 new FilePermission(targetPath.resolve("notifications").toAbsolutePath().toString() + File.separatorChar + '-', "read, write"),
+                new FilePermission(targetPath.resolve("wildfly-core").resolve("target").toAbsolutePath().toString(), "read, write"),
+                new FilePermission(targetPath.resolve("wildfly-core").resolve("target").toAbsolutePath().toString() + File.separatorChar + '-', "read, write"),
                 getMBeanPermission(RunningStateJmx.class, targetName, "addNotificationListener"),
                 getMBeanPermission(RunningStateJmx.class, targetName, "removeNotificationListener"),
                 new PropertyPermission("user.dir", "read")


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5372

Use absolute path in permissions.xml in JMX test. Relative path in permissions.xml file doesn't work on JDK11, see:
* https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8164705
* https://bugs.openjdk.java.net/browse/JDK-8165836