### PR TITLE
Fix for WFCORE-5704, Upgrade galleon plugins to 5.2.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>5.2.5.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.2.6.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <version.org.wildfly.jar.plugin>5.0.2.Final</version.org.wildfly.jar.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5704
Diff: https://github.com/wildfly/galleon-plugins/compare/5.2.5.Final...5.2.6.Final
