### PR TITLE
[WFCORE-5425] Upgrade Undertow to 2.2.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
         <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.6.Final</version.io.undertow>
+        <version.io.undertow>2.2.8.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-14815

Requires https://github.com/wildfly/wildfly/pull/14314 (https://issues.redhat.com/browse/WFLY-14815) or else WildFly testsuite won't pass.
I'll be submitting another PR later today for WFLY-14815 with a proper fix for the tests. That PR will only pass with the Undertow upgrade.


        Release Notes - Undertow - Version 2.2.7.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1837'>UNDERTOW-1837</a>] -         ServletRequest#getLocalPort(), getLocalAddr() and getLocalName() can return wrong information when ProxyPeerAddressHandler or ForwardedHandler is enabled
</li>
</ul>
                                                                                                                                                                                                                                            

        Release Notes - Undertow - Version 2.2.8.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1468'>UNDERTOW-1468</a>] -         MultipartFile.transferTo throws FileAlreadyExistsException
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1501'>UNDERTOW-1501</a>] -         Wait-indefinitely hang bug in WebSocket session container shutdown code.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1651'>UNDERTOW-1651</a>] -         High CPU usage Java 11 and SSL WebSockets
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1834'>UNDERTOW-1834</a>] -         Http2EndExchangeTestCase and LoadBalancingProxyHTTP2TestCase are failing with IBM JDK 1.8
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1864'>UNDERTOW-1864</a>] -         EAP returns 403 even after adding the welcome file to unmanaged exploded deploy
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1876'>UNDERTOW-1876</a>] -         security-manager and reflection permissions in DirectByteBufferDeallocator/undertow with JDK 11
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1877'>UNDERTOW-1877</a>] -         HTTP2 implementation returns PUSH PROMISES for frames that are already a promise (even id)
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1886'>UNDERTOW-1886</a>] -         Request dispatcher is returned when the path points to outside the servlet context
</li>
</ul>
                                                                                                                                                                                                                                            