### PR TITLE
[WFCORE-5685] KerberosHttpMgmtSaslTestCase & KerberosNativeMgmtSaslTestCase tests fail on JDK 18 EA

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/AbstractKrb5ConfServerSetupTask.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/AbstractKrb5ConfServerSetupTask.java
@@ -98,7 +98,7 @@ public abstract class AbstractKrb5ConfServerSetupTask implements ServerSetupTask
         final String cannonicalHost = NetworkUtils.formatPossibleIpv6Address(CoreUtils.getCannonicalHost(TestSuiteEnvironment.getServerAddress()));
         final Map<String, String> map = new HashMap<String, String>();
         map.put("hostname", cannonicalHost);
-        final String supportedEncTypes = CoreUtils.IBM_JDK ? getSupportedEncTypes() : "des-cbc-md5,des3-cbc-sha1-kd";
+        final String supportedEncTypes = getSupportedEncTypes();
         map.put("enctypes", supportedEncTypes);
         LOGGER.trace("Supported enctypes in krb5.conf: " + supportedEncTypes);
         FileUtils.write(

--- a/testsuite/elytron/src/test/resources/org/wildfly/test/security/common/kerberos/krb5.conf
+++ b/testsuite/elytron/src/test/resources/org/wildfly/test/security/common/kerberos/krb5.conf
@@ -2,6 +2,7 @@
 	default_realm = JBOSS.ORG
 	default_tgs_enctypes = ${enctypes}
 	default_tkt_enctypes = ${enctypes}
+	permitted_enctypes = ${enctypes}
 	kdc_timeout = 5000
 	dns_lookup_realm = false
 	dns_lookup_kdc = false


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5685

The ldap/kerberos tests now also add all the enc-types defined in the keytab to the `permitted_enctypes` option in the `krb5.conf` file. This way the allowed enc-types don't depend on the default JDK values. Besides, previously the enc-types selected by the tests were different for ibm and non-ibm JDKs, this part has been also changed (don't know why but with non-ibm only two types were selected, this was done since the creation of the file).

Both tests pass for me with for jdk-18 and the current JDKs (I tried with a lot of versions and vendors).