### PR TITLE
[WFCORE-5651] Remove management identity's default security domain configuration

### DIFF
--- a/core-feature-pack/galleon-common/src/main/resources/layers/standalone/management/layer-spec.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/layers/standalone/management/layer-spec.xml
@@ -6,10 +6,6 @@
 
     <feature-group name="unsecured-management"/>
 
-    <feature spec="core-service.management.access.identity">
-        <param name="security-domain" value="ManagementDomain"/>
-    </feature>
-
     <feature spec="core-service.management.management-interface.http-interface">
         <param name="socket-binding" value="management-http"/>
         <param name="http-authentication-factory" value="management-http-authentication"/>

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
@@ -286,8 +286,7 @@ public abstract class AbstractMgmtSaslTestBase {
     }
 
     protected void assertDigestMechPassWhoAmI(String mechanismName, String digestAlg) {
-        // as the "digest-*" users are not in the ManagementFsRealm, the management identity will be "anonymous" here
-        createValidConfigForMechanism(mechanismName, digestAlg).run(() -> assertWhoAmI("anonymous"));
+        createValidConfigForMechanism(mechanismName, digestAlg).run(() -> assertWhoAmI(digestAlg));
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5651 