### PR TITLE
[WFCORE-5489] As a developer, I want to override management attribute…

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -168,4 +168,53 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <environmentVariables>
+                                <!-- Used in EnvVarAttributeOverrideModelTestCase -->
+                                <!-- This corresponds to the /subsystem=custom resource and its my-attr attribute -->
+                                <SUBSYSTEM_CUSTOM__MY_ATTR>5678</SUBSYSTEM_CUSTOM__MY_ATTR>
+                            </environmentVariables>
+                            <excludes>
+                                <exclude>org/jboss/as/controller/EnvVarAttributeOverrideModel$EnabledOverridingEnvVarTestCase</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>env-var-overrides</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <environmentVariables>
+                                <!-- Used in EnvVarAttributeOverrideModelTestCase -->
+                                <!-- The presence of this env var is required to trigger the overridding feature -->
+                                <WILDFLY_OVERRIDING_ENV_VARS>1</WILDFLY_OVERRIDING_ENV_VARS>
+                                <!-- This corresponds to the /subsystem=custom resource and its my-attr attribute -->
+                                <SUBSYSTEM_CUSTOM__MY_ATTR>5678</SUBSYSTEM_CUSTOM__MY_ATTR>
+                                <!-- test that a complex attribute is not overidden -->
+                                <SUBSYSTEM_CUSTOM__MY_LIST_ATTR>[a, b, c]</SUBSYSTEM_CUSTOM__MY_LIST_ATTR>
+                            </environmentVariables>
+                            <includes>
+                                <include>org/jboss/as/controller/EnvVarAttributeOverrideModel$EnabledOverridingEnvVarTestCase</include>
+                            </includes>
+                            <excludes>
+                                <exclude></exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/controller/src/main/java/org/jboss/as/controller/EnvVarAttributeOverrider.java
+++ b/controller/src/main/java/org/jboss/as/controller/EnvVarAttributeOverrider.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.controller;
+
+import org.jboss.as.controller.logging.ControllerLogger;
+
+/**
+ * Utility class to override the value of an attribute by setting an env var corresponding to the
+ * address of the resource and the name of the attribute to override.
+ */
+public class EnvVarAttributeOverrider {
+
+    private static final boolean ENABLED = System.getenv().containsKey("WILDFLY_OVERRIDING_ENV_VARS");
+
+    /**
+     * Overriding the value of a management attribute with an environment variable is enabled only
+     * when the {@code WILDFLY_OVERRIDING_ENV_VARS} env var is present (its value does not matter).
+     */
+    static boolean isEnabled() {
+        return ENABLED;
+    }
+
+    static String getOverriddenValueFromEnvVar(final PathAddress address, final String attributeName) {
+        // check if there is an env var that overrides the attribute value
+        String envVar = replaceNonAlphanumericByUnderscoreAndMakeUpperCase(address, attributeName);
+        String envVarValue = System.getenv(envVar);
+        if (envVarValue != null) {
+            ControllerLogger.ROOT_LOGGER.debugf("The value of the '%s' attribute of the '%s' resource is set by the environment variable '%s'",
+                    attributeName, address, envVar);
+            return envVarValue;
+        }
+        return null;
+    }
+
+    static String replaceNonAlphanumericByUnderscoreAndMakeUpperCase(final PathAddress address, final String attributeName) {
+        // we use 2 underscores to separate the address from the attribute name:
+        // 1. for readability
+        // 2. to avoid any collusion
+        //   attribute b-c on /resource=a => RESOURCE_A__B_C
+        //   attribute c on /resource=a-b => RESOURCE_A_B__C
+        String name = address.toCLIStyleString().substring(1) + "__" + attributeName;
+        int length = name.length();
+        StringBuilder sb = new StringBuilder();
+        int c;
+        for (int i = 0; i < length; i += Character.charCount(c)) {
+            c = Character.toUpperCase(name.codePointAt(i));
+            if ('A' <= c && c <= 'Z' ||
+                    '0' <= c && c <= '9') {
+                sb.appendCodePoint(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        return sb.toString();
+    }
+
+
+
+}

--- a/controller/src/test/java/org/jboss/as/controller/EnvVarAttributeOverrideModel.java
+++ b/controller/src/test/java/org/jboss/as/controller/EnvVarAttributeOverrideModel.java
@@ -1,0 +1,207 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.EnvVarAttributeOverrider.replaceNonAlphanumericByUnderscoreAndMakeUpperCase;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.test.AbstractControllerTestBase;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author jmesnil
+ */
+public abstract class EnvVarAttributeOverrideModel extends AbstractControllerTestBase {
+    private static final SimpleAttributeDefinition MY_ATTR = new SimpleAttributeDefinitionBuilder("my-attr", ModelType.INT, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleListAttributeDefinition MY_LIST_ATTR = new SimpleListAttributeDefinition.Builder("my-list-attr", MY_ATTR)
+            .setRequired(false)
+            .build();
+
+    private static final PathAddress CUSTOM_RESOURCE_ADDR = PathAddress.pathAddress("subsystem", "custom");
+    private static final int VALUE_FROM_MODEL = 1234;
+    private static final int VALUE_FROM_ENV_VAR = 5678;
+
+    @Override
+    protected void initModel(ManagementModel managementModel) {
+        ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+        // register the global operations to be able to call :read-attribute and :write-attribute
+        GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+        // register the global notifications so there is no warning that emitted notifications are not described by the resource.
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
+
+        ResourceDefinition profileDefinition = createDummyProfileResourceDefinition();
+        rootRegistration.registerSubModel(profileDefinition);
+    }
+
+    private static ResourceDefinition createDummyProfileResourceDefinition() {
+        return ResourceBuilder.Factory.create(CUSTOM_RESOURCE_ADDR.getElement(0),
+                new NonResolvingResourceDescriptionResolver())
+                .setAddOperation(new AbstractAddStepHandler(Arrays.asList(MY_ATTR, MY_LIST_ATTR)))
+                .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addReadWriteAttribute(MY_ATTR, null, new ReloadRequiredWriteAttributeHandler(MY_ATTR))
+                .addReadWriteAttribute(MY_LIST_ATTR, null, new ReloadRequiredWriteAttributeHandler(MY_LIST_ATTR))
+                .build();
+    }
+
+    /**
+     * This test creates a resource with an attribute set to "value1".
+     * The test runs with an env var corresponding to the resource attribute set to "value2"
+     *
+     * When we read the attribute value we verify that the value comes from the env var (i.e. "value2").
+     *
+     * @throws OperationFailedException
+     */
+    protected void testOverriddenSpecifiedAttributeValue(boolean featureEnabled) throws OperationFailedException {
+        ModelNode addOp = createOperation("add", CUSTOM_RESOURCE_ADDR);
+        addOp.get(MY_ATTR.getName()).set("1234");
+        executeCheckNoFailure(addOp);
+
+        ModelNode readResource = createOperation(READ_RESOURCE_OPERATION, CUSTOM_RESOURCE_ADDR);
+        executeCheckNoFailure(readResource);
+
+        ModelNode readAttribute = createOperation(READ_ATTRIBUTE_OPERATION, CUSTOM_RESOURCE_ADDR);
+        readAttribute.get(NAME).set(MY_ATTR.getName());
+        ModelNode response = executeCheckNoFailure(readAttribute);
+        if (featureEnabled) {
+            assertEquals(VALUE_FROM_ENV_VAR, response.get(RESULT).asInt());
+        } else {
+            assertEquals(VALUE_FROM_MODEL, response.get(RESULT).asInt());
+        }
+    }
+
+    /**
+     * This test creates a resource with an undefined attribute.
+     * The test runs with an env var corresponding to the resource attribute set to "value2"
+     *
+     * When we read the attribute value we verify that the value comes from the env var (i.e. "value2").
+     *
+     * @throws OperationFailedException
+     */
+    protected void testOverriddenOptionalAttributeValue(boolean featureEnabled) throws OperationFailedException {
+        ModelNode addOp = createOperation("add", CUSTOM_RESOURCE_ADDR);
+        executeCheckNoFailure(addOp);
+
+        ModelNode readResource = createOperation(READ_RESOURCE_OPERATION, CUSTOM_RESOURCE_ADDR);
+        executeCheckNoFailure(readResource);
+
+        ModelNode readAttribute = createOperation(READ_ATTRIBUTE_OPERATION, CUSTOM_RESOURCE_ADDR);
+        readAttribute.get(NAME).set(MY_ATTR.getName());
+        ModelNode response = executeCheckNoFailure(readAttribute);
+        if (featureEnabled) {
+            assertEquals(VALUE_FROM_ENV_VAR, response.get(RESULT).asInt());
+        } else {
+            assertFalse(response.get(RESULT).isDefined());
+        }
+    }
+
+    @Test
+    public void testAttributeMapping() {
+        // /interface=management:read-attribute(name=inet-address)
+        assertEquals("INTERFACE_MANAGEMENT__INET_ADDRESS",
+                replaceNonAlphanumericByUnderscoreAndMakeUpperCase(PathAddress.pathAddress(INTERFACE, MANAGEMENT), "inet-address"));
+
+        // /subsystem=undertow/server=default-server/http-listener=default:read-attribute(name=proxy-address-forwarding)
+        assertEquals("SUBSYSTEM_UNDERTOW_SERVER_DEFAULT_SERVER_HTTP_LISTENER_DEFAULT__PROXY_ADDRESS_FORWARDING",
+                replaceNonAlphanumericByUnderscoreAndMakeUpperCase(PathAddress.pathAddress(SUBSYSTEM, "undertow").append(SERVER, "default-server").append("http-listener", DEFAULT),
+                        "proxy-address-forwarding"));
+
+        // /resource=a:read-attribute(name=b-c)
+        assertEquals("RESOURCE_A__B_C",
+                replaceNonAlphanumericByUnderscoreAndMakeUpperCase(PathAddress.pathAddress("resource", "a"), "b-c"));
+        // /resource=a-b:read-attribute(name=c)
+        assertEquals("RESOURCE_A_B__C",
+                replaceNonAlphanumericByUnderscoreAndMakeUpperCase(PathAddress.pathAddress("resource", "a-b"), "c"));
+    }
+
+    public static final class EnabledOverridingEnvVarTestCase extends EnvVarAttributeOverrideModel {
+
+        @BeforeClass
+        public static void setup() {
+            Assume.assumeTrue(EnvVarAttributeOverrider.isEnabled());
+        }
+
+        @Test
+        public void testOverriddenSpecifiedAttributeValue() throws OperationFailedException {
+            testOverriddenSpecifiedAttributeValue(true);
+        }
+
+        @Test
+        public void testOverriddenOptionalAttributeValue() throws OperationFailedException {
+            testOverriddenOptionalAttributeValue(true);
+        }
+
+        @Test
+        public void textComplexAttributeIsIgnored() throws OperationFailedException {
+            // verify that there is an env var matching the my-list-addr attribute
+            String envVarName = replaceNonAlphanumericByUnderscoreAndMakeUpperCase(CUSTOM_RESOURCE_ADDR, MY_LIST_ATTR.getName());
+            assertFalse(System.getenv(envVarName).isEmpty());
+
+            ModelNode addOp = createOperation("add", CUSTOM_RESOURCE_ADDR);
+            executeCheckNoFailure(addOp);
+
+            ModelNode readResource = createOperation(READ_RESOURCE_OPERATION, CUSTOM_RESOURCE_ADDR);
+            executeCheckNoFailure(readResource);
+
+            ModelNode readAttribute = createOperation(READ_ATTRIBUTE_OPERATION, CUSTOM_RESOURCE_ADDR);
+            readAttribute.get(NAME).set(MY_LIST_ATTR.getName());
+            ModelNode response = executeCheckNoFailure(readAttribute);
+            assertFalse(response.get(RESULT).isDefined());
+        }
+    }
+
+    public static final class DisabledOverridingEnvVarTestCase extends EnvVarAttributeOverrideModel {
+
+        @BeforeClass
+        public static void setup() {
+            Assume.assumeFalse(EnvVarAttributeOverrider.isEnabled());
+        }
+
+        @Test
+        public void testOverriddenSpecifiedAttributeValue() throws OperationFailedException {
+            testOverriddenSpecifiedAttributeValue(false);
+        }
+
+        @Test
+        public void testOverriddenOptionalAttributeValue() throws OperationFailedException {
+            testOverriddenOptionalAttributeValue(false);
+        }
+    }
+}


### PR DESCRIPTION
… values using environment variables

When validating and setting the value for an attribute, check if there is an env var
that would override its value before doing any expression resolution or
correction.

This feature is enabled by the existence of the
`WILDFLY_OVERRIDING_ENV_VARS` environment variable.

JIRA: https://issues.redhat.com/browse/WFCORE-5489

Dev analysis is at https://github.com/wildfly/wildfly-proposals/pull/404

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
