### PR TITLE
[WFCORE-5805] Fix for HostControllerBootOperationsTestCase intermiten…

### DIFF
--- a/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
+++ b/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
@@ -3,7 +3,7 @@ CLASS org.jboss.as.server.mgmt.domain.HostControllerConnection$ServerRegisterReq
 METHOD sendRequest
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 15*1000)
+DO waitFor($this, 25*1000)
 ENDRULE
 
 RULE Delay Server finish boot
@@ -11,5 +11,5 @@ CLASS org.jboss.as.server.ServerService
 METHOD finishBoot
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 15*1000)
+DO waitFor($this, 25*1000)
 ENDRULE


### PR DESCRIPTION
…t failures

- Incremented the timeouts of the byteman rules
- Fix operations that ensure the test conditions are satisfied
- In addition, to help out with debugging, added traces to get the duration of the read operations

Jira issue: https://issues.redhat.com/browse/WFCORE-5805
