### PR TITLE
[WFCORE-5413] Upgrade Apache sshd-common to a version that depends on slf4j 1.7.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <version.org.apache.logging.log4j>2.14.1</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
-        <version.org.apache.sshd>2.4.0</version.org.apache.sshd>
+        <version.org.apache.sshd>2.6.0</version.org.apache.sshd>
         <version.org.apache.xerces>2.12.0.SP03</version.org.apache.xerces>
         <version.org.bouncycastle>1.68</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5413
