### PR TITLE
[16.x][WFCORE-5461] Upgrade bouncycastle to 1.69 + module dependencies

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -243,6 +243,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk15on</artifactId>
+         </dependency>
+
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
@@ -31,5 +31,6 @@
     
     <dependencies>
         <module name="org.bouncycastle.bcprov" services="import"/>
+        <module name="org.bouncycastle.bcutil"/>
     </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpkix/main/module.xml
@@ -32,5 +32,7 @@
     <dependencies>
         <module name="org.bouncycastle.bcprov" services="import"/>
         <module name="org.bouncycastle.bcutil"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
     </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcprov/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcprov/main/module.xml
@@ -34,4 +34,8 @@
             <with-class name="org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider"/>
         </service>
     </provides>
+    <dependencies>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+    </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcutil/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcutil/main/module.xml
@@ -19,19 +19,17 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.9" name="org.bouncycastle.bcprov">
+<module xmlns="urn:jboss:module:1.9" name="org.bouncycastle.bcutil">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.bouncycastle:bcprov-jdk15on}"/>
+        <artifact name="${org.bouncycastle:bcutil-jdk15on}"/>
     </resources>
-    <provides>
-        <service name="java.security.Provider">
-            <with-class name="org.bouncycastle.jce.provider.BouncyCastleProvider"/>
-            <with-class name="org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider"/>
-        </service>
-    </provides>
+
+    <dependencies>
+        <module name="org.bouncycastle.bcprov"/>
+    </dependencies>
 </module>

--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -279,6 +279,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-ldap-codec-standalone</artifactId>
             <version>1.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.6.0</version.org.apache.sshd>
         <version.org.apache.xerces>2.12.0.SP03</version.org.apache.xerces>
-        <version.org.bouncycastle>1.68</version.org.bouncycastle>
+        <version.org.bouncycastle>1.69</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>6.0.3</version.org.codehaus.woodstox.woodstox-core>
@@ -1223,6 +1223,10 @@
                         <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcutil-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>net.i2p.crypto</groupId>
                         <artifactId>eddsa</artifactId>
                     </exclusion>
@@ -1290,6 +1294,12 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcmail-jdk15on</artifactId>
                 <version>${version.org.bouncycastle}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcutil-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -1300,10 +1310,21 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>${version.org.bouncycastle}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcutil-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
+                <version>${version.org.bouncycastle}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk15on</artifactId>
                 <version>${version.org.bouncycastle}</version>
             </dependency>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -225,6 +225,11 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -176,6 +176,10 @@
                         <groupId>org.bouncycastle</groupId>
                         <artifactId>bcpkix-jdk15on</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcutil-jdk15on</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -106,6 +106,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
* [WFCORE-5461] Upgrade bouncycastle to 1.69
  * JIRA https://issues.redhat.com/browse/WFCORE-5461
  * `main` https://github.com/wildfly/wildfly-core/pull/4628
* [WFCORE-5480] Bouncyclastle provider module requires a dependency on java.sql and java.naming
  * JIRA https://issues.redhat.com/browse/WFCORE-5480
  * `main` https://github.com/wildfly/wildfly-core/pull/4648 (I just realised that the commit message references WFCORE-5495 instead of WFCORE-5480)
* WFCORE-5482 Bouncycastle bcpkix module requires a dependency on java.logging and java.naming
  * JIRA https://issues.redhat.com/browse/WFCORE-5482
  * `main` PR https://github.com/wildfly/wildfly-core/pull/4654
