### PR TITLE
[WFCORE-2592] Procrun syntax characters escaping

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/service/service.bat
+++ b/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/service/service.bat
@@ -518,7 +518,7 @@ if not "%JBOSSUSER%" == "" (
     echo When specifying a user, you need to specify the password
     goto endBatch
   )
-  set "CREDENTIALS=--user=%JBOSSUSER% --password=!JBOSSPASS!"
+  set "CREDENTIALS=--user=%JBOSSUSER% --password='!JBOSSPASS!'"
 )
 
 set RUNAS=


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-2592

Addition of procrun syntax characters ( ; and # ) escaping
