### PR TITLE
[WFCORE-5717] Upgrade Undertow version to 2.2.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-lang>2.6</version.commons-lang>
-        <version.io.undertow>2.2.12.Final</version.io.undertow>
+        <version.io.undertow>2.2.13.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5717


        Release Notes - Undertow - Version 2.2.13.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1993'>UNDERTOW-1993</a>] -         AbstractLoadBalancingProxyTestCase.teardown can throw NPE
</li>
</ul>
                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1409'>UNDERTOW-1409</a>] -         sendRedirect to relative urls does not properly encode the current path
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1459'>UNDERTOW-1459</a>] -         ProxyHandler returns status code 503 instead of 504
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1739'>UNDERTOW-1739</a>] -         Sub groups don&#39;t work with nested predicate
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1740'>UNDERTOW-1740</a>] -         Predicate Language parsing fails on semi-colon before &quot;else&quot; keyword
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1786'>UNDERTOW-1786</a>] -         Client-side termination of the connection is not handled properly
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1801'>UNDERTOW-1801</a>] -         ProxyPeerAddressHandler incorrectly parses X_FORWARDED_FOR headers
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1872'>UNDERTOW-1872</a>] -         parseIpv6Address fails for some addresses
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1964'>UNDERTOW-1964</a>] -         IPAddressAccessControlHandler stops working when ProxyPeerAddressHandler is enabled and X-Forwarded-For request header contains multiple IP addresses
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1980'>UNDERTOW-1980</a>] -         AbstractFramedChannel readData race
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1981'>UNDERTOW-1981</a>] -         Unify DefaultServlet &amp; ServletInitialHandler in handling forbidden subpaths
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1984'>UNDERTOW-1984</a>] -         GOAWAY sent by HTTP2 server when a RST is sent after upgrade
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1989'>UNDERTOW-1989</a>] -         Setup actions are not executed when using the async Start method
</li>
</ul>
                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-318'>UNDERTOW-318</a>] -         Improve authentication mechanisms logging
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1883'>UNDERTOW-1883</a>] -         Enable mod_cluster proxy to register apps in stopped or disabled state
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1913'>UNDERTOW-1913</a>] -         apply ReadTimeoutStreamSourceConduit/WriteTimeoutStreamSinkConduit also on the UndertowClient side if READ_TIMEOUT/WRITE_TIMEOUT options are set
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1965'>UNDERTOW-1965</a>] -         Initialize ProxyHandler with enabling &quot;setReuseXForwarded(true)&quot; inside DefaultServer for X-Forwarded-* header related unit tests
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1975'>UNDERTOW-1975</a>] -         Add @IPv6Ignore and @IPv6Only annotations for unit tests
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1982'>UNDERTOW-1982</a>] -         Jakartaee9 undertow artifacts not deployed during maven life cycle
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1983'>UNDERTOW-1983</a>] -         At HttpString eliminate duplicate code in hashCode calculation
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1992'>UNDERTOW-1992</a>] -         Add PooledAdaptor.toString
</li>
</ul>
                                                                                                                        
