### PR TITLE
[WFCORE-5784] Deprecate the org.jboss.log4j.logmanager module. Also a…

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.9" name="org.apache.log4j">
 
     <properties>
-        <property name="jboss.api" value="public"/>
+        <property name="jboss.api" value="deprecated"/>
     </properties>
 
     <dependencies>

--- a/logging/src/main/java/org/jboss/as/logging/deployments/LoggingConfigDeploymentProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/LoggingConfigDeploymentProcessor.java
@@ -227,6 +227,7 @@ public class LoggingConfigDeploymentProcessor extends AbstractLoggingDeploymentP
 
             // Check the type of the configuration file
             if (isLog4jConfiguration(fileName)) {
+                LoggingLogger.ROOT_LOGGER.usageOfLog4j1Config(configFile.getPathName(), root.getRootName());
                 final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
                 final LogContext old = logContextSelector.setLocalContext(logContext);
                 try {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/HandlerOperations.java
@@ -199,6 +199,7 @@ final class HandlerOperations {
                 // Check the POJO names
                 final PojoConfiguration log4jPojo = logContextConfiguration.getPojoConfiguration(name);
                 if (log4jPojo != null) {
+                    LoggingLogger.ROOT_LOGGER.usageOfAppender(log4jPojo.getClassName());
                     replaceHandler = (!className.equals(log4jPojo.getClassName()) || (moduleName == null ? log4jPojo.getModuleName() != null : !moduleName.equals(log4jPojo.getModuleName())));
                 }
             } else if (!className.equals(configuration.getClassName()) || (moduleName == null ? configuration.getModuleName() != null : !moduleName.equals(configuration.getModuleName()))) {
@@ -253,6 +254,7 @@ final class HandlerOperations {
                 try {
                     final Class<?> actualClass = Class.forName(className, false, moduleLoader.loadModule(moduleName).getClassLoader());
                     if (Appender.class.isAssignableFrom(actualClass)) {
+                        LoggingLogger.ROOT_LOGGER.usageOfAppender(actualClass.getCanonicalName());
                         final PojoConfiguration pojoConfiguration;
                         // Check for construction parameters
                         if (constructionProperties == null) {

--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -1029,4 +1029,25 @@ public interface LoggingLogger extends BasicLogger {
 //     */
 //    @Message(id = 98, value = "Cannot remove filter %s as it's assigned to: %s")
 //    OperationFailedException cannotRemoveFilter(String name, Collection<String> references);
+
+    /**
+     * Logs a warning message indicating the deprecation of an appender being used for custom-handler.
+     *
+     * @param appenderType the appender being used
+     */
+    @Message(id = 99, value = "Usage of a log4j appender (%s) found in a custom-handler. Support for using appenders as " +
+            "custom handlers has been deprecated and will be removed in a future release.")
+    @LogMessage(level = WARN)
+    void usageOfAppender(String appenderType);
+
+    /**
+     * Logs a warning message indicating the deprecation of log4j configuration files in a deployment.
+     *
+     * @param fileName       the log4j configuration file
+     * @param deploymentName the deployment name
+     */
+    @Message(id = 100, value = "Usage of a log4j configuration file (%s) was found in deployment %s. Support for log4j " +
+            "configuration files in deployments has been deprecated and will be removed in a future release.")
+    @LogMessage(level = WARN)
+    void usageOfLog4j1Config(String fileName, String deploymentName);
 }


### PR DESCRIPTION
…dded deprecation log messages when a log4j configuration file is used or an appender is used as a custom-handler.

https://issues.redhat.com/browse/WFCORE-5784