### PR TITLE
[WFCORE-5490] Integrate Elytron credential expressions into system-pr…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -184,7 +184,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
     /**
      * Name of a capability that extensions that provide {@link ExpressionResolverExtension} implementations
      * can use to register their extensions with the core {@link ExpressionResolver}.
+     *
+     * @deprecated Will be removed in an upcoming major version.
      */
+    @Deprecated
     protected static final String EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME =
             "org.wildfly.management.expression-resolver-extension-registry";
 
@@ -209,6 +212,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
     private final BootErrorCollector bootErrorCollector;
     private final CapabilityRegistry capabilityRegistry;
     private final ConfigurationExtension configExtension;
+    private final RuntimeCapability<ExpressionResolver.ResolverExtensionRegistry> extensionRegistryCapability;
 
     /**
      * Construct a new instance.
@@ -385,6 +389,13 @@ public abstract class AbstractControllerService implements Service<ModelControll
         this.processState = processState;
         this.prepareStep = prepareStep;
         this.expressionResolver = expressionResolver;
+        if (expressionResolver instanceof ExpressionResolver.ResolverExtensionRegistry) {
+            this.extensionRegistryCapability =
+                    RuntimeCapability.Builder.of(EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME,
+                            (ExpressionResolver.ResolverExtensionRegistry) expressionResolver).build();
+        } else {
+            this.extensionRegistryCapability = null;
+        }
         this.auditLogger = auditLogger;
         this.authorizer = authorizer;
         this.securityIdentitySupplier = securityIdentitySupplier;
@@ -439,6 +450,11 @@ public abstract class AbstractControllerService implements Service<ModelControll
             final ServiceBuilder<?> notifyRegistrySB = target.addService(notifyRegistrySN);
             notifyRegistrySB.setInstance(new SimpleService(notifyRegistrySB.provides(notifyRegistrySN), controller.getNotificationRegistry()));
             notifyRegistrySB.install();
+        }
+        if (extensionRegistryCapability != null) {
+            capabilityRegistry.registerCapability(
+                    new RuntimeCapabilityRegistration(extensionRegistryCapability, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
+            rootResourceRegistration.registerCapability(extensionRegistryCapability);
         }
         capabilityRegistry.publish();  // These are visible immediately; no waiting for finishBoot
                                        // We publish even if we didn't register anything in case parent services did

--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -66,7 +66,9 @@ import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
 import org.jboss.as.controller.client.impl.AdditionalBootCliScriptInvoker;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
+import org.jboss.as.controller.extension.ResolverExtensionRegistry;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.notification.NotificationHandlerRegistry;
 import org.jboss.as.controller.notification.NotificationSupport;
@@ -212,7 +214,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
     private final BootErrorCollector bootErrorCollector;
     private final CapabilityRegistry capabilityRegistry;
     private final ConfigurationExtension configExtension;
-    private final RuntimeCapability<ExpressionResolver.ResolverExtensionRegistry> extensionRegistryCapability;
+    private final RuntimeCapability<ResolverExtensionRegistry> extensionRegistryCapability;
 
     /**
      * Construct a new instance.
@@ -389,10 +391,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
         this.processState = processState;
         this.prepareStep = prepareStep;
         this.expressionResolver = expressionResolver;
-        if (expressionResolver instanceof ExpressionResolver.ResolverExtensionRegistry) {
+        if (expressionResolver instanceof ResolverExtensionRegistry) {
             this.extensionRegistryCapability =
                     RuntimeCapability.Builder.of(EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME,
-                            (ExpressionResolver.ResolverExtensionRegistry) expressionResolver).build();
+                            (ResolverExtensionRegistry) expressionResolver).build();
         } else {
             this.extensionRegistryCapability = null;
         }

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolver.java
@@ -35,7 +35,7 @@ import org.jboss.dmr.ModelNode;
 public interface ExpressionResolver {
 
     /** A {@link Pattern} that can be used to identify strings that include expression syntax */
-    Pattern EXPRESSION_PATTERN = Pattern.compile(".*\\$\\{.*\\}.*");
+    Pattern EXPRESSION_PATTERN = Pattern.compile(".*\\$\\{.*}.*");
 
     /**
      * Resolves any expressions in the passed in ModelNode.
@@ -93,21 +93,21 @@ public interface ExpressionResolver {
     /**
      * An {@code ExpressionResolver} that can only resolve from system properties
      * and environment variables. Should not be used for most product resolution use cases as it does
-     * not support resolution from a security vault.
+     * not support resolution from resolver extensions.
      */
     ExpressionResolver SIMPLE = new ExpressionResolverImpl();
 
     /**
      * An {@code ExpressionResolver} suitable for test cases that can only resolve from system properties
      * and environment variables.
-     * Should not be used for production code as it does not support resolution from a security vault.
+     * Should not be used for production code as it does not support resolution from resolver extensions.
      */
     ExpressionResolver TEST_RESOLVER = SIMPLE;
 
     /**
      * An expression resolver that will not throw an {@code OperationFailedException} when it encounters an
      * unresolvable expression, instead simply returning that expression. Should not be used for most product
-     * resolution use cases as it does not support resolution from a security vault.
+     * resolution use cases as it does not support resolution from resolver extensions.
      */
     ExpressionResolver SIMPLE_LENIENT = new ExpressionResolverImpl(true);
 
@@ -125,6 +125,23 @@ public interface ExpressionResolver {
             }
             // It wasn't an expression anyway; convert the node to type STRING
             node.set(expression);
+        }
+    };
+
+    /**
+     * An expression resolver that throws an {@link ExpressionResolutionServerException} if any
+     * {@link ExpressionResolverExtension#EXTENSION_EXPRESSION_PATTERN extension expressions} are found, otherwise
+     * providing the same behavior as {@link #SIMPLE}.
+     * Intended for use in cases where {@link ExpressionResolverExtension}s cannot be available but non-extension
+     * expression resolution is wanted.
+     */
+    ExpressionResolver EXTENSION_REJECTING = new ExpressionResolverImpl() {
+        @Override
+        protected void resolvePluggableExpression(ModelNode node, OperationContext context) throws OperationFailedException {
+            String expression = node.asString();
+            if (ExpressionResolverExtension.EXTENSION_EXPRESSION_PATTERN.matcher(expression).matches()) {
+                throw ControllerLogger.ROOT_LOGGER.resolverExtensionExpressionsNotAllowed(expression);
+            } // else do nothing and standard resolution will take over
         }
     };
 
@@ -170,7 +187,7 @@ public interface ExpressionResolver {
      * where this is unclear.
      * <p>
      * <strong>Note:</strong> this should only be thrown to report problems resulting from user
-     * errors. Use {@link ExpressionResolverExtension.ExpressionResolutionServerException} to report faults in
+     * errors. Use {@link ExpressionResolutionServerException} to report faults in
      * {@link ExpressionResolverExtension#resolveExpression(String, OperationContext)} execution that
      * are not due to user inputs.
      */

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolver.java
@@ -23,6 +23,8 @@ package org.jboss.as.controller;
 
 import java.util.regex.Pattern;
 
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
+import org.jboss.as.controller.extension.ResolverExtensionRegistry;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.dmr.ModelNode;
 
@@ -144,26 +146,6 @@ public interface ExpressionResolver {
             } // else do nothing and standard resolution will take over
         }
     };
-
-    /**
-     * Registry for {@link ExpressionResolverExtension extensions} to a server or host controller's {@link ExpressionResolver}.
-     * The registry will be available using the {@code org.wildfly.management.expression-resolver-extension-registry}
-     * capability.
-     */
-    interface ResolverExtensionRegistry {
-
-        /**
-         * Adds an extension to the set used by the {@link ExpressionResolver}.
-         * @param extension the extension. Cannot be {@code null}
-         */
-        void addResolverExtension(ExpressionResolverExtension extension);
-
-        /**
-         * Removes an extension from the set used by the {@link ExpressionResolver}.
-         * @param extension the extension. Cannot be {@code null}
-         */
-        void removeResolverExtension(ExpressionResolverExtension extension);
-    }
 
     /**
      * Runtime exception used to indicate some user-driven problem that prevented expression

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolverExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolverExtension.java
@@ -26,7 +26,10 @@ public interface ExpressionResolverExtension {
 
     /**
      * Initialize the extension using the given {@link OperationContext}. May be called multiple times
-     * for a given extension, so extensions should handle that appropriately.
+     * for a given extension, so extensions should handle that appropriately. Note that this method
+     * may be invoked in {@link OperationContext.Stage#MODEL}. Implementations are not required to support initialization
+     * in [@code OperationContext.Stage.MODEL} but should throw {@link org.jboss.as.controller.ExpressionResolver.ExpressionResolutionServerException}
+     * if they do not.
      *
      * @param context the {@link OperationContext}. Will not be {@code null}
      * @throws OperationFailedException if a problem initializing occurs that indicates a user mistake
@@ -34,12 +37,19 @@ public interface ExpressionResolverExtension {
      *                                  Do not use for non-user-driven problems; use runtime exceptions for those.
      *                                  Throwing a runtime exception that implements {@link OperationClientException}
      *                                  is also a valid way to handle user mistakes.
+     * @throws org.jboss.as.controller.ExpressionResolver.ExpressionResolutionServerException if a non-user-driven
+     *                                 problem occurs, including an invocation during {@link OperationContext.Stage#MODEL}
+     *                                 if that is not supported.
      */
     void initialize(OperationContext context) throws OperationFailedException;
 
     /**
      * Resolve a given simple expression string, returning {@code null} if the string is not of a form
      * recognizable to the plugin.
+     * <p>
+     * <strong>Note:</strong> A thread invoking this method must immediately precede the invocation with a call to
+     * {@link #initialize(OperationContext)}.
+     * </p>
      *
      * @param expression a string that begins with <code>${</code> and ends with <code>}</code> and that does not have
      *                   any substrings that match that pattern.

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolverExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolverExtension.java
@@ -18,11 +18,24 @@
 
 package org.jboss.as.controller;
 
+import java.util.regex.Pattern;
+
 /**
  * Object that can be used to extend the functionality of an {@link ExpressionResolver} by handling
  * expression strings in formats not understood by the expression resolver.
+ * <p>
+ * Extension expressions must be of the form {@code ${extensionidentifier::someextensionspecificdetails}}, where
+ * {@code extensionidentifier} is some string that identifies the desired extension. All resolver extensions in
+ * a process must have unique identifiers. Best practice is for subsystems that register extensions to allow end user
+ * configuration control over the identifier so they can provide non-conflicting identifiers.  The
+ * {@code someextensionspecificdetails} part of the expression is an opaque string understood by the relevant
+ * resolver extension.
+ * </p>
  */
 public interface ExpressionResolverExtension {
+
+    /** A {@link Pattern} that strings must match for any ExpressionResolverExtension to handle them. */
+    Pattern EXTENSION_EXPRESSION_PATTERN = Pattern.compile("\\$\\{.+::.+}");
 
     /**
      * Initialize the extension using the given {@link OperationContext}. May be called multiple times
@@ -51,7 +64,7 @@ public interface ExpressionResolverExtension {
      * {@link #initialize(OperationContext)}.
      * </p>
      *
-     * @param expression a string that begins with <code>${</code> and ends with <code>}</code> and that does not have
+     * @param expression a string that matches {@link #EXTENSION_EXPRESSION_PATTERN} and that does not have
      *                   any substrings that match that pattern.
      * @param context    the current {@code OperationContext} to provide additional contextual information.
      * @return a string representing the resolve expression, or {@code null} if {@code expression} is not of a

--- a/controller/src/main/java/org/jboss/as/controller/ExtensionContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExtensionContext.java
@@ -26,6 +26,7 @@ package org.jboss.as.controller;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.services.path.PathManager;
 
 /**

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExpressionResolverExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExpressionResolverExtension.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2021 Red Hat, Inc., and individual contributors
+ * Copyright 2022 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +16,14 @@
  * limitations under the License.
  */
 
-package org.jboss.as.controller;
+package org.jboss.as.controller.extension;
 
 import java.util.regex.Pattern;
+
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.OperationClientException;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 
 /**
  * Object that can be used to extend the functionality of an {@link ExpressionResolver} by handling

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -41,8 +41,6 @@ import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.ExpressionResolver;
-import org.jboss.as.controller.ExpressionResolverExtension;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.ExtensionContext;
@@ -129,7 +127,7 @@ public final class ExtensionRegistry {
 
     private SubsystemXmlWriterRegistry writerRegistry;
     private volatile PathManager pathManager;
-    private volatile ExpressionResolver.ResolverExtensionRegistry resolverExtensionRegistry;
+    private volatile ResolverExtensionRegistry resolverExtensionRegistry;
 
     private final ConcurrentMap<String, ExtensionInfo> extensions = new ConcurrentHashMap<String, ExtensionInfo>();
     // subsystem -> extension
@@ -192,7 +190,7 @@ public final class ExtensionRegistry {
         this.pathManager = pathManager;
     }
 
-    public void setResolverExtensionRegistry(ExpressionResolver.ResolverExtensionRegistry registry) {
+    public void setResolverExtensionRegistry(ResolverExtensionRegistry registry) {
         this.resolverExtensionRegistry = registry;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/extension/ResolverExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ResolverExtensionRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller.extension;
+
+import org.jboss.as.controller.ExpressionResolver;
+
+/**
+ * Registry for {@link ExpressionResolverExtension extensions} to a server or host controller's {@link ExpressionResolver}.
+ * The registry will be available using the {@code org.wildfly.management.expression-resolver-extension-registry}
+ * capability.
+ */
+public interface ResolverExtensionRegistry {
+
+    /**
+     * Adds an extension to the set used by the {@link ExpressionResolver}.
+     *
+     * @param extension the extension. Cannot be {@code null}
+     */
+    void addResolverExtension(ExpressionResolverExtension extension);
+
+    /**
+     * Removes an extension from the set used by the {@link ExpressionResolver}.
+     *
+     * @param extension the extension. Cannot be {@code null}
+     */
+    void removeResolverExtension(ExpressionResolverExtension extension);
+}

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3701,6 +3701,9 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 493, value = "The attribute %s hasn't a valueType properly defined.")
     UnsupportedOperationException missingListAttributeValueType(String name);
 
+    @Message(id = 494, value = "Resolution of extension expression '%s' is not allowed at this point.")
+    ExpressionResolver.ExpressionResolutionServerException resolverExtensionExpressionsNotAllowed(String expression);
+
     @Message(id = NONE, value = "While constructing a mapping; %s; expected a mapping for merging, but found %s")
     String errorConstructingYAMLMapping(Mark mark, NodeId node);
 

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -122,9 +122,9 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
     TestModelControllerService(ProcessType processType, RunningModeControl runningModeControl, StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
             TestModelType type, ModelInitializer modelInitializer, TestDelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState, ExtensionRegistry extensionRegistry,
-            CapabilityRegistry capabilityRegistry) {
+            CapabilityRegistry capabilityRegistry, RuntimeExpressionResolver expressionResolver) {
         super(processType, runningModeControl, null, persister, validateOpsFilter, rootResourceDefinition, processState,
-                new RuntimeExpressionResolver(), capabilityRegistry);
+                expressionResolver, capabilityRegistry);
         this.type = type;
         this.runningModeControl = runningModeControl;
         this.pathManagerService = type == TestModelType.STANDALONE ? new ServerPathManagerService(capabilityRegistry) : new HostPathManagerService(capabilityRegistry);
@@ -145,8 +145,10 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
     static TestModelControllerService create(ProcessType processType, RunningModeControl runningModeControl, StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
             TestModelType type, ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry, CapabilityRegistry capabilityRegistry) {
+        RuntimeExpressionResolver expressionResolver = new RuntimeExpressionResolver();
+        extensionRegistry.setResolverExtensionRegistry(expressionResolver);
         return new TestModelControllerService(processType, runningModeControl, persister, validateOpsFilter, type, modelInitializer,
-                new TestDelegatingResourceDefinition(type), new ControlledProcessState(true), extensionRegistry, capabilityRegistry);
+                new TestDelegatingResourceDefinition(type), new ControlledProcessState(true), extensionRegistry, capabilityRegistry, expressionResolver);
     }
 
     InjectedValue<ContentRepository> getContentRepositoryInjector(){

--- a/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
@@ -275,6 +275,8 @@ class Capabilities {
             .Builder.of(JACC_POLICY_CAPABILITY, false, Policy.class)
             .build();
 
+    static final String EXPRESSION_RESOLVER_CAPABILITY = CAPABILITY_BASE + "expression-resolver";
+
     /**
      * Requirements, capabilities from other subsystems.
      */
@@ -283,7 +285,5 @@ class Capabilities {
      * Required by the {@link JdbcRealmDefinition}.
      */
     static final String DATA_SOURCE_CAPABILITY_NAME = "org.wildfly.data-source";
-
-    static final String EXPRESSION_RESOLVER_CAPABILITY = "org.wildfly.controller.expression-resolver";
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -53,7 +53,7 @@ import javax.security.auth.message.config.AuthConfigFactory;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
-import org.jboss.as.controller.ExpressionResolverExtension;
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationContext.AttachmentKey;
 import org.jboss.as.controller.OperationContext.Stage;

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -20,8 +20,10 @@ package org.wildfly.extension.elytron;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 
+import org.jboss.as.controller.ExpressionResolverExtension;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
@@ -153,10 +155,12 @@ public class ElytronExtension implements Extension {
         // Elytron is expected to be used everywhere.
         subsystemRegistration.setHostCapable();
 
-        final ManagementResourceRegistration registration = subsystemRegistration.registerSubsystemModel(ElytronDefinition.INSTANCE);
+        AtomicReference<ExpressionResolverExtension> resolverRef = new AtomicReference<>();
+        final ManagementResourceRegistration registration = subsystemRegistration.registerSubsystemModel(new ElytronDefinition(resolverRef));
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
-
         subsystemRegistration.registerXMLElementWriter(() -> new ElytronSubsystemParser15_0());
+
+        context.registerExpressionResolverExtension(resolverRef::get, ExpressionResolverResourceDefinition.INITIAL_PATTERN, false);
     }
 
     @SuppressWarnings("unchecked")

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -23,7 +23,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 
-import org.jboss.as.controller.ExpressionResolverExtension;
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ExpressionResolverResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ExpressionResolverResourceDefinition.java
@@ -30,7 +30,7 @@ import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
-import org.jboss.as.controller.ExpressionResolverExtension;
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;

--- a/elytron/src/main/java/org/wildfly/extension/elytron/expression/DeploymentExpressionResolverProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/expression/DeploymentExpressionResolverProcessor.java
@@ -36,7 +36,7 @@ public final class DeploymentExpressionResolverProcessor implements DeploymentUn
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         CapabilityServiceSupport serviceSupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         try {
-            final ElytronExpressionResolver resolver = serviceSupport.getCapabilityRuntimeAPI("org.wildfly.controller.expression-resolver", ElytronExpressionResolver.class);
+            final ElytronExpressionResolver resolver = serviceSupport.getCapabilityRuntimeAPI("org.wildfly.security.expression-resolver", ElytronExpressionResolver.class);
             deploymentUnit.addToAttachmentList(Attachments.DEPLOYMENT_EXPRESSION_RESOLVERS, (s) -> resolver.resolveDeploymentExpression(s, serviceSupport));
         } catch (CapabilityServiceSupport.NoSuchCapabilityException e) {
             // /subsystem=elytron/expression=encryption resource is not present, so there's nothing to do.

--- a/elytron/src/main/java/org/wildfly/extension/elytron/expression/ElytronExpressionResolver.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/expression/ElytronExpressionResolver.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 
 import org.jboss.as.controller.ExpressionResolver;
-import org.jboss.as.controller.ExpressionResolverExtension;
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.OperationClientException;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;

--- a/elytron/src/main/java/org/wildfly/extension/elytron/expression/ExpressionResolverRuntimeHandler.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/expression/ExpressionResolverRuntimeHandler.java
@@ -28,7 +28,7 @@ import org.jboss.as.controller.OperationFailedException;
 public final class ExpressionResolverRuntimeHandler {
 
     public static void initializeResolver(OperationContext context) throws OperationFailedException {
-        ElytronExpressionResolver resolver = context.getCapabilityRuntimeAPI("org.wildfly.controller.expression-resolver", ElytronExpressionResolver.class);
+        ElytronExpressionResolver resolver = context.getCapabilityRuntimeAPI("org.wildfly.security.expression-resolver", ElytronExpressionResolver.class);
         resolver.ensureInitialised(null, context);
     }
 }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -20,14 +20,8 @@ package org.wildfly.extension.elytron;
 import mockit.Mock;
 import mockit.MockUp;
 
-import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
-import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.server.RuntimeExpressionResolver;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -171,15 +165,6 @@ class TestEnvironment extends AdditionalInitialization {
         }
 
         return initializer;
-    }
-
-    @Override
-    protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
-        super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
-        RuntimeCapability<ExpressionResolver.ResolverExtensionRegistry> extRegCap =
-                RuntimeCapability.Builder.of("org.wildfly.management.expression-resolver-extension-registry",
-                        (ExpressionResolver.ResolverExtensionRegistry) new RuntimeExpressionResolver()).build();
-        registerCapabilities(capabilityRegistry, extRegCap);
     }
 
     public static void startLdapService() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -110,7 +110,6 @@ import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorize
 import org.jboss.as.controller.access.management.ManagementSecurityIdentitySupplier;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
 import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.capability.registry.CapabilityScope;
 import org.jboss.as.controller.capability.registry.ImmutableCapabilityRegistry;
 import org.jboss.as.controller.capability.registry.RegistrationPoint;
@@ -286,7 +285,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
         final ExtensionRegistry extensionRegistry = new ExtensionRegistry(processType, runningModeControl, auditLogger, authorizer, securityIdentitySupplier, hostControllerInfoAccessor);
         final PrepareStepHandler prepareStepHandler = new PrepareStepHandler(hostControllerInfo,
                 hostProxies, serverProxies, ignoredRegistry, extensionRegistry);
-        final ExpressionResolver expressionResolver = new RuntimeExpressionResolver();
+        final RuntimeExpressionResolver expressionResolver = new RuntimeExpressionResolver();
+        hostExtensionRegistry.setResolverExtensionRegistry(expressionResolver);
         final DomainHostExcludeRegistry domainHostExcludeRegistry = new DomainHostExcludeRegistry();
         HostControllerEnvironmentService.addService(environment, serviceTarget);
 
@@ -575,18 +575,12 @@ public class DomainModelControllerService extends AbstractControllerService impl
         capabilityReg.registerCapability(
                 new RuntimeCapabilityRegistration(CONSOLE_AVAILABILITY_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
 
-        RuntimeCapability<ExpressionResolver.ResolverExtensionRegistry> extRegCap =
-                RuntimeCapability.Builder.of(EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME, (ExpressionResolver.ResolverExtensionRegistry) expressionResolver).build();
-        capabilityReg.registerCapability(
-                new RuntimeCapabilityRegistration(extRegCap, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
-
         // Record the core capabilities with the root MRR so reads of it will show it as their provider
         // This also gets them recorded as 'possible capabilities' in the capability registry
         rootRegistration.registerCapability(PATH_MANAGER_CAPABILITY);
         rootRegistration.registerCapability(EXECUTOR_CAPABILITY);
         rootRegistration.registerCapability(PROCESS_STATE_NOTIFIER_CAPABILITY);
         rootRegistration.registerCapability(CONSOLE_AVAILABILITY_CAPABILITY);
-        rootRegistration.registerCapability(extRegCap);
 
         // Register the slave host info
         ResourceProvider.Tool.addResourceProvider(HOST_CONNECTION, new ResourceProvider() {

--- a/server/src/main/java/org/jboss/as/server/RuntimeExpressionResolver.java
+++ b/server/src/main/java/org/jboss/as/server/RuntimeExpressionResolver.java
@@ -25,12 +25,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.jboss.as.controller.ExpressionResolver;
-import org.jboss.as.controller.ExpressionResolverExtension;
+import org.jboss.as.controller.extension.ExpressionResolverExtension;
 import org.jboss.as.controller.ExpressionResolverImpl;
 import org.jboss.as.controller.OperationClientException;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.extension.ResolverExtensionRegistry;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 
@@ -39,7 +39,7 @@ import org.jboss.logging.Logger;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class RuntimeExpressionResolver extends ExpressionResolverImpl implements ExpressionResolver.ResolverExtensionRegistry {
+public class RuntimeExpressionResolver extends ExpressionResolverImpl implements ResolverExtensionRegistry {
 
     private static final Logger log = Logger.getLogger(RuntimeExpressionResolver.class);
 

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -50,7 +50,6 @@ import org.jboss.as.controller.BootContext;
 import org.jboss.as.controller.CapabilityRegistry;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.DelegatingResourceDefinition;
-import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelControllerServiceInitialization;
 import org.jboss.as.controller.OperationStepHandler;
@@ -255,6 +254,7 @@ public final class ServerService extends AbstractControllerService {
 
         final CapabilityRegistry capabilityRegistry = configuration.getCapabilityRegistry();
         final RuntimeExpressionResolver expressionResolver = new RuntimeExpressionResolver();
+        configuration.getExtensionRegistry().setResolverExtensionRegistry(expressionResolver);
 
         ServiceBuilder<?> serviceBuilder = serviceTarget.addService(Services.JBOSS_SERVER_CONTROLLER);
         final boolean allowMCE = configuration.getServerEnvironment().isAllowModelControllerExecutor();
@@ -509,12 +509,6 @@ public final class ServerService extends AbstractControllerService {
         capabilityRegistry.registerCapability(
                 new RuntimeCapabilityRegistration(CONSOLE_AVAILABILITY_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
 
-        RuntimeCapability<ExpressionResolver.ResolverExtensionRegistry> extRegCap =
-                RuntimeCapability.Builder.of(EXPRESSION_RESOLVER_EXTENSION_REGISTRY_CAPABILITY_NAME, (ExpressionResolver.ResolverExtensionRegistry) expressionResolver).build();
-        capabilityRegistry.registerCapability(
-                new RuntimeCapabilityRegistration(extRegCap, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
-
-
         // Record the core capabilities with the root MRR so reads of it will show it as their provider
         // This also gets them recorded as 'possible capabilities' in the capability registry
         ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
@@ -524,7 +518,6 @@ public final class ServerService extends AbstractControllerService {
         rootRegistration.registerCapability(PROCESS_STATE_NOTIFIER_CAPABILITY);
         rootRegistration.registerCapability(EXTERNAL_MODULE_CAPABILITY);
         rootRegistration.registerCapability(CONSOLE_AVAILABILITY_CAPABILITY);
-        rootRegistration.registerCapability(extRegCap);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/operations/SystemPropertyAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/SystemPropertyAddHandler.java
@@ -19,15 +19,17 @@
 package org.jboss.as.server.operations;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition.BOOT_TIME;
 import static org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition.VALUE;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.OperationClientException;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -42,7 +44,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-public class SystemPropertyAddHandler implements OperationStepHandler{
+public class SystemPropertyAddHandler implements OperationStepHandler {
 
     public static final String OPERATION_NAME = ADD;
 
@@ -86,23 +88,28 @@ public class SystemPropertyAddHandler implements OperationStepHandler{
             attr.validateAndSet(operation, model);
         }
 
-        final String name = PathAddress.pathAddress(operation.get(OP_ADDR)).getLastElement().getValue();
-        final String value = operation.hasDefined(VALUE.getName()) ? operation.get(VALUE.getName()).asString() : null;
+        final String name = context.getCurrentAddressValue();
+        final ModelNode valueNode = model.get(VALUE.getName());
+        final String value = valueNode.asStringOrNull();
         final boolean applyToRuntime = systemPropertyUpdater != null && systemPropertyUpdater.isRuntimeSystemPropertyUpdateAllowed(name, value, context.isBooting());
         final boolean reload = !applyToRuntime && context.getProcessType().isServer();
 
+        final AtomicReference<String> currentValue = new AtomicReference<>();
         if (applyToRuntime) {
+            // Cache the current value for use in rollback
+            currentValue.set(WildFlySecurityManager.getPropertyPrivileged(name, null));
+
             String setValue = null;
             boolean setIt = false;
             try {
-                setValue = value != null ? VALUE.resolveModelAttribute(context, model).asString() : null;
+                setValue = value != null ? VALUE.resolveModelAttribute(context, model).asStringOrNull() : null;
                 setIt = true;
             } catch (Exception resolutionFailure) {
-                handleResolutionFailure(context, model, name, resolutionFailure);
+                handleDeferredResolution(context, model, name, resolutionFailure);
             }
 
             if (setIt) {
-                setProperty(name, setValue);
+                setProperty(name, setValue, systemPropertyUpdater);
             }
 
         } else if (reload) {
@@ -115,17 +122,14 @@ public class SystemPropertyAddHandler implements OperationStepHandler{
                 if (reload) {
                     context.revertReloadRequired();
                 }
-                if (systemPropertyUpdater != null) {
-                    WildFlySecurityManager.clearPropertyPrivileged(name);
-                    if (systemPropertyUpdater != null) {
-                        systemPropertyUpdater.systemPropertyUpdated(name, null);
-                    }
+                if (applyToRuntime) {
+                    setProperty(name, currentValue.get(), systemPropertyUpdater);
                 }
             }
         });
     }
 
-    private void setProperty(String name, String value) {
+    private static void setProperty(String name, String value, ProcessEnvironmentSystemPropertyUpdater systemPropertyUpdater) {
         if (value != null) {
             WildFlySecurityManager.setPropertyPrivileged(name, value);
         } else {
@@ -136,57 +140,139 @@ public class SystemPropertyAddHandler implements OperationStepHandler{
         }
     }
 
-    private void handleResolutionFailure(OperationContext context, ModelNode model,
+    private void handleDeferredResolution(OperationContext context, ModelNode model,
                                          final String propertyName, final Exception resolutionFailure) {
 
-        assert resolutionFailure instanceof RuntimeException || resolutionFailure instanceof OperationFailedException
+        assert resolutionFailure == null
+                || resolutionFailure instanceof RuntimeException
+                || resolutionFailure instanceof OperationFailedException
                 : "invalid resolutionFailure type " + resolutionFailure.getClass();
 
         DeferredProcessor deferredResolver = (DeferredProcessor) context.getAttachment(SystemPropertyDeferredProcessor.ATTACHMENT_KEY);
         if (deferredResolver == null) {
-            deferredResolver = new DeferredProcessor();
+            deferredResolver = new DeferredProcessor(systemPropertyUpdater);
             context.attach(SystemPropertyDeferredProcessor.ATTACHMENT_KEY, deferredResolver);
         }
-        deferredResolver.unresolved.put(propertyName, model);
+        deferredResolver.addDeferredProcessee(propertyName, model, resolutionFailure);
 
-        context.addStep(new OperationStepHandler() {
-            @Override
-            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                DeferredProcessor deferredResolver = (DeferredProcessor) context.getAttachment(SystemPropertyDeferredProcessor.ATTACHMENT_KEY);
-                if (deferredResolver != null && deferredResolver.unresolved.containsKey(propertyName)) {
-                    context.setRollbackOnly();
-                    if (resolutionFailure instanceof RuntimeException) {
-                        throw (RuntimeException) resolutionFailure;
-                    } else if (resolutionFailure instanceof OperationFailedException) {
-                        throw (OperationFailedException) resolutionFailure;
+        // Try again to resolve in Stage.RUNTIME, when runtime-only ExpressionResolverExtensions may be available
+        // If that fails it will add a step to see in Stage.VERIFY if some other OSH resolved it
+        final DeferredProcessor finalDeferredResolver = deferredResolver;
+        context.addStep((context1, operation) -> {
+            // See if the property can be processed now
+            if (!finalDeferredResolver.processDeferredPropertyAtRuntime(propertyName, context1)) {
+
+                // It's possible some other OSH(s) will call processDeferredProperties,
+                // so add a Stage.VERIFY step to see if one has successfully resolved our prop,
+                // and to fail the overall op if not.
+                context.addStep((context2, operation2) -> {
+                    DeferredProcesee procesee = finalDeferredResolver.getUnresolved(propertyName);
+                    if (procesee != null) {
+                        // If there is an OFE cached, throw it in preference to any cached RuntimeException
+                        if (procesee.ofe != null) {
+                            context2.setRollbackOnly();
+                            throw procesee.ofe;
+                        } else if (procesee.re != null) {
+                            context2.setRollbackOnly();
+                            throw procesee.re;
+                        } //
                     }
-                    // Should not be possible -- see initial assert
-                    throw new RuntimeException(resolutionFailure);
-                }
+                }, OperationContext.Stage.VERIFY);
+
             }
-        }, OperationContext.Stage.VERIFY);
+        }, OperationContext.Stage.RUNTIME);
     }
 
-    private class DeferredProcessor implements SystemPropertyDeferredProcessor {
+    static final class DeferredProcessor implements SystemPropertyDeferredProcessor {
 
-        private final Map<String, ModelNode> unresolved = new HashMap<String, ModelNode>();
+        private final Map<String, DeferredProcesee> unresolved = new HashMap<>();
+        private final ProcessEnvironmentSystemPropertyUpdater systemPropertyUpdater;
 
-        @Override
-        public void processDeferredProperties(OperationContext context) throws OperationFailedException {
-            for (Iterator<Map.Entry<String, ModelNode>> it = unresolved.entrySet().iterator(); it.hasNext();) {
-                Map.Entry<String, ModelNode> entry = it.next();
+        DeferredProcessor(ProcessEnvironmentSystemPropertyUpdater systemPropertyUpdater) {
+            this.systemPropertyUpdater = systemPropertyUpdater;
+        }
+
+        synchronized void addDeferredProcessee(String propertyName, ModelNode model, Exception resolutionFailure) {
+            unresolved.put(propertyName, new DeferredProcesee(model, resolutionFailure));
+        }
+
+        /**
+         * Try to resolve a single property.
+         * @param property the name of the property. Cannot be {@code null}
+         * @param resolver the resolver to use to attempt resolution. Cannot be {@code null}
+         * @return {@code true} if the property had already been resolved or if this call set the property; {@code false} otherwise
+         */
+        synchronized boolean processDeferredPropertyAtRuntime(String property, ExpressionResolver resolver) {
+            DeferredProcesee procesee = unresolved.get(property);
+            if (procesee != null) {
                 try {
-                    final String setValue = VALUE.resolveModelAttribute(context, entry.getValue()).asString();
-                    setProperty(entry.getKey(), setValue);
-                    it.remove();
-                } catch (OperationFailedException resolutionFailure) {
-                    context.setRollbackOnly();
-                    throw resolutionFailure;
-                }  catch (RuntimeException resolutionFailure) {
-                    context.setRollbackOnly();
-                    throw resolutionFailure;
+                    final String setValue = VALUE.resolveModelAttribute(resolver, procesee.model).asString();
+                    setProperty(property, setValue, systemPropertyUpdater);
+                    unresolved.remove(property);
+                } catch (RuntimeException | OperationFailedException resolutionFailure) {
+                    procesee.setDeferredProcessingException(resolutionFailure);
+                    return false;
                 }
             }
+            return true;
+        }
+
+        @Override
+        public synchronized void processDeferredProperties(ExpressionResolver resolver) {
+            for (Iterator<Map.Entry<String, DeferredProcesee>> it = unresolved.entrySet().iterator(); it.hasNext();) {
+                Map.Entry<String, DeferredProcesee> entry = it.next();
+                try {
+                    DeferredProcesee procesee = entry.getValue();
+                    final String setValue = VALUE.resolveModelAttribute(resolver, procesee.model).asString();
+                    setProperty(entry.getKey(), setValue, systemPropertyUpdater);
+                    it.remove();
+                } catch (RuntimeException | OperationFailedException resolutionFailure) {
+                    entry.getValue().setDeferredProcessingException(resolutionFailure);
+                }
+            }
+        }
+
+        // For unit tests
+        synchronized DeferredProcesee getUnresolved(String propertyName) {
+            return unresolved.get(propertyName);
+        }
+    }
+
+    static final class DeferredProcesee {
+        private final ModelNode model;
+        private OperationFailedException ofe;
+        private RuntimeException re;
+
+        private DeferredProcesee(ModelNode model, Exception resolutionFailure) {
+            this.model = model;
+            if (resolutionFailure != null) {
+                setDeferredProcessingException(resolutionFailure);
+            }
+        }
+
+        private void setDeferredProcessingException(Exception e) {
+            assert  e instanceof RuntimeException || e instanceof OperationFailedException;
+            if (e instanceof OperationFailedException) {
+                this.ofe = (OperationFailedException) e;
+                this.re = null;
+            } else {
+                this.re = (RuntimeException) e;
+                // Don't discard any cached OFE unless this RuntimeException is an OperationClientException
+                // If we fail we prefer to throw OFE as it indicates a client failure
+                if (e instanceof OperationClientException) {
+                    this.ofe = null;
+                }
+            }
+        }
+
+        // Expose internals to unit tests
+
+        OperationFailedException getOperationFailedException() {
+            return ofe;
+        }
+
+        RuntimeException getRuntimeException() {
+            return re;
         }
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/SystemPropertyDeferredProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/operations/SystemPropertyDeferredProcessor.java
@@ -22,27 +22,33 @@
 
 package org.jboss.as.server.operations;
 
+import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 
 /**
  * WFLY-1904: performs deferred resolution and storage of system properties,
- * after any security vault has had a chance to initialize. This makes
- * it possible for vault expressions to be used in the configured
- * property value.
+ * after any runtime services that back an {@code ExpressionResolverExtension}
+ * have had a chance to initialize. This makes it possible for expressions
+ * resolvable by an {@code ExpressionResolverExtension} to be used in the
+ * configured property value.
  *
  * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ *
+ * @deprecated Will be removed in the next major release
  */
+@Deprecated
 public interface SystemPropertyDeferredProcessor {
 
+    /**
+     *
+     */
     /**
      * Resolve and store any system properties that could not be resolved during
      * the normal handling of system properties.
      *
      * @param context the operation context
-     * @throws OperationFailedException if any properties could still not be resolved
      */
-    void processDeferredProperties(OperationContext context) throws OperationFailedException;
+    void processDeferredProperties(ExpressionResolver context);
 
     /** Key under which the {@code SystemPropertyDeferredProcessor} should be attached to the operation context. */
     OperationContext.AttachmentKey<SystemPropertyDeferredProcessor> ATTACHMENT_KEY = OperationContext.AttachmentKey.create(SystemPropertyDeferredProcessor.class);

--- a/server/src/test/java/org/jboss/as/server/operations/SystemPropertyAddHandlerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/operations/SystemPropertyAddHandlerUnitTestCase.java
@@ -1,0 +1,159 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ValueExpression;
+import org.junit.Test;
+
+/**
+ * Tests of the {@link SystemPropertyAddHandler} class.
+ */
+public class SystemPropertyAddHandlerUnitTestCase {
+
+    private static final String text = "text";
+
+    @Test
+    public void testDeferredProcessor() {
+
+
+        // Mock resolver that reads a map to decide what to do; we manipulate the map content
+        // to drive test scenarios
+        final Map<String, Object> map = new HashMap<>();
+        final ExpressionResolver resolver = new ExpressionResolver() {
+            @Override
+            public ModelNode resolveExpressions(ModelNode node) throws OperationFailedException {
+                String key = node.asExpression().getExpressionString();
+                Object val = map.get(key);
+                if (val instanceof String) {
+                    return new ModelNode((String) val);
+                } else if (val instanceof OperationFailedException) {
+                    throw (OperationFailedException) val;
+                } else if (val != null) {
+                    throw (RuntimeException) val;
+                }
+                throw new ExpressionResolutionServerException(key);
+            }
+        };
+
+        SystemPropertyAddHandler.DeferredProcessor testee = new SystemPropertyAddHandler.DeferredProcessor(null);
+
+        // Add 5 properties to the DeferredProcessor under test
+        // 1 resolves in processDeferredProperty
+        // 1 resolves in first call to processDeferredProperties
+        // 1 resolves in second call to processDeferredProperties
+        // 2 don't resolve
+
+        String keyA = "${A}";
+        String keyB = "${B}";
+        String keyC = "${C}";
+        String keyD = "${D}";
+        String keyE = "${E}";
+        ModelNode modelA = new ModelNode();
+        modelA.get("value").set(new ValueExpression(keyA));
+        testee.addDeferredProcessee("A", modelA, null);
+        ModelNode modelB = new ModelNode();
+        modelB.get("value").set(new ValueExpression(keyB));
+        testee.addDeferredProcessee("B", modelB, new OperationFailedException(keyB));
+        ModelNode modelC = new ModelNode();
+        modelC.get("value").set(new ValueExpression(keyC));
+        testee.addDeferredProcessee("C", modelC, new ExpressionResolver.ExpressionResolutionUserException(keyC));
+        ModelNode modelD = new ModelNode();
+        modelD.get("value").set(new ValueExpression(keyD));
+        testee.addDeferredProcessee("D", modelD, new ExpressionResolver.ExpressionResolutionServerException(keyD));
+        ModelNode modelE = new ModelNode();
+        modelE.get("value").set(new ValueExpression(keyE));
+        testee.addDeferredProcessee("E", modelE, new OperationFailedException(keyE));
+
+        // Validate setup
+        validateDeferredProcessee(testee.getUnresolved("A"), null, false);
+        validateDeferredProcessee(testee.getUnresolved("B"), null, true);
+        validateDeferredProcessee(testee.getUnresolved("C"), ExpressionResolver.ExpressionResolutionUserException.class, false);
+        validateDeferredProcessee(testee.getUnresolved("D"), ExpressionResolver.ExpressionResolutionServerException.class, false);
+        validateDeferredProcessee(testee.getUnresolved("E"), null, true);
+
+        // Round of Stage.RUNTIME resolution
+        map.put("${A}", "Avalue");
+        map.put("${B}", new ExpressionResolver.ExpressionResolutionServerException("B"));
+        map.put("${C}", ":C");
+        map.put("${D}", new OperationFailedException("D"));
+        map.put("${E}", new ExpressionResolver.ExpressionResolutionUserException("E"));
+
+        testee.processDeferredPropertyAtRuntime("A", resolver);
+        testee.processDeferredPropertyAtRuntime("B", resolver);
+        // Don't invoke for C
+        //testee.processDeferredPropertyAtRuntime("C", resolver);
+        testee.processDeferredPropertyAtRuntime("D", resolver);
+        testee.processDeferredPropertyAtRuntime("E", resolver);
+
+        assertEquals("Avalue", System.getProperty("A"));
+        assertNull(testee.getUnresolved("A"));
+        validateDeferredProcessee(testee.getUnresolved("B"), ExpressionResolver.ExpressionResolutionServerException.class, true);
+        validateDeferredProcessee(testee.getUnresolved("C"), ExpressionResolver.ExpressionResolutionUserException.class, false);
+        validateDeferredProcessee(testee.getUnresolved("D"), null, true);
+        assertSame(map.get("${D}"), testee.getUnresolved("D").getOperationFailedException());
+        validateDeferredProcessee(testee.getUnresolved("E"), ExpressionResolver.ExpressionResolutionUserException.class, false);
+
+        // First call to processDeferredProperties
+        map.remove("${A}");
+        map.put("${B}", new OperationFailedException("B"));
+        map.put("${C}", "Cvalue");
+        map.put("${D}", new ExpressionResolver.ExpressionResolutionServerException("D"));
+        map.put("${E}", new ExpressionResolver.ExpressionResolutionServerException("E"));
+        testee.processDeferredProperties(resolver);
+
+        assertEquals("Avalue", System.getProperty("A"));
+        assertNull(testee.getUnresolved("A"));
+        validateDeferredProcessee(testee.getUnresolved("B"), null, true);
+        assertSame(map.get("${B}"), testee.getUnresolved("B").getOperationFailedException());
+        assertEquals("Cvalue", System.getProperty("C"));
+        assertNull(testee.getUnresolved("C"));
+        validateDeferredProcessee(testee.getUnresolved("D"), ExpressionResolver.ExpressionResolutionServerException.class, true);
+        validateDeferredProcessee(testee.getUnresolved("E"), ExpressionResolver.ExpressionResolutionServerException.class, false);
+
+
+
+    }
+
+    private static void validateDeferredProcessee(SystemPropertyAddHandler.DeferredProcesee dp,
+                                                  Class<? extends RuntimeException> reClazz, boolean expectOFE) {
+        assertNotNull(dp);
+        if (reClazz != null) {
+            assertTrue(dp.getRuntimeException().getClass().isAssignableFrom(reClazz));
+        } else {
+            assertNull(dp.getRuntimeException());
+        }
+        if (expectOFE) {
+            assertNotNull(dp.getOperationFailedException());
+        } else {
+            assertNull(dp.getOperationFailedException());
+        }
+    }
+}

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
@@ -98,8 +98,10 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
                                                            AdditionalInitialization additionalInit, ExtensionRegistry extensionRegistry,
                                                            StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
                                                            boolean registerTransformers){
+                RuntimeExpressionResolver runtimeExpressionResolver = new RuntimeExpressionResolver();
+                extensionRegistry.setResolverExtensionRegistry(runtimeExpressionResolver);
                 return TestModelControllerService.create(mainExtension, controllerInitializer, additionalInit, extensionRegistry,
-                        persister, validateOpsFilter, registerTransformers, new RuntimeExpressionResolver(), capabilityRegistry);
+                        persister, validateOpsFilter, registerTransformers, runtimeExpressionResolver, capabilityRegistry);
             }
         };
         if (legacyModelVersion != null) {

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -99,6 +99,9 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
            this.additionalInit = additionalInit;
            this.controllerInitializer = controllerInitializer;
            this.extensionRegistry = extensionRegistry;
+           if (expressionResolver instanceof ExpressionResolver.ResolverExtensionRegistry) {
+               extensionRegistry.setResolverExtensionRegistry((ExpressionResolver.ResolverExtensionRegistry) expressionResolver);
+           }
            this.runningModeControl = runningModeControl;
            this.registerTransformers = registerTransformers;
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
+import org.jboss.as.controller.extension.ResolverExtensionRegistry;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -99,8 +100,8 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
            this.additionalInit = additionalInit;
            this.controllerInitializer = controllerInitializer;
            this.extensionRegistry = extensionRegistry;
-           if (expressionResolver instanceof ExpressionResolver.ResolverExtensionRegistry) {
-               extensionRegistry.setResolverExtensionRegistry((ExpressionResolver.ResolverExtensionRegistry) expressionResolver);
+           if (expressionResolver instanceof ResolverExtensionRegistry) {
+               extensionRegistry.setResolverExtensionRegistry((ResolverExtensionRegistry) expressionResolver);
            }
            this.runningModeControl = runningModeControl;
            this.registerTransformers = registerTransformers;

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/expression/SystemPropertyExpressionTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/expression/SystemPropertyExpressionTestCase.java
@@ -122,6 +122,7 @@ public class SystemPropertyExpressionTestCase {
             ModelNode addOp = Util.createAddOperation(CREDENTIAL_STORE_ADDRESS);
             addOp.get("location").set(CS_PATH);
             addOp.get("credential-reference", "clear-text").set(CNAME);
+            addOp.get("providers").set("combined-providers");
             managementClient.executeForResult(addOp);
         }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/expression/SystemPropertyExpressionTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/expression/SystemPropertyExpressionTestCase.java
@@ -1,0 +1,245 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.expression;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PLATFORM_MBEAN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.SecretKeyCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
+import org.wildfly.security.encryption.SecretKeyUtil;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+@RunWith(WildflyTestRunner.class)
+@ServerSetup(SystemPropertyExpressionTestCase.ServerSetup.class)
+public class SystemPropertyExpressionTestCase {
+
+    private static final String CNAME = SystemPropertyExpressionTestCase.class.getSimpleName();
+    private static final String CS_PATH = "target/" + CNAME + ".cs";
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(SUBSYSTEM, "elytron");
+    private static final PathAddress ENCRYPTION_ADDRESS = SUBSYSTEM_ADDRESS.append("expression", "encryption");
+    private static final String CREDENTIAL_STORE = "credential-store";
+    private static final PathAddress CREDENTIAL_STORE_ADDRESS = SUBSYSTEM_ADDRESS.append(CREDENTIAL_STORE, CNAME);
+    private static final String SECURE_KEY = "RUxZAUsXHVcDh99zAdxGEzTBK1h2qjW+sZg2+37w7ijhDEiJEw==";
+    private static final PathAddress RUNTIME_ADDRESS = PathAddress.pathAddress(CORE_SERVICE, PLATFORM_MBEAN).append(TYPE, "runtime");
+    private static final String PROP = CNAME;
+    private static final String MISSING_PROP = PROP + "-missing";
+
+    private static final String CLEAR_TEXT = "Lorem ipsum dolor sit amet";
+
+    public static final class ServerSetup implements ServerSetupTask {
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+            addCredentialStore(managementClient);
+            managementClient.executeForResult(getAddExpressionEncyryptionOp());
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+            try {
+                safeRemoveSystemProperty(managementClient, PROP);
+                safeRemoveSystemProperty(managementClient, MISSING_PROP);
+                removeExpressionEncryption(managementClient.getControllerClient());
+            } finally {
+                removeCredentialStore(managementClient);
+            }
+        }
+
+        private static void  addCredentialStore(ManagementClient managementClient) throws GeneralSecurityException, IOException, UnsuccessfulOperationException {
+            cleanCredentialStoreFile();
+            KeyStore ks = KeyStore.getInstance("JCEKS");
+            ks.load(null, null);
+            ks.store(new FileOutputStream(CS_PATH), CNAME.toCharArray());
+
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put("location", CS_PATH);
+            attributes.put("keyStoreType", "JCEKS");
+            attributes.put("modifiable", "true");
+
+            PasswordCredential credential = new PasswordCredential(ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, CNAME.toCharArray()));
+            CredentialStore credentialStore = CredentialStore.getInstance(KeyStoreCredentialStore.KEY_STORE_CREDENTIAL_STORE);
+
+            credentialStore.initialize(attributes,
+                    new CredentialStore.CredentialSourceProtectionParameter(IdentityCredentials.NONE.withCredential(credential)));
+            credentialStore.store("securekey", new SecretKeyCredential(SecretKeyUtil.importSecretKey(SECURE_KEY)));
+            credentialStore.flush();
+
+            ModelNode addOp = Util.createAddOperation(CREDENTIAL_STORE_ADDRESS);
+            addOp.get("location").set(CS_PATH);
+            addOp.get("credential-reference", "clear-text").set(CNAME);
+            managementClient.executeForResult(addOp);
+        }
+
+        private static void safeRemoveSystemProperty(ManagementClient managementClient, String prop) {
+            try {
+                managementClient.getControllerClient().execute(Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, prop)));
+            } catch (Exception e) {
+                e.printStackTrace(System.out);
+            }
+        }
+
+        private static void removeCredentialStore(ManagementClient managementClient) throws UnsuccessfulOperationException {
+            try {
+                ModelNode removeOp = Util.createRemoveOperation(CREDENTIAL_STORE_ADDRESS);
+                managementClient.executeForResult(removeOp);
+                ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            } finally {
+                cleanCredentialStoreFile();
+            }
+        }
+
+        private static void cleanCredentialStoreFile() {
+            File f = new File(CS_PATH);
+            assert !f.exists() || f.delete();
+        }
+    }
+
+    private static ModelNode getAddExpressionEncyryptionOp() {
+        ModelNode encAdd = Util.createAddOperation(ENCRYPTION_ADDRESS);
+        encAdd.get("default-resolver").set("Default");
+        ModelNode resolvers = encAdd.get("resolvers");
+        ModelNode resolver = new ModelNode();
+        resolver.get("name").set("Default");
+        resolver.get(CREDENTIAL_STORE).set(CNAME);
+        resolver.get("secret-key").set("securekey");
+        resolvers.add(resolver);
+        return  encAdd;
+    }
+
+    private static void removeExpressionEncryption(ModelControllerClient modelControllerClient) throws IOException {
+        ModelNode removeOp = Util.createRemoveOperation(ENCRYPTION_ADDRESS);
+        removeOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        assertSuccess(modelControllerClient.execute(removeOp));
+    }
+
+    @Test
+    public void testEncryptedSystemProperties() throws Exception {
+
+        PathAddress propAddress = PathAddress.pathAddress(SYSTEM_PROPERTY, PROP);
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+
+            assertNull(getSystemProperty(client, PROP));
+            assertNull(getSystemProperty(client, MISSING_PROP));
+
+            ModelNode response = createExpression(client);
+            assertSuccess(response);
+            String expression = response.get(ClientConstants.RESULT).get("expression").asString();
+
+            ModelNode addOp = Util.createAddOperation(propAddress);
+            addOp.get(VALUE).set(expression);
+
+            response = client.execute(addOp);
+            assertSuccess(response);
+
+            assertEquals(CLEAR_TEXT, getSystemProperty(client, PROP));
+
+            removeExpressionEncryption(client);
+
+            // Removing the resolver doesn't affect the system property
+            assertEquals(CLEAR_TEXT, getSystemProperty(client, PROP));
+
+            ModelNode missingAddOp = Util.createAddOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, MISSING_PROP));
+            missingAddOp.get(VALUE).set(expression);
+            // The add should succeed, but the expression would be resolved as if it were a standard expression with a default
+            assertSuccess(client.execute(missingAddOp));
+            assertEquals(expression.substring(expression.indexOf(":Default:"), expression.length() - 1), getSystemProperty(client, MISSING_PROP));
+
+            // Clean up
+            assertSuccess(client.execute(Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, MISSING_PROP))));
+            assertNull(getSystemProperty(client, MISSING_PROP));
+
+            // If the prop and the resolver are added in a composite, then proper resolution can occur during op execution
+            ModelNode composite = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+            ModelNode steps = composite.get(STEPS);
+            steps.add(missingAddOp);
+
+            steps.add(getAddExpressionEncyryptionOp());
+
+            assertSuccess(client.execute(composite));
+
+            assertEquals(CLEAR_TEXT, getSystemProperty(client, MISSING_PROP));
+
+            // Test boot behavior. Reload and confirm the property is set.
+            ServerReload.executeReloadAndWaitForCompletion(client);
+
+            assertEquals(CLEAR_TEXT, getSystemProperty(client, PROP));
+
+        }
+    }
+
+    private static ModelNode createExpression(ModelControllerClient client) throws IOException {
+        ModelNode createExpression = Util.createEmptyOperation("create-expression", ENCRYPTION_ADDRESS);
+        createExpression.get("resolver").set("Default");
+        createExpression.get("clear-text").set(CLEAR_TEXT);
+
+        return client.execute(createExpression);
+    }
+
+    private static void assertSuccess(ModelNode response) {
+        if (!response.get(OUTCOME).asString().equals(SUCCESS)) {
+            Assert.fail(response.toJSONString(false));
+        }
+    }
+
+    private static String getSystemProperty(ModelControllerClient client, String property) throws IOException {
+        ModelNode response = client.execute(Util.getReadAttributeOperation(RUNTIME_ADDRESS, "system-properties"));
+        assertSuccess(response);
+        ModelNode val = response.get(RESULT, property);
+        return val.isDefined() ? val.asString() : null;
+    }
+}


### PR DESCRIPTION
…operty resource handling.

As was done with vault expressions, if expressions in system-property resource value attributes cannot be resolved in Stage.MODEL, defer and try in Stage.RUNTIME.

Remove capability-based integration with RuntimeExpressionResolver by Elytron and deprecate the general-use capability based integration. Replace with integration via the ExtensionContext via an API that accounts for the fact that resolution may be attempted in Stage.MODEL.

https://issues.redhat.com/browse/WFCORE-5490