### PR TITLE
[WFCORE-5609] Fix AbstractOperationContext#getCurrentOperationName()

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -545,7 +545,7 @@ abstract class AbstractOperationContext implements OperationContext {
         ModelNode operation = activeStep.operation;
 
         assert operation != null;
-        return operation.get(NAME).asString();
+        return operation.get(OP).asString();
     }
 
     @Override


### PR DESCRIPTION
The name of the operation is held by the `OP` constant (`"operation"`)
and not by the `NAME` constant (that would contain an eventual `"name"`
parameter of the given operation).

JIRA: https://issues.redhat.com/browse/WFCORE-5609

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
