### PR TITLE
[WFCORE-4314] - verbose and recursive parameter in read-alias(es)

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
@@ -521,14 +521,14 @@ class AdvancedModifiableKeyStoreDecorator extends ModifiableKeyStoreDecorator {
                                     throw ROOT_LOGGER.trustedCertificateAlreadyInCacertsKeyStore(trustedCertificateAlias);
                                 }
                             }
-                            writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate);
+                            writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate, true);
                             throw ROOT_LOGGER.unableToDetermineIfCertificateIsTrusted();
                         } else {
                             try {
                                 final HashMap<Principal, HashSet<X509Certificate>> certificatesMap = getKeyStoreCertificates(keyStore, cacertsKeyStore);
                                 X500.createX509CertificateChain(trustedCertificate, certificatesMap);
                             } catch (IllegalArgumentException e) {
-                                writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate);
+                                writeCertificate(context.getResult().get(ElytronDescriptionConstants.CERTIFICATE), trustedCertificate, true);
                                 throw ROOT_LOGGER.unableToDetermineIfCertificateIsTrusted();
                             }
                         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CertificateChainAttributeDefinitions.java
@@ -115,17 +115,25 @@ class CertificateChainAttributeDefinitions {
     }
 
     static void writeCertificate(final ModelNode certificateModel, final Certificate certificate) throws CertificateEncodingException, NoSuchAlgorithmException {
-        certificateModel.get(ElytronDescriptionConstants.TYPE).set(certificate.getType());
+        writeCertificate(certificateModel, certificate, true);
+    }
+
+    static void writeCertificate(final ModelNode certificateModel, final Certificate certificate, final boolean verbose) throws CertificateEncodingException, NoSuchAlgorithmException {
+       certificateModel.get(ElytronDescriptionConstants.TYPE).set(certificate.getType());
 
         PublicKey publicKey = certificate.getPublicKey();
         certificateModel.get(ElytronDescriptionConstants.ALGORITHM).set(publicKey.getAlgorithm());
         certificateModel.get(ElytronDescriptionConstants.FORMAT).set(publicKey.getFormat());
-        certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY).set(encodedHexString(publicKey.getEncoded()));
+        if (verbose) {
+            certificateModel.get(ElytronDescriptionConstants.PUBLIC_KEY).set(encodedHexString(publicKey.getEncoded()));
+        }
 
         byte[] encodedCertificate = certificate.getEncoded();
         certificateModel.get(ElytronDescriptionConstants.SHA_1_DIGEST).set(encodedHexString(digest(SHA_1, encodedCertificate)));
         certificateModel.get(ElytronDescriptionConstants.SHA_256_DIGEST).set(encodedHexString(digest(SHA_256, encodedCertificate)));
-        certificateModel.get(ElytronDescriptionConstants.ENCODED).set(encodedHexString(encodedCertificate));
+        if (verbose) {
+            certificateModel.get(ElytronDescriptionConstants.ENCODED).set(encodedHexString(encodedCertificate));
+        }
 
         if (certificate instanceof X509Certificate) {
             writeX509Certificate(certificateModel, (X509Certificate) certificate);
@@ -154,10 +162,23 @@ class CertificateChainAttributeDefinitions {
      * @throws NoSuchAlgorithmException
      */
     static void writeCertificates(final ModelNode result, final Certificate[] certificates) throws CertificateEncodingException, NoSuchAlgorithmException {
+        writeCertificates(result, certificates, true);
+    }
+
+    /**
+     * Populate the supplied response with the model representation of the certificates.
+     *
+     * @param result the response to populate.
+     * @param certificates the certificates to add to the response.
+     * @param verbose mode of output.
+     * @throws CertificateEncodingException
+     * @throws NoSuchAlgorithmException
+     */
+    static void writeCertificates(final ModelNode result, final Certificate[] certificates, final boolean verbose) throws CertificateEncodingException, NoSuchAlgorithmException {
         if (certificates != null) {
             for (Certificate current : certificates) {
                 ModelNode certificate = new ModelNode();
-                writeCertificate(certificate, current);
+                writeCertificate(certificate, current, verbose);
                 result.add(certificate);
             }
         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -450,6 +450,7 @@ interface ElytronDescriptionConstants {
     String REALMS = "realms";
     String REASON = "reason";
     String RECONNECT_ATTEMPTS = "reconnect-attempts";
+    String RECURSIVE = "recursive";
     String REFERENCE = "reference";
     String REFERRAL_MODE = "referral-mode";
     String REGISTER_JASPI_FACTORY = "register-jaspi-factory";
@@ -600,6 +601,7 @@ interface ElytronDescriptionConstants {
     String VALIDATE = "validate";
     String VALIDITY = "validity";
     String VALUE = "value";
+    String VERBOSE = "verbose";
     String VERIFIABLE = "verifiable";
     String VERSION = "version";
     String VERSION_COMPARISON = "version-comparison";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -137,6 +137,20 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
     private static void from15_1(ChainedTransformationDescriptionBuilder chainedBuilder) {
         ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(ELYTRON_15_1_0, ELYTRON_15_0_0);
 
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.KEY_STORE))
+        .addOperationTransformationOverride(ElytronDescriptionConstants.READ_ALIAS)
+        .setDiscard(DiscardAttributeChecker.UNDEFINED, ModifiableKeyStoreDecorator.ReadAliasHandler.VERBOSE)
+        .addRejectCheck(new RejectAttributeChecker.SimpleRejectAttributeChecker(ModelNode.FALSE), ElytronDescriptionConstants.VERBOSE)
+        .end();
+
+        builder.addChildResource(PathElement.pathElement(ElytronDescriptionConstants.KEY_STORE))
+        .addOperationTransformationOverride(ElytronDescriptionConstants.READ_ALIASES)
+        .setDiscard(DiscardAttributeChecker.UNDEFINED, ModifiableKeyStoreDecorator.ReadAliasesHandler.VERBOSE)
+        .setDiscard(DiscardAttributeChecker.UNDEFINED, ModifiableKeyStoreDecorator.ReadAliasesHandler.RECURSIVE)
+        .addRejectCheck(new RejectAttributeChecker.SimpleRejectAttributeChecker(ModelNode.TRUE), ElytronDescriptionConstants.VERBOSE)
+        .addRejectCheck(new RejectAttributeChecker.SimpleRejectAttributeChecker(ModelNode.TRUE), ElytronDescriptionConstants.RECURSIVE)
+        .end();
+
     }
 
     private static void from15(ChainedTransformationDescriptionBuilder chainedBuilder) {

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1139,7 +1139,10 @@ elytron.key-store.alias.certificate-chain.version=The certificate version.
 
 elytron.modifiable-key-store.read-alias=Read an alias from a KeyStore.
 elytron.modifiable-key-store.read-alias.alias=The alias of the KeyStore item to read.
+elytron.modifiable-key-store.read-alias.verbose=Whether or not to include the public key and encoded form of a certificate in the output. The default value is true.
 elytron.modifiable-key-store.read-aliases=Read aliases from a KeyStore.
+elytron.modifiable-key-store.read-aliases.recursive=Include information about each alias in the KeyStore. The default value is false.
+elytron.modifiable-key-store.read-aliases.verbose=Whether or not to include the public key and encoded form of a certificate in the output. The default value is true.
 elytron.modifiable-key-store.remove-alias=Remove an alias from a KeyStore.
 elytron.modifiable-key-store.remove-alias.alias=The alias of the KeyStore item to remove.
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-4314
Related: https://github.com/wildfly/wildfly-core/pull/5008

Improve read commands for elytron keystore.
Resubmit after rebase and few tweaks to doc.

This will require version bump.