### PR TITLE
[WFLY-14431] Do not use WildFly Core dependency management for dependencies that are test-only in core

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -30,6 +30,18 @@
 
     <name>WildFly: Elytron Subsystem</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-core-testbom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -142,14 +142,12 @@
             versions, add the artifactId or other qualifier to the property name.
             For example: <version.org.jboss.hal.release-stream>
          -->
-        <version.com.fasterxml.jackson.core.jackson-databind>2.11.3</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.googlecode.javaewah>1.1.7</version.com.googlecode.javaewah>
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>
         <version.com.google.guava>30.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
-        <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
         <version.io.undertow>2.2.6.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
@@ -228,11 +226,11 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.15.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.0.Final</version.org.wildfly.security.elytron-web>
-        <version.xalan>2.7.1.jbossorg-5</version.xalan>
-       
+
     </properties>
 
     <modules>
+        <module>testbom</module>
         <module>cli</module>
         <module>controller</module>
         <module>controller-client</module>
@@ -733,11 +731,6 @@
                         <artifactId>mockserver-netty</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${version.commons-io}</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
@@ -2174,12 +2167,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.directory.server</groupId>
                 <artifactId>apacheds-all</artifactId>
                 <version>${version.org.apache.ds}</version>
@@ -2278,12 +2265,6 @@
                 <groupId>org.syslog4j</groupId>
                 <artifactId>syslog4j</artifactId>
                 <version>${version.org.syslog4j}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>xalan</groupId>
-                <artifactId>xalan</artifactId>
-                <version>${version.xalan}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/remoting/tests/pom.xml
+++ b/remoting/tests/pom.xml
@@ -38,6 +38,18 @@
     <name>WildFly: Remoting Subsystem Test</name>
     <description>This is not in the remoting subsystem as it introduces circular dependencies</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-core-testbom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+  ~
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2021, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -19,6 +20,7 @@
   ~ License along with this software; if not, write to the Free
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -30,41 +32,40 @@
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-core-parent</artifactId>
         <version>16.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>wildfly-subsystem-test-parent</artifactId>
+    <artifactId>wildfly-core-testbom</artifactId>
     <packaging>pom</packaging>
-    <name>WildFly: Core Model Test Parent</name>
 
-    <modules>
-        <module>framework</module>
-	<module>test-controller-optional</module>
-        <module>tests</module>
-    </modules>
+    <name>WildFly: Core BOM of Test Dependencies</name>
+
+    <properties>
+        <version.com.fasterxml.jackson.core.jackson-databind>2.11.3</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.commons-io>2.5</version.commons-io>
+        <version.xalan>2.7.1.jbossorg-5</version.xalan>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-testbom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${version.commons-io}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>${version.xalan}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <dependencies>
-        <dependency>
-           <groupId>org.wildfly.core</groupId>
-           <artifactId>wildfly-model-test</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.marshalling</groupId>
-            <artifactId>jboss-marshalling-river</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -157,6 +157,13 @@
         <dependencies>
             <dependency>
                 <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-core-testbom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-core-testsuite-shared</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -56,6 +56,18 @@
         </resources>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-core-testbom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>
@@ -66,6 +78,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14431

That this PR does:

* Create a new module called: `testbom` which holds all test dependencies in core but are production dependencies in WildFly
* Added the dependency of `testbom` to modules that need it as `import` scope
* Move `commons-io`, `xalan`, `jackson-databind` from top level pom to `testbom/pom.xml` because they are test only dependencies in core, but they are production dependencies in WildFly.

