### PR TITLE
WFCORE-5396 Remove the wildlfy-elytron-http-deprecated dependency module to no longer rely on deprecated classes

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -339,10 +339,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-http-deprecated</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-external</artifactId>
         </dependency>
         <dependency>

--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -1359,17 +1359,6 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
-      <artifactId>wildfly-elytron-http-deprecated</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-http-digest</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
@@ -57,7 +57,6 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-http-bearer}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-cert}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-digest}"/>
-        <artifact name="${org.wildfly.security:wildfly-elytron-http-deprecated}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-external}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-form}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-spnego}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1817,11 +1817,6 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
-                <artifactId>wildfly-elytron-http-deprecated</artifactId>
-                <version>${version.org.wildfly.security.elytron}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http-digest</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5396
