### PR TITLE
[WFCORE-5414] / [WFCORE-5415] WildFly Elytron and Elytron Web Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.15.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.15.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.0.Final</version.org.wildfly.security.elytron-web>
 
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.15.4.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.9.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.9.1.Final</version.org.wildfly.security.elytron-web>
 
     </properties>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5414
https://issues.redhat.com/browse/WFCORE-5415

Elytron 1.15.4.Final

https://github.com/wildfly-security/wildfly-elytron/compare/1.15.3.Final...1.15.4.Final


        Release Notes - WildFly Elytron - Version 1.15.4.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2111'>ELY-2111</a>] -         JwkManager uses incorrect non url-safe Base64 to load the jwks endpoint
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2118'>ELY-2118</a>] -         Elytron tool command execution fails with java.lang.UnsupportedOperationException on AIX OS.
</li>
</ul>
                    
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2125'>ELY-2125</a>] -         Release WildFly Elytron 1.15.4.Final
</li>
</ul>
                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2113'>ELY-2113</a>] -         Configuration option to disable session ID change
</li>
</ul>
                                                                                                                        
Elytron Web 1.9.1.Final

https://github.com/wildfly-security/elytron-web/compare/1.9.0.Final...1.9.1.Final


        Release Notes - Elytron Web - Version 1.9.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-133'>ELYWEB-133</a>] -         SecurityContextImpl.login incorrectly assumes authenticate would be called first.
</li>
</ul>
                    
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-139'>ELYWEB-139</a>] -         Release Elytron Web 1.9.1.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-138'>ELYWEB-138</a>] -         Upgrade WildFly Elytron to 1.15.4.Final
</li>
</ul>
                                                                                                                            