### PR TITLE
[WFCORE-5406] Add --add-opens to the SE 9+ VM launch for expected reflective access by the server (round 2)

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -36,10 +36,14 @@ goto :eof
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
       rem Needed by JBoss Marshalling
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.io=ALL-UNNAMED"
+      rem Needed for marshalling of proxies
+      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
       rem Needed by WildFly Security Manager
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.security=ALL-UNNAMED"
-      rem Needed for marshalling of enum maps
+      rem Needed for marshalling of collections
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.util=ALL-UNNAMED"
+      rem Needed for marshalling of concurrent collections
+      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
       rem EE integration with sar mbeans requires deep reflection in javax.management
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.management/javax.management=ALL-UNNAMED"
       rem InitialContext proxy generation requires deep reflection in javax.naming

--- a/core-feature-pack/common/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.ps1
@@ -149,12 +149,16 @@ Param(
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.lang=ALL-UNNAMED"
         # Needed by the MicroProfile REST Client subsystem
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+        # Needed for marshalling of proxies
+        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
         # Needed by JBoss Marshalling
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.io=ALL-UNNAMED"
         # Needed by WildFly Security Manager
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.security=ALL-UNNAMED"
-        # Needed for marshalling of enum maps
+        # Needed for marshalling of collections
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.util=ALL-UNNAMED"
+        # Needed for marshalling of concurrent collections
+        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
         # EE integration with sar mbeans requires deep reflection in javax.management
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.management/javax.management=ALL-UNNAMED"
         # InitialContext proxy generation requires deep reflection in javax.naming

--- a/core-feature-pack/common/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.sh
@@ -32,12 +32,16 @@ setDefaultModularJvmOptions() {
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
       # Needed by the MicroProfile REST Client subsystem
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+      # Needed for marshalling of proxies
+      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
       # Needed by JBoss Marshalling
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.io=ALL-UNNAMED"
       # Needed by WildFly Security Manager
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.security=ALL-UNNAMED"
-      # Needed for marshalling of enum maps
+      # Needed for marshalling of collections
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.util=ALL-UNNAMED"
+      # Needed for marshalling of concurrent collections
+      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
       # EE integration with sar mbeans requires deep reflection in javax.management
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.management/javax.management=ALL-UNNAMED"
       # InitialContext proxy generation requires deep reflection in javax.naming

--- a/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
@@ -62,9 +62,11 @@ public final class JvmType {
         modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.io=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.security=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.util=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
         DEFAULT_MODULAR_JVM_ARGUMENTS = Collections.unmodifiableList(modularJavaOpts);

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -128,7 +128,7 @@ public class ManagedServerBootCmdFactoryTestCase {
         List<String> result = instance.getServerLaunchCommand();
         Assert.assertThat(result.size(), is(notNullValue()));
         if (result.size() > 18) {
-            Assert.assertThat(result.size(), is(27));
+            Assert.assertThat(result.size(), is(29));
         } else {
             Assert.assertThat(result.size(), is(18));
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -63,9 +63,11 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.io=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.security=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.util=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
         // As of jboss-modules 1.9.1.Final the java.se module is no longer required to be added. However as this API is

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -261,9 +261,11 @@ public class CommandBuilderTest {
             assertArgumentExists(command, "--add-exports=java.desktop/sun.awt=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED", expectedCount);
+            assertArgumentExists(command, "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-opens=java.base/java.io=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-opens=java.base/java.security=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-opens=java.base/java.util=ALL-UNNAMED", expectedCount);
+            assertArgumentExists(command, "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-opens=java.management/javax.management=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-opens=java.naming/javax.naming=ALL-UNNAMED", expectedCount);
             assertArgumentExists(command, "--add-modules=java.se", expectedCount);
@@ -276,12 +278,16 @@ public class CommandBuilderTest {
                     command.contains("--add-opens=java.base/java.lang=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-opens=java.base/java.lang.invoke=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"));
+            Assert.assertFalse("Did not expect \"--add-opens=java.base/java.lang.reflect=ALL-UNNAMED\" to be in the command list",
+                    command.contains("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-opens=java.base/java.io=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-opens=java.base/java.io=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-opens=java.base/java.security=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-opens=java.base/java.security=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-opens=java.base/java.util=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-opens=java.base/java.util=ALL-UNNAMED"));
+            Assert.assertFalse("Did not expect \"--add-opens=java.base/java.util.concurrent=ALL-UNNAMED\" to be in the command list",
+                    command.contains("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-opens=java.management/javax.management=ALL-UNNAMED\" to be in the command list",
                     command.contains("--add-opens=java.management/javax.management=ALL-UNNAMED"));
             Assert.assertFalse("Did not expect \"--add-opens=java.naming/javax.naming=ALL-UNNAMED\" to be in the command list",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5406

Further opens clauses are needed after recent upstream changes.