### PR TITLE
[WFCORE-5603] Downgrade Jandex to 2.3.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.byteman>4.0.16</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.jandex>2.4.0.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.3.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.15.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFCORE-5603

---

Dev tag: https://github.com/wildfly/jandex/releases/tag/2.3.1.Final
Diff to previous Jandex version without regression: https://github.com/wildfly/jandex/compare/2.2.3.Final...2.3.1.Final