### PR TITLE
[WFCORE-5457] Add missing permission for JmxControlledStateNotificationsTestCase on J9

### DIFF
--- a/testsuite/shared/src/main/java/org/wildfly/test/jmx/ServiceActivatorDeploymentUtil.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/jmx/ServiceActivatorDeploymentUtil.java
@@ -116,6 +116,8 @@ public class ServiceActivatorDeploymentUtil {
                 new FilePermission(targetPath.resolve("notifications").toAbsolutePath().toString() + File.separatorChar + '-', "read, write"),
                 new FilePermission(targetPath.resolve("wildfly-core").resolve("target").toAbsolutePath().toString(), "read, write"),
                 new FilePermission(targetPath.resolve("wildfly-core").resolve("target").toAbsolutePath().toString() + File.separatorChar + '-', "read, write"),
+                new FilePermission(targetPath.resolve("domains").resolve("JmxControlledStateNotificationsTestCase").resolve("master").resolve("target").toAbsolutePath().toString(), "read, write"),
+                new FilePermission(targetPath.resolve("domains").resolve("JmxControlledStateNotificationsTestCase").resolve("master").resolve("target").toAbsolutePath().toString() + File.separatorChar + '-', "read, write"),
                 getMBeanPermission(RunningStateJmx.class, targetName, "addNotificationListener"),
                 getMBeanPermission(RunningStateJmx.class, targetName, "removeNotificationListener"),
                 new PropertyPermission("user.dir", "read")


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5457