### PR TITLE
Fix for WFCORE-5384, RemoveManagementRealmTestCase tests intermittently fail

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
@@ -696,6 +696,10 @@ public class ReadlineConsole {
     }
 
     public String readLine(Prompt prompt, Completion completer) throws InterruptedException, IOException {
+        if (closed) {
+            LOG.tracef("Console already closed, ignoring readLine");
+            return null;
+        }
         if (started) {
             // If there are some output collected, flush it.
             printCollectedOutput();


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5384

On some platform, we can enter the case where a read for input is attempted again (in the reload loop) although the console has been closed by a Ctrl-C. The closed state must be checked prior to attempt a read.