### PR TITLE
[WFCORE-5709][WFCORE-5705] Make ElytronExpressionResolver useful in S…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -180,6 +180,13 @@ public abstract class AbstractControllerService implements Service<ModelControll
             RuntimeCapability.Builder.of("org.wildfly.management.process-state-notifier", ProcessStateNotifier.class)
                     .build();
 
+    /**
+     * Name of a capability that extensions that provide {@link ExpressionResolverExtension} implementations
+     * can use to register their extensions with the core {@link ExpressionResolver}.
+     */
+    protected static final String EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME =
+            "org.wildfly.management.expression-resolver-extension-registry";
+
     private static final OperationDefinition INIT_CONTROLLER_OP = new SimpleOperationDefinitionBuilder("boottime-controller-initializer-step", null)
         .setPrivateEntry()
         .build();

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolver.java
@@ -41,17 +41,23 @@ public interface ExpressionResolver {
      * Resolves any expressions in the passed in ModelNode.
      *
      * Expressions may represent system properties, vaulted date, or a custom format to be handled by an
-     * ExpressionResolver registered using the "org.wildfly.controller.expression-resolver" capability.
-     *
-     * For vaulted data the format is ${VAULT::vault_block::attribute_name::sharedKey}
+     * {@link ExpressionResolverExtension} registered using the {@link ResolverExtensionRegistry}.
      *
      * @param node the ModelNode containing expressions.
      * @return a copy of the node with expressions resolved
      *
-     * @throws OperationFailedException if there is a value of type {@link org.jboss.dmr.ModelType#EXPRESSION} in the node tree and
-     *            there is no system property or environment variable that matches the expression, or if a security
-     *            manager exists and its {@link SecurityManager#checkPermission checkPermission} method doesn't allow
-     *            access to the relevant system property or environment variable
+     * @throws ExpressionResolutionUserException if {@code expression} is a form understood by the resolver but in some
+     *                                             way is unacceptable. This should only be thrown due to flaws in the
+     *                                             provided {@code expression} or the configuration of resources used by
+     *                                             a resolver extension, which are 'user' problems. It should not
+     *                                             be used for internal problems in the resolver or any extension. If a
+     *                                             if a security manager exists and its
+     *                                             {@link SecurityManager#checkPermission checkPermission} method doesn't
+     *                                             allow access to a relevant system property or environment variable,
+     *                                             an {@code ExpressionResolutionUserException} should be thrown.
+     * @throws OperationFailedException if an {@link ExpressionResolverExtension} throws one from its
+     *            {@link ExpressionResolverExtension#initialize(OperationContext)} method.
+     * @throws ExpressionResolver.ExpressionResolutionServerException if some other internal expression resolution failure occurs.
      */
     ModelNode resolveExpressions(ModelNode node) throws OperationFailedException;
 
@@ -59,7 +65,7 @@ public interface ExpressionResolver {
      * Resolves any expressions in the passed in ModelNode.
      *
      * Expressions may represent system properties, vaulted date, or a custom format to be handled by an
-     * ExpressionResolver registered using the "org.wildfly.controller.expression-resolver" capability.
+     * {@link ExpressionResolverExtension} registered using the {@link ResolverExtensionRegistry}.
      *
      * For vaulted data the format is ${VAULT::vault_block::attribute_name::sharedKey}
      *
@@ -67,10 +73,18 @@ public interface ExpressionResolver {
      * @param context the current {@code OperationContext} to provide additional contextual information.
      * @return a copy of the node with expressions resolved
      *
-     * @throws OperationFailedException if there is a value of type {@link org.jboss.dmr.ModelType#EXPRESSION} in the node tree and
-     *            there is no system property or environment variable that matches the expression, or if a security
-     *            manager exists and its {@link SecurityManager#checkPermission checkPermission} method doesn't allow
-     *            access to the relevant system property or environment variable
+     * @throws ExpressionResolutionUserException if {@code expression} is a form understood by the resolver but in some
+     *                                             way is unacceptable. This should only be thrown due to flaws in the
+     *                                             provided {@code expression} or the configuration of resources used by
+     *                                             the resolver extension, which are 'user' problems>. It should not
+     *                                             be used for internal problems in the resolver extension. If a
+     *                                             if a security manager exists and its
+     *                                             {@link SecurityManager#checkPermission checkPermission} method doesn't
+     *                                             allow access to a relevant system property or environment variable,
+     *                                             an {@code ExpressionResolutionUserException} should be thrown
+     * @throws OperationFailedException if an {@link ExpressionResolverExtension} throws one from its
+     *            {@link ExpressionResolverExtension#initialize(OperationContext)} method.
+     * @throws ExpressionResolver.ExpressionResolutionServerException if some other internal expression resolution failure occurs.
      */
     default ModelNode resolveExpressions(ModelNode node, OperationContext context) throws OperationFailedException {
         return resolveExpressions(node);
@@ -113,4 +127,91 @@ public interface ExpressionResolver {
             node.set(expression);
         }
     };
+
+    /**
+     * Registry for {@link ExpressionResolverExtension extensions} to a server or host controller's {@link ExpressionResolver}.
+     * The registry will be available using the {@code org.wildfly.management.expression-resolver-extension-registry}
+     * capability.
+     */
+    interface ResolverExtensionRegistry {
+
+        /**
+         * Adds an extension to the set used by the {@link ExpressionResolver}.
+         * @param extension the extension. Cannot be {@code null}
+         */
+        void addResolverExtension(ExpressionResolverExtension extension);
+
+        /**
+         * Removes an extension from the set used by the {@link ExpressionResolver}.
+         * @param extension the extension. Cannot be {@code null}
+         */
+        void removeResolverExtension(ExpressionResolverExtension extension);
+    }
+
+    /**
+     * Runtime exception used to indicate some user-driven problem that prevented expression
+     * resolution, for example:
+     * <ol>
+     *     <li>
+     * A flaw in a user provided expression string that results in a {@link ExpressionResolverExtension}
+     * not being able to resolve the expression.
+     *     </li>
+     *     <li>
+     * A server configuration flaw that prevents initialization of runtime services used by the resolver extension.
+     *     </li>
+     * </ol>
+     * <p>
+     * This class implements {@link OperationClientException}, so if it is thrown during
+     * execution of an {@code OperationStepHandler}, the management kernel will properly
+     * handle the exception as a user mistake, not a server fault.
+     * <p>
+     * <strong>Note:</strong> this should only be thrown if the {@link ExpressionResolverExtension} is
+     * sure the expression string is meant to be resolved by itself. Do not throw this in situations
+     * where this is unclear.
+     * <p>
+     * <strong>Note:</strong> this should only be thrown to report problems resulting from user
+     * errors. Use {@link ExpressionResolverExtension.ExpressionResolutionServerException} to report faults in
+     * {@link ExpressionResolverExtension#resolveExpression(String, OperationContext)} execution that
+     * are not due to user inputs.
+     */
+    class ExpressionResolutionUserException extends RuntimeException implements OperationClientException {
+
+        public ExpressionResolutionUserException(String msg) {
+            super(msg);
+        }
+
+        public ExpressionResolutionUserException(String msg, Throwable cause) {
+            super(msg, cause);
+        }
+
+        @Override
+        public ModelNode getFailureDescription() {
+            return new ModelNode(getLocalizedMessage());
+        }
+    }
+
+    /**
+     * Runtime exception used to indicate a failure in some
+     * {@link ExpressionResolverExtension#resolveExpression(String, OperationContext) resolver extension execution}
+     * not due to problems with user input like the expression string being resolved or the configuration
+     * of resources backing the resolver extension.
+     * <p>
+     * <strong>Note:</strong> this should only be thrown if the {@link ExpressionResolverExtension} is
+     * sure the expression string is meant to be resolved by itself. Do not throw this in situations
+     * where this is unclear.
+     * <p>
+     * <strong>Note:</strong> this should only be thrown to report internal failures in the
+     * {@link ExpressionResolverExtension#resolveExpression(String, OperationContext)} execution.
+     * Use {@link ExpressionResolutionUserException} to report problems with user inputs.
+     */
+    class ExpressionResolutionServerException extends RuntimeException {
+
+        public ExpressionResolutionServerException(String msg) {
+            super(msg);
+        }
+
+        public ExpressionResolutionServerException(String msg, Throwable cause) {
+            super(msg, cause);
+        }
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolverExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolverExtension.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+/**
+ * Object that can be used to extend the functionality of an {@link ExpressionResolver} by handling
+ * expression strings in formats not understood by the expression resolver.
+ */
+public interface ExpressionResolverExtension {
+
+    /**
+     * Initialize the extension using the given {@link OperationContext}. May be called multiple times
+     * for a given extension, so extensions should handle that appropriately.
+     *
+     * @param context the {@link OperationContext}. Will not be {@code null}
+     * @throws OperationFailedException if a problem initializing occurs that indicates a user mistake
+     *                                  (e.g. an improper configuration of a resource used by the extension.)
+     *                                  Do not use for non-user-driven problems; use runtime exceptions for those.
+     *                                  Throwing a runtime exception that implements {@link OperationClientException}
+     *                                  is also a valid way to handle user mistakes.
+     */
+    void initialize(OperationContext context) throws OperationFailedException;
+
+    /**
+     * Resolve a given simple expression string, returning {@code null} if the string is not of a form
+     * recognizable to the plugin.
+     *
+     * @param expression a string that begins with <code>${</code> and ends with <code>}</code> and that does not have
+     *                   any substrings that match that pattern.
+     * @param context    the current {@code OperationContext} to provide additional contextual information.
+     * @return a string representing the resolve expression, or {@code null} if {@code expression} is not of a
+     * form understood by the plugin.
+     * @throws ExpressionResolver.ExpressionResolutionUserException   if {@code expression} is a form understood by the plugin but in some
+     *                                             way is unacceptable. This should only be thrown due to flaws in the
+     *                                             provided {@code expression} or the configuration of resources used by
+     *                                             the resolver extension, which are 'user' problems. It should not
+     *                                             be used for internal problems in the resolver extension.
+     * @throws ExpressionResolver.ExpressionResolutionServerException if some other internal expression resolution failure occurs.
+     */
+    String resolveExpression(String expression, OperationContext context);
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java
@@ -250,7 +250,7 @@ public class ExpressionResolverImpl implements ExpressionResolver {
                                 continue;
                             }
                             String toResolve = getStringToResolve(initialValue, stack, i);
-                            final String resolved = resolveExpressionString(toResolve, context); // TODO we could catch OFE here
+                            final String resolved = resolveExpressionString(toResolve, context); // TODO we could catch OFE or ERUE here
                                                                                         // and if lenient respond with
                                                                                         // the initial value, else rethrow
                                                                                         // But for now it's a corner case
@@ -366,10 +366,8 @@ public class ExpressionResolverImpl implements ExpressionResolver {
      * Perform a standard {@link org.jboss.dmr.ModelNode#resolve()} on the given {@code unresolved} node.
      * @param unresolved  the unresolved node, which should be of type {@link org.jboss.dmr.ModelType#EXPRESSION}
      * @return a node of type {@link ModelType#STRING}
-     *
-     * @throws OperationFailedException if {@code ignoreFailures} is {@code false} and the expression cannot be resolved
      */
-    private static String resolveStandardExpression(final ModelNode unresolved) throws OperationFailedException {
+    private static String resolveStandardExpression(final ModelNode unresolved) {
         try {
             return unresolved.resolve().asString();
         } catch (SecurityException e) {
@@ -377,7 +375,7 @@ public class ExpressionResolverImpl implements ExpressionResolver {
             // this method for any expression will have ignoreUnresolvable set to 'false' which means a basic test of
             // ability to read system properties will have already passed. So a failure with ignoreUnresolvable set to
             // true means a specific property caused the failure, and that should not be ignored
-            throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.noPermissionToResolveExpression(unresolved, e));
+            throw ControllerLogger.ROOT_LOGGER.noPermissionToResolveExpression(unresolved, e);
         } catch (IllegalStateException e) {
             return unresolved.asString();
         }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -44,6 +44,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -2394,7 +2395,7 @@ public interface ControllerLogger extends BasicLogger {
      * @return an {@link OperationFailedException} for the caller
      */
     @Message(id = 210, value = "Caught SecurityException attempting to resolve expression '%s' -- %s")
-    String noPermissionToResolveExpression(ModelNode toResolve, SecurityException e);
+    ExpressionResolver.ExpressionResolutionUserException noPermissionToResolveExpression(ModelNode toResolve, SecurityException e);
 
     /**
      * Creates an exception message indicating an expression could not be resolved due to no corresponding system property
@@ -2404,7 +2405,7 @@ public interface ControllerLogger extends BasicLogger {
      * @return an {@link OperationFailedException} for the caller
      */
     @Message(id = 211, value = "Cannot resolve expression '%s'")
-    OperationFailedException cannotResolveExpression(String toResolve);
+    ExpressionResolver.ExpressionResolutionUserException cannotResolveExpression(String toResolve);
 
     /**
      * Creates an exception indicating the resource is a duplicate.
@@ -3243,7 +3244,7 @@ public interface ControllerLogger extends BasicLogger {
     String unsupportedUsageOfExpression();
 
     @Message(id = 370, value="Incomplete expression: %s")
-    OperationFailedException incompleteExpression(String expression);
+    ExpressionResolver.ExpressionResolutionUserException incompleteExpression(String expression);
 
     @Message(id = 371, value="The element '%s' is no longer supported, please use '%s' instead")
     XMLStreamException unsupportedElement(QName name, @Param Location location, String supportedElement);

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ResolveExpressionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ResolveExpressionHandler.java
@@ -101,11 +101,10 @@ public class ResolveExpressionHandler implements OperationStepHandler {
                     }
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 } catch (SecurityException e) {
-                    throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.noPermissionToResolveExpression(toResolve, e));
-                } catch (IllegalStateException e) {
-                    final ModelNode failureDescription = ControllerLogger.ROOT_LOGGER.cannotResolveExpression(toResolve.asString()).getFailureDescription();
-                    deferFailureReporting(context, failureDescription);
-                } catch (OperationFailedException e) {
+                    throw ControllerLogger.ROOT_LOGGER.noPermissionToResolveExpression(toResolve, e);
+                } catch (IllegalStateException | ExpressionResolver.ExpressionResolutionServerException e) {
+                    deferFailureReporting(context, new ModelNode(e.getLocalizedMessage()));
+                } catch (OperationFailedException | ExpressionResolver.ExpressionResolutionUserException e) {
                     deferFailureReporting(context, e.getFailureDescription());
                 }
             }

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/OperationValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/OperationValidator.java
@@ -456,7 +456,7 @@ public class OperationValidator {
         ModelNode resolved;
         try {
             resolved = expressionResolver.resolveExpressions(value);
-        } catch (OperationFailedException e) {
+        } catch (OperationFailedException | ExpressionResolver.ExpressionResolutionUserException e) {
             // Dealing with an unresolvable expression is beyond what this class can do.
             // So fall through and see what happens. Basically if modelType is EXPRESSION or STRING
             // it will pass, otherwise an IAE will be thrown

--- a/controller/src/test/java/org/jboss/as/controller/ExpressionResolverUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ExpressionResolverUnitTestCase.java
@@ -37,11 +37,11 @@ import org.junit.Test;
  */
 public class ExpressionResolverUnitTestCase {
 
-    @Test(expected = OperationFailedException.class)
+    @Test(expected = ExpressionResolver.ExpressionResolutionUserException.class)
     public void testDefaultExpressionResolverWithNoResolutions() throws OperationFailedException {
         ModelNode unresolved = createModelNode();
         ExpressionResolver.TEST_RESOLVER.resolveExpressions(unresolved);
-        fail("Did not fail with OFE: " + unresolved);
+        fail("Did not fail with ERUE: " + unresolved);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class ExpressionResolverUnitTestCase {
         checkResolved(node);
     }
 
-    @Test(expected = OperationFailedException.class)
+    @Test(expected = ExpressionResolver.ExpressionResolutionUserException.class)
     public void testPluggableExpressionResolverNotResolved() throws OperationFailedException {
         ModelNode unresolved = createModelNode();
         new ExpressionResolverImpl() {
@@ -159,7 +159,7 @@ public class ExpressionResolverUnitTestCase {
 
         }.resolveExpressions(unresolved);
 
-        fail("Did not fail with OFE: " + unresolved);
+        fail("Did not fail with ERUE: " + unresolved);
     }
 
     @Test
@@ -366,12 +366,12 @@ public class ExpressionResolverUnitTestCase {
     /**
      * Test that a incomplete expression to a system property reference throws an ISE
      */
-    @Test(expected = OperationFailedException.class)
+    @Test(expected = ExpressionResolver.ExpressionResolutionUserException.class)
     public void testIncompleteReference() throws OperationFailedException {
         System.setProperty("test.property1", "test.property1.value");
         try {
             ModelNode resolved = ExpressionResolver.TEST_RESOLVER.resolveExpressions(expression("${test.property1"));
-            fail("Did not fail with OFE: " + resolved);
+            fail("Did not fail with ERUE: " + resolved);
         } finally {
             System.clearProperty("test.property1");
         }
@@ -388,12 +388,12 @@ public class ExpressionResolverUnitTestCase {
     /**
      * Test that a incomplete expression to a system property reference throws an ISE
      */
-    @Test(expected = OperationFailedException.class)
+    @Test(expected = ExpressionResolver.ExpressionResolutionUserException.class)
     public void testIncompleteReferenceFollowingSuccessfulResolve() throws OperationFailedException {
         System.setProperty("test.property1", "test.property1.value");
         try {
             ModelNode resolved = ExpressionResolver.TEST_RESOLVER.resolveExpressions(expression("${test.property1} ${test.property1"));
-            fail("Did not fail with OFE: "+ resolved);
+            fail("Did not fail with ERUE: "+ resolved);
         } finally {
             System.clearProperty("test.property1");
         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ExpressionResolverResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ExpressionResolverResourceDefinition.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.ExpressionResolverExtension;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -62,6 +63,8 @@ class ExpressionResolverResourceDefinition extends SimpleResourceDefinition {
     private static final StandardResourceDescriptionResolver RESOURCE_RESOLVER =
             ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.EXPRESSION, ElytronDescriptionConstants.ENCRYPTION);
 
+    private static final String EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME =
+            "org.wildfly.management.expression-resolver-extension-registry";
     /*
      * As this resource is attempting to make available an ExpressionResolver for use at runtime we need all values to be known before
      * first use so the use of expressions is disabled on this resource.
@@ -129,7 +132,7 @@ class ExpressionResolverResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     ExpressionResolverResourceDefinition(OperationStepHandler add, OperationStepHandler remove,
-            RuntimeCapability<ExpressionResolver> expressionResolverRuntimeCapability) {
+            RuntimeCapability<ExpressionResolverExtension> expressionResolverRuntimeCapability) {
         super(new Parameters(PathElement.pathElement(ElytronDescriptionConstants.EXPRESSION, ElytronDescriptionConstants.ENCRYPTION),
                 RESOURCE_RESOLVER)
                 .setAddHandler(add)
@@ -182,26 +185,66 @@ class ExpressionResolverResourceDefinition extends SimpleResourceDefinition {
 
         ElytronExpressionResolver expressionResolver = new ElytronExpressionResolver(
                 (e, c) -> configureExpressionResolver(resourceAddress, e, c));
-        RuntimeCapability<ExpressionResolver> expressionResolverRuntimeCapability =  RuntimeCapability
-                .Builder.<ExpressionResolver>of(EXPRESSION_RESOLVER_CAPABILITY, false, expressionResolver)
+        RuntimeCapability<ExpressionResolverExtension> expressionResolverRuntimeCapability =  RuntimeCapability
+                .Builder.<ExpressionResolverExtension>of(EXPRESSION_RESOLVER_CAPABILITY, false, expressionResolver)
                 .build();
 
         AbstractAddStepHandler add = new ExpressionResolverAddHandler(expressionResolverRuntimeCapability);
-        OperationStepHandler remove = new TrivialCapabilityServiceRemoveHandler(add, expressionResolverRuntimeCapability);
+        OperationStepHandler remove = new ExpressionResolverRemoveHandler(add, expressionResolverRuntimeCapability);
 
         return new ExpressionResolverResourceDefinition(add, remove, expressionResolverRuntimeCapability);
     }
 
     private static class ExpressionResolverAddHandler extends BaseAddHandler {
 
-        ExpressionResolverAddHandler(RuntimeCapability<ExpressionResolver> expressionResolverRuntimeCapability) {
+        private final ElytronExpressionResolver expressionResolver;
+
+        ExpressionResolverAddHandler(RuntimeCapability<ExpressionResolverExtension> expressionResolverRuntimeCapability) {
             super(expressionResolverRuntimeCapability, ATTRIBUTES);
+            expressionResolver = (ElytronExpressionResolver) expressionResolverRuntimeCapability.getRuntimeAPI();
         }
 
         @Override
         protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource)
                 throws OperationFailedException {
             super.recordCapabilitiesAndRequirements(context, operation, resource);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+
+            ExpressionResolver.ResolverExtensionRegistry registry =
+                    context.getCapabilityRuntimeAPI(EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME,
+                            ExpressionResolver.ResolverExtensionRegistry.class);
+            registry.addResolverExtension(expressionResolver);
+        }
+
+    }
+
+    private static class ExpressionResolverRemoveHandler extends TrivialCapabilityServiceRemoveHandler {
+
+        private final ElytronExpressionResolver expressionResolver;
+
+        ExpressionResolverRemoveHandler(AbstractAddStepHandler add, RuntimeCapability<ExpressionResolverExtension> expressionResolverRuntimeCapability) {
+            super(add, expressionResolverRuntimeCapability);
+            expressionResolver = (ElytronExpressionResolver) expressionResolverRuntimeCapability.getRuntimeAPI();
+        }
+
+        @Override
+        protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource)
+                throws OperationFailedException {
+            super.recordCapabilitiesAndRequirements(context, operation, resource);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+            if (context.isResourceServiceRestartAllowed()) {
+                ExpressionResolver.ResolverExtensionRegistry registry =
+                        context.getCapabilityRuntimeAPI(EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME,
+                                ExpressionResolver.ResolverExtensionRegistry.class);
+                registry.removeResolverExtension(expressionResolver);
+            }
+            super.performRuntime(context, operation, model);
         }
 
     }
@@ -213,8 +256,8 @@ class ExpressionResolverResourceDefinition extends SimpleResourceDefinition {
             String resolver = RESOLVER_PARAM.resolveModelAttribute(context, operation).asStringOrNull();
             String clearText = CLEAR_TEXT.resolveModelAttribute(context, operation).asString();
 
-            ExpressionResolver expressionResolver = context.getCapabilityRuntimeAPI(EXPRESSION_RESOLVER_CAPABILITY, ExpressionResolver.class);
-            String expression = ((ElytronExpressionResolver) expressionResolver).createExpression(resolver, clearText, context);
+            ElytronExpressionResolver expressionResolver = (ElytronExpressionResolver) context.getCapabilityRuntimeAPI(EXPRESSION_RESOLVER_CAPABILITY, ExpressionResolverExtension.class);
+            String expression = expressionResolver.createExpression(resolver, clearText, context);
 
             context.getResult().get(ElytronDescriptionConstants.EXPRESSION).set(expression);
         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -30,6 +30,7 @@ import java.security.Provider;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -380,7 +381,7 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     String updateDependantServices(String alias);
 
     @Message(id = 922, value = "Unable to load credential from credential store.")
-    OperationFailedException unableToLoadCredential(@Cause Throwable cause);
+    ExpressionResolver.ExpressionResolutionUserException unableToLoadCredential(@Cause Throwable cause);
 
     @Message(id = 923, value = "Unable to encrypt the supplied clear text.")
     OperationFailedException unableToEncryptClearText(@Cause Throwable cause);
@@ -657,19 +658,28 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     OperationFailedException noResolverWithSpecifiedName(String name);
 
     @Message(id = 1202, value = "A cycle has been detected initialising the expression resolver for '%s' and '%s'.")
-    OperationFailedException cycleDetectedInitialisingExpressionResolver(String firstExpression, String secondExpression);
+    ExpressionResolver.ExpressionResolutionUserException cycleDetectedInitialisingExpressionResolver(String firstExpression, String secondExpression);
 
     @Message(id = 1203, value = "Expression resolver initialisation has already failed.")
-    OperationFailedException expressionResolverInitialisationAlreadyFailed(@Cause Throwable cause);
+    ExpressionResolver.ExpressionResolutionUserException expressionResolverInitialisationAlreadyFailed(@Cause Throwable cause);
 
     @Message(id = 1204, value = "The expression '%s' does not specify a resolver and no default is defined.")
-    OperationFailedException expressionResolutionWithoutResolver(String expression);
+    ExpressionResolver.ExpressionResolutionUserException expressionResolutionWithoutResolver(String expression);
 
     @Message(id = 1205, value = "The expression '%s' specifies a resolver configuration which does not exist.")
-    OperationFailedException invalidResolver(String expression);
+    ExpressionResolver.ExpressionResolutionUserException invalidResolver(String expression);
 
     @Message(id = 1206, value = "Unable to decrypt expression '%s'.")
-    OperationFailedException unableToDecryptExpression(String expression, @Cause Throwable cause);
+    ExpressionResolver.ExpressionResolutionUserException unableToDecryptExpression(String expression, @Cause Throwable cause);
+
+    @Message(id = 1207, value = "Resolution of credential store expressions is not supported in the MODEL stage of operation execution.")
+    ExpressionResolver.ExpressionResolutionServerException modelStageResolutionNotSupported(@Cause IllegalStateException cause);
+
+    @Message(id = 1208, value = "Unable to resolve CredentialStore %s -- %s")
+    ExpressionResolver.ExpressionResolutionServerException unableToResolveCredentialStore(String storeName, String details, @Cause Exception cause);
+
+    @Message(id = 1209, value = "Unable to initialize CredentialStore %s -- %s")
+    ExpressionResolver.ExpressionResolutionUserException unableToInitializeCredentialStore(String storeName, String details, @Cause Exception cause);
 
     /*
      * Don't just add new errors to the end of the file, there may be an appropriate section above for the resource.

--- a/elytron/src/test/java/org/wildfly/extension/elytron/ElytronSubsystem13_0TestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/ElytronSubsystem13_0TestCase.java
@@ -20,7 +20,9 @@ package org.wildfly.extension.elytron;
 
 import java.io.IOException;
 
+import org.jboss.as.controller.RunningMode;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
 
 /**
  *
@@ -40,6 +42,12 @@ public class ElytronSubsystem13_0TestCase extends AbstractSubsystemBaseTest {
     @Override
     protected void compareXml(String configId, String original, String marshalled) throws Exception {
         //
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        // Our use of the expression=encryption resource requires kernel capability setup that TestEnvironment provides
+        return new TestEnvironment(RunningMode.ADMIN_ONLY);
     }
 
 }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/ElytronSubsystem14_0TestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/ElytronSubsystem14_0TestCase.java
@@ -20,7 +20,9 @@ package org.wildfly.extension.elytron;
 
 import java.io.IOException;
 
+import org.jboss.as.controller.RunningMode;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
 
 /**
  *
@@ -35,6 +37,12 @@ public class ElytronSubsystem14_0TestCase extends AbstractSubsystemBaseTest {
     @Override
     protected String getSubsystemXml() throws IOException {
         return readResource("elytron-subsystem-14.0.xml");
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        // Our use of the expression=encryption resource requires kernel capability setup that TestEnvironment provides
+        return new TestEnvironment(RunningMode.ADMIN_ONLY);
     }
 
 }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/ExpressionResolutionTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/ExpressionResolutionTestCase.java
@@ -37,10 +37,12 @@ import java.util.Set;
 
 import javax.crypto.SecretKey;
 
+import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
@@ -122,6 +124,11 @@ public class ExpressionResolutionTestCase extends AbstractSubsystemBaseTest {
             cleanUp(csTwo);
             cleanUp(csThree);
         }
+    }
+
+    protected AdditionalInitialization createAdditionalInitialization() {
+        // Our use of the expression=encryption resource requires kernel capability setup that TestEnvironment provides
+        return new TestEnvironment(RunningMode.ADMIN_ONLY);
     }
 
     private static void cleanUp(CredentialStoreUtility csUtil) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/ResolveExpressionAttributesTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/ResolveExpressionAttributesTestCase.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
@@ -50,7 +52,7 @@ public class ResolveExpressionAttributesTestCase extends AbstractSubsystemBaseTe
 
     @Before
     public void init() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXml(getSubsystemXml());
         KernelServices kernelServices = builder.build();
         Assert.assertTrue("Subsystem boot failed!", kernelServices.isSuccessfulBoot());
@@ -61,6 +63,12 @@ public class ResolveExpressionAttributesTestCase extends AbstractSubsystemBaseTe
     @Override
     protected String getSubsystemXml() throws IOException {
         return readResource("elytron-expressions.xml");
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        // Our use of the expression=encryption resource requires kernel capability setup that TestEnvironment provides
+        return new TestEnvironment(RunningMode.ADMIN_ONLY);
     }
 
     @Test

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -105,6 +105,13 @@ public final class Attachments {
      */
     public static final AttachmentKey<Function<String, String>> WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(Function.class);
 
+    /**
+     * Functions that can be used to resolve expressions found in deployment resources.
+     * Functions that cannot resolve a particular input must return null.
+     */
+    public static final AttachmentKey<AttachmentList<Function<String, String>>>
+            DEPLOYMENT_EXPRESSION_RESOLVERS = AttachmentKey.createList(Function.class);
+
     //
     // STRUCTURE
     //

--- a/server/src/main/java/org/jboss/as/server/parsing/SystemPropertiesXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/SystemPropertiesXml.java
@@ -144,7 +144,7 @@ class SystemPropertiesXml {
                 if (oldPropertyValue != null && !oldPropertyValue.equals(newPropertyValue)) {
                     ControllerLogger.ROOT_LOGGER.systemPropertyAlreadyExist(name);
                 }
-            } catch (OperationFailedException e) {
+            } catch (OperationFailedException | ExpressionResolver.ExpressionResolutionUserException e) {
                 ServerLogger.AS_ROOT_LOGGER.tracef(e, "Failed to resolve value for system property %s at parse time.", name);
             }
 
@@ -153,7 +153,7 @@ class SystemPropertiesXml {
                 //only do this for standalone servers
                 try {
                     System.setProperty(name, SystemPropertyResourceDefinition.VALUE.resolveValue(ExpressionResolver.SIMPLE, op.get(VALUE)).asString());
-                } catch (OperationFailedException e) {
+                } catch (OperationFailedException | ExpressionResolver.ExpressionResolutionUserException e) {
                     ServerLogger.AS_ROOT_LOGGER.tracef(e, "Failed to set property %s at parse time, it will be set later in the boot process", name);
                 }
             }

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -646,7 +646,7 @@
                                         <exclude>org.jboss.as.test.manualmode.mgmt.elytron.ElytronModelControllerClientTestCase</exclude>
                                         
                                         <!--- remove a module after having closed the server -->
-                                        <exclude>org.jboss.as.test.manualmode.vault.CustomVaultInModuleTestCase</exclude>
+                                        <exclude>org.jboss.as.test.manualmode.expressions.CredentialStoreExpressionsTestCase</exclude>
                                         
                                         <!-- admin mode -->
                                         <exclude>org.wildfly.core.test.standalone.mgmt.HTTPSManagementInterfaceTestCase</exclude>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/AbstractSecureExpressionsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/AbstractSecureExpressionsTestCase.java
@@ -1,0 +1,214 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.manualmode.expressions;
+
+import static org.jboss.as.test.manualmode.expressions.module.TestSecureExpressionsExtension.ATTR;
+import static org.jboss.as.test.manualmode.expressions.module.TestSecureExpressionsExtension.MODULE_NAME;
+import static org.jboss.as.test.manualmode.expressions.module.TestSecureExpressionsExtension.PARAM_EXPRESSION;
+import static org.jboss.as.test.manualmode.expressions.module.TestSecureExpressionsExtension.PATH;
+import static org.jboss.as.test.manualmode.expressions.module.TestSecureExpressionsExtension.RESOLVE;
+
+import java.io.File;
+import javax.inject.Inject;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.manualmode.expressions.module.TestSecureExpressionsExtension;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.SecureExpressionUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.ValueExpression;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.common.function.ExceptionFunction;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
+import org.xnio.IoUtils;
+
+/**
+ * Abstract base class for tests of secure expression handling. Can be used for different kinds of secure expressions.
+ *
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ * @author Brian Stansberry
+ */
+abstract class AbstractSecureExpressionsTestCase {
+
+    public static final String CLEAR_TEXT = "123_Testing_Stuff_thing";
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(PATH);
+
+    private static SecureExpressionUtil.SecureExpressionData EXPRESSION_DATA = null;
+
+    @Inject
+    private static ServerController containerController;
+
+    private static TestModule testModule;
+
+    /**
+     * Exercise OperationContext expression resolution via the test subsystem's custom 'resolve' op,
+     * the OSH for which uses the OperationContext to resolve a expression.
+     */
+    @Test
+    public void testOperationContextResolution() throws Exception {
+        ManagementClient client = containerController.getClient();
+
+        ModelNode op = createResolveExpressionOp(EXPRESSION_DATA.getExpression());
+        ModelNode result = client.executeForResult(op);
+        Assert.assertEquals(result.toString(), CLEAR_TEXT, result.asString());
+
+        op = createResolveExpressionOp(getInvalidExpression());
+        ModelTestUtils.checkFailed(client.getControllerClient().execute(op));
+    }
+
+    /**
+     * Validate that the top-level 'resolve-expression' op and the 'resolve-expressions' param to the
+     * standard read-resource and read-attribute ops don't result in returning resolved secure expression
+     * values to a remote client.
+     */
+    @Test
+    public void testStandardRemoteExpressionResolution() throws Exception {
+        ModelControllerClient client = containerController.getClient().getControllerClient();
+
+        String secureExpression = EXPRESSION_DATA.getExpression();
+
+        ModelNode op = Util.createEmptyOperation("resolve-expression", PathAddress.EMPTY_ADDRESS);
+        op.get(PARAM_EXPRESSION.getName()).set(secureExpression);
+        ModelNode response = client.execute(op);
+        Assert.assertEquals(response.toString(), secureExpression, response.get("result").asString());
+        String responseHeaders = response.get("response-headers").asString();
+        Assert.assertTrue(response.toString(), responseHeaders.contains(secureExpression));
+        Assert.assertTrue(response.toString(), responseHeaders.contains("WFLYCTL0480"));
+
+        // First confirm a non-resolving read-attribute is as expected
+        op = Util.getReadAttributeOperation(SUBSYSTEM_ADDRESS, ATTR.getName());
+        response = client.execute(op);
+        ModelNode attrValue = response.get("result");
+        Assert.assertEquals(response.toString(), ModelType.EXPRESSION, attrValue.getType());
+        Assert.assertEquals(response.toString(), secureExpression, attrValue.asString());
+
+        // Now a resolving read
+        op.get("resolve-expressions").set(true);
+        response = client.execute(op);
+        attrValue = response.get("result");
+        Assert.assertEquals(response.toString(), ModelType.EXPRESSION, attrValue.getType());
+        Assert.assertEquals(response.toString(), secureExpression, attrValue.asString());
+        responseHeaders = response.get("response-headers").asString();
+        Assert.assertTrue(response.toString(), responseHeaders.contains(secureExpression));
+        Assert.assertTrue(response.toString(), responseHeaders.contains("WFLYCTL0479"));
+
+        // First confirm a non-resolving read-resource is as expected
+        op = Util.createEmptyOperation("read-resource", SUBSYSTEM_ADDRESS);
+        response = client.execute(op);
+        attrValue = response.get("result", ATTR.getName());
+        Assert.assertEquals(response.toString(), ModelType.EXPRESSION, attrValue.getType());
+        Assert.assertEquals(response.toString(), secureExpression, attrValue.asString());
+
+        // Now a resolving read
+        op.get("resolve-expressions").set(true);
+        response = client.execute(op);
+        attrValue = response.get("result", ATTR.getName());
+        Assert.assertEquals(response.toString(), ModelType.EXPRESSION, attrValue.getType());
+        Assert.assertEquals(response.toString(), secureExpression, attrValue.asString());
+        // TODO uncomment when WFCORE-5305 is resolved
+        //responseHeaders = response.get("response-headers").asString();
+        //Assert.assertTrue(response.toString(), responseHeaders.contains("${VAULT::Testing::Stuff::thing}"));
+        //Assert.assertTrue(response.toString(), responseHeaders.contains("WFLYCTL0479"));
+    }
+
+    static void tearDownServer(ExceptionFunction<ManagementClient, Void, Exception> securityTeardown) throws Exception {
+        ModelControllerClient client = null;
+        try {
+            ManagementClient managementClient = containerController.getClient();
+            client = managementClient.getControllerClient();
+
+            ModelNode subsystemResult = client.execute(Util.createRemoveOperation(SUBSYSTEM_ADDRESS));
+            ModelNode extensionResult = client.execute(Util.createRemoveOperation(PathAddress.pathAddress(ModelDescriptionConstants.EXTENSION, MODULE_NAME)));
+
+            securityTeardown.apply(managementClient);
+
+            ModelTestUtils.checkOutcome(subsystemResult);
+            ModelTestUtils.checkOutcome(extensionResult);
+
+        } finally {
+            containerController.stop();
+            testModule.remove();
+            IoUtils.safeClose(client);
+        }
+        containerController.stop();
+    }
+
+    private static void createTestModule(Class<?>... additionalModuleClasses) throws Exception {
+        File moduleXml = new File(TestSecureExpressionsExtension.class.getResource("test-secure-expressions-module.xml").toURI());
+        testModule = new TestModule(MODULE_NAME, moduleXml);
+
+        JavaArchive jar = testModule.addResource("test-secure-expressions.jar");
+        jar.addClass(TestSecureExpressionsExtension.class)
+                .addClass(TestSecureExpressionsExtension.Parser.class)
+                .addClass(TestSecureExpressionsExtension.ResourceDescription.class)
+                .addClass(TestSecureExpressionsExtension.ResolveHandler.class)
+                .addAsServiceProvider(Extension.class, TestSecureExpressionsExtension.class);
+
+        if (additionalModuleClasses != null) {
+            for (Class<?> additional : additionalModuleClasses) {
+                jar.addClass(additional);
+            }
+        }
+
+        testModule.create(true);
+    }
+
+    static void setupServerWithSecureExpressions(@SuppressWarnings("SameParameterValue") SecureExpressionUtil.SecureExpressionData expressionData,
+                                                 ExceptionFunction<ManagementClient, Void, Exception> securitySetup) throws Exception {
+
+        EXPRESSION_DATA = expressionData;
+
+        createTestModule();
+
+        containerController.start();
+        ManagementClient managementClient = containerController.getClient();
+
+        securitySetup.apply(managementClient);
+
+        ModelControllerClient client = managementClient.getControllerClient();
+
+        //Add the extension
+        final ModelNode addExtension = Util.createAddOperation(PathAddress.pathAddress(ModelDescriptionConstants.EXTENSION, MODULE_NAME));
+        ModelTestUtils.checkOutcome(client.execute(addExtension));
+
+        final ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(PATH));
+        addSubsystem.get(ATTR.getName()).set(new ValueExpression(EXPRESSION_DATA.getExpression()));
+        ModelTestUtils.checkOutcome(client.execute(addSubsystem));
+
+        ServerReload.executeReloadAndWaitForCompletion(client);
+    }
+
+    private ModelNode createResolveExpressionOp(String expression) {
+        ModelNode op = Util.createOperation(RESOLVE.getName(), SUBSYSTEM_ADDRESS);
+        op.get(PARAM_EXPRESSION.getName()).set(new ValueExpression(expression));
+        return op;
+    }
+
+    abstract String getInvalidExpression();
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/CredentialStoreExpressionsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/CredentialStoreExpressionsTestCase.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.manualmode.expressions;
+
+import org.jboss.as.test.shared.SecureExpressionUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ * @author Brian Stansberry
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class CredentialStoreExpressionsTestCase extends AbstractSecureExpressionsTestCase {
+
+    private static final SecureExpressionUtil.SecureExpressionData EXPRESSION_DATA =
+            new SecureExpressionUtil.SecureExpressionData(CLEAR_TEXT);
+    static final String UNIQUE_NAME = "CredentialStoreExpressionsTestCase";
+    static final String STORE_LOCATION = CredentialStoreExpressionsTestCase.class.getResource("/").getPath() + "security/" + UNIQUE_NAME + ".cs";
+
+    private static final String STORE_NAME = CredentialStoreExpressionsTestCase.class.getSimpleName();
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        setupServerWithSecureExpressions(EXPRESSION_DATA, CredentialStoreExpressionsTestCase::setupFunction);
+    }
+
+    @AfterClass
+    public static void tearDownServer() throws Exception {
+        tearDownServer(CredentialStoreExpressionsTestCase::tearDownFunction);
+    }
+
+    static Void setupFunction(ManagementClient managementClient) throws Exception {
+        SecureExpressionUtil.setupCredentialStoreExpressions(STORE_NAME, EXPRESSION_DATA);
+        SecureExpressionUtil.setupCredentialStore(managementClient, STORE_NAME, STORE_LOCATION);
+        return null;
+    }
+
+    static Void tearDownFunction(ManagementClient managementClient) throws Exception {
+        SecureExpressionUtil.teardownCredentialStore(managementClient, STORE_NAME, STORE_LOCATION);
+        return null;
+    }
+
+    @Override
+    String getInvalidExpression() {
+        return EXPRESSION_DATA.getExpression().replace(STORE_NAME, "notavalidresolver");
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/module/TestSecureExpressionsExtension.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/module/TestSecureExpressionsExtension.java
@@ -1,0 +1,167 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.manualmode.expressions.module;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+
+/**
+ *
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class TestSecureExpressionsExtension implements Extension {
+
+    private static final Logger log = Logger.getLogger(TestSecureExpressionsExtension.class.getPackage().getName());
+
+    public static final String MODULE_NAME = "test.secure.expressions.module";
+    public static final String SUBSYSTEM_NAME = "test-secure-expressions";
+
+
+    public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
+
+    public static final AttributeDefinition ATTR = SimpleAttributeDefinitionBuilder.create("attribute", ModelType.STRING)
+            .setAllowExpression(true)
+            .setRequired(true)
+            .setRestartAllServices()
+            .build();
+
+    public static final AttributeDefinition PARAM_EXPRESSION = SimpleAttributeDefinitionBuilder.create("expression", ModelType.STRING, false)
+            .setAllowExpression(true)
+            .build();
+
+    public static final OperationDefinition RESOLVE = new SimpleOperationDefinitionBuilder("resolve", new NonResolvingResourceDescriptionResolver())
+            .addParameter(PARAM_EXPRESSION)
+            .build();
+
+    public static final AttributeDefinition PARAM_SYS_PROP = SimpleAttributeDefinitionBuilder.create("system-property", ModelType.STRING, false)
+            .build();
+
+    public static final OperationDefinition READ_SYS_PROP = new SimpleOperationDefinitionBuilder("read-system-property", new NonResolvingResourceDescriptionResolver())
+            .addParameter(PARAM_SYS_PROP)
+            .build();
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        registration.registerSubsystemModel(new ResourceDescription());
+        registration.registerXMLElementWriter(new Parser());
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        //Don't need a parser, just register a dummy writer in the initialize() method
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Parser.NAMESPACE, new Parser());
+    }
+
+    public static final class Parser extends PersistentResourceXMLParser {
+
+        private static final String NAMESPACE = "urn:jboss:domain:test-secure-expressions:1.0";
+
+        @Override
+        public PersistentResourceXMLDescription getParserDescription() {
+            return builder(PATH, NAMESPACE)
+                    .addAttribute(ATTR)
+                    .build();
+        }
+
+    }
+
+    public static class ResourceDescription extends PersistentResourceDefinition {
+
+        public ResourceDescription() {
+            super(new SimpleResourceDefinition.Parameters(PATH, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler(ATTR))
+                    .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
+        }
+
+        @Override
+        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+            super.registerOperations(resourceRegistration);
+            resourceRegistration.registerOperationHandler(RESOLVE, new ResolveHandler());
+            resourceRegistration.registerOperationHandler(READ_SYS_PROP, new ReadSystemPropertyHandler());
+        }
+
+        @Override
+        public Collection<AttributeDefinition> getAttributes() {
+            return Collections.singleton(ATTR);
+        }
+
+    }
+
+    public static class ResolveHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            PARAM_EXPRESSION.validateOperation(operation);
+            log.fine("Resolving " + operation.get(PARAM_EXPRESSION.getName()) + " for " + context.getCurrentAddress());
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext context, ModelNode operation)
+                        throws OperationFailedException {
+                    context.getResult().set(context.resolveExpressions(operation.get(PARAM_EXPRESSION.getName())));
+                }
+            }, OperationContext.Stage.RUNTIME);
+        }
+
+    }
+
+    public static class ReadSystemPropertyHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            String prop = operation.get(PARAM_SYS_PROP.getName()).asString();
+            log.fine("Checking property " + prop);
+            String value = System.getProperty(prop);
+            ModelNode result = context.getResult();
+            if (value != null) {
+                result.set(value);
+            }
+        }
+
+    }
+}

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/org.jboss.as.controller.Extension
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.jboss.as.test.manualmode.expressions.module.TestVaultExtension

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/security-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/security-module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2014, JBoss Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.security">
+
+    <resources>
+        <resource-root path="custom-vault-reader.jar"/>
+    </resources>
+    <dependencies>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.wildfly.security.elytron"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.picketbox"/>
+        <module name="javax.xml.stream.api"/>
+    </dependencies>
+</module>

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/test-secure-expressions-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/test-secure-expressions-module.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ~ JBoss, Home of Professional Open Source. ~ Copyright 2012, Red Hat, 
+	Inc., and individual contributors ~ as indicated by the @author tags. See 
+	the copyright.txt file in the ~ distribution for a full listing of individual 
+	contributors. ~ ~ This is free software; you can redistribute it and/or modify 
+	it ~ under the terms of the GNU Lesser General Public License as ~ published 
+	by the Free Software Foundation; either version 2.1 of ~ the License, or 
+	(at your option) any later version. ~ ~ This software is distributed in the 
+	hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the 
+	implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+	See the GNU ~ Lesser General Public License for more details. ~ ~ You should 
+	have received a copy of the GNU Lesser General Public ~ License along with 
+	this software; if not, write to the Free ~ Software Foundation, Inc., 51 
+	Franklin St, Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site: 
+	http://www.fsf.org. -->
+
+<module xmlns="urn:jboss:module:1.5" name="test.secure.expressions.module">
+  <resources>
+    <resource-root path="test-secure-expressions.jar"/>
+  </resources>
+  <dependencies>
+    <module name="org.jboss.as.controller"/>
+    <module name="org.jboss.as.server"/>
+    <module name="org.jboss.staxmapper"/>
+    <module name="java.xml"/>
+    <module name="sun.jdk"/>
+  </dependencies>
+</module>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/SecureExpressionUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/SecureExpressionUtil.java
@@ -1,0 +1,221 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.shared;
+
+
+
+import java.io.File;
+import java.security.GeneralSecurityException;
+
+import javax.crypto.SecretKey;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.security.encryption.CipherUtil;
+import org.wildfly.security.encryption.SecretKeyUtil;
+
+/**
+ * Utilities for dealing with 'secure' expressions (e.g. Elytron credential store expressions)
+ * in tests.
+ */
+public final class SecureExpressionUtil {
+
+    private static final PathAddress SUBSYSTEM = PathAddress.pathAddress("subsystem", "elytron");
+    private static final PathAddress EXPRESSION_RESOLVER = SUBSYSTEM.append("expression", "encryption");
+
+    private static SecretKey expressionKey;
+    private static String exportedExpressionKey;
+
+    /**
+     * Data class for passing information about secure expressions from/to the caller
+     * of the SecurityExpressionUtil utility methods.
+     */
+    public static final class SecureExpressionData {
+        private final String clearText;
+        private volatile String expression;
+
+        /**
+         * Constructs a SecureExpressionData object.
+         *
+         * @param clearText the clear text value the secure expression should resolve to. Cannot be {@code null}.
+         */
+        public SecureExpressionData(String clearText) {
+            assert clearText != null : "clearText is null";
+            this.clearText = clearText;
+        }
+
+        /**
+         * Gets the value of the secure expression that will resolve to the {@code clearText} parameter passed
+         * to the constructor. This value will be set by utility methods that determine the appropriate expression.
+         *
+         * @return the expression string. Will not return {@code null}, as invoking this method on an object
+         *         that has not had its expression value set will result in an {@link IllegalStateException}.
+         *
+         * @throws IllegalStateException if invoked before a utility method that sets the value has been called.
+         */
+        public String getExpression() {
+            String result = expression;
+            if (result == null) {
+                throw new IllegalStateException("Expression cannot be read before it has been created");
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Uses an internal {@link SecretKey} to create credential store expressions for the clear text values
+     * in the provided {@link SecureExpressionData} instances, and stores the generated expressions in those instances.
+     *
+     * @param storeName the name to use for the credential store and expression resolver. Cannot be {@code null}
+     * @param toConfigure data objects to use for getting clear text and storing credential store expressions. Cannot be {@code null}
+     *
+     * @throws Exception if a problem occurs
+     *
+     * @see #setupCredentialStore(ManagementClient, String, String) to create server resources that can resolve the expressions
+     */
+    public static void setupCredentialStoreExpressions(String storeName,
+                                                       SecureExpressionData... toConfigure) throws Exception {
+        // Get or create the key that will be imported into the server credential store
+        // and use it to create expressions
+        SecretKey secretKey = getExpressionKey();
+        for (SecureExpressionData expressionData : toConfigure) {
+            expressionData.expression = "${ENC::" + storeName + ":"
+                    + CipherUtil.encrypt(expressionData.clearText, secretKey) + "}";
+        }
+    }
+
+    /**
+     * Uses the given management client to create an Elytron subsystem secret-key-credential store resource with the
+     * given {@code storeName}, as well as an expression encryption resource with a resolver with that name configured
+     * to reference the credential store. Imports the Elytron {@link SecretKey} that this class uses to
+     * {@link #setupCredentialStoreExpressions(String, SecureExpressionData...) create credential store expressions}
+     * into the credential store so it can use it to resolve those expressions.
+     *
+     * @param client the client to use to invoke on the server's management layer. Cannot be {@code null}
+     * @param storeName the name to use for the credential store and expression resolver. Cannot be {@code null}
+     * @param storeLocation absolute path of the file to use to back the credential store. Cannot be {@code null}
+     *
+     * @throws Exception if a problem occurs
+     */
+    public static void setupCredentialStore(ManagementClient client, String storeName, String storeLocation) throws Exception {
+
+        cleanStore(storeLocation);
+
+        // Add store
+        PathAddress storeAddress = SUBSYSTEM.append("secret-key-credential-store", storeName);
+        ModelNode storeAdd = Util.createAddOperation(storeAddress);
+        storeAdd.get("path").set(storeLocation);
+        storeAdd.get("populate").set(false);
+        client.executeForResult(storeAdd);
+
+        // Import the key we used to create expressions so the store can resolve them
+        ModelNode importKey = Util.createEmptyOperation("import-secret-key", storeAddress);
+        importKey.get("alias").set(storeName);
+        importKey.get("key").set(getExportedEpressionKey());
+        client.executeForResult(importKey);
+
+        // Add expression-resolver
+        ModelNode exprsAdd = Util.createAddOperation(EXPRESSION_RESOLVER);
+        ModelNode resolver = new ModelNode();
+        resolver.get("name").set(storeName);
+        resolver.get("credential-store").set(storeName);
+        resolver.get("secret-key").set(storeName);
+        exprsAdd.get("resolvers").add(resolver);
+        client.executeForResult(exprsAdd);
+    }
+
+    /**
+     * Removes Elytron subsystem expression encryption and secret-key-credential store resources created by
+     * {@link #setupCredentialStore(ManagementClient, String, String)}.
+     *
+     * @param client the client to use to invoke on the server's management layer. Cannot be {@code null}
+     * @param storeName the name to use for the credential store and expression resolver. Cannot be {@code null}
+     * @param storeLocation location of the file that backs the credential store. Cannot be {@code null}
+     *
+     * @throws Exception  if a problem occurs
+     */
+    public static void teardownCredentialStore(ManagementClient client, String storeName, String storeLocation) throws Exception {
+
+        UnsuccessfulOperationException toThrow = null;
+        try {
+            // Remove expression-resolver
+            client.executeForResult(Util.createRemoveOperation(EXPRESSION_RESOLVER));
+        } catch (UnsuccessfulOperationException uoe) {
+            toThrow = uoe;
+        } catch (RuntimeException re) {
+            toThrow = new UnsuccessfulOperationException(re.toString());
+        } finally {
+            try {
+                // Remove store
+                client.executeForResult(Util.createRemoveOperation(SUBSYSTEM.append("secret-key-credential-store", storeName)));
+            } catch (UnsuccessfulOperationException uoe) {
+                if (toThrow == null) {
+                    toThrow = uoe;
+                }
+            } catch (RuntimeException re) {
+                if (toThrow == null) {
+                    toThrow = new UnsuccessfulOperationException(re.toString());
+                }
+            }
+        }
+
+        if (toThrow != null) {
+            throw toThrow;
+        }
+
+        ServerReload.reloadIfRequired(client.getControllerClient());
+
+        cleanStore(storeLocation);
+    }
+
+    private static synchronized SecretKey getExpressionKey() throws GeneralSecurityException {
+        if (expressionKey == null) {
+            expressionKey = SecretKeyUtil.generateSecretKey(256);
+        }
+        return expressionKey;
+    }
+
+    private static synchronized String getExportedEpressionKey() throws GeneralSecurityException {
+        if (exportedExpressionKey == null) {
+            exportedExpressionKey = SecretKeyUtil.exportSecretKey(expressionKey);
+        }
+        return exportedExpressionKey;
+    }
+
+    private static void cleanStore(String storeLocation) {
+
+        if (storeLocation != null) {
+            File f = new File(storeLocation);
+            if (f.exists()) {
+                if (!f.delete()) {
+                    // TODO log
+                }
+            }
+        }
+
+    }
+
+    private SecureExpressionUtil() {
+        // prevent instantiation
+    }
+}


### PR DESCRIPTION
…tage.MODEL

Create a separate ExpressionResolverExtension interface that core expression resolver plugins like ElytronExpressionResolver implement instead of ExpressionResolver

Add a capability that can be used by ExpressionResolverExtension impls to register themselves with the core expression resolver, allowing their use in Stage.MODEL

Separate ExpressionResolverExtension initialization from resolution so initialization failures can be handled separately and not be treated as indicating the extension regarded a given expression as relevant to it, but failed to resolve it.

Clarify ExpressionResolverExtension resolution exception handling to distinguish user problems from server problems and not throw OperationFailedException.

Update ReadAttributeHandler.ResolveAttributeHandler to understand the ExpressionResolverExtension exceptions and to treat their presence as indication that a secure expression was present.

Add manualmode test case analogous to the old CustomVaultInModuleTestCase, but using credential expressions.

https://issues.redhat.com/browse/WFCORE-5709
https://issues.redhat.com/browse/WFCORE-5705