### PR TITLE
Fix for WFCORE-5732, Missing modular options in bootable JAR manifest

### DIFF
--- a/bootable-jar/boot/pom.xml
+++ b/bootable-jar/boot/pom.xml
@@ -58,7 +58,7 @@
                             <Multi-Release>true</Multi-Release>
                             <!-- NB: In case an update is made to these exports and opens, make sure that common.sh script is in sync. -->
                             <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</Add-Exports>
-                            <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.io java.base/java.security java.base/java.util java.management/javax.management java.naming/javax.naming</Add-Opens>
+                            <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.io java.base/java.security java.base/java.util java.base/java.util.concurrent java.management/javax.management java.naming/javax.naming</Add-Opens>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5732
