### PR TITLE
[17.x][WFCORE-5630] Limit maven resource filtering to the intended files

### DIFF
--- a/core-feature-pack/galleon-feature-pack/pom.xml
+++ b/core-feature-pack/galleon-feature-pack/pom.xml
@@ -118,6 +118,15 @@
                             <resources>
                                 <resource>
                                     <directory>${common.resources.directory}</directory>
+                                    <excludes>
+                                        <exclude>modules/**/module.xml</exclude>
+                                    </excludes>
+                                </resource>
+                                <resource>
+                                    <directory>${common.resources.directory}</directory>
+                                    <includes>
+                                        <include>modules/**/module.xml</include>
+                                    </includes>
                                     <filtering>true</filtering>
                                 </resource>
                             </resources>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5630

Upstream: https://github.com/wildfly/wildfly-core/pull/4839
