### PR TITLE
Roll back Jandex to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.byteman>4.0.16</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.jandex>2.4.0.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.3.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.15.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>


### PR DESCRIPTION
I have a theory the Jandex 2.4.0 upgrade is causing CDI TCK issues so this is an experiment in rolling it back. But not all the way to 2.2.3; just to 2.3.1.

I expect failures in the full integration tests as other libs have been upgraded expecting 2.4.0 to be present. https://github.com/wildfly/wildfly/pull/14743 is an experiment in full with rolling jandex back there. I filed this here mostly to get the core CI jobs to run.