### PR TITLE
[WFCORE-5536] list-snapshots() should include snapshot file with a cu…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
@@ -107,6 +107,7 @@ public class ConfigurationFile {
     private static final Pattern VERSION_PATTERN = Pattern.compile("v\\d+");
     private static final Pattern FILE_WITH_VERSION_PATTERN = Pattern.compile("\\S*\\.v\\d+\\.xml");
     private static final Pattern SNAPSHOT_XML = Pattern.compile(TIMESTAMP_STRING + "\\S*\\.xml");
+    private static final Pattern GENERAL_SNAPSHOT_XML = Pattern.compile("\\S*\\.xml");
 
 
     private final AtomicInteger sequence = new AtomicInteger();
@@ -818,7 +819,7 @@ public class ConfigurationFile {
             for (String name : snapshotsDirectory.list(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
-                    return SNAPSHOT_XML.matcher(name).matches();
+                    return GENERAL_SNAPSHOT_XML.matcher(name).matches();
                 }
             })) {
                 names.add(name);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ModelPersistenceTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ModelPersistenceTestCase.java
@@ -228,6 +228,16 @@ public class ModelPersistenceTestCase extends ContainerResourceMgmtTestBase {
         File snapshotFile = new File(snapshotFileName);
         assertTrue(snapshotFile.exists());
 
+        // WFCORE-5536 take snapshot with custom name;
+        op = createOpNode(null, "take-snapshot");
+        op.get("name").set("sp1");
+        result = executeOperation(op);
+
+        // check that the snapshot file with custom name also exists
+        snapshotFileName = result.asString();
+        File snapshotFileWithCustomName = new File(snapshotFileName);
+        assertTrue(snapshotFileWithCustomName.exists());
+
         // get the snapshot listing
         op = createOpNode(null, "list-snapshots");
         result = executeOperation(op);
@@ -236,6 +246,7 @@ public class ModelPersistenceTestCase extends ContainerResourceMgmtTestBase {
 
         List<String> snapshotNames = ModelUtil.modelNodeAsStingList(result.get("names"));
         assertTrue(snapshotNames.contains(snapshotFile.getName()));
+        assertTrue(snapshotNames.contains(snapshotFileWithCustomName.getName()));
 
     }
 


### PR DESCRIPTION
…stom name (not only snapshot with timestamp prefix).

Issue: https://issues.redhat.com/browse/WFCORE-5536

It's possible to take a snapshot with a custom name, but list-snapshots() doesn't include them. I think it should pick files in snapshot directory with a more general filter.
