### PR TITLE
[WFCORE-5602] security enable-http-auth-http-server command fails for the security domain "other"

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerEnableAuthCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerEnableAuthCommand.java
@@ -167,11 +167,10 @@ public class HTTPServerEnableAuthCommand extends AbstractEnableAuthenticationCom
     protected void secure(CommandContext ctx, AuthSecurityBuilder builder) throws Exception {
         ApplicationSecurityDomain secDomain = HTTPServer.getSecurityDomain(ctx, securityDomain);
         if (secDomain != null) {
-            if (secDomain.getSecurityDomain() != null) {
-                if (!secDomain.getSecurityDomain().equals(builder.getReferencedSecurityDomain())) {
-                    // re-write the existing security domain
-                    HTTPServer.writeReferencedSecurityDomain(builder, securityDomain, ctx);
-                }
+            if (secDomain.getSecurityDomain() != null && builder.getReferencedSecurityDomain() != null
+                    && !secDomain.getSecurityDomain().equals(builder.getReferencedSecurityDomain())) {
+                // re-write the existing security domain
+                HTTPServer.writeReferencedSecurityDomain(builder, securityDomain, ctx);
             }
         } else {
             // add a new security domain resource
@@ -185,6 +184,7 @@ public class HTTPServerEnableAuthCommand extends AbstractEnableAuthenticationCom
         if (!HTTPServer.isReferencedSecurityDomainSupported(context)) {
             return super.buildSecurityRequest(context);
         }
+        ApplicationSecurityDomain existingDomain = HTTPServer.getSecurityDomain(ctx, securityDomain);
         AuthSecurityBuilder builder = null;
         if (getMechanism() == null) {
             if (referencedSecurityDomain == null) {
@@ -194,9 +194,12 @@ public class HTTPServerEnableAuthCommand extends AbstractEnableAuthenticationCom
                 throw new CommandException("Can't enable HTTP Authentication, security domain "
                         + referencedSecurityDomain + " doesn't exist");
             }
+            if (existingDomain != null && existingDomain.getFactory() != null) {
+                throw new CommandException("Can't mix mechanism and referenced security domain");
+            }
             builder = new AuthSecurityBuilder(referencedSecurityDomain);
         } else {
-            if (referencedSecurityDomain != null) {
+            if (referencedSecurityDomain != null || (existingDomain != null && existingDomain.getSecurityDomain() != null)) {
                 throw new CommandException("Can't mix mechanism and referenced security domain");
             }
             return super.buildSecurityRequest(context);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5602

When executing a security command over an existing undertow app domain it can happen that it was defined using referenced domain and the command is trying to add an http factory (or vice-versa). In one case the command returns the weird error detected in the JIRA and in the other the domain is not modified at all. This PR just detects that situation and throws an error: `Can't mix mechanism and referenced security domain` (the same error that was already used when the command passed both parameters).

The tests seem to be in wildfly `SecurityAuthCommandsTestCase.java` class. But we need to wait for that test to be re-enabled in WFLY-15057 (PR https://github.com/wildfly/wildfly/pull/14670).

@jfdenise Please review this when you have some time.

Thanks!