### PR TITLE
[WFCORE-5347][WFCORE-5529] Replace WF23 ModelTestControllerVersion by 7.4.0.GA and correct it on Elytron transformer tests

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -68,7 +68,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
         data.add(new TransformersTestParameter(ModelVersion.create(5, 0, 0), ModelTestControllerVersion.EAP_7_1_0));
         data.add(new TransformersTestParameter(ModelVersion.create(8, 0, 0), ModelTestControllerVersion.EAP_7_2_0));
         data.add(new TransformersTestParameter(ModelVersion.create(10, 0, 0), ModelTestControllerVersion.EAP_7_3_0));
-        data.add(new TransformersTestParameter(ModelVersion.create(16, 0, 0), ModelTestControllerVersion.EAP_7_4_0_TEMP));
+        data.add(new TransformersTestParameter(ModelVersion.create(16, 0, 0), ModelTestControllerVersion.EAP_7_4_0));
         return data;
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -20,6 +20,7 @@ import static org.jboss.as.model.test.FailedOperationTransformationConfig.REJECT
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_1_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_2_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_3_0;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_4_0;
 import static org.junit.Assert.assertTrue;
 
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.DISTRIBUTED_REALM;
@@ -217,7 +218,7 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
      */
     @Test
     public void testRejectingTransformersEAP740() throws Exception {
-        testRejectingTransformers(EAP_7_3_0, "elytron-transformers-13.0-reject.xml", new FailedOperationTransformationConfig()
+        testRejectingTransformers(EAP_7_4_0, "elytron-transformers-13.0-reject.xml", new FailedOperationTransformationConfig()
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SERVER_SSL_SNI_CONTEXT, "SNIwithCaret")),
                         new FailedOperationTransformationConfig.NewAttributesConfig(ElytronDescriptionConstants.HOST_CONTEXT_MAP)
                 )
@@ -265,7 +266,7 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
      */
     @Test
     public void testTransformerEAP740() throws Exception {
-        testTransformation(EAP_7_3_0);
+        testTransformation(EAP_7_4_0);
     }
 
     private KernelServices buildKernelServices(String xml, ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -48,10 +48,7 @@ public enum ModelTestControllerVersion {
     // WildFly legacy test will need to rename the *-wf14.dmr files to *-7.2.0.dmr
     EAP_7_2_0("7.2.0.GA-redhat-00005", true, "14.0.0", "6.0.11.Final-redhat-00001", "7.2.0"),
     EAP_7_3_0("7.3.0.GA-redhat-00004", true, "18.0.0", "10.1.2.Final-redhat-00001", "7.3.0"),
-    // We use a 7.4.0_TEMP version which is based on WF23. Once we get 7.4.0.GA out, we will replace this by:
-    // EAP_7_4_0("7.4.0.GA-redhat-?????", true, "23.0.0", "15.0.0.Final-redhat-?????", "7.4.0"),
-    // See https://issues.redhat.com/browse/WFCORE-5347
-    EAP_7_4_0_TEMP("23.0.0.Final", false, "23.0.0", "15.0.0.Final", "wf23"),
+    EAP_7_4_0("7.4.0.GA-redhat-00005", true, "23.0.0", "15.0.2.Final-redhat-00001", "7.4.0"),
     ;
 
     private final String mavenGavVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.legacy.test>6.0.0.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>6.0.1.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.1.4.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/WFCORE-5347
Jira Issue: https://issues.redhat.com/browse/WFCORE-5529

Replaces the temporal WF23 model controller version used for the transformer tests and fixes its uses in Elytron tests