### PR TITLE
[Security Realm Removal] Fix for WFCORE-5522, CLI security SSL commands are too tied to the default config

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -92,6 +92,7 @@ public class Util {
     public static final String ALTERNATIVES = "alternatives";
     public static final String APPLICATION_REALM = "ApplicationRealm";
     public static final String APPLICATION_SECURITY_DOMAIN = "application-security-domain";
+    public static final String APPLICATION_SERVER_SSL_CONTEXT = "applicationSSC";
     public static final String ARCHIVE = "archive";
     public static final String ATTACHED_STREAMS = "attached-streams";
     public static final String ATTRIBUTES = "attributes";
@@ -770,6 +771,31 @@ public class Util {
             builder.setOperationName(Util.READ_CHILDREN_NAMES);
             builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
             builder.addProperty(Util.CHILD_TYPE, Util.SERVER);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (isSuccess(outcome)) {
+                return getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static List<String> getUndertowHTTSListeners(ModelControllerClient client, String serverName) {
+
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+            builder.addNode(Util.SERVER, serverName);
+            builder.addProperty(Util.CHILD_TYPE, Util.HTTPS_LISTENER);
             request = builder.buildRequest();
         } catch (OperationFormatException e) {
             throw new IllegalStateException("Failed to build operation", e);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
@@ -125,6 +125,14 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation> {
     public static final String OPT_SECURITY_DOMAIN = "security-domain";
     public static final String OPT_REFERENCED_SECURITY_DOMAIN = "referenced-security-domain";
 
+    public static final String OPT_OVERRIDE_SSL_CONTEXT = "override-ssl-context";
+    public static final String OPT_ADD_HTTPS_LISTENER = "add-https-listener";
+    public static final String OPT_HTTPS_LISTENER_NAME = "https-listener-name";
+    public static final String OPT_HTTPS_LISTENER_SOCKET_BINDING_NAME = "https-listener-socket-binding-name";
+
+    public static final String OPT_REMOVE_HTTPS_LISTENER = "remove-https-listener";
+    public static final String OPT_DEFAULT_SERVER_SSL_CONTEXT = "default-server-ssl-context";
+
     private final CommandContext ctx;
     private final AtomicReference<EmbeddedProcessLaunch> embeddedServerRef;
 
@@ -184,6 +192,37 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation> {
             @Override
             protected List<String> getItems(CLICompleterInvocation completerInvocation) {
                 return Util.getUndertowServerNames(completerInvocation.getCommandContext().getModelControllerClient());
+            }
+        }
+
+         public static class HTTPSListenerCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                HTTPServerDisableSSLCommand cmd = (HTTPServerDisableSSLCommand) completerInvocation.getCommand();
+                String serverName = cmd.getServerName(completerInvocation.getCommandContext());
+                return Util.getUndertowHTTSListeners(completerInvocation.getCommandContext().getModelControllerClient(), serverName);
+            }
+        }
+
+         public static class NewHTTPSListenerCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                HTTPServerEnableSSLCommand cmd = (HTTPServerEnableSSLCommand) completerInvocation.getCommand();
+                if (cmd.hasAddHTTPSListener()) {
+                    return Collections.emptyList();
+                }
+                String serverName = cmd.getServerName(completerInvocation.getCommandContext());
+                return Util.getUndertowHTTSListeners(completerInvocation.getCommandContext().getModelControllerClient(), serverName);
+            }
+        }
+
+        public static class SocketBindingCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return Util.getStandardSocketBindings(completerInvocation.getCommandContext().getModelControllerClient());
             }
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
@@ -478,6 +478,10 @@ public abstract class ElytronUtil {
         return null;
     }
 
+    public static boolean hasServerSSLContext(CommandContext context, String sslContextName) {
+        return getChildResource(sslContextName, Util.SERVER_SSL_CONTEXT, context) != null;
+    }
+
     public static ServerSSLContext getServerSSLContext(CommandContext context, String sslContextName) {
         ModelNode sslContext = getChildResource(sslContextName, Util.SERVER_SSL_CONTEXT, context);
         ServerSSLContext ctx = null;

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerDisableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerDisableSSLCommand.java
@@ -15,6 +15,7 @@ limitations under the License.
  */
 package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
 
+import java.io.IOException;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
@@ -25,10 +26,15 @@ import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_DEFAULT_SERVER_SSL_CONTEXT;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_HTTPS_LISTENER_NAME;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_REMOVE_HTTPS_LISTENER;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SERVER_NAME;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+import org.jboss.as.cli.operation.OperationFormatException;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.core.cli.command.DMRCommand;
 import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
@@ -45,9 +51,38 @@ public class HTTPServerDisableSSLCommand implements Command<CLICommandInvocation
     @Option(name = OPT_SERVER_NAME, completer = OptionCompleters.ServerNameCompleter.class)
     String serverName;
 
+    @Option(name = OPT_REMOVE_HTTPS_LISTENER,
+            hasValue = false)
+    boolean removeHttpsListener;
+
+    @Option(name = OPT_HTTPS_LISTENER_NAME,
+            completer = OptionCompleters.HTTPSListenerCompleter.class,
+            defaultValue = Util.HTTPS)
+    String httpsListener;
+
+    @Option(name = OPT_DEFAULT_SERVER_SSL_CONTEXT,
+            hasValue = true, defaultValue = Util.APPLICATION_SERVER_SSL_CONTEXT)
+    String defaultAppSSLContext;
+
+    public String getServerName(CommandContext ctx) {
+        String sName = serverName;
+        if (sName == null) {
+            sName = DefaultResourceNames.getDefaultServerName(ctx);
+        }
+        return sName;
+    }
+
     @Override
     public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
         CommandContext ctx = commandInvocation.getCommandContext();
+        try {
+            serverName = getServerName(ctx);
+            if (!HTTPServer.hasHttpsListener(ctx, serverName, httpsListener)) {
+                throw new CommandException("No HTTPS Listener named "+ httpsListener + " found in " + serverName);
+            }
+        } catch (OperationFormatException | IOException ex) {
+            throw new CommandException(ex);
+        }
         ModelNode request;
         try {
             request = buildRequest(ctx);
@@ -56,6 +91,9 @@ public class HTTPServerDisableSSLCommand implements Command<CLICommandInvocation
         }
         SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER, noReload);
         ctx.printLine("SSL disabled for " + serverName);
+        if (removeHttpsListener) {
+            ctx.printLine("HTTPS listener " + httpsListener + " has been removed");
+        }
         return CommandResult.SUCCESS;
     }
 
@@ -65,8 +103,15 @@ public class HTTPServerDisableSSLCommand implements Command<CLICommandInvocation
         composite.get(Util.OPERATION).set(Util.COMPOSITE);
         composite.get(Util.ADDRESS).setEmptyList();
         try {
+            // Check that we are not disabling the default one.
+            if (!HTTPServer.isLegacySecurityRealmSupported(context) && !removeHttpsListener) {
+                if (defaultAppSSLContext.equals(HTTPServer.getSSLContextName(serverName, httpsListener, context))) {
+                    throw new CommandFormatException("The SSL Context " + defaultAppSSLContext + " is already set on "
+                            + httpsListener + " HTTPS listener");
+                }
+            }
             serverName = HTTPServer.disableSSL(context,
-                    serverName, composite.get(Util.STEPS));
+                    serverName, removeHttpsListener, httpsListener, defaultAppSSLContext, composite.get(Util.STEPS));
         } catch (Exception ex) {
             throw new CommandFormatException(ex.getLocalizedMessage() == null
                     ? ex.toString() : ex.getLocalizedMessage(), ex);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerEnableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerEnableSSLCommand.java
@@ -17,15 +17,22 @@ package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
 
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
 import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_ADD_HTTPS_LISTENER;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_HTTPS_LISTENER_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_HTTPS_LISTENER_SOCKET_BINDING_NAME;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_OVERRIDE_SECURITY_REALM;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_OVERRIDE_SSL_CONTEXT;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SERVER_NAME;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.SSLSecurityBuilder;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
 
 /**
  * Command to enable SSL for a given undertow server.
@@ -43,26 +50,75 @@ public class HTTPServerEnableSSLCommand extends AbstractEnableSSLCommand {
             hasValue = false)
     boolean noOverride;
 
+    @Option(name = OPT_OVERRIDE_SSL_CONTEXT,
+            hasValue = false)
+    boolean overrideSSLContext;
+
+    @Option(name = OPT_ADD_HTTPS_LISTENER,
+            hasValue = false)
+    boolean addHttpsListener;
+
+    @Option(name = OPT_HTTPS_LISTENER_NAME,
+            completer= OptionCompleters.NewHTTPSListenerCompleter.class,
+            hasValue = true, defaultValue = Util.HTTPS)
+    String httpsListener;
+
+    @Option(name = OPT_HTTPS_LISTENER_SOCKET_BINDING_NAME,
+            activator = OptionActivators.DependsOnAddHttpsListenerActivator.class,
+            hasValue = true, defaultValue = Util.HTTPS, completer = OptionCompleters.SocketBindingCompleter.class)
+    String httpsListenerSocketBinding;
+
     public HTTPServerEnableSSLCommand(CommandContext ctx) {
         super(ctx);
+    }
+
+    public boolean hasAddHTTPSListener() {
+        return addHttpsListener;
+    }
+
+    public String getServerName(CommandContext ctx) {
+        String sName = serverName;
+        if (sName == null) {
+            sName = DefaultResourceNames.getDefaultServerName(ctx);
+        }
+        return sName;
     }
 
     @Override
     protected void secure(CommandContext ctx, SSLSecurityBuilder builder) throws CommandException {
         try {
-            HTTPServer.enableSSL(serverName, noOverride, ctx, builder);
+            HTTPServer.enableSSL(serverName, addHttpsListener, httpsListener, httpsListenerSocketBinding, noOverride, ctx, builder);
         } catch (Exception ex) {
             throw new CommandException(ex);
         }
     }
 
     @Override
-    protected boolean isSSLEnabled(CommandContext ctx) throws Exception {
-        String target = serverName;
-        if (target == null) {
-            target = DefaultResourceNames.getDefaultServerName(ctx);
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        CommandResult result = super.execute(commandInvocation);
+         if (addHttpsListener) {
+            commandInvocation.getCommandContext().printLine("HTTPS listener " + httpsListener + " has been added");
         }
-        return HTTPServer.getSSLContextName(target, ctx) != null;
+         return result;
+    }
+
+    @Override
+    protected boolean isSSLEnabled(CommandContext ctx) throws Exception {
+        String target = getServerName(ctx);
+        if (HTTPServer.hasHttpsListener(ctx, target, httpsListener)) {
+            if (HTTPServer.getSSLContextName(target, httpsListener, ctx) != null) {
+                if (!overrideSSLContext) {
+                    throw new Exception("An SSL server context already exists on the HTTPS listener, use --" +
+                            OPT_OVERRIDE_SSL_CONTEXT + " option to overwrite the existing SSL context");
+                }
+            }
+        } else {
+            if (!addHttpsListener) {
+                throw new Exception("No HTTPS listener found, you must use --" + OPT_ADD_HTTPS_LISTENER +
+                        " option to add an https listener to " + target + " server.");
+            }
+        }
+        return false;
     }
 
     @Override

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/ssl/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/ssl/command_resources.properties
@@ -214,8 +214,26 @@ Optional, the name of the http server to apply SSL to.
 security.enable-ssl-http-server.option.server-name.value=server name
 
 security.enable-ssl-http-server.option.no-override-security-realm.description=\
-Optional, by default the legacy security-realm attached to the https server will be erased. \
-Use this option to not erase it.
+Optional, by default the legacy security-realm attached to the HTTPS server will be erased. \
+Use this option to not erase it. Only applies to server configuration that supports deprecated security-realm \
+to secure the HTTPS listener.
+
+security.enable-ssl-http-server.option.add-https-listener.description=\
+Optional, by default the command expects that the 'https' HTTPS listener exists. If that is not the case, \
+use this option to add an HTTPS listener named with the '--https-listener-name' option.
+
+security.enable-ssl-http-server.option.override-ssl-context.description=\
+Optional, in order to override any SSL context already set on the HTTPS listener. Default to false.
+
+security.enable-ssl-http-server.option.https-listener-name.description=\
+Optional, the name of the HTTPS listener to apply SSL to. Default to 'https'.
+
+security.enable-ssl-http-server.option.https-listener-name.value=HTTPS listener name
+
+security.enable-ssl-http-server.option.https-listener-socket-binding-name.description=\
+Optional, the name of the socket binding used when adding a new HTTPS listener. Default to 'https'.
+
+security.enable-ssl-http-server.option.https-listener-socket-binding-name.value=HTTPS listener socket binding name
 
 security.disable-ssl-http-server.description=\
 Disable https for the undertow http server. This command is only available if the undertow subsystem \
@@ -234,3 +252,17 @@ security.disable-ssl-http-server.option.server-name.description=\
 Optional, the name of the http server. By default 'default-server' is used.
 
 security.disable-ssl-http-server.option.server-name.value=server name
+
+security.disable-ssl-http-server.option.remove-https-listener.description=\
+Optional, set this option to remove the HTTPS listener.
+
+security.disable-ssl-http-server.option.https-listener-name.description=\
+Optional, the name of the HTTPS listener to remove. Default to 'https'.
+
+security.disable-ssl-http-server.option.https-listener-name.value=HTTPS listener name
+
+security.disable-ssl-http-server.option.default-server-ssl-context.description=\
+Optional, the name of the server SSL context to set if the HTTPS listener is not removed. Defaults to \
+'applicationSSC'.
+
+security.disable-ssl-http-server.option.default-server-ssl-context.value=SSL server context name


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5522
This is the security-realm removal impact on WildFly CLI specified in: https://github.com/wildfly/wildfly-proposals/pull/418
