### PR TITLE
[WFCORE-5598] Upgrade Undertow to 2.2.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.10.Final</version.io.undertow>
+        <version.io.undertow>2.2.12.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.3</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5598


        Release Notes - Undertow - Version 2.2.12.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1969'>UNDERTOW-1969</a>] -         Cannot create certificate from header on SE17
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1972'>UNDERTOW-1972</a>] -         InMemorySessionManager can mistake PLACE_HOLDER_SESSION with a real session
</li>
</ul>
                                                                                                                                                                                                                                                

        Release Notes - Undertow - Version 2.2.11.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1959'>UNDERTOW-1959</a>] -         DefaultServletCachingListenerTestCase.testWelcomePages still fails sporadically with File was not refreshed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1960'>UNDERTOW-1960</a>] -         Address already in use in LoadBalancingProxy test cases
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1962'>UNDERTOW-1962</a>] -         Prevent BindException (Address already in use) in all points that invoke Undertow.close() and XnioWorker.shutdown
</li>
</ul>
                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1198'>UNDERTOW-1198</a>] -         IPAddressAccessControlHandler does not recognize IPV6 loopback address ::1
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1532'>UNDERTOW-1532</a>] -         PathResourceManager doesn&#39;t seem work properly with Windows shortened file names
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1568'>UNDERTOW-1568</a>] -         AbstractFramedChannel.toString() is not synchronized
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1789'>UNDERTOW-1789</a>] -         Bring back bumpTimeout in setMaxInactiveInterval of HttpSession
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1869'>UNDERTOW-1869</a>] -         InMemorySessionManager Session Creation Not Thread Safe
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1910'>UNDERTOW-1910</a>] -         AbstractFramedStreamSinkChannel.awaitWritable() never returns if peer fails to update HTTP2 window
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1917'>UNDERTOW-1917</a>] -         Logic in try/finally blocks hides exceptions
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1931'>UNDERTOW-1931</a>] -         Null pointers should not be dereferenced
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1932'>UNDERTOW-1932</a>] -         ALPNHackSSLEngine field manipulation methods are not consistent.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1933'>UNDERTOW-1933</a>] -         Short-circuit logic for boolean
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1950'>UNDERTOW-1950</a>] -         Fix NullPointerException in PreCompressedResourceSupplier
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1957'>UNDERTOW-1957</a>] -         The undertow-servlet-jakartaee9 and undertow-websockets-jsr-jakartaee9 artifacts are not under dependency management
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1915'>UNDERTOW-1915</a>] -         Remove unneccesary code
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1916'>UNDERTOW-1916</a>] -         Review PathResourceManager exception handling
</li>
</ul>
                                                                                                                                                                                                                                        
