### PR TITLE
[WFCORE-5638] Ignore compatibility testing of AS 7.1.1 clients on SE 17

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestBase.java
@@ -37,6 +37,7 @@ import org.jboss.as.model.test.ChildFirstClassLoaderBuilder;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -44,7 +45,6 @@ import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -134,6 +134,8 @@ public abstract class ClientCompatibilityUnitTestBase {
 
     @Test
     public void test711Final() throws Exception {
+        // This hangs on SE 17. No good reason to sort out why a 2011 client doesn't work on a 2021 SE, so ignore
+        AssumeTestGroupUtil.assumeJDKVersionBefore(12);
         testAS7("7.1.1.Final");
     }
 
@@ -147,21 +149,9 @@ public abstract class ClientCompatibilityUnitTestBase {
         test(createClient(WF_CLIENT, "8.0.0.Final", CONTROLLER_ADDRESS, 9999));
     }
 
-    @Ignore("http upgrade compat issue")
-    @Test
-    public void test800FinalHttp() throws Exception {
-        test(createClient(WF_CLIENT, "8.0.0.Final", CONTROLLER_ADDRESS, 9990));
-    }
-
     @Test
     public void test810Final() throws Exception {
         test(createClient(WF_CLIENT, "8.1.0.Final", CONTROLLER_ADDRESS, 9999));
-    }
-
-    @Ignore("http upgrade compat issue")
-    @Test
-    public void test810FinalHttp() throws Exception {
-        test(createClient(WF_CLIENT, "8.1.0.Final", CONTROLLER_ADDRESS, 9990));
     }
 
     @Test
@@ -169,21 +159,9 @@ public abstract class ClientCompatibilityUnitTestBase {
         test(createClient(WF_CLIENT, "8.2.0.Final", CONTROLLER_ADDRESS, 9999));
     }
 
-    @Ignore("http upgrade compat issue")
-    @Test
-    public void test820FinalHttp() throws Exception {
-        test(createClient(WF_CLIENT, "8.2.0.Final", CONTROLLER_ADDRESS, 9990));
-    }
-
     @Test
     public void test821Final() throws Exception {
         test(createClient(WF_CLIENT, "8.2.1.Final", CONTROLLER_ADDRESS, 9999));
-    }
-
-    @Ignore("http upgrade compat issue")
-    @Test
-    public void test821FinalHttp() throws Exception {
-        test(createClient(WF_CLIENT, "8.2.1.Final", CONTROLLER_ADDRESS, 9990));
     }
 
     @Test

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/AssumeTestGroupUtil.java
@@ -1,0 +1,85 @@
+package org.jboss.as.test.shared;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.function.Supplier;
+
+import org.junit.Assume;
+
+/**
+ * Helper methods which help to skip tests that are not appropriate for execution in particular tests environments.
+ * Call these methods directly in a particular test method or, if you want to skip whole test class,
+ * put the method call into method annotated with {@link org.junit.BeforeClass}.
+ *
+ */
+public final class AssumeTestGroupUtil {
+
+    /**
+     * Assume for tests that fail when the security manager is enabled. This should be used sparingly and issues should
+     * be filed for failing tests so a proper fix can be done.
+     * <p>
+     * Note that this checks the {@code security.manager} system property and <strong>not</strong> that the
+     * {@link System#getSecurityManager()} is {@code null}. The property is checked so that the assumption check can be
+     * done in a {@link org.junit.Before @Before} or {@link org.junit.BeforeClass @BeforeClass} method.
+     * </p>
+     */
+    public static void assumeSecurityManagerDisabled() {
+        assumeCondition("Tests failing if the security manager is enabled.", () -> System.getProperty("security.manager") == null);
+    }
+
+    /**
+     * Assume for tests that fail when the JVM version is too low. This should be used sparingly.
+     *
+     * @param javaSpecificationVersion the JDK specification version. Use 8 for JDK 8. Must be 8 or higher.
+     */
+    public static void assumeJDKVersionAfter(int javaSpecificationVersion) {
+        assert javaSpecificationVersion >= 8; // we only support 8 or later so no reason to call this for 8
+        assumeCondition("Tests failing if the JDK in use is before " + javaSpecificationVersion + ".",
+                () -> getJavaSpecificationVersion() > javaSpecificationVersion);
+    }
+
+    /**
+     * Assume for tests that fail when the JVM version is too high. This should be used sparingly.
+     *
+     * @param javaSpecificationVersion the JDK specification version. Must be 9 or higher.
+     */
+    public static void assumeJDKVersionBefore(int javaSpecificationVersion) {
+        assert javaSpecificationVersion >= 9; // we only support 8 or later so no reason to call this for 8
+        assumeCondition("Tests failing if the JDK in use is after " + javaSpecificationVersion + ".",
+                () -> getJavaSpecificationVersion() < javaSpecificationVersion);
+    }
+
+    // BES 2020/05/18 I added this along with assumeJDKVersionAfter/assumeJDKVersionBefore but commented it
+    // out because using it seems like bad practice. If there's a legit need some day, well, here's the code...
+//    /**
+//     * Assume for tests that fail when the JVM version is something. This should be used sparingly and issues should
+//     * be filed for failing tests so a proper fix can be done, as it's inappropriate to limit a test to a single version.
+//     *
+//     * @param javaSpecificationVersion the JDK specification version. Use 8 for JDK 8. Must be 8 or higher.
+//     */
+//    public static void assumeJDKVersionEquals(int javaSpecificationVersion) {
+//        assert javaSpecificationVersion >= 8; // we only support 8 or later
+//        assumeCondition("Tests failing if the JDK in use is other than " + javaSpecificationVersion + ".",
+//                () -> getJavaSpecificationVersion() == javaSpecificationVersion);
+//    }
+
+    private static int getJavaSpecificationVersion() {
+        String versionString = System.getProperty("java.specification.version");
+        versionString = versionString.startsWith("1.") ? versionString.substring(2) : versionString;
+        return Integer.parseInt(versionString);
+    }
+
+    private static void assumeCondition(final String message, final Supplier<Boolean> assumeTrueCondition) {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+                Assume.assumeTrue(message, assumeTrueCondition.get());
+                return null;
+            }
+        });
+    }
+
+    private AssumeTestGroupUtil() {
+        // prevent instantiation
+    }
+}


### PR DESCRIPTION
Also delete some test methods that have been ignored for years where we're never going to sort out whatever was preventing such old clients working.

https://issues.redhat.com/browse/WFCORE-5638
