### PR TITLE
[WFCORE-5778] Reset 'java.security.manager' default value back to "allow" by default in launcher

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -42,6 +42,8 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
     static final String HOME_DIR = Environment.HOME_DIR;
     static final String SECURITY_MANAGER_ARG = "-secmgr";
     static final String SECURITY_MANAGER_PROP = "java.security.manager";
+    static final String ALLOW_VALUE = "allow";
+    static final String SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE = "-D" + SECURITY_MANAGER_PROP + "=" + ALLOW_VALUE;
     static final String[] DEFAULT_VM_ARGUMENTS;
     static final Collection<String> DEFAULT_MODULAR_VM_ARGUMENTS;
 

--- a/launcher/src/main/java/org/wildfly/core/launcher/BootableJarCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/BootableJarCommandBuilder.java
@@ -453,6 +453,9 @@ public class BootableJarCommandBuilder implements CommandBuilder {
         if (jvm.isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        if (jvm.enhancedSecurityManagerAvailable()) {
+            cmd.add(AbstractCommandBuilder.SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
+        }
         if (modulesLocklessArg != null) {
             cmd.add(modulesLocklessArg);
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
@@ -620,6 +620,9 @@ public class CliCommandBuilder implements CommandBuilder {
         if (environment.getJvm().isModular()) {
             cmd.addAll(AbstractCommandBuilder.DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        if (environment.getJvm().enhancedSecurityManagerAvailable()) {
+            cmd.add(AbstractCommandBuilder.SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
+        }
         cmd.add("-jar");
         cmd.add(environment.getModuleJar().toString());
         cmd.add("-mp");

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -126,7 +126,13 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
                     }
                     break;
                 case SECURITY_MANAGER_PROP:
-                    setUseSecurityManager(true);
+                    if (ALLOW_VALUE.equals(argument.getValue())) {
+                        // [WFCORE-5778] java.security.manager system property with value "allow" detected.
+                        // It doesn't mean SM is going to be installed but it indicates SM can be installed dynamically.
+                        setUseSecurityManager(false);
+                    } else {
+                        setUseSecurityManager(true);
+                    }
                     break;
                 default:
                     javaOpts.add(argument);
@@ -546,6 +552,9 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         cmd.addAll(getJavaOptions());
         if (environment.getJvm().isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
+        }
+        if (environment.getJvm().enhancedSecurityManagerAvailable()) {
+            cmd.add(SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
         }
         // Add these to JVM level system properties
         addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -256,6 +256,13 @@ public class CommandBuilderTest {
     }
 
     private void testModularJvmArguments(final Collection<String> command, final int expectedCount) {
+        // If we're using Java 12+ ensure enhanced security manager option was added
+        if (Jvm.current().enhancedSecurityManagerAvailable()) {
+            assertArgumentExists(command, "-Djava.security.manager=allow", expectedCount);
+        } else {
+            Assert.assertFalse("Did not expect \"-Djava.security.manager=allow\" to be in the command list",
+                    command.contains("-Djava.security.manager=allow"));
+        }
         // If we're using Java 9+ ensure the modular JDK options were added
         if (Jvm.current().isModular()) {
             assertArgumentExists(command, "--add-exports=java.desktop/sun.awt=ALL-UNNAMED", expectedCount);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5778
