### PR TITLE
[WFCORE-5593] Upgrade WildFly Elytron to 1.17.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.17.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.17.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.9.1.Final</version.org.wildfly.security.elytron-web>
 
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5593


        Release Notes - WildFly Elytron - Version 1.17.1.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2070'>ELY-2070</a>] -         CredentialStore is not able to get data from credential storage in file on IBM JDK 8
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2197'>ELY-2197</a>] -         Close resource - potential resource leak
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2198'>ELY-2198</a>] -         Remove old unused private code
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2215'>ELY-2215</a>] -         Release WildFly Elytron 1.17.1.Final
</li>
</ul>
                       