### PR TITLE
[WFCORE-5482] Bouncycastle bcpkix module requires a dependency on java logging and java.naming

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
@@ -32,5 +32,7 @@
     <dependencies>
         <module name="org.bouncycastle.bcprov" services="import"/>
         <module name="org.bouncycastle.bcutil"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5482