### PR TITLE
[WFCORE-5541] Upgrade Undertow to 2.2.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.9.Final</version.io.undertow>
+        <version.io.undertow>2.2.10.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5541


        Release Notes - Undertow - Version 2.2.10.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1929'>UNDERTOW-1929</a>] -         Several tests fail with SocketTimeoutException: Read timed out
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1940'>UNDERTOW-1940</a>] -         BindException Address already in use in SSL tests
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1941'>UNDERTOW-1941</a>] -         At Http2ClientTestCase prevent suppressing of original failure by NPE in afterClass
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1946'>UNDERTOW-1946</a>] -         DefaultServletCachingListenerTestCase.testWelcomePages fails sporadically with File was not refreshed
</li>
</ul>
                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1935'>UNDERTOW-1935</a>] -         buffer leak on incoming websocket PONG message
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1939'>UNDERTOW-1939</a>] -         Upload dump files in Github Actions CI
</li>
</ul>
                                                                                                                                                                                                                                        