### PR TITLE
[WFCORE-5389] Split out Jakarta Authentication and Authorization implementation modules.

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-base">
+    <properties>
+        <!--
+             Although this module is private see the module 'org.wildfly.security.elytron' for the re-exported public API.
+         -->
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <exports>
+        <exclude path="org/wildfly/security/_private"/>
+        <exclude path="org/wildfly/security/manager/_private"/>
+        <exclude path="org/wildfly/security/sasl/digest/_private"/>
+        <exclude path="org/wildfly/security/util/_private"/>
+    </exports>
+
+    <resources>
+        <artifact name="${org.wildfly.security:wildfly-elytron-asn1}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-audit}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-auth}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-auth-server}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-auth-server-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-auth-server-http}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-auth-server-sasl}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-auth-util}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-base}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-client}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-credential}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-credential-source-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-credential-source-impl}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-credential-store}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-digest}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-encryption}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-basic}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-bearer}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-cert}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-digest}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-external}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-form}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-spnego}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-sso}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-http-util}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-jacc}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-json-util}"/>
+        <!-- <artifact name="${org.wildfly.security:wildfly-elytron-jwt}"/> To be added as independent module in WildFly -->
+        <artifact name="${org.wildfly.security:wildfly-elytron-keystore}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-mechanism}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-mechanism-digest}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-mechanism-http}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-mechanism-gssapi}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-mechanism-oauth2}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-mechanism-scram}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-password-impl}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-permission}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-provider-util}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-realm}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-realm-jdbc}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-realm-ldap}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-realm-token}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-auth-util}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-anonymous}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-digest}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-entity}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-external}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-gs2}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-gssapi}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-localuser}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-oauth2}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-otp}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-plain}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-sasl-scram}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-security-manager}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-security-manager-action}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-ssl}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-util}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-x500}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-x500-cert}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-x500-cert-acme}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-x500-cert-util}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-x500-deprecated}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-x500-principal}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
+        <module name="java.security.sasl"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <module name="javax.json.api"/>
+        <module name="jdk.security.auth"/>
+        <module name="jdk.unsupported"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.threads"/>
+        <module name="javax.security.jacc.api" optional="true"/>
+        <module name="org.wildfly.common"/>
+        <module name="javax.xml.ws.api" optional="true"/>
+        <module name="org.jboss.ws.spi" optional="true"/>
+        <module name="org.apache.sshd"/>
+        <module name="org.jboss.resteasy.resteasy-jaxrs" optional="true"/>
+        <!--
+        This is only exported because some of the ElytronXmlParser methods throw an exception in this module. If other
+        modules use the parser, they need to have visibility to this module.
+        -->
+        <module name="org.wildfly.client.config" export="true"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
@@ -64,7 +64,6 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-http-spnego}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-sso}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-util}"/>
-        <artifact name="${org.wildfly.security:wildfly-elytron-jacc}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-json-util}"/>
         <!-- <artifact name="${org.wildfly.security:wildfly-elytron-jwt}"/> To be added as independent module in WildFly -->
         <artifact name="${org.wildfly.security:wildfly-elytron-keystore}"/>
@@ -121,7 +120,6 @@
         <module name="org.jboss.logmanager"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.threads"/>
-        <module name="javax.security.jacc.api" optional="true"/>
         <module name="org.wildfly.common"/>
         <module name="javax.xml.ws.api" optional="true"/>
         <module name="org.jboss.ws.spi" optional="true"/>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authentication/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authentication/main/module.xml
@@ -18,7 +18,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-private">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.jakarta.authentication">
     <properties>
         <!--
              Although this module is private see the module 'org.wildfly.security.elytron' for the re-exported public API.
@@ -26,17 +26,21 @@
         <property name="jboss.api" value="private"/>
     </properties>
 
+    <exports>
+        <exclude path="org/wildfly/security/auth/jaspi/_private"/>
+    </exports>
+
     <resources>
+        <artifact name="${org.wildfly.security:wildfly-elytron-jaspi}"/>
     </resources>
 
     <dependencies>
-        <!--
-        This is only exported because some of the ElytronXmlParser methods throw an exception in this module. If other
-        modules use the parser, they need to have visibility to this module.
-        -->
-        <module name="org.wildfly.client.config" export="true"/>
-        <!-- The artifacts in these dependencies were previously exported by this module. -->
-        <module name="org.wildfly.security.elytron-base" services="export" export="true"/>
-        <module name="org.wildfly.security.jakarta.authentication" export="true"/>
+        <module name="jdk.security.auth"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager"/>
+        <module name="javax.security.auth.message.api"/>
+        <module name="javax.servlet.api" optional="true"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron-base"/>
     </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authorization/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authorization/main/module.xml
@@ -18,7 +18,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-private">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.jakarta.authorization">
     <properties>
         <!--
              Although this module is private see the module 'org.wildfly.security.elytron' for the re-exported public API.
@@ -27,17 +27,15 @@
     </properties>
 
     <resources>
+        <artifact name="${org.wildfly.security:wildfly-elytron-jacc}"/>
     </resources>
 
     <dependencies>
-        <!--
-        This is only exported because some of the ElytronXmlParser methods throw an exception in this module. If other
-        modules use the parser, they need to have visibility to this module.
-        -->
-        <module name="org.wildfly.client.config" export="true"/>
-        <!-- The artifacts in these dependencies were previously exported by this module. -->
-        <module name="org.wildfly.security.elytron-base" services="export" export="true"/>
-        <module name="org.wildfly.security.jakarta.authentication" export="true"/>
-        <module name="org.wildfly.security.jakarta.authorization" export="true"/>
+        <module name="jdk.security.auth"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager"/>
+        <module name="javax.security.jacc.api" optional="true"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron-base"/>
     </dependencies>
 </module>


### PR DESCRIPTION
I am just starting off on hold whilst I complete some more steps but this should be ready to go.

Two new modules have been added to make it easier to replace them with Jakarta EE 9 implementations for WildFly Preview.

The Jakarta implementations needed a dependency on some WildFly Elytron artifacts so they have been moved to a base module allowing Jakarta EE to sit in the middle.

https://issues.redhat.com/browse/WFCORE-5389
