### PR TITLE
WFCORE-5394 Remove the  wildlfy-elytron-auth-server-deprecated depend…

### DIFF
--- a/remoting/subsystem/pom.xml
+++ b/remoting/subsystem/pom.xml
@@ -86,10 +86,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-auth-server-deprecated</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-util</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Remove the wildlfy-elytron-auth-server-deprecated dependency from remoting subsystem

Thanks for submitting your Pull Request!
https://issues.redhat.com/browse/WFCORE-5394