### PR TITLE
[WFCORE-5528] Missing EAP 7.4 host exclusion as a known release

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -66,6 +66,7 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         EAP71("EAP7.1", KernelAPIVersion.VERSION_5_0),
         EAP72("EAP7.2", KernelAPIVersion.VERSION_8_0),
         EAP73("EAP7.3", KernelAPIVersion.VERSION_10_0),
+        EAP74("EAP7.4", KernelAPIVersion.VERSION_16_0),
         WILDFLY10("WildFly10.0", KernelAPIVersion.VERSION_4_0),
         WILDFLY10_1("WildFly10.1", KernelAPIVersion.VERSION_4_2),
         WILDFLY11("WildFly11.0", KernelAPIVersion.VERSION_5_0),


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-5528
