### PR TITLE
[WFCORE-5515] Upgrade log4j-jboss-logmanager to 1.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.18.Final</version.org.jboss.logmanager.jboss-logmanager>
-        <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
+        <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.11.0.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5515

Diff: https://github.com/jboss-logging/log4j-jboss-logmanager/compare/1.2.0.Final...1.2.2.Final
