### PR TITLE
[WFCORE-5516] If JBOSS_BASE_DIR variable is empty -Djboss.server.base.dir is not added in wildfly-init-redhat.sh and wildfly-init-debian.sh scripts.

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-debian.sh
@@ -97,9 +97,8 @@ fi
 
 if [ -z "$JBOSS_BASE_DIR" ]; then
          JBOSS_BASE_DIR="$JBOSS_HOME/$JBOSS_MODE"
-else
-         JBOSS_OPTS="$JBOSS_OPTS -Djboss.server.base.dir=$JBOSS_BASE_DIR"
 fi
+JBOSS_OPTS="$JBOSS_OPTS -Djboss.server.base.dir=$JBOSS_BASE_DIR"
 
 JBOSS_MARKERFILE=$JBOSS_BASE_DIR/tmp/startup-marker
 

--- a/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-redhat.sh
+++ b/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-redhat.sh
@@ -115,9 +115,8 @@ fi
 
 if [ -z "$JBOSS_BASE_DIR" ]; then
          JBOSS_BASE_DIR="$JBOSS_HOME/$JBOSS_MODE"
-else
-         JBOSS_OPTS="$JBOSS_OPTS -Djboss.server.base.dir=$JBOSS_BASE_DIR"
 fi
+JBOSS_OPTS="$JBOSS_OPTS -Djboss.server.base.dir=$JBOSS_BASE_DIR"
 
 JBOSS_MARKERFILE=$JBOSS_BASE_DIR/tmp/startup-marker
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5516