### PR TITLE
Fix for WFCORE-5453, Include add-opens and add-exports to Bootable JAR runtime manifest

### DIFF
--- a/bootable-jar/boot/pom.xml
+++ b/bootable-jar/boot/pom.xml
@@ -53,6 +53,9 @@
                             <mainClass>org.wildfly.core.jar.boot.Main</mainClass>
                             <manifestEntries>
                                 <Multi-Release>true</Multi-Release>
+                                <!-- NB: In case an update is made to these exports and opens, make sure that common.sh script is in sync. -->
+                                <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</Add-Exports>
+                                <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.io java.base/java.security java.base/java.util java.management/javax.management java.naming/javax.naming</Add-Opens>
                             </manifestEntries>
                         </transformer>
                     </transformers>

--- a/core-feature-pack/common/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.sh
@@ -22,6 +22,7 @@ setDefaultModularJvmOptions() {
     DEFAULT_MODULAR_JVM_OPTIONS=`echo $* | $GREP "\-\-add\-modules"`
     if [ "x$DEFAULT_MODULAR_JVM_OPTIONS" = "x" ]; then
       # Set default modular jdk options
+      # NB: In case an update is made to these exports and opens, make sure that bootable-jar/boot/pom.xml script is in sync.
       # Needed by the iiop-openjdk subsystem
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.desktop/sun.awt=ALL-UNNAMED"
       # Needed to instantiate the default InitialContextFactory implementation used by the


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5453
The set of add-opens and add-exports used in bin/common.sh launch script is added to Bootable JAR manifest file.
Having them in all cases for all JDK doesn't appear to be an issue. On JDK8, these entries are ignored.
Users can still add their own --add-opens --add-exports to the command line and both sources of options are honored.