### PR TITLE
WFCORE-5581 Upgrade Jandex to 2.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.byteman>4.0.16</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.jandex>2.3.1.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.4.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.15.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5581

Fixes https://github.com/wildfly/jandex/issues/148 which causes a CDI TCK regression.