### PR TITLE
[WFCORE-5692]: Upgrade WildFly Galleon plugins to 5.2.5.Final.

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -618,6 +618,18 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+            <classifier>client</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-deployment-scanner</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>5.2.4.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.2.5.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <version.org.wildfly.jar.plugin>5.0.2.Final</version.org.wildfly.jar.plugin>


### PR DESCRIPTION
* Upgrading the galleon plugins to 5.2.5.Final
* fixing the feature pack to define the version of the cli artefact
  with the classifier 'client'.

Jira: https://issues.redhat.com/browse/WFCORE-5692