### PR TITLE
[WFCORE-5801] Upgrade Undertow to 2.2.16.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang>2.6</version.commons-lang>
         <version.commons-lang3>3.11</version.commons-lang3>
-        <version.io.undertow>2.2.15.Final</version.io.undertow>
+        <version.io.undertow>2.2.16.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5801

18.x PR: #4963 


        Release Notes - Undertow - Version 2.2.16.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2026'>UNDERTOW-2026</a>] -         Do not create a session on DigestAuthenticationMechanism.sendChallenge (reverts UNDERTOW-2007)
</li>
</ul>
