### PR TITLE
[WFCORE-5801] Upgrade Undertow to 2.2.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang>2.6</version.commons-lang>
         <version.commons-lang3>3.11</version.commons-lang3>
-        <version.io.undertow>2.2.14.Final</version.io.undertow>
+        <version.io.undertow>2.2.15.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira https://issues.redhat.com/browse/WFCORE-5801
Fix: CVE-2021-3859


        Release Notes - Undertow - Version 2.2.15.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1986'>UNDERTOW-1986</a>] -         Buffer leak errors involving buffer allocated by ChunkedStreamSourceConduit
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1979'>UNDERTOW-1979</a>] -         CVE-2021-3859 Continuation frames are not read correctly 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1994'>UNDERTOW-1994</a>] -         Method declareRoles not implemented in ServletContextImpl
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2002'>UNDERTOW-2002</a>] -         StackOverflowError upon AJP read timeout
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2007'>UNDERTOW-2007</a>] -         Digest mechanism needs sticky sessions
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2011'>UNDERTOW-2011</a>] -         NPE from PathResource.getName() for drive root
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2012'>UNDERTOW-2012</a>] -         Undertow does&#39;t create temporary directory use to save upload files when it does not exist
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2015'>UNDERTOW-2015</a>] -         URLUtils QueryStringParser#parse() should not add a query parameter to HttpServerExchange when parameter name and value are empty
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2017'>UNDERTOW-2017</a>] -         Nullpointer in HttpRequestConduit
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2018'>UNDERTOW-2018</a>] -         FixedLengthStreamSourceConduit NPE after a failure parsing request
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2019'>UNDERTOW-2019</a>] -         Content-Length response header for HEAD requests wrong when using BlockingHandler
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2025'>UNDERTOW-2025</a>] -         Add a test case for UNDERTOW-1981
</li>
</ul>
                                                                                                            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2006'>UNDERTOW-2006</a>] -         Add a test for headers with different case
</li>
</ul>
                                                                                                                            