### PR TITLE
[WFCORE-5510] Upgrade WildFly Elytron to 1.16.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.16.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.16.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.1.Final</version.org.wildfly.security.elytron-web>
 
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5510

        Release Notes - WildFly Elytron - Version 1.16.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2137'>ELY-2137</a>] -         Possible NullPointerException in AuthenticationConfiguration
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2140'>ELY-2140</a>] -         Elytron Tool: Mask command will fail when secret is not provided.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2141'>ELY-2141</a>] -         Elytron Tool: Default platform encoding used in Command.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2142'>ELY-2142</a>] -         Elytron Tool: Default platform encoding used in VaultCommand.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2143'>ELY-2143</a>] -         The constructor of CachingSecurityRealm is not correctly implemented. 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2145'>ELY-2145</a>] -         Default platform encoding used in OAuth2IntrospectValidator and OAuth2CredentialSource.
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2147'>ELY-2147</a>] -         SCRAM Timing Attack Hardening
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2184'>ELY-2184</a>] -         Refactor the Digest mechanisms to use MessageDigest#isEqual instead of Arrays#equals
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2188'>ELY-2188</a>] -         Release WildFly Elytron 1.16.1.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2138'>ELY-2138</a>] -         Upgrade slfj-jboss-logmanager to 1.0.4.GA
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2139'>ELY-2139</a>] -         Upgrade JBoss Logging to 3.4.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2148'>ELY-2148</a>] -         Upgrade MP-JWT API to 1.2.1
</li>
</ul>
                                                                                                                            