### PR TITLE
Try excluding transitive test dep on rhino as it has a CVE

### DIFF
--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -179,6 +179,10 @@
                         <groupId>org.bouncycastle</groupId>
                         <artifactId>bcutil-jdk15on</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.mozilla</groupId>
+                        <artifactId>rhino</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
See if we can get https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31684 off our radar screen.