### PR TITLE
WFCORE-5760 Replace deprecated EnumValidator constructors and methods

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/QueryOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/QueryOperationHandler.java
@@ -81,7 +81,7 @@ public final class QueryOperationHandler extends GlobalOperationHandlers.Abstrac
     private static final AttributeDefinition OPERATOR_ATT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.OPERATOR, ModelType.STRING)
             .setRequired(false)
             .setDefaultValue(new ModelNode().set(Operator.AND.name()))
-            .setValidator(EnumValidator.create(Operator.class, true, false))
+            .setValidator(EnumValidator.create(Operator.class))
             .build();
 
     private static final AttributeDefinition SELECT_ATT = new PrimitiveListAttributeDefinition.Builder(ModelDescriptionConstants.SELECT, ModelType.STRING)

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -118,7 +118,7 @@ public class ReadResourceDescriptionHandler extends GlobalOperationHandlers.Abst
     private static final SimpleAttributeDefinition ACCESS_CONTROL = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ACCESS_CONTROL, ModelType.STRING)
             .setRequired(false)
             .setDefaultValue(new ModelNode(AccessControl.NONE.toString()))
-            .setValidator(EnumValidator.create(AccessControl.class, true, AccessControl.NONE, AccessControl.COMBINED_DESCRIPTIONS, AccessControl.TRIM_DESCRIPTONS))
+            .setValidator(EnumValidator.create(AccessControl.class, AccessControl.NONE, AccessControl.COMBINED_DESCRIPTIONS, AccessControl.TRIM_DESCRIPTONS))
             .build();
 
 

--- a/controller/src/test/java/org/jboss/as/controller/SimpleAttributeDefinitionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/SimpleAttributeDefinitionUnitTestCase.java
@@ -51,7 +51,7 @@ public class SimpleAttributeDefinitionUnitTestCase {
     @Test
     public void testAllowedValuesWithValidator() {
         SimpleAttributeDefinition ad = new SimpleAttributeDefinitionBuilder("test", ModelType.STRING)
-                .setValidator(new EnumValidator<TestEnum>(TestEnum.class, false, false, TestEnum.A, TestEnum.B))
+                .setValidator(new EnumValidator<TestEnum>(TestEnum.class, TestEnum.A, TestEnum.B))
                 .build();
 
         ParameterValidator pv = ad.getValidator();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
@@ -26,7 +26,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHORIZATION;
 
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -77,12 +76,12 @@ public class AccessAuthorizationResourceDefinition extends SimpleResourceDefinit
     public static final SimpleAttributeDefinition PERMISSION_COMBINATION_POLICY =
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PERMISSION_COMBINATION_POLICY, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(CombinationPolicy.PERMISSIVE.toString()))
-            .setValidator(new EnumValidator<CombinationPolicy>(CombinationPolicy.class, EnumSet.allOf(CombinationPolicy.class)))
+            .setValidator(EnumValidator.create(CombinationPolicy.class))
             .build();
 
     public static final SimpleAttributeDefinition PROVIDER = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PROVIDER, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(Provider.SIMPLE.toString()))
-            .setValidator(new EnumValidator<Provider>(Provider.class, EnumSet.allOf(Provider.class)))
+            .setValidator(EnumValidator.create(Provider.class))
             .build();
 
     public static final SimpleAttributeDefinition USE_IDENTITY_ROLES = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.USE_IDENTITY_ROLES, ModelType.BOOLEAN, true)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHORIZATION;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -76,12 +77,12 @@ public class AccessAuthorizationResourceDefinition extends SimpleResourceDefinit
     public static final SimpleAttributeDefinition PERMISSION_COMBINATION_POLICY =
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PERMISSION_COMBINATION_POLICY, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(CombinationPolicy.PERMISSIVE.toString()))
-            .setValidator(new EnumValidator<CombinationPolicy>(CombinationPolicy.class, true, false))
+            .setValidator(new EnumValidator<CombinationPolicy>(CombinationPolicy.class, EnumSet.allOf(CombinationPolicy.class)))
             .build();
 
     public static final SimpleAttributeDefinition PROVIDER = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PROVIDER, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(Provider.SIMPLE.toString()))
-            .setValidator(new EnumValidator<Provider>(Provider.class, true, false))
+            .setValidator(new EnumValidator<Provider>(Provider.class, EnumSet.allOf(Provider.class)))
             .build();
 
     public static final SimpleAttributeDefinition USE_IDENTITY_ROLES = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.USE_IDENTITY_ROLES, ModelType.BOOLEAN, true)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalResourceDefinition.java
@@ -25,8 +25,6 @@ package org.jboss.as.domain.management.access;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
 
-import java.util.EnumSet;
-
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -56,7 +54,7 @@ public class PrincipalResourceDefinition extends SimpleResourceDefinition {
     }
 
     public static final SimpleAttributeDefinition TYPE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.TYPE,
-            ModelType.STRING, false).setValidator(new EnumValidator<>(Type.class, EnumSet.allOf(Type.class))).build();
+            ModelType.STRING, false).setValidator(EnumValidator.create(Type.class)).build();
 
     public static final SimpleAttributeDefinition REALM = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.REALM,
             ModelType.STRING, true).setDeprecated(ModelVersion.create(5)).build();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalResourceDefinition.java
@@ -25,6 +25,8 @@ package org.jboss.as.domain.management.access;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -54,7 +56,7 @@ public class PrincipalResourceDefinition extends SimpleResourceDefinition {
     }
 
     public static final SimpleAttributeDefinition TYPE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.TYPE,
-            ModelType.STRING, false).setValidator(new EnumValidator<>(Type.class, false, false)).build();
+            ModelType.STRING, false).setValidator(new EnumValidator<>(Type.class, EnumSet.allOf(Type.class))).build();
 
     public static final SimpleAttributeDefinition REALM = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.REALM,
             ModelType.STRING, true).setDeprecated(ModelVersion.create(5)).build();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
@@ -39,7 +39,6 @@ import static org.jboss.as.domain.management.audit.SyslogAuditLogHandlerService.
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -87,7 +86,7 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
         .setRequired(false)
         .setDefaultValue(new ModelNode(SyslogHandler.SyslogType.RFC5424.toString()))
         .setAllowExpression(true)
-        .setValidator(new EnumValidator<>(SyslogHandler.SyslogType.class, EnumSet.allOf(SyslogHandler.SyslogType.class)))
+        .setValidator(EnumValidator.create(SyslogHandler.SyslogType.class))
         .setMinSize(1)
         .build();
 
@@ -105,7 +104,7 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
 
     public static final SimpleAttributeDefinition FACILITY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.FACILITY, ModelType.STRING)
         .setRequired(false)
-        .setValidator(new EnumValidator<SyslogAuditLogHandler.Facility>(SyslogAuditLogHandler.Facility.class, EnumSet.allOf(SyslogAuditLogHandler.Facility.class)))
+        .setValidator(EnumValidator.create(SyslogAuditLogHandler.Facility.class))
         .setDefaultValue(new ModelNode(SyslogAuditLogHandler.Facility.USER_LEVEL.name()))
         .setAllowExpression(true)
         .build();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
@@ -39,6 +39,7 @@ import static org.jboss.as.domain.management.audit.SyslogAuditLogHandlerService.
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -86,7 +87,7 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
         .setRequired(false)
         .setDefaultValue(new ModelNode(SyslogHandler.SyslogType.RFC5424.toString()))
         .setAllowExpression(true)
-        .setValidator(new EnumValidator<>(SyslogHandler.SyslogType.class, true, true))
+        .setValidator(new EnumValidator<>(SyslogHandler.SyslogType.class, EnumSet.allOf(SyslogHandler.SyslogType.class)))
         .setMinSize(1)
         .build();
 
@@ -104,7 +105,7 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
 
     public static final SimpleAttributeDefinition FACILITY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.FACILITY, ModelType.STRING)
         .setRequired(false)
-        .setValidator(new EnumValidator<SyslogAuditLogHandler.Facility>(SyslogAuditLogHandler.Facility.class, true, true))
+        .setValidator(new EnumValidator<SyslogAuditLogHandler.Facility>(SyslogAuditLogHandler.Facility.class, EnumSet.allOf(SyslogAuditLogHandler.Facility.class)))
         .setDefaultValue(new ModelNode(SyslogAuditLogHandler.Facility.USER_LEVEL.name()))
         .setAllowExpression(true)
         .build();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
@@ -43,6 +43,7 @@ import org.jboss.as.core.security.AccessMechanism;
 import org.jboss.as.domain.management._private.DomainManagementResolver;
 import org.jboss.dmr.ModelType;
 
+
 /**
  * {@code ResourceDefinition} for a currently executing operation.
  *
@@ -64,7 +65,7 @@ public class ActiveOperationResourceDefinition extends SimpleResourceDefinition 
     private static final AttributeDefinition ACCESS_MECHANISM =
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ACCESS_MECHANISM, ModelType.STRING)
                     .setRequired(false)
-                    .setValidator(EnumValidator.create(AccessMechanism.class, true, false))
+                    .setValidator(EnumValidator.create(AccessMechanism.class))
                     .build();
     private static final AttributeDefinition DOMAIN_UUID =
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DOMAIN_UUID, ModelType.STRING, true).build();
@@ -73,7 +74,7 @@ public class ActiveOperationResourceDefinition extends SimpleResourceDefinition 
 
     private static final AttributeDefinition EXECUTION_STATUS =
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.EXECUTION_STATUS, ModelType.STRING)
-                    .setValidator(EnumValidator.create(OperationContext.ExecutionStatus.class, false, false))
+                    .setValidator(EnumValidator.create(OperationContext.ExecutionStatus.class))
                     .build();
     private static final AttributeDefinition CANCELLED =
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CANCELLED, ModelType.BOOLEAN).build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -108,7 +108,7 @@ class DirContextDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition REFERRAL_MODE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REFERRAL_MODE, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(ReferralMode.IGNORE.toString()))
             .setAllowedValues(ReferralMode.FOLLOW.toString(), ReferralMode.IGNORE.toString(), ReferralMode.THROW.toString())
-            .setValidator(EnumValidator.create(ReferralMode.class, true, true))
+            .setValidator(EnumValidator.create(ReferralMode.class))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -90,7 +90,7 @@ class PermissionMapperDefinitions {
     static final SimpleAttributeDefinition LOGICAL_OPERATION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LOGICAL_OPERATION, ModelType.STRING, false)
             .setAllowExpression(true)
             .setAllowedValues(ElytronDescriptionConstants.AND, ElytronDescriptionConstants.OR, ElytronDescriptionConstants.XOR, ElytronDescriptionConstants.UNLESS)
-            .setValidator(EnumValidator.create(LogicalMapperOperation.class, false, true))
+            .setValidator(EnumValidator.create(LogicalMapperOperation.class))
             .setMinSize(1)
             .setRestartAllServices()
             .build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RoleMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RoleMapperDefinitions.java
@@ -104,7 +104,7 @@ class RoleMapperDefinitions {
     static final SimpleAttributeDefinition LOGICAL_OPERATION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LOGICAL_OPERATION, ModelType.STRING, false)
         .setAllowExpression(true)
         .setAllowedValues(ElytronDescriptionConstants.AND, ElytronDescriptionConstants.MINUS, ElytronDescriptionConstants.OR, ElytronDescriptionConstants.XOR)
-        .setValidator(EnumValidator.create(LogicalOperation.class, false, true))
+        .setValidator(EnumValidator.create(LogicalOperation.class))
         .setMinSize(1)
         .setRestartAllServices()
         .build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -147,7 +147,7 @@ class SaslServerDefinitions {
         .setDefaultValue(new ModelNode(ElytronDescriptionConstants.LESS_THAN))
         .setRequires(ElytronDescriptionConstants.PROVIDER_VERSION)
         .setAllowedValues(ElytronDescriptionConstants.LESS_THAN, ElytronDescriptionConstants.GREATER_THAN)
-        .setValidator(EnumValidator.create(Comparison.class, true, true))
+        .setValidator(EnumValidator.create(Comparison.class))
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .build();
@@ -168,7 +168,7 @@ class SaslServerDefinitions {
         .setAllowExpression(true)
         .setXmlName("predefined")
         .setAllowedValues(NamePredicate.names())
-        .setValidator(EnumValidator.create(NamePredicate.class, true, true))
+        .setValidator(EnumValidator.create(NamePredicate.class))
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
         .setAlternatives(ElytronDescriptionConstants.PATTERN_FILTER)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -42,14 +42,12 @@ import java.security.KeyStoreException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -117,7 +115,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition HOSTNAME_VERIFICATION_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HOST_NAME_VERIFICATION_POLICY, ModelType.STRING, true)
-            .setValidator(new EnumValidator<>(HostnameVerificationPolicy.class, EnumSet.allOf(HostnameVerificationPolicy.class)))
+            .setValidator(EnumValidator.create(HostnameVerificationPolicy.class))
             .setAllowExpression(true)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -42,6 +42,7 @@ import java.security.KeyStoreException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -116,7 +117,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition HOSTNAME_VERIFICATION_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HOST_NAME_VERIFICATION_POLICY, ModelType.STRING, true)
-            .setValidator(new EnumValidator<>(HostnameVerificationPolicy.class, true, true))
+            .setValidator(new EnumValidator<>(HostnameVerificationPolicy.class, EnumSet.allOf(HostnameVerificationPolicy.class)))
             .setAllowExpression(true)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -88,7 +88,7 @@ public class DomainServerLifecycleHandlers {
 
     private static final AttributeDefinition START_MODE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.START_MODE, ModelType.STRING, true)
             .setDefaultValue(new ModelNode(StartMode.NORMAL.toString()))
-            .setValidator(new EnumValidator<>(StartMode.class, true, true))
+            .setValidator(new EnumValidator<>(StartMode.class, EnumSet.allOf(StartMode.class)))
             .build();
 
     @Deprecated

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -87,8 +87,9 @@ public class DomainServerLifecycleHandlers {
             .build();
 
     private static final AttributeDefinition START_MODE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.START_MODE, ModelType.STRING, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(StartMode.NORMAL.toString()))
-            .setValidator(new EnumValidator<>(StartMode.class, EnumSet.allOf(StartMode.class)))
+            .setValidator(EnumValidator.create(StartMode.class))
             .build();
 
     @Deprecated

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -34,6 +34,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -163,7 +164,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition LAUNCH_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.LAUNCH_TYPE, ModelType.STRING)
-            .setValidator(new EnumValidator<LaunchType>(LaunchType.class, false, false))
+            .setValidator(new EnumValidator<LaunchType>(LaunchType.class, EnumSet.allOf(LaunchType.class)))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -34,7 +34,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -164,7 +163,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition LAUNCH_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.LAUNCH_TYPE, ModelType.STRING)
-            .setValidator(new EnumValidator<LaunchType>(LaunchType.class, EnumSet.allOf(LaunchType.class)))
+            .setValidator(EnumValidator.create(LaunchType.class))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -116,7 +116,7 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.HOST_RELEASE, ModelType.STRING, false)
                     .setXmlName("id")
                     .setAlternatives(ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION)
-                    .setValidator(EnumValidator.create(KnownRelease.class, false, false))
+                    .setValidator(EnumValidator.create(KnownRelease.class))
                     .build();
 
     public static final SimpleAttributeDefinition MANAGEMENT_MAJOR_VERSION =

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.host.controller.model.host;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_ORGANIZATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.services.path.PathResourceDefinition.PATH_CAPABILITY;
 
 import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.ControlledProcessState;
@@ -71,7 +72,6 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
-import static org.jboss.as.controller.services.path.PathResourceDefinition.PATH_CAPABILITY;
 import org.jboss.as.domain.controller.DomainController;
 import org.jboss.as.domain.controller.operations.DomainServerLifecycleHandlers;
 import org.jboss.as.domain.controller.operations.HostProcessReloadHandler;
@@ -203,7 +203,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition DIRECTORY_GROUPING = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DIRECTORY_GROUPING, ModelType.STRING, true).
             addFlag(AttributeAccess.Flag.RESTART_ALL_SERVICES).
             setDefaultValue(DirectoryGrouping.defaultValue().toModelNode()).
-            setValidator(EnumValidator.create(DirectoryGrouping.class, true, true)).
+            setValidator(EnumValidator.create(DirectoryGrouping.class)).
             setAllowExpression(true).
             build();
     public static final SimpleAttributeDefinition MASTER = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.MASTER, ModelType.BOOLEAN, true)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
@@ -25,17 +25,15 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
-import java.util.EnumSet;
-
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.validation.EnumValidator;
@@ -55,7 +53,6 @@ import org.jboss.as.repository.HostFileRepository;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.security.auth.client.AuthenticationContext;
-
 
 /**
  *
@@ -88,7 +85,7 @@ public abstract class DomainControllerWriteAttributeHandler extends ReloadRequir
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ADMIN_ONLY_POLICY, ModelType.STRING, true)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_JVM)
-                    .setValidator(new EnumValidator<AdminOnlyDomainConfigPolicy>(AdminOnlyDomainConfigPolicy.class, EnumSet.allOf(AdminOnlyDomainConfigPolicy.class)))
+                    .setValidator(EnumValidator.create(AdminOnlyDomainConfigPolicy.class))
                     .setDefaultValue(new ModelNode(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG.toString()))
                     .build();
     public static final SimpleAttributeDefinition IGNORE_UNUSED_CONFIG =
@@ -109,7 +106,7 @@ public abstract class DomainControllerWriteAttributeHandler extends ReloadRequir
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PROTOCOL, ModelType.STRING)
                     .setRequired(false)
                     .setAllowExpression(true)
-                    .setValidator(new EnumValidator(Protocol.class, EnumSet.allOf(Protocol.class)))
+                    .setValidator(EnumValidator.create(Protocol.class))
                     .setDefaultValue(org.jboss.as.remoting.Protocol.REMOTE.toModelNode())
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setRequires(ModelDescriptionConstants.HOST, ModelDescriptionConstants.PORT)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
@@ -25,6 +25,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -53,6 +55,7 @@ import org.jboss.as.repository.HostFileRepository;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.security.auth.client.AuthenticationContext;
+
 
 /**
  *
@@ -85,7 +88,7 @@ public abstract class DomainControllerWriteAttributeHandler extends ReloadRequir
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ADMIN_ONLY_POLICY, ModelType.STRING, true)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_JVM)
-                    .setValidator(new EnumValidator<AdminOnlyDomainConfigPolicy>(AdminOnlyDomainConfigPolicy.class, true, true))
+                    .setValidator(new EnumValidator<AdminOnlyDomainConfigPolicy>(AdminOnlyDomainConfigPolicy.class, EnumSet.allOf(AdminOnlyDomainConfigPolicy.class)))
                     .setDefaultValue(new ModelNode(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG.toString()))
                     .build();
     public static final SimpleAttributeDefinition IGNORE_UNUSED_CONFIG =
@@ -106,7 +109,7 @@ public abstract class DomainControllerWriteAttributeHandler extends ReloadRequir
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PROTOCOL, ModelType.STRING)
                     .setRequired(false)
                     .setAllowExpression(true)
-                    .setValidator(new EnumValidator(Protocol.class, true, true))
+                    .setValidator(new EnumValidator(Protocol.class, EnumSet.allOf(Protocol.class)))
                     .setDefaultValue(org.jboss.as.remoting.Protocol.REMOTE.toModelNode())
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setRequires(ModelDescriptionConstants.HOST, ModelDescriptionConstants.PORT)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
@@ -24,10 +24,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.dmr.ModelType.STRING;
 
-import java.util.EnumSet;
-
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -35,7 +34,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.EnumValidator;
@@ -105,7 +103,7 @@ public class RemoteDomainControllerAddHandler implements OperationStepHandler {
     public static final SimpleAttributeDefinition ADMIN_ONLY_POLICY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ADMIN_ONLY_POLICY, ModelType.STRING, true)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
-            .setValidator(new EnumValidator<>(AdminOnlyDomainConfigPolicy.class, EnumSet.allOf(AdminOnlyDomainConfigPolicy.class)))
+            .setValidator(EnumValidator.create(AdminOnlyDomainConfigPolicy.class))
             .setDefaultValue(new ModelNode(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG.toString()))
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
@@ -24,6 +24,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.dmr.ModelType.STRING;
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -75,7 +77,7 @@ public class RemoteDomainControllerAddHandler implements OperationStepHandler {
     public static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PROTOCOL, ModelType.STRING)
             .setRequired(false)
             .setAllowExpression(true)
-            .setValidator(EnumValidator.create(Protocol.class, true, true))
+            .setValidator(EnumValidator.create(Protocol.class))
             .setDefaultValue(Protocol.REMOTE.toModelNode())
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setRequires(ModelDescriptionConstants.HOST, ModelDescriptionConstants.PORT)
@@ -103,7 +105,7 @@ public class RemoteDomainControllerAddHandler implements OperationStepHandler {
     public static final SimpleAttributeDefinition ADMIN_ONLY_POLICY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ADMIN_ONLY_POLICY, ModelType.STRING, true)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
-            .setValidator(new EnumValidator<>(AdminOnlyDomainConfigPolicy.class, true, true))
+            .setValidator(new EnumValidator<>(AdminOnlyDomainConfigPolicy.class, EnumSet.allOf(AdminOnlyDomainConfigPolicy.class)))
             .setDefaultValue(new ModelNode(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG.toString()))
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -39,7 +39,6 @@ import static org.jboss.as.server.controller.resources.ServerRootResourceDefinit
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -133,7 +132,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ServerStatusHandler.ATTRIBUTE_NAME, ModelType.STRING)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
-            .setValidator(new EnumValidator<ServerStatus>(ServerStatus.class, EnumSet.allOf(ServerStatus.class)))
+            .setValidator(EnumValidator.create(ServerStatus.class))
             .build();
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -39,6 +39,7 @@ import static org.jboss.as.server.controller.resources.ServerRootResourceDefinit
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -132,7 +133,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ServerStatusHandler.ATTRIBUTE_NAME, ModelType.STRING)
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
-            .setValidator(new EnumValidator<ServerStatus>(ServerStatus.class, false, false))
+            .setValidator(new EnumValidator<ServerStatus>(ServerStatus.class, EnumSet.allOf(ServerStatus.class)))
             .build();
 
     /**

--- a/logging/src/main/java/org/jboss/as/logging/handlers/AsyncHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/AsyncHandlerResourceDefinition.java
@@ -89,7 +89,7 @@ public class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
             .setDefaultValue(new ModelNode(OverflowAction.BLOCK.name()))
             .setPropertyName("overflowAction")
             .setResolver(OverflowActionResolver.INSTANCE)
-            .setValidator(EnumValidator.create(OverflowAction.class, false, false))
+            .setValidator(EnumValidator.create(OverflowAction.class))
             .build();
 
     static final SimpleAttributeDefinition HANDLER = SimpleAttributeDefinitionBuilder.create("handler", ModelType.STRING)

--- a/logging/src/main/java/org/jboss/as/logging/handlers/ConsoleHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/ConsoleHandlerResourceDefinition.java
@@ -50,7 +50,7 @@ public class ConsoleHandlerResourceDefinition extends AbstractHandlerDefinition 
             .setAttributeMarshaller(ElementAttributeMarshaller.NAME_ATTRIBUTE_MARSHALLER)
             .setDefaultValue(new ModelNode(Target.SYSTEM_OUT.toString()))
             .setResolver(TargetResolver.INSTANCE)
-            .setValidator(EnumValidator.create(Target.class, true, false))
+            .setValidator(EnumValidator.create(Target.class))
             .build();
 
     private static final AttributeDefinition[] ATTRIBUTES = Logging.join(DEFAULT_ATTRIBUTES, AUTOFLUSH, TARGET, NAMED_FORMATTER);

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CommonAttributes.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CommonAttributes.java
@@ -84,7 +84,7 @@ class CommonAttributes {
             .build();
 
     static final SimpleAttributeDefinition THREAD_STATE = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.THREAD_STATE, ModelType.STRING, true)
-            .setValidator(new EnumValidator<Thread.State>(Thread.State.class, false))
+            .setValidator(new EnumValidator<Thread.State>(Thread.State.class))
             .build();
 
     static final SimpleAttributeDefinition BLOCKED_TIME = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.BLOCKED_TIME, ModelType.LONG, false)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
@@ -58,7 +58,7 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     private static AttributeDefinition TYPE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TYPE, ModelType.STRING, false)
-            .setValidator(new EnumValidator<MemoryType>(MemoryType.class, false))
+            .setValidator(new EnumValidator<MemoryType>(MemoryType.class))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -24,6 +24,8 @@ package org.jboss.as.remoting;
 
 import static org.jboss.as.remoting.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationStepHandler;
@@ -73,7 +75,7 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
 
     public static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(
             CommonAttributes.PROTOCOL, ModelType.STRING, true).setValidator(
-                    new EnumValidator<Protocol>(Protocol.class, true, false))
+                    new EnumValidator<Protocol>(Protocol.class, EnumSet.allOf(Protocol.class)))
             .setDefaultValue(new ModelNode(Protocol.HTTP_REMOTING.toString()))
             .setAllowExpression(true)
             .setAlternatives(CommonAttributes.AUTHENTICATION_CONTEXT)

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -24,8 +24,6 @@ package org.jboss.as.remoting;
 
 import static org.jboss.as.remoting.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 
-import java.util.EnumSet;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationStepHandler;
@@ -74,8 +72,7 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
             .build();
 
     public static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(
-            CommonAttributes.PROTOCOL, ModelType.STRING, true).setValidator(
-                    new EnumValidator<Protocol>(Protocol.class, EnumSet.allOf(Protocol.class)))
+            CommonAttributes.PROTOCOL, ModelType.STRING, true).setValidator(EnumValidator.create(Protocol.class))
             .setDefaultValue(new ModelNode(Protocol.HTTP_REMOTING.toString()))
             .setAllowExpression(true)
             .setAlternatives(CommonAttributes.AUTHENTICATION_CONTEXT)

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -127,7 +127,7 @@ public class DeploymentAttributes {
             .build();
 
     public static final AttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.STATUS, ModelType.STRING, true)
-        .setValidator(new EnumValidator<AbstractDeploymentUnitService.DeploymentStatus>(AbstractDeploymentUnitService.DeploymentStatus.class, true))
+        .setValidator(new EnumValidator<AbstractDeploymentUnitService.DeploymentStatus>(AbstractDeploymentUnitService.DeploymentStatus.class))
         .build();
 
     public static final SimpleAttributeDefinition ENABLED_TIME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ENABLED_TIME, ModelType.LONG, true)

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -32,8 +32,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND;
 import static org.jboss.as.controller.services.path.PathResourceDefinition.PATH_CAPABILITY;
 
-import java.util.EnumSet;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.CapabilityRegistry;
@@ -215,19 +213,19 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition LAUNCH_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.LAUNCH_TYPE, ModelType.STRING)
-            .setValidator(new EnumValidator<LaunchType>(LaunchType.class, EnumSet.allOf(LaunchType.class)))
+            .setValidator(EnumValidator.create(LaunchType.class))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();
 
     public static final AttributeDefinition RUNNING_MODE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.RUNNING_MODE, ModelType.STRING)
-            .setValidator(new EnumValidator<RunningMode>(RunningMode.class, EnumSet.allOf(RunningMode.class)))
+            .setValidator(EnumValidator.create(RunningMode.class))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();
 
     public static final AttributeDefinition SUSPEND_STATE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SUSPEND_STATE, ModelType.STRING)
-            .setValidator(new EnumValidator<SuspendController.State>(SuspendController.State.class, EnumSet.allOf(SuspendController.State.class)))
+            .setValidator(EnumValidator.create(SuspendController.State.class))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -32,6 +32,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND;
 import static org.jboss.as.controller.services.path.PathResourceDefinition.PATH_CAPABILITY;
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.CapabilityRegistry;
@@ -135,6 +137,7 @@ import org.jboss.as.server.services.net.SpecifiedInterfaceResolveHandler;
 import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -212,19 +215,19 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition LAUNCH_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.LAUNCH_TYPE, ModelType.STRING)
-            .setValidator(new EnumValidator<LaunchType>(LaunchType.class, false, false))
+            .setValidator(new EnumValidator<LaunchType>(LaunchType.class, EnumSet.allOf(LaunchType.class)))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();
 
     public static final AttributeDefinition RUNNING_MODE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.RUNNING_MODE, ModelType.STRING)
-            .setValidator(new EnumValidator<RunningMode>(RunningMode.class, false, false))
+            .setValidator(new EnumValidator<RunningMode>(RunningMode.class, EnumSet.allOf(RunningMode.class)))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();
 
     public static final AttributeDefinition SUSPEND_STATE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SUSPEND_STATE, ModelType.STRING)
-            .setValidator(new EnumValidator<SuspendController.State>(SuspendController.State.class, false, false))
+            .setValidator(new EnumValidator<SuspendController.State>(SuspendController.State.class, EnumSet.allOf(SuspendController.State.class)))
             .setStorageRuntime()
             .setRuntimeServiceNotRequired()
             .build();

--- a/server/src/main/java/org/jboss/as/server/operations/ServerProcessReloadHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerProcessReloadHandler.java
@@ -21,7 +21,6 @@
 */
 package org.jboss.as.server.operations;
 
-import java.util.EnumSet;
 import java.util.Locale;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -66,7 +65,7 @@ public class ServerProcessReloadHandler extends ProcessReloadHandler<RunningMode
             .build();
 
     protected static final AttributeDefinition START_MODE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.START_MODE, ModelType.STRING, true)
-            .setValidator(new EnumValidator<>(StartMode.class, EnumSet.allOf(StartMode.class)))
+            .setValidator(EnumValidator.create(StartMode.class))
             .setAlternatives(ModelDescriptionConstants.ADMIN_ONLY)
             .setDefaultValue(new ModelNode(StartMode.NORMAL.toString())).build();
     private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {ADMIN_ONLY, USE_CURRENT_SERVER_CONFIG, SERVER_CONFIG, START_MODE};

--- a/server/src/main/java/org/jboss/as/server/operations/ServerProcessReloadHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerProcessReloadHandler.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.server.operations;
 
+import java.util.EnumSet;
 import java.util.Locale;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -65,7 +66,7 @@ public class ServerProcessReloadHandler extends ProcessReloadHandler<RunningMode
             .build();
 
     protected static final AttributeDefinition START_MODE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.START_MODE, ModelType.STRING, true)
-            .setValidator(new EnumValidator<>(StartMode.class, true, false))
+            .setValidator(new EnumValidator<>(StartMode.class, EnumSet.allOf(StartMode.class)))
             .setAlternatives(ModelDescriptionConstants.ADMIN_ONLY)
             .setDefaultValue(new ModelNode(StartMode.NORMAL.toString())).build();
     private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {ADMIN_ONLY, USE_CURRENT_SERVER_CONFIG, SERVER_CONFIG, START_MODE};

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -78,7 +78,7 @@ public class BlockerExtension implements Extension {
     public static final AttributeDefinition TARGET_HOST = SimpleAttributeDefinitionBuilder.create(HOST, ModelType.STRING, true).build();
     public static final AttributeDefinition TARGET_SERVER = SimpleAttributeDefinitionBuilder.create(SERVER, ModelType.STRING, true).build();
     public static final AttributeDefinition BLOCK_POINT = SimpleAttributeDefinitionBuilder.create("block-point", ModelType.STRING)
-            .setValidator(EnumValidator.create(BlockPoint.class, false, false))
+            .setValidator(EnumValidator.create(BlockPoint.class))
             .build();
     public static final AttributeDefinition BLOCK_TIME = SimpleAttributeDefinitionBuilder.create("block-time", ModelType.LONG, true)
             .setDefaultValue(new ModelNode(20000))

--- a/threads/src/main/java/org/jboss/as/threads/KeepAliveTimeAttributeDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/KeepAliveTimeAttributeDefinition.java
@@ -65,7 +65,7 @@ class KeepAliveTimeAttributeDefinition extends ObjectTypeAttributeDefinition {
     static final SimpleAttributeDefinition KEEPALIVE_TIME_UNIT = new SimpleAttributeDefinitionBuilder(CommonAttributes.UNIT, ModelType.STRING, false)
             .setXmlName("unit")
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<TimeUnit>(TimeUnit.class, EnumSet.allOf(TimeUnit.class)))
+            .setValidator(EnumValidator.create(TimeUnit.class))
             .setAttributeMarshaller( new DefaultAttributeMarshaller(){
                 @Override
                 public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {

--- a/threads/src/main/java/org/jboss/as/threads/KeepAliveTimeAttributeDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/KeepAliveTimeAttributeDefinition.java
@@ -65,7 +65,7 @@ class KeepAliveTimeAttributeDefinition extends ObjectTypeAttributeDefinition {
     static final SimpleAttributeDefinition KEEPALIVE_TIME_UNIT = new SimpleAttributeDefinitionBuilder(CommonAttributes.UNIT, ModelType.STRING, false)
             .setXmlName("unit")
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<TimeUnit>(TimeUnit.class, false, true))
+            .setValidator(new EnumValidator<TimeUnit>(TimeUnit.class, EnumSet.allOf(TimeUnit.class)))
             .setAttributeMarshaller( new DefaultAttributeMarshaller(){
                 @Override
                 public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5760 

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```