### PR TITLE
[WFCORE-5731] Upgrade Elytron Web to 1.10.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.18.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.10.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
 
     </properties>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5731


        Release Notes - Elytron Web - Version 1.10.1.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-163'>ELYWEB-163</a>] -         Update ElytronHttpExchange#getRequestURI to no longer use the 7 argument URI constructor
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-161'>ELYWEB-161</a>] -         Update branches in pr-ci.yaml
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-166'>ELYWEB-166</a>] -         Release Elytron Web 1.10.1.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-168'>ELYWEB-168</a>] -         Upgrade WildFly Elytron to 1.18.0.Final
</li>
</ul>
                                                                                                                            