### PR TITLE
[WFCORE-5796] Bump netty-codec-http from 4.1.63.Final to 4.1.71.Final…

### DIFF
--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
         <version.commons-io>2.10.0</version.commons-io>
-        <version.io.netty>4.1.63.Final</version.io.netty>
+        <version.io.netty>4.1.71.Final</version.io.netty>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>
         <version.xom.xom>1.3.7</version.xom.xom>


### PR DESCRIPTION
… in /testbom

Bumps [netty-codec-http](https://github.com/netty/netty) from 4.1.63.Final to 4.1.71.Final.
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.63.Final...netty-4.1.71.Final)

---
updated-dependencies:
- dependency-name: io.netty:netty-codec-http
  dependency-type: direct:development
...

https://issues.redhat.com/browse/WFCORE-5796
Upstream: #4937