### PR TITLE
[WFCORE-5776] Upgrade WildFly Elytron to 1.18.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>2.1.0.SP01</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.18.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.18.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5776


        Release Notes - WildFly Elytron - Version 1.18.3.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2290'>ELY-2290</a>] -         Update OidcClientConfiguration#resetUrls to handle the case where the provider-url or auth-server-url isn&#39;t valid
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2291'>ELY-2291</a>] -         Release WildFly Elytron 1.18.3.Final
</li>
</ul>
                                                                                                                                                                                                                        
