### PR TITLE
[WFCORE-5754] Upgrade log4j2-jboss-logmanager to 1.1.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.18.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
-        <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
+        <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.1.1.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.0.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.13.Final</version.org.jboss.msc.jboss-msc>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5754

Release tags:
- https://github.com/jboss-logging/log4j2-jboss-logmanager/releases/tag/1.1.0.Final 
- https://github.com/jboss-logging/log4j2-jboss-logmanager/releases/tag/1.1.1.Final

Diff: https://github.com/jboss-logging/log4j2-jboss-logmanager/compare/1.0.0.Final...1.1.1.Final