### PR TITLE
[WFCORE-5677] Upgrade Elytron Web to 1.10.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.17.2.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.9.1.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.10.0.Final</version.org.wildfly.security.elytron-web>
 
     </properties>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5677


        Release Notes - Elytron Web - Version 1.10.0.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-133'>ELYWEB-133</a>] -         SecurityContextImpl.login incorrectly assumes authenticate would be called first.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-155'>ELYWEB-155</a>] -          Don&#39;t override the deployment&#39;s authentication mechanisms when overrideDeploymentConfig is false and the loginConfig is null
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-143'>ELYWEB-143</a>] -         Provide more details in the project README
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-144'>ELYWEB-144</a>] -         Add parameter validation to the builder setters in SecurityContextImpl
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-156'>ELYWEB-156</a>] -         Release Elytron Web 1.10.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-134'>ELYWEB-134</a>] -         Upgrade Undertow to 2.2.7.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-138'>ELYWEB-138</a>] -         Upgrade WildFly Elytron to 1.15.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-140'>ELYWEB-140</a>] -         Upgrade Undertow to 2.2.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-141'>ELYWEB-141</a>] -         Upgrade JBoss Logging to 3.4.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-142'>ELYWEB-142</a>] -         Upgrade WildFly Elytron to 1.16.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-145'>ELYWEB-145</a>] -         Upgrade Elytron to 1.16.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-146'>ELYWEB-146</a>] -         Upgrade Undertow to 2.2.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-149'>ELYWEB-149</a>] -         Update the Ubuntu version that gets used by GitHub Actions
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-150'>ELYWEB-150</a>] -         Upgrade infinispan to 9.4.23.Final 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-151'>ELYWEB-151</a>] -         Upgrade Elytron to 1.17.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-152'>ELYWEB-152</a>] -         Upgrade Undertow to 2.2.12.Final
</li>
</ul>
                                                           
