### PR TITLE
[WFCORE-5727] Upgrade XNIO to 3.8.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.4.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.5.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5727


        Release Notes - XNIO - Version 3.8.5.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-386'>XNIO-386</a>] -         XNIO001009 logging does not include a stack trace
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-388'>XNIO-388</a>] -         IOException Broken pipe error on JsseSslConduitEngine.doFlush when closing connection
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-394'>XNIO-394</a>] -         Broken pipe errors and premature closes show up intermitently when closing SSL connections
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-395'>XNIO-395</a>] -         Close listener invocation can be skipped
</li>
</ul>
                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-383'>XNIO-383</a>] -         Add XnioWorker.toString() to ClosedWorkerException
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-389'>XNIO-389</a>] -         BlockingByteChannelTests fail sometimes
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-393'>XNIO-393</a>] -         Make JsseSslConduitEngine.closeOutbound idempotent
</li>
</ul>
                                                                                                                        