### PR TITLE
[WFCORE-5772] Upgrade WildFly Elytron to 1.18.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.18.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.18.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5772


        Release Notes - WildFly Elytron - Version 1.18.2.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2284'>ELY-2284</a>] -         Wildfly OIDC secured App generates a lot of keycloak requests
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2286'>ELY-2286</a>] -         OIDC-Adapter should support multi tenancy
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2288'>ELY-2288</a>] -         Release WildFly Elytron 1.18.2.Final
</li>
</ul>
                                                                                                                                                                                                                                                                                                                     