### PR TITLE
[WFCORE-5382]: The same Additional Runtime Dependency can be added several times for a single resource definition.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3639,10 +3639,12 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 479, value = "Attribute '%s' at resource '%s' with unresolved value '%s' cannot be resolved using the non-security-sensitive sources resolution supported by the 'resolve' parameter. Response will report the unresolved value.")
     String attributeUnresolvableUsingSimpleResolution(String attribute, String address, ModelNode unresolved);
 
-    @Message(id = 480, value = "Expression '%s' cannot be resolved using the non-security-sensitive sources resolution supported by the '%s' operatiob. Response will report the unresolved value.")
+    @Message(id = 480, value = "Expression '%s' cannot be resolved using the non-security-sensitive sources resolution supported by the '%s' operation. Response will report the unresolved value.")
     String expressionUnresolvableUsingSimpleResolution(ModelNode unresolved, String opName);
 
-
+    @LogMessage(level = WARN)
+    @Message(id = 481, value = "The runtime dependency package '%s' is already registered at location '%s'")
+    void runtimePackageDependencyAlreadyRegistered(String pckg, String location);
 
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
@@ -73,6 +73,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
@@ -197,9 +198,12 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                 extensionParam.get(DEFAULT).set(extension);
                 feature.get(FEATURE).get(PARAMS).add(extensionParam);
                 ModelNode packages = feature.get(FEATURE).get(PACKAGES);
-                ModelNode packageNode = new ModelNode();
-                packageNode.get(PACKAGE).set(extension);
-                packages.add(packageNode);
+                Set<String> alreadyRegisteredPackages = packages.isDefined() ? packages.asList().stream().map(node -> node.get(PACKAGE).asString()).collect(Collectors.toSet()) : new HashSet<>();
+                if (!alreadyRegisteredPackages.contains(extension)) {
+                    ModelNode pkgNode = new ModelNode();
+                    pkgNode.get(PACKAGE).set(extension);
+                    packages.add(pkgNode);
+                }
             }
         }
         final Map<PathElement, ModelNode> childResources = recursive ? new HashMap<>() : Collections.<PathElement, ModelNode>emptyMap();

--- a/controller/src/main/java/org/jboss/as/controller/registry/RuntimePackageDependency.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/RuntimePackageDependency.java
@@ -23,6 +23,8 @@ package org.jboss.as.controller.registry;
 
 import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
+import java.util.Objects;
+
 
 /**
  * A runtime package dependency expresses a dependency to a galleon package. A
@@ -34,6 +36,7 @@ import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerExceptio
  * @author jdenise@redhat.com
  */
 public final class RuntimePackageDependency {
+
     private enum TYPE {
         REQUIRED,
         OPTIONAL,
@@ -113,5 +116,39 @@ public final class RuntimePackageDependency {
      */
     public static RuntimePackageDependency optional(String name) {
         return new RuntimePackageDependency(name, TYPE.OPTIONAL);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 71 * hash + Objects.hashCode(this.name);
+        hash = 71 * hash + Objects.hashCode(this.type);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final RuntimePackageDependency other = (RuntimePackageDependency) obj;
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        if (this.type != other.type) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RuntimePackageDependency{" + "name=" + name + ", type=" + type + '}';
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
@@ -612,7 +612,7 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
 
         private static final RuntimeCapability MAIN_RESOURCE_CAPABILITY =
                 RuntimeCapability.Builder.of(MAIN_RESOURCE_CAPABILITY_NAME, true)
-                        .addAdditionalRequiredPackages(MAIN_RESOURCE_PACKAGE_NAME)
+                        .addAdditionalRequiredPackages(MAIN_RESOURCE_PACKAGE_NAME, MAIN_RESOURCE_PACKAGE_NAME)
                         .build();
 
         private static final AttributeDefinition OPTIONAL_ATTRIBUTE =


### PR DESCRIPTION
 * Logging a warning if a runtime dependency is added several times.
 * If the extension package is added as an additional runtime dependecy,
   protecting the read-feature operation form this duplication.

Jira: https://issues.redhat.com/browse/WFCORE-5382
