### PR TITLE
[WFCORE-5416]: Jgit incorrect reference in org.jboss.as.controller module.

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -58,6 +58,5 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>
         <module name="org.projectodd.vdx"/>
-        <module name="org.eclipse.jgit" optional="true" export="true"/>
     </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -107,5 +107,6 @@
         <module name="org.wildfly.extension.core-management-client" />
         <!-- Allow javax->jakarta deployment transformation if this module is provided -->
         <module name="org.wildfly.deployment.transformation" optional="true" services="import"/>
+        <module name="org.eclipse.jgit" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
 * Removing jgit from org.jboss.as.controller module
 * Adding jgit as a dependency of org.jboss.as.server module.

Issue: https://issues.redhat.com/browse/WFCORE-5416
