### PR TITLE
[WFCORE-5797] Upgrade XNIO to 3.8.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.5.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.6.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5797


        Release Notes - XNIO - Version 3.8.6.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-391'>XNIO-391</a>] -         PushBackStreamSourceConduit/Channel leaks pushed back buffer
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-392'>XNIO-392</a>] -         StreamConnection should shutdown reads and writes on notify operation closed
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-398'>XNIO-398</a>] -         JsseSslConduitEngine.isDataAvailable tests for readBuffer.hasRemaining()
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-397'>XNIO-397</a>] -         Remove indirect wildfly-common dependency via widlfy-client-config dependency
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-399'>XNIO-399</a>] -         Upgrade dependencies to latest minor releases
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-400'>XNIO-400</a>] -         Fix wrong code comment at JsseSslConduitEngine.handleUnwrapResult
</li>
</ul>
                                                                                                                            
