### PR TITLE
Fix for WFCORE-5722, Can't upgrade JBoss Modules artifact

### DIFF
--- a/bootable-jar/boot/pom.xml
+++ b/bootable-jar/boot/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -46,28 +47,21 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
+                <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                    <archive>
+                        <index>false</index>
+                        <manifest>
                             <mainClass>org.wildfly.core.jar.boot.Main</mainClass>
-                            <manifestEntries>
-                                <Multi-Release>true</Multi-Release>
-                                <!-- NB: In case an update is made to these exports and opens, make sure that common.sh script is in sync. -->
-                                <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</Add-Exports>
-                                <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.io java.base/java.security java.base/java.util java.management/javax.management java.naming/javax.naming</Add-Opens>
-                            </manifestEntries>
-                        </transformer>
-                    </transformers>
+                        </manifest>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                            <!-- NB: In case an update is made to these exports and opens, make sure that common.sh script is in sync. -->
+                            <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</Add-Exports>
+                            <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.io java.base/java.security java.base/java.util java.management/javax.management java.naming/javax.naming</Add-Opens>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.org.wildfly.galleon-plugins>5.2.6.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
-        <version.org.wildfly.jar.plugin>5.0.2.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>6.1.1.Final</version.org.wildfly.jar.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.2.0.Final</version.org.wildfly.plugins>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5722

* The Bootable JAR boot artifact is no more shading org.jboss:jboss-modules. It is expected that this assembly is done by the Bootable JAR maven plugin.

* The Bootable JAR Maven plugin used by tests is updated to the latest version (required upgrade).

Diff: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/5.0.2.Final...6.1.1.Final