### PR TITLE
[16.x][WFCORE-5510] Upgrade WildFly Elytron to 1.16.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.16.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.16.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.1.Final</version.org.wildfly.security.elytron-web>
 
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5510
Upstream: https://github.com/wildfly/wildfly-core/pull/4664
