### PR TITLE
[WFCORE-5807] Update logback test dependency to 1.2.9 (CVE-2021-42550)

### DIFF
--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -38,7 +38,7 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
-        <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
+        <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5807
