### PR TITLE
[WFCORE-5783] Upgrade log4j-jboss-logmanager to 1.3.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.18.Final</version.org.jboss.logmanager.jboss-logmanager>
-        <version.org.jboss.logmanager.log4j-jboss-logmanager>1.2.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
+        <version.org.jboss.logmanager.log4j-jboss-logmanager>1.3.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.1.1.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.0.0.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
Upstream: #4940 

https://issues.redhat.com/browse/WFCORE-5783

Note this upgrade removes the following:
* `org.apache.log4j.chainsaw.*`
* `org.apache.log4j.jdbc.JDBCAppender`
* `org.apache.log4j.net.JMSAppender`
* `org.apache.log4j.net.JMSSink`

Diff: https://github.com/jboss-logging/log4j-jboss-logmanager/compare/1.2.2.Final...1.3.0.Final
Tag: https://github.com/jboss-logging/log4j-jboss-logmanager/releases/tag/1.3.0.Final