### PR TITLE
[18.x] Fix for WFCORE-5756, Upgrade bootable jar to 7.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.org.wildfly.galleon-plugins>5.2.7.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
-        <version.org.wildfly.jar.plugin>6.1.1.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>7.0.0.Final</version.org.wildfly.jar.plugin>
         <!-- plugins related to wildfly build and tooling -->
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.plugins>2.2.0.Final</version.org.wildfly.plugins>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5756
Diff: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/6.1.1.Final...7.0.0.Final
