### PR TITLE
[WFCORE-5496] Upgrading JBoss MSC from 1.4.12.Final to 1.4.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.11.0.Final</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.4.12.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.4.13.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.23.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5496

Brings in:
 * [MSC-256] Fix ServiceBuilder javadoc
 * [MSC-257] Unregistering container's WeakReference from shutdown hook containers set on container shutdown
 * [MSC-258] Use one shutdown hook per container and let JVM keep track of them
