### PR TITLE
[WFCORE-5746] Bump Management API to 20.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -83,8 +83,8 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY22("WildFly22.0", KernelAPIVersion.VERSION_15_0),
         WILDFLY23("WildFly23.0", KernelAPIVersion.VERSION_16_0),
         WILDFLY24("WildFly24.0", KernelAPIVersion.VERSION_17_0),
-        WILDFLY25("WildFly25.0", KernelAPIVersion.VERSION_18_0);
-
+        WILDFLY25("WildFly25.0", KernelAPIVersion.VERSION_18_0),
+        WILDFLY26("WildFly26.0", KernelAPIVersion.VERSION_19_0);
 
         private static final Map<String, KnownRelease> map = new HashMap<>();
         static {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -76,6 +76,8 @@ public enum KernelAPIVersion {
     VERSION_17_0(17, 0, 0),
     // WildFly 25.0.0
     VERSION_18_0(18, 0, 0),
+    // WildFLy 26.0.0
+    VERSION_19_0(19, 0, 0),
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);
 

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -35,7 +35,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 19;
+    public static final int MANAGEMENT_MAJOR_VERSION = 20;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
The XSD version stays at urn:jboss:domain:19.0 until there is an actual
change change in the XML schema.

JIRA: https://issues.redhat.com/browse/WFCORE-5746

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
