### PR TITLE
[WFCORE-5778] Reset 'java.security.manager' default value back to "allow" by default in launcher

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -39,9 +39,12 @@ import org.wildfly.core.launcher.logger.LauncherMessages;
 @SuppressWarnings("unused")
 abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> implements CommandBuilder {
 
+    private static final String ALLOW_VALUE = "allow";
+    private static final String DISALLOW_VALUE = "disallow";
     static final String HOME_DIR = Environment.HOME_DIR;
     static final String SECURITY_MANAGER_ARG = "-secmgr";
     static final String SECURITY_MANAGER_PROP = "java.security.manager";
+    static final String SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE = "-D" + SECURITY_MANAGER_PROP + "=" + ALLOW_VALUE;
     static final String[] DEFAULT_VM_ARGUMENTS;
     static final Collection<String> DEFAULT_MODULAR_VM_ARGUMENTS;
 
@@ -657,5 +660,9 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         if (value != null) {
             cmd.add("-D" + key + "=" + value);
         }
+    }
+
+    protected static boolean isJavaSecurityManagerConfigured(final Argument argument) {
+        return !ALLOW_VALUE.equals(argument.getValue()) && !DISALLOW_VALUE.equals(argument.getValue());
     }
 }

--- a/launcher/src/main/java/org/wildfly/core/launcher/BootableJarCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/BootableJarCommandBuilder.java
@@ -453,6 +453,9 @@ public class BootableJarCommandBuilder implements CommandBuilder {
         if (jvm.isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        if (jvm.enhancedSecurityManagerAvailable()) {
+            cmd.add(AbstractCommandBuilder.SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
+        }
         if (modulesLocklessArg != null) {
             cmd.add(modulesLocklessArg);
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
@@ -620,6 +620,9 @@ public class CliCommandBuilder implements CommandBuilder {
         if (environment.getJvm().isModular()) {
             cmd.addAll(AbstractCommandBuilder.DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        if (environment.getJvm().enhancedSecurityManagerAvailable()) {
+            cmd.add(AbstractCommandBuilder.SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
+        }
         cmd.add("-jar");
         cmd.add(environment.getModuleJar().toString());
         cmd.add("-mp");

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -581,7 +581,9 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
         if (arg != null && !arg.trim().isEmpty()) {
             final Argument argument = Arguments.parse(arg);
             if (argument.getKey().equals(SECURITY_MANAGER_PROP)) {
-                setUseSecurityManager(true);
+                // [WFCORE-5778] java.security.manager system property with value "allow" detected.
+                // It doesn't mean SM is going to be installed but it indicates SM can be installed dynamically.
+                setUseSecurityManager(isJavaSecurityManagerConfigured(argument));
             } else {
                 processControllerJavaOpts.add(argument);
             }
@@ -714,6 +716,9 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
         if (environment.getJvm().isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
         }
+        if (environment.getJvm().enhancedSecurityManagerAvailable()) {
+            cmd.add(SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
+        }
 
         cmd.add(getBootLogArgument("process-controller.log"));
         cmd.add(getLoggingPropertiesArgument("logging.properties"));
@@ -741,6 +746,9 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
         cmd.addAll(hostControllerJavaOpts.asList());
         if (hostControllerJvm.isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
+        }
+        if (hostControllerJvm.enhancedSecurityManagerAvailable()) {
+            cmd.add(SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
         }
 
         cmd.add("--");

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -126,7 +126,9 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
                     }
                     break;
                 case SECURITY_MANAGER_PROP:
-                    setUseSecurityManager(true);
+                    // [WFCORE-5778] java.security.manager system property with value "allow" detected.
+                    // It doesn't mean SM is going to be installed but it indicates SM can be installed dynamically.
+                    setUseSecurityManager(isJavaSecurityManagerConfigured(argument));
                     break;
                 default:
                     javaOpts.add(argument);
@@ -546,6 +548,9 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
         cmd.addAll(getJavaOptions());
         if (environment.getJvm().isModular()) {
             cmd.addAll(DEFAULT_MODULAR_VM_ARGUMENTS);
+        }
+        if (environment.getJvm().enhancedSecurityManagerAvailable()) {
+            cmd.add(SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
         }
         // Add these to JVM level system properties
         addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -256,6 +256,13 @@ public class CommandBuilderTest {
     }
 
     private void testModularJvmArguments(final Collection<String> command, final int expectedCount) {
+        // If we're using Java 12+ ensure enhanced security manager option was added
+        if (Jvm.current().enhancedSecurityManagerAvailable()) {
+            assertArgumentExists(command, "-Djava.security.manager=allow", expectedCount);
+        } else {
+            Assert.assertFalse("Did not expect \"-Djava.security.manager=allow\" to be in the command list",
+                    command.contains("-Djava.security.manager=allow"));
+        }
         // If we're using Java 9+ ensure the modular JDK options were added
         if (Jvm.current().isModular()) {
             assertArgumentExists(command, "--add-exports=java.desktop/sun.awt=ALL-UNNAMED", expectedCount);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5778

Supersedes https://github.com/wildfly/wildfly-core/pull/4934 which I closed by mistake :(