### PR TITLE
[WFCORE-5767] Add the Elytron OIDC Client related dependencies to Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1845,6 +1845,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-http-oidc</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http-spnego</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>
@@ -1866,6 +1871,16 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-jaspi</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-jose-jwk</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-jose-util</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5767

Moving the Elytron OIDC Client related dependencies from WildFly to Core. The modules that actually make use of these dependencies will remain in WildFly.
