### PR TITLE
[WFCORE-5587] maximum-cert-path does not work with empty certificate-revocation-list in Elytron trust-manager

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -689,14 +689,8 @@ class SSLDefinitions {
                 final String aliasFilter = ALIAS_FILTER.resolveModelAttribute(context, model).asStringOrNull();
                 final String algorithm = algorithmName != null ? algorithmName : TrustManagerFactory.getDefaultAlgorithm();
 
-                ModelNode crlNode = CERTIFICATE_REVOCATION_LIST.resolveModelAttribute(context, model);
-                ModelNode ocspNode = OCSP.resolveModelAttribute(context, model);
-                boolean softFail = SOFT_FAIL.resolveModelAttribute(context, model).asBoolean();
-                Integer maxCertPath = MAXIMUM_CERT_PATH.resolveModelAttribute(context, model).asIntOrNull();
-                ModelNode multipleCrlsNode = CERTIFICATE_REVOCATION_LISTS.resolveModelAttribute(context, model);
-
-                if (crlNode.isDefined() || ocspNode.isDefined() || multipleCrlsNode.isDefined()) {
-                        return createX509RevocationTrustManager(serviceBuilder, context, algorithm, providerName, providersInjector, keyStoreInjector, softFail, crlNode, multipleCrlsNode, ocspNode, maxCertPath, aliasFilter);
+                if (model.hasDefined(CERTIFICATE_REVOCATION_LIST.getName()) || model.hasDefined(OCSP.getName()) || model.hasDefined(CERTIFICATE_REVOCATION_LISTS.getName())) {
+                    return createX509RevocationTrustManager(serviceBuilder, context, model, algorithm, providerName, providersInjector, keyStoreInjector, aliasFilter);
                 }
 
                 DelegatingTrustManager delegatingTrustManager = new DelegatingTrustManager();
@@ -734,7 +728,16 @@ class SSLDefinitions {
                 };
             }
 
-            private ValueSupplier<TrustManager> createX509RevocationTrustManager(ServiceBuilder<TrustManager> serviceBuilder, OperationContext context, String algorithm, String providerName, InjectedValue<Provider[]> providersInjector, InjectedValue<KeyStore> keyStoreInjector, boolean softFail, ModelNode crlNode, ModelNode multipleCrlsNode, ModelNode ocspNode, Integer maxCertPath, String aliasFilter) throws OperationFailedException {
+            private ValueSupplier<TrustManager> createX509RevocationTrustManager(ServiceBuilder<TrustManager> serviceBuilder, OperationContext context,
+                    ModelNode model, String algorithm, String providerName, InjectedValue<Provider[]> providersInjector,
+                    InjectedValue<KeyStore> keyStoreInjector, String aliasFilter) throws OperationFailedException {
+
+                ModelNode crlNode = CERTIFICATE_REVOCATION_LIST.resolveModelAttribute(context, model);
+                ModelNode ocspNode = OCSP.resolveModelAttribute(context, model);
+                ModelNode multipleCrlsNode = CERTIFICATE_REVOCATION_LISTS.resolveModelAttribute(context, model);
+                boolean softFail = SOFT_FAIL.resolveModelAttribute(context, model).asBoolean();
+                boolean onlyLeafCert = ONLY_LEAF_CERT.resolveModelAttribute(context, model).asBoolean();
+                Integer maxCertPath = MAXIMUM_CERT_PATH.resolveModelAttribute(context, model).asIntOrNull();
 
                 //BW compatibility, max cert path is now in trust-manager
                 @Deprecated
@@ -761,21 +764,21 @@ class SSLDefinitions {
                             serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, pathManagerInjector);
                             serviceBuilder.requires(pathName(crlRelativeTo));
                         }
+                        crlFiles.add(new CrlFile(crlPath, crlRelativeTo, pathManagerInjector));
                     }
-
-                    crlFiles.add(new CrlFile(crlPath, crlRelativeTo, pathManagerInjector));
-
                 } else if (multipleCrlsNode.isDefined()) {
                     // certificate-revocation-lists and certificate-revocation-list are mutually exclusive
                     for (ModelNode crl : multipleCrlsNode.asList()) {
                         crlPath = PATH.resolveModelAttribute(context, crl).asStringOrNull();
                         crlRelativeTo = RELATIVE_TO.resolveModelAttribute(context, crl).asStringOrNull();
                         pathManagerInjector = new InjectedValue();
-                        if (crlPath != null && crlRelativeTo != null) {
-                            serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, pathManagerInjector);
-                            serviceBuilder.requires(pathName(crlRelativeTo));
+                        if (crlPath != null) {
+                            if (crlRelativeTo != null) {
+                                serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, pathManagerInjector);
+                                serviceBuilder.requires(pathName(crlRelativeTo));
+                            }
+                            crlFiles.add(new CrlFile(crlPath, crlRelativeTo, pathManagerInjector));
                         }
-                        crlFiles.add(new CrlFile(crlPath, crlRelativeTo, pathManagerInjector));
                     }
                 }
 
@@ -802,18 +805,19 @@ class SSLDefinitions {
                 X509RevocationTrustManager.Builder builder = X509RevocationTrustManager.builder();
                 builder.setResponderURI(responderUri);
                 builder.setSoftFail(softFail);
+                builder.setOnlyEndEntity(onlyLeafCert);
                 if (maxCertPath != null) {
                     builder.setMaxCertPath(maxCertPath.intValue());
                 }
-                if (crlNode.isDefined()) {
-                    if (!ocspNode.isDefined()) {
+                if (model.hasDefined(CERTIFICATE_REVOCATION_LIST.getName()) || model.hasDefined(CERTIFICATE_REVOCATION_LISTS.getName())) {
+                    if (!model.hasDefined(OCSP.getName())) {
                         builder.setPreferCrls(true);
                         builder.setNoFallback(true);
                     }
                 }
-                if (ocspNode.isDefined()) {
+                if (model.hasDefined(OCSP.getName())) {
                     builder.setResponderURI(responderUri);
-                    if (!crlNode.isDefined()) {
+                    if (!model.hasDefined(CERTIFICATE_REVOCATION_LIST.getName()) && !model.hasDefined(CERTIFICATE_REVOCATION_LISTS.getName())) {
                         builder.setPreferCrls(false);
                         builder.setNoFallback(true);
                     } else {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -66,6 +66,8 @@ import org.bouncycastle.cert.X509v2CRLBuilder;
 import org.bouncycastle.openssl.MiscPEMGenerator;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemWriter;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
@@ -80,6 +82,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.ssl.X509RevocationTrustManager;
 import org.wildfly.security.x500.cert.BasicConstraintsExtension;
 import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
 import org.wildfly.security.x500.cert.X509CertificateBuilder;
@@ -557,12 +560,24 @@ public class TlsTestCase extends AbstractSubsystemTest {
     public void testRevocationListsDp() throws Throwable {
         ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl-dp");
         TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManager);
+        MatcherAssert.assertThat(trustManager, CoreMatchers.instanceOf(X509RevocationTrustManager.class));
 
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add(ElytronDescriptionConstants.TRUST_MANAGER, "trust-with-crl-dp");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST);
         Assert.assertTrue(services.executeOperation(operation).get(OUTCOME).asString().equals(FAILED)); // not realoadable
+    }
+
+    @Test
+    public void testRevocationListsDpOnlyDeprecatedMaximumCertPath() throws Throwable {
+        ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl-dp-deprecated-max-cert-path");
+        TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
+        MatcherAssert.assertThat(trustManager, CoreMatchers.instanceOf(X509RevocationTrustManager.class));
+
+        ModelNode operation = new ModelNode();
+        operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add(ElytronDescriptionConstants.TRUST_MANAGER, "trust-with-crl-dp-deprecated-max-cert-path");
+        operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST);
+        Assert.assertTrue(services.executeOperation(operation).get(OUTCOME).asString().equals(FAILED)); // not reloadable
     }
 
     /**
@@ -572,7 +587,7 @@ public class TlsTestCase extends AbstractSubsystemTest {
     public void testCertificateRevocationListsDp() throws Throwable {
         ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crls-dp");
         TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManager);
+        MatcherAssert.assertThat(trustManager, CoreMatchers.instanceOf(X509RevocationTrustManager.class));
 
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add(ElytronDescriptionConstants.TRUST_MANAGER, "trust-with-crls-dp");
@@ -653,14 +668,14 @@ public class TlsTestCase extends AbstractSubsystemTest {
     public void testOcspCrl() {
         ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-ocsp-crl");
         TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManager);
+        MatcherAssert.assertThat(trustManager, CoreMatchers.instanceOf(X509RevocationTrustManager.class));
     }
 
     @Test
     public void testOcspSimple() {
         ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-ocsp-simple");
         TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManager);
+        MatcherAssert.assertThat(trustManager, CoreMatchers.instanceOf(X509RevocationTrustManager.class));
     }
 
     private SSLContext getSslContext(String contextName) {

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -78,6 +78,9 @@
             <trust-manager name="trust-with-crl-dp" algorithm="PKIX" key-store="ElytronCaTruststore">
                 <certificate-revocation-list />
             </trust-manager>
+            <trust-manager name="trust-with-crl-dp-deprecated-max-cert-path" algorithm="PKIX" key-store="ElytronCaTruststore">
+                <certificate-revocation-list maximum-cert-path="1"/>
+            </trust-manager>
             <trust-manager name="trust-with-crls-dp" algorithm="PKIX" key-store="ElytronCaTruststore">
                 <certificate-revocation-lists />
             </trust-manager>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-oracle13plus.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-oracle13plus.xml
@@ -78,6 +78,9 @@
             <trust-manager name="trust-with-crl-dp" algorithm="PKIX" key-store="ElytronCaTruststore">
                 <certificate-revocation-list />
             </trust-manager>
+            <trust-manager name="trust-with-crl-dp-deprecated-max-cert-path" algorithm="PKIX" key-store="ElytronCaTruststore">
+                <certificate-revocation-list maximum-cert-path="1"/>
+            </trust-manager>
             <trust-manager name="trust-with-crls-dp" algorithm="PKIX" key-store="ElytronCaTruststore">
                 <certificate-revocation-lists />
             </trust-manager>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -78,6 +78,9 @@
             <trust-manager name="trust-with-crl-dp" algorithm="PKIX" key-store="ElytronCaTruststore">
                 <certificate-revocation-list />
             </trust-manager>
+            <trust-manager name="trust-with-crl-dp-deprecated-max-cert-path" algorithm="PKIX" key-store="ElytronCaTruststore">
+                <certificate-revocation-list maximum-cert-path="1"/>
+            </trust-manager>
             <trust-manager name="trust-with-crls-dp" algorithm="PKIX" key-store="ElytronCaTruststore">
                 <certificate-revocation-lists />
             </trust-manager>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -44,6 +44,9 @@
             <trust-manager name="trust-with-crl-dp" algorithm="SunX509" key-store="jks_store">
                 <certificate-revocation-list />
             </trust-manager>
+            <trust-manager name="trust-with-crl-dp-deprecated-max-cert-path" algorithm="SunX509" key-store="jks_store">
+                <certificate-revocation-list maximum-cert-path="1"/>
+            </trust-manager>
             <trust-manager name="trust-with-ocsp-crl" algorithm="PKIX" key-store="jks_store" soft-fail="true" only-leaf-cert="true">
                 <certificate-revocation-list />
                 <ocsp responder="http://localhost/ocsp"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5587

A few problems in the `SSLDefinitions` class:

1. The `certificate-revocation-list` can be defined empty and although it exists the current call to `isDefined` returns `false`. This is because no other element is defined inside it (no default value or whatever) and it's resolved to undefined. It is important to detect that this node is set (even empty) because distribution points (DP) should be checked in that case. The call to `isDefined` is changed to `hasDefined` in the parent node that detects its presence correctly. This is changed in the places that DP should be considered.
2. The `CrlFile` is added to the list when the `path` is null, that throws a NPE. For example when setting the `certificate-revocation-list` only with the `maximum-cert-path` set.
3. The `only-leaf-cert` property was never set in the builder.

Tests modified to detect 1 and 2.

@fjuma Take a look to this when you have time.