### PR TITLE
[WFCORE-5590]: Provide a separate javax.* namespace Jakarta JSON api …

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -39,7 +39,6 @@
     <dependencies>
 
         <!-- module and copy artifact dependencies -->
-
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
@@ -48,6 +47,26 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-json_1.1_spec</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-core</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -79,6 +79,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-json_1.1_spec</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <licenses>
@@ -92,6 +103,17 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-core</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/internal/javax/json/api/ee8/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/internal/javax/json/api/ee8/main/module.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2013, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<module xmlns="urn:jboss:module:1.9" name="internal.javax.json.api.ee8">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.apache.geronimo.specs:geronimo-json_1.1_spec}"/>
+        <artifact name="${org.apache.johnzon:johnzon-core}"/>
+    </resources>
+
+    <provides>
+        <service name="javax.json.spi.JsonProvider">
+            <with-class name="org.apache.johnzon.core.JsonProviderImpl"></with-class>
+        </service>
+    </provides>
+
+    <dependencies>
+        <module name="java.logging"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -180,8 +180,10 @@
              (the current workaround causes test failures in domain-management tests).
              Cannot bump to AM25 due to https://issues.apache.org/jira/browse/DIRSERVER-2247.
         -->
+        <version.org.apache.geronimo.json.api>1.3</version.org.apache.geronimo.json.api>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.14</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.johnzon>1.2.15</version.org.apache.johnzon>
         <version.org.apache.logging.log4j>2.17.1</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
@@ -872,6 +874,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-json_1.1_spec</artifactId>
+                <version>${version.org.apache.geronimo.json.api}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>${version.org.apache.httpcomponents.httpcore}</version>
@@ -903,6 +910,11 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.johnzon</groupId>
+                <artifactId>johnzon-core</artifactId>
+                <version>${version.org.apache.johnzon}</version>
             </dependency>
 
             <dependency>
@@ -976,7 +988,6 @@
                 <version>${version.org.fusesource.jansi}</version>
             </dependency>
             <!-- JSR-353 JSONP RI implementation -->
-            <!-- used by elytron audit logging -->
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.json</artifactId>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -52,7 +52,9 @@ public class LayersTestCase {
         // wildfly-elytron-tool
         "org.apache.commons.cli",
         "org.apache.commons.lang3",
-        "org.wildfly.security.elytron-tool"
+        "org.wildfly.security.elytron-tool",
+        //internal json 1 API
+        "internal.javax.json.api.ee8"
     };
     // Packages that are not referenced from the module graph but needed.
     // This is the expected set of un-referenced modules found when scanning
@@ -81,7 +83,7 @@ public class LayersTestCase {
         // Brought by galleon ServerRootResourceDefinition
         "wildflyee.api",
         // bootable jar runtime
-        "org.wildfly.bootable-jar"
+        "org.wildfly.bootable-jar",
     };
 
     /**


### PR DESCRIPTION
…module and impl module for use by components that use JSON internally

* Adding a new module  'internal.javax.json.api.ee8' with Geronimo Json
  API and Johnzon implementation.

Jira: https://issues.redhat.com/browse/WFCORE-5590