### PR TITLE
WFLY-5792: ensure configuration files are inside the configuration directory

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
@@ -367,7 +367,16 @@ public class ConfigurationFile {
             mainName = stripPrefixSuffix(name);
         }
         if (mainName != null) {
-            return new File(configurationDir, new File(mainName).getName());
+            try {
+                final File mainFile = new File(configurationDir, name != null ? name : mainName);
+                if (mainFile.getCanonicalPath().startsWith(configurationDir.getCanonicalPath())) {
+                    return new File(configurationDir, new File(mainName).getName());
+                } else if (interactionPolicy.isReadOnly()) {
+                    return mainFile;
+                }
+            } catch (IOException ioe) {
+                throw ControllerLogger.ROOT_LOGGER.canonicalMainFileNotFound(ioe, mainFile);
+            }
         }
 
         throw ControllerLogger.ROOT_LOGGER.mainFileNotFound(name != null ? name : rawName, configurationDir);

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
@@ -354,6 +354,23 @@ public class PersistanceResourceTestCase {
     }
 
     @Test
+    public void testRelativePathFromOutsideConfigDirectory() throws Exception {
+        File file = createFile(externalDir, "standard.xml", "test");
+        try {
+            ConfigurationFile configurationFile = new ConfigurationFile(standardDir, "standard.xml", "../external/standard.xml", true);
+            Assert.fail("Should have rejected relative path");
+        } catch (IllegalStateException ise) {
+            // expected
+        }
+
+        try {
+            ConfigurationFile configurationFile = new ConfigurationFile(standardDir, "standard.xml", "../external/standard.xml", false);
+        } catch (IllegalStateException ise) {
+            Assert.fail("Should not have rejected relative path");
+        }
+    }
+
+    @Test
     public void testDefaultNonPersistentConfigurationFile() throws Exception {
         assertFileContents(standardFile, "std");
         Assert.assertFalse(historyDir.exists());


### PR DESCRIPTION
Issue: [WFCORE-5792](https://issues.redhat.com/browse/WFCORE-5792)