### PR TITLE
[WFCORE-5597] Remove references to the security-integration module as it is being removed from WildFly.

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -55,7 +55,5 @@
         <module name="org.jboss.logmanager"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
-        <!-- WFCORE-5032 Dependency on legacy security integration to enable discovery of services if available. --> 
-        <module name="org.jboss.as.security-integration" optional="true" services="import" />
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5597