### PR TITLE
[WFCORE-5741] Upgrade WildFly Elytron to 1.18.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.18.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.18.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
 
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5741


        Release Notes - WildFly Elytron - Version 1.18.1.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2195'>ELY-2195</a>] -         Use daemon threads in default ScheduledExecutorService
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2263'>ELY-2263</a>] -         Release WildFly Elytron 1.18.1.Final
</li>
</ul>
                                                                                                                                                                                                                        
