### PR TITLE
[WFCORE-5423][WFCORE-5424] Upgrade jboss-remoting to 5.0.23.Final and add test dependency from protocol to wildfly-elytron-security-manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.11.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.12.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.21.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.23.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -126,6 +126,11 @@
            <artifactId>junit</artifactId>
            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-security-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Jiras
https://issues.redhat.com/browse/WFCORE-5423 (see release notes below for further info on dependency upgrade)
https://issues.redhat.com/browse/WFCORE-5424

Fixes CVE-2020-35510


        Release Notes - JBoss Remoting (3+) - Version 5.0.23.Final
                                                            
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-381'>REM3-381</a>] -         Revert REM3-378 in Remoting 5.0.x
</li>
</ul>
                                                                                                                                                                                                                                        


        Release Notes - JBoss Remoting (3+) - Version 5.0.22.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-379'>REM3-379</a>] -         CVE-2020-35510 Threads hold up forever in the EJB server by suppressing the ack from an EJB client
</li>
<li>[<a href='https://issues.redhat.com/browse/REM3-380'>REM3-380</a>] -         Add OutboundMessage info to messages logged by this class
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-378'>REM3-378</a>] -         Updated all classes with a dependency on deprecated Elytron modules to no longer rely on deprecated classes
</li>
</ul>
                                                                                                                                                                                                                                        