### PR TITLE
[WFLY-5498] Upgrade commons-io to 2.10.0

### DIFF
--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
-        <version.commons-io>2.5</version.commons-io>
+        <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.63.Final</version.io.netty>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ModuleTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ModuleTestCase.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.test.integration.management.cli;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -34,14 +32,17 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
-import org.apache.commons.io.FileUtils;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.codehaus.plexus.util.FileUtils;
 import org.jboss.as.cli.Util;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.shared.TestSuiteEnvironment;


### PR DESCRIPTION
Replace its use in ModuleTestCase as it was not able
to delete directory with recursive symlinks
