### PR TITLE
WFCORE-5808 NonResolvingResourceDescriptionResolver.INSTANCE should b…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
@@ -29,13 +29,18 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 /**
- * Resource description resovler that does no resolving at all.
+ * Resource description resolver that does no resolving at all.
  *
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class NonResolvingResourceDescriptionResolver extends StandardResourceDescriptionResolver {
-    public static NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
+    public static final NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
 
+    /**
+     * No-arg constructor.
+     * @deprecated use {@link #INSTANCE} instead
+     */
+    @Deprecated
     public NonResolvingResourceDescriptionResolver() {
         super("", "", NonResolvingResourceDescriptionResolver.class.getClassLoader());
     }
@@ -122,6 +127,6 @@ public class NonResolvingResourceDescriptionResolver extends StandardResourceDes
 
     @Override
     public StandardResourceDescriptionResolver getChildResolver(String key) {
-        return new NonResolvingResourceDescriptionResolver();
+        return NonResolvingResourceDescriptionResolver.INSTANCE;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -403,11 +403,11 @@ public class ReadResourceDescriptionHandler extends GlobalOperationHandlers.Abst
      */
     static final class CheckResourceAccessHandler implements OperationStepHandler {
 
-        static final OperationDefinition DEFAULT_DEFINITION = new SimpleOperationDefinitionBuilder(GlobalOperationHandlers.CHECK_DEFAULT_RESOURCE_ACCESS, new NonResolvingResourceDescriptionResolver())
+        static final OperationDefinition DEFAULT_DEFINITION = new SimpleOperationDefinitionBuilder(GlobalOperationHandlers.CHECK_DEFAULT_RESOURCE_ACCESS, NonResolvingResourceDescriptionResolver.INSTANCE)
             .setPrivateEntry()
             .build();
 
-        static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(GlobalOperationHandlers.CHECK_RESOURCE_ACCESS, new NonResolvingResourceDescriptionResolver())
+        static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(GlobalOperationHandlers.CHECK_RESOURCE_ACCESS, NonResolvingResourceDescriptionResolver.INSTANCE)
             .setPrivateEntry()
             .build();
 

--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -197,7 +197,7 @@ abstract class AbstractCapabilityResolutionTestCase {
 
     private static ResourceDefinition createResourceDefinition(String key) {
         PathElement pe = key == null ? null : PathElement.pathElement(key);
-        return ResourceBuilder.Factory.create(pe, new NonResolvingResourceDescriptionResolver()).build();
+        return ResourceBuilder.Factory.create(pe, NonResolvingResourceDescriptionResolver.INSTANCE).build();
     }
 
     private static class ModelControllerService extends TestModelControllerService {
@@ -221,7 +221,7 @@ abstract class AbstractCapabilityResolutionTestCase {
             // real address pattern a bit, as those patterns are what drive the WFCORE-750 capability resolution logic
             rootRegistration.registerSubModel(createResourceDefinition(GLOBAL));
             ManagementResourceRegistration profile = rootRegistration.registerSubModel(createResourceDefinition(PROFILE));
-            OperationDefinition od = new SimpleOperationDefinitionBuilder("include", new NonResolvingResourceDescriptionResolver()).build();
+            OperationDefinition od = new SimpleOperationDefinitionBuilder("include", NonResolvingResourceDescriptionResolver.INSTANCE).build();
             OperationStepHandler includeHandler = new ParentIncludeHandler();
             profile.registerOperationHandler(od, includeHandler);
             profile.registerSubModel(createResourceDefinition(SUBSYSTEM));

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -159,7 +159,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
             .addOperation(SimpleOperationDefinitionBuilder.of("add-cap",
-                            new NonResolvingResourceDescriptionResolver()).build(),
+                            NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     (context, operation) -> {
                         ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
                         mrr.registerCapability(TEST_CAPABILITY1);
@@ -186,14 +186,14 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
             .addCapability(TEST_CAPABILITY2)
             .addOperation(SimpleOperationDefinitionBuilder.of("add-sub-resource",
-                            new NonResolvingResourceDescriptionResolver()).build(),
+                            NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     (context, operation) -> {
                         ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
                         mrr.registerSubModel(SUB_RESOURCE);
                     })
 
             .addOperation(SimpleOperationDefinitionBuilder.of("remove-sub-resource",
-                            new NonResolvingResourceDescriptionResolver()).build(),
+                            NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     (context, operation) -> {
                         ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
                         mrr.unregisterSubModel(SUB_RESOURCE.getPathElement());

--- a/controller/src/test/java/org/jboss/as/controller/EnvVarAttributeOverrideModel.java
+++ b/controller/src/test/java/org/jboss/as/controller/EnvVarAttributeOverrideModel.java
@@ -73,7 +73,7 @@ public abstract class EnvVarAttributeOverrideModel extends AbstractControllerTes
 
     private static ResourceDefinition createDummyProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(CUSTOM_RESOURCE_ADDR.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler(Arrays.asList(MY_ATTR, MY_LIST_ATTR)))
                 .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .addReadWriteAttribute(MY_ATTR, null, new ReloadRequiredWriteAttributeHandler(MY_ATTR))

--- a/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
@@ -147,7 +147,7 @@ public class InterleavedSubsystemTestCase {
             extensions.registerOperationHandler("add", new FakeExtensionAddHandler(rootRegistration), ModelControllerImplUnitTestCase.DESC_PROVIDER);*/
             SimpleResourceDefinition subsystemResource = new SimpleResourceDefinition(
                     PathElement.pathElement(EXTENSION),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new FakeExtensionAddHandler(rootRegistration, getMutableRootResourceRegistrationProvider()),
                     ReloadRequiredRemoveStepHandler.INSTANCE
             ){
@@ -181,7 +181,7 @@ public class InterleavedSubsystemTestCase {
 
             SimpleResourceDefinition subsystemResource = new SimpleResourceDefinition(
                     PathElement.pathElement(SUBSYSTEM, module),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new FakeSubsystemAddHandler(),
                     ReloadRequiredRemoveStepHandler.INSTANCE
             ){

--- a/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
@@ -258,7 +258,7 @@ public class MetricsRegistrationTestCase {
                 .build();
 
         public TestResourceDefinition() {
-            super(ELEMENT, new NonResolvingResourceDescriptionResolver(),
+            super(ELEMENT, NonResolvingResourceDescriptionResolver.INSTANCE,
                     new ModelOnlyAddStepHandler(), new ModelOnlyRemoveStepHandler());
         }
 

--- a/controller/src/test/java/org/jboss/as/controller/MetricsUndefinedValueUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/MetricsUndefinedValueUnitTestCase.java
@@ -248,7 +248,7 @@ public class MetricsUndefinedValueUnitTestCase {
                 new SimpleAttributeDefinitionBuilder(TEST_METRIC, ModelType.INT, true);
 
         public TestResourceDefinition() {
-            super(ELEMENT, new NonResolvingResourceDescriptionResolver(),
+            super(ELEMENT, NonResolvingResourceDescriptionResolver.INSTANCE,
                     new ModelOnlyAddStepHandler(), new ModelOnlyRemoveStepHandler());
         }
 

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -855,7 +855,7 @@ public class ModelControllerImplUnitTestCase {
 
             SimpleResourceDefinition childResource = new SimpleResourceDefinition(
                     PathElement.pathElement("child"),
-                    new NonResolvingResourceDescriptionResolver()
+                    NonResolvingResourceDescriptionResolver.INSTANCE
             );
             ManagementResourceRegistration childRegistration = rootRegistration.registerSubModel(childResource);
             childRegistration.registerReadOnlyAttribute(TestUtils.createNillableAttribute("attribute1", ModelType.INT), null);

--- a/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
@@ -173,7 +173,7 @@ public class OperationCancellationUnitTestCase {
 
             GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
-            rootRegistration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver()));
+            rootRegistration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("child"), NonResolvingResourceDescriptionResolver.INSTANCE));
             this.managementControllerResource = modelControllerResource;
         }
     }

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -242,7 +242,7 @@ public class OperationTimeoutUnitTestCase {
     }
 
     public static class BlockingServiceHandler implements OperationStepHandler {
-        static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
+        static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", NonResolvingResourceDescriptionResolver.INSTANCE)
                 // this isn't really runtime-only but we lie and say it is to let
                 // testBlockAwaitingRuntimeLock() work. That test relies on first
                 // messing up MSC in order to how the next op that blocks waiting

--- a/controller/src/test/java/org/jboss/as/controller/RemoveNotEsistingResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/RemoveNotEsistingResourceTestCase.java
@@ -134,7 +134,7 @@ public class RemoveNotEsistingResourceTestCase {
 
             SimpleResourceDefinition subsystemResource = new SimpleResourceDefinition(
                     PathElement.pathElement(EXTENSION),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new FakeExtensionAddHandler(rootRegistration, getMutableRootResourceRegistrationProvider()),
                     ReloadRequiredRemoveStepHandler.INSTANCE
             ){
@@ -168,7 +168,7 @@ public class RemoveNotEsistingResourceTestCase {
 
             SimpleResourceDefinition subsystemResource = new SimpleResourceDefinition(
                     PathElement.pathElement(SUBSYSTEM, module),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(),
                     ReloadRequiredRemoveStepHandler.INSTANCE
             ){
@@ -187,7 +187,7 @@ public class RemoveNotEsistingResourceTestCase {
 
         public FakeSubmodelChild() {
             super(PathElement.pathElement(SUBMODEL_NAME),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(),
                     new RestartParentResourceRemoveHandler("attr") {
 

--- a/controller/src/test/java/org/jboss/as/controller/SocketCapabilityOnHostResolutionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/SocketCapabilityOnHostResolutionUnitTestCase.java
@@ -203,7 +203,7 @@ public class SocketCapabilityOnHostResolutionUnitTestCase {
 
     private static ResourceDefinition createResourceDefinition(String key) {
         PathElement pe = key == null ? null : PathElement.pathElement(key);
-        return ResourceBuilder.Factory.create(pe, new NonResolvingResourceDescriptionResolver()).build();
+        return ResourceBuilder.Factory.create(pe, NonResolvingResourceDescriptionResolver.INSTANCE).build();
     }
 
     private static class CapabilityOSH implements OperationStepHandler {

--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -61,12 +61,12 @@ public abstract class TestModelControllerService extends AbstractControllerServi
 
     protected TestModelControllerService(ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
         this(processType, configurationPersister, processState,
-                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+                ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build());
     }
 
     protected TestModelControllerService(final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
         this(ProcessType.EMBEDDED_SERVER, configurationPersister, processState,
-                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+                ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build());
     }
 
     protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
@@ -129,6 +129,6 @@ public abstract class TestModelControllerService extends AbstractControllerServi
     }
 
     static SimpleOperationDefinitionBuilder getODBuilder(String name) {
-        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver());
+        return new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE);
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/ValidateModelTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ValidateModelTestCase.java
@@ -67,7 +67,7 @@ public class ValidateModelTestCase extends AbstractControllerTestBase {
 
     private static ResourceDefinition createDummyProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(TEST_ADDRESS.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler() {
 
                     @Override

--- a/controller/src/test/java/org/jboss/as/controller/access/constraint/ApplicationTypeConstraintUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/constraint/ApplicationTypeConstraintUnitTestCase.java
@@ -69,7 +69,7 @@ public class ApplicationTypeConstraintUnitTestCase {
     private static final ApplicationTypeAccessConstraintDefinition atacda = new ApplicationTypeAccessConstraintDefinition(a);
     private static final ApplicationTypeAccessConstraintDefinition atacdb = new ApplicationTypeAccessConstraintDefinition(b);
 
-    private static final OperationDefinition WRITE_CONFIG_DEF = new SimpleOperationDefinitionBuilder("write-config", new NonResolvingResourceDescriptionResolver())
+    private static final OperationDefinition WRITE_CONFIG_DEF = new SimpleOperationDefinitionBuilder("write-config", NonResolvingResourceDescriptionResolver.INSTANCE)
             .build();
 
     private static final Constraint DEPLOYER_WRITE_CONFIG = ApplicationTypeConstraint.FACTORY.getStandardUserConstraint(StandardRole.DEPLOYER, Action.ActionEffect.WRITE_CONFIG);
@@ -88,7 +88,7 @@ public class ApplicationTypeConstraintUnitTestCase {
         a.setConfiguredApplication(isA);
         b.setConfiguredApplication(isB);
 
-        ResourceDefinition rootRd = new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
+        ResourceDefinition rootRd = new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public List<AccessConstraintDefinition> getAccessConstraints() {
                 return rootResourceConstraints;
@@ -98,7 +98,7 @@ public class ApplicationTypeConstraintUnitTestCase {
         rootRegistration.registerOperationHandler(WRITE_CONFIG_DEF, NoopOperationStepHandler.WITHOUT_RESULT, true);
 
         PathElement childPE = PathElement.pathElement("child");
-        ResourceDefinition childRd = new SimpleResourceDefinition(childPE, new NonResolvingResourceDescriptionResolver()) {
+        ResourceDefinition childRd = new SimpleResourceDefinition(childPE, NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public List<AccessConstraintDefinition> getAccessConstraints() {
                 return childResourceConstraints;

--- a/controller/src/test/java/org/jboss/as/controller/access/constraint/SensitiveTargetConstraintUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/constraint/SensitiveTargetConstraintUnitTestCase.java
@@ -68,7 +68,7 @@ public class SensitiveTargetConstraintUnitTestCase {
     private static final SensitiveTargetAccessConstraintDefinition stacda = new SensitiveTargetAccessConstraintDefinition(a);
     private static final SensitiveTargetAccessConstraintDefinition stacdb = new SensitiveTargetAccessConstraintDefinition(b);
 
-    private static final OperationDefinition READ_CONFIG_DEF = new SimpleOperationDefinitionBuilder("read-config", new NonResolvingResourceDescriptionResolver())
+    private static final OperationDefinition READ_CONFIG_DEF = new SimpleOperationDefinitionBuilder("read-config", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setReadOnly()
             .build();
 
@@ -90,7 +90,7 @@ public class SensitiveTargetConstraintUnitTestCase {
     }
 
     private void setupResources() {
-        ResourceDefinition rootRd = new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
+        ResourceDefinition rootRd = new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public List<AccessConstraintDefinition> getAccessConstraints() {
                 return rootResourceConstraints;
@@ -99,7 +99,7 @@ public class SensitiveTargetConstraintUnitTestCase {
         ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootRd);
         rootRegistration.registerOperationHandler(READ_CONFIG_DEF, NoopOperationStepHandler.WITH_RESULT, true);
         PathElement childPE = PathElement.pathElement("child");
-        ResourceDefinition childRd = new SimpleResourceDefinition(childPE, new NonResolvingResourceDescriptionResolver()) {
+        ResourceDefinition childRd = new SimpleResourceDefinition(childPE, NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public List<AccessConstraintDefinition> getAccessConstraints() {
                 return childResourceConstraints;

--- a/controller/src/test/java/org/jboss/as/controller/access/permission/ManagementPermissionAuthorizerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/permission/ManagementPermissionAuthorizerTestCase.java
@@ -55,7 +55,7 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  */
 public class ManagementPermissionAuthorizerTestCase {
 
-    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
+    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE) {
         @Override
         public List<AccessConstraintDefinition> getAccessConstraints() {
             return Collections.emptyList();

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
@@ -387,7 +387,7 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
 
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler())
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -403,7 +403,7 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints) {
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraints));
         }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
@@ -491,7 +491,7 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
         }
 
         TestResourceDefinition(PathElement element, AccessConstraintDefinition... constraintDefinitions) {
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraintDefinitions));
@@ -510,12 +510,12 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
 
     private static final class TestOperationStepHandler implements OperationStepHandler {
         private static final SimpleOperationDefinition RO_DEFINITION
-                = new SimpleOperationDefinitionBuilder(READONLY_OPERATION, new NonResolvingResourceDescriptionResolver())
+                = new SimpleOperationDefinitionBuilder(READONLY_OPERATION, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setReplyType(ModelType.INT)
                 .build();
 
         private static final SimpleOperationDefinition RW_DEFINITION
-                = new SimpleOperationDefinitionBuilder(READWRITE_OPERATION, new NonResolvingResourceDescriptionResolver())
+                = new SimpleOperationDefinitionBuilder(READWRITE_OPERATION, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setReplyType(ModelType.INT)
                 .build();
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DefaultPermissionFactoryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DefaultPermissionFactoryTestCase.java
@@ -63,7 +63,7 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  */
 public class DefaultPermissionFactoryTestCase {
 
-    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
+    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE) {
         @Override
         public List<AccessConstraintDefinition> getAccessConstraints() {
             return Collections.emptyList();

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
@@ -602,7 +602,7 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         }
 
         TestResourceDefinition(PathElement element, AccessConstraintDefinition... constraintDefinitions) {
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraintDefinitions));
@@ -643,7 +643,7 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
 
     private static final class TestOperationStepHandler implements OperationStepHandler {
         private static SimpleOperationDefinition definition(String name) {
-            return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
+            return new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setReplyType(ModelType.INT)
                     .build();
         }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenNamesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenNamesTestCase.java
@@ -167,11 +167,11 @@ public class FilteredReadChildrenNamesTestCase extends AbstractRbacTestBase {
         GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new SimpleResourceDefinition(
-                new Parameters(pathElement(UNCONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                new Parameters(pathElement(UNCONSTRAINED_RESOURCE), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})));
         registration.registerSubModel(new SimpleResourceDefinition(
-                new Parameters(pathElement(SENSITIVE_CONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                new Parameters(pathElement(SENSITIVE_CONSTRAINED_RESOURCE), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(MY_SENSITIVE_CONSTRAINT)));

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenResourcesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenResourcesTestCase.java
@@ -159,11 +159,11 @@ public class FilteredReadChildrenResourcesTestCase extends AbstractRbacTestBase 
         GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new SimpleResourceDefinition(
-                new Parameters(pathElement(UNCONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                new Parameters(pathElement(UNCONSTRAINED_RESOURCE), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})));
         registration.registerSubModel(new SimpleResourceDefinition(
-                new Parameters(pathElement(SENSITIVE_CONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                new Parameters(pathElement(SENSITIVE_CONSTRAINED_RESOURCE), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(MY_SENSITIVE_CONSTRAINT)));

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
@@ -211,7 +211,7 @@ public class FilteredReadResourceTestCase extends AbstractRbacTestBase {
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
 
         TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
-             super(new Parameters(pathElement(path), new NonResolvingResourceDescriptionResolver())
+             super(new Parameters(pathElement(path), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraintDefinitions));

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
@@ -291,7 +291,7 @@ public class ReadAttributeTestCase extends AbstractRbacTestBase {
         private final boolean useDefaultReadAttributeHandler;
 
         TestResourceDefinition(String path, boolean useDefaultReadAttributeHandler, AccessConstraintDefinition... constraintDefinitions) {
-             super(new Parameters(pathElement(path), new NonResolvingResourceDescriptionResolver())
+             super(new Parameters(pathElement(path), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraintDefinitions));

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationDescriptionAccessControlTestCase.java
@@ -265,7 +265,7 @@ public class ReadOperationDescriptionAccessControlTestCase extends AbstractContr
 
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -283,14 +283,14 @@ public class ReadOperationDescriptionAccessControlTestCase extends AbstractContr
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraints));
         }
 
         void addOperation(String name, boolean readOnly, boolean runtimeOnly, AccessConstraintDefinition...constraints) {
-            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver());
+            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE);
             if (constraints != null) {
                 builder.setAccessConstraints(constraints);
             }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationNamesRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationNamesRbacTestCase.java
@@ -289,7 +289,7 @@ public class ReadOperationNamesRbacTestCase extends AbstractControllerTestBase {
 
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -307,14 +307,14 @@ public class ReadOperationNamesRbacTestCase extends AbstractControllerTestBase {
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraints));
         }
 
         void addOperation(String name, boolean readOnly, boolean runtimeOnly, AccessConstraintDefinition...constraints) {
-            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver());
+            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE);
             if (constraints != null) {
                 builder.setAccessConstraints(constraints);
             }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessConstraintDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessConstraintDefinitionTestCase.java
@@ -81,7 +81,7 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
     private static final AccessConstraintDefinition SENSITIVE_CONSTRAINT = new SensitiveTargetAccessConstraintDefinition(new SensitivityClassification("test", "SENSITIVE-CONSTRAINT", true, true, true));
     private static final AccessConstraintDefinition DEPLOYMENT_APPLICATION_CONSTRAINT = new ApplicationTypeAccessConstraintDefinition(ApplicationTypeConfig.DEPLOYMENT);
     private static final AccessConstraintDefinition APPLICATION_CONSTRAINT = new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("test", "APPLICATION-CONSTRAINT", true));
-    private static final OperationDefinition CUSTOM_OPERATION = new SimpleOperationDefinitionBuilder("custom", new NonResolvingResourceDescriptionResolver())
+    private static final OperationDefinition CUSTOM_OPERATION = new SimpleOperationDefinitionBuilder("custom", NonResolvingResourceDescriptionResolver.INSTANCE)
         .addAccessConstraint(SOCKET_CONFIG_SENSITIVE_CONSTRAINT)
         .build();
 
@@ -233,7 +233,7 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
 
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -259,7 +259,7 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
 
     private static class ConstrainedChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         ConstrainedChildResourceDefinition(){
-            super(new Parameters(PathElement.pathElement("constrained-resource"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("constrained-resource"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(SOCKET_CONFIG_SENSITIVE_CONSTRAINT));
@@ -285,7 +285,7 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
 
     private static class NonConstrainedChildResourceDefinition extends SimpleResourceDefinition {
         NonConstrainedChildResourceDefinition(){
-            super(new Parameters(PathElement.pathElement("nonconstrained-resource"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("nonconstrained-resource"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -298,7 +298,7 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
 
     private static class ApplicationChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         ApplicationChildResourceDefinition(){
-            super(new Parameters(PathElement.pathElement("application-resource"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("application-resource"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(DEPLOYMENT_APPLICATION_CONSTRAINT));

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -2022,7 +2022,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -2040,7 +2040,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraints));
@@ -2063,7 +2063,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         }
 
         void addOperation(String name, boolean readOnly, boolean runtimeOnly, AccessConstraintDefinition...constraints) {
-            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver());
+            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE);
             if (constraints != null) {
                 builder.setAccessConstraints(constraints);
             }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/RemoveResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/RemoveResourceTestCase.java
@@ -207,7 +207,7 @@ public class RemoveResourceTestCase extends AbstractControllerTestBase {
 
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
@@ -223,7 +223,7 @@ public class RemoveResourceTestCase extends AbstractControllerTestBase {
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraints));

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/WriteAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/WriteAttributeTestCase.java
@@ -311,7 +311,7 @@ public class WriteAttributeTestCase extends AbstractRbacTestBase {
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
 
         TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
-            super(new Parameters(pathElement(path), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(pathElement(path), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraintDefinitions));

--- a/controller/src/test/java/org/jboss/as/controller/boot/cli/hook/BootCliReloadHandler.java
+++ b/controller/src/test/java/org/jboss/as/controller/boot/cli/hook/BootCliReloadHandler.java
@@ -39,7 +39,7 @@ public class BootCliReloadHandler implements OperationStepHandler {
 
     public static final BootCliReloadHandler INSTANCE = new BootCliReloadHandler();
 
-    public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("reload", new NonResolvingResourceDescriptionResolver())
+    public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("reload", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setRuntimeOnly()
             .build();
     Map<String, ModelNode> parameters;

--- a/controller/src/test/java/org/jboss/as/controller/boot/cli/hook/BootCliShutdownHandler.java
+++ b/controller/src/test/java/org/jboss/as/controller/boot/cli/hook/BootCliShutdownHandler.java
@@ -39,7 +39,7 @@ public class BootCliShutdownHandler implements OperationStepHandler {
 
     public static final BootCliShutdownHandler INSTANCE = new BootCliShutdownHandler();
 
-    public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("shutdown", new NonResolvingResourceDescriptionResolver())
+    public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("shutdown", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setRuntimeOnly()
             .build();
     Map<String, ModelNode> parameters;

--- a/controller/src/test/java/org/jboss/as/controller/boot/cli/hook/ForceRestartRequiredHandler.java
+++ b/controller/src/test/java/org/jboss/as/controller/boot/cli/hook/ForceRestartRequiredHandler.java
@@ -31,7 +31,7 @@ import org.jboss.dmr.ModelNode;
  */
 public class ForceRestartRequiredHandler implements OperationStepHandler {
     static final String NAME = "force-reload-required";
-    static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(NAME, new NonResolvingResourceDescriptionResolver())
+    static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(NAME, NonResolvingResourceDescriptionResolver.INSTANCE)
             .setPrivateEntry()
             .setRuntimeOnly()
             .build();

--- a/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
@@ -108,7 +108,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
     private static ResourceDefinition createDummyProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(RESOURCE_ADDRESS_PATTERN.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler() {
 
                     @Override

--- a/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
@@ -65,7 +65,7 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
         ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
         registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
 
-        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, new NonResolvingResourceDescriptionResolver())
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, NonResolvingResourceDescriptionResolver.INSTANCE)
                         .setParameters(FAIL_OPERATION)
                 .setPrivateEntry()
                 .build(),
@@ -82,7 +82,7 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
                     }
                 }
         );
-        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, new NonResolvingResourceDescriptionResolver()).build());
+        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, NonResolvingResourceDescriptionResolver.INSTANCE).build());
     }
 
     @Test

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
@@ -74,7 +74,7 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
     @Override
     protected void initModel(ManagementModel managementModel) {
         ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
-        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, new NonResolvingResourceDescriptionResolver())
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, NonResolvingResourceDescriptionResolver.INSTANCE)
                         .setParameters(FAIL_FIRST_STEP, FAIL_SECOND_STEP)
                         .setPrivateEntry()
                         .build(),
@@ -112,7 +112,7 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
                     }
                 }
         );
-        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, new NonResolvingResourceDescriptionResolver()).build());
+        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, NonResolvingResourceDescriptionResolver.INSTANCE).build());
     }
 
     @Test

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
@@ -57,7 +57,7 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
     @Override
     protected void initModel(ManagementModel managementModel) {
         ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
-        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, new NonResolvingResourceDescriptionResolver())
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, NonResolvingResourceDescriptionResolver.INSTANCE)
                         .setPrivateEntry()
                         .build(),
                 new OperationStepHandler() {
@@ -68,7 +68,7 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
                     }
                 }
         );
-        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, new NonResolvingResourceDescriptionResolver()).build());
+        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, NonResolvingResourceDescriptionResolver.INSTANCE).build());
     }
 
     @Test

--- a/controller/src/test/java/org/jboss/as/controller/operation/global/CollectionOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operation/global/CollectionOperationsTestCase.java
@@ -60,7 +60,7 @@ public class CollectionOperationsTestCase extends AbstractCollectionOperationsTe
     @Override
     protected ResourceDefinition createProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(TEST_ADDRESS.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler() {
                     @Override
                     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {

--- a/controller/src/test/java/org/jboss/as/controller/operation/global/EnhancedSyntaxTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operation/global/EnhancedSyntaxTestCase.java
@@ -114,7 +114,7 @@ public class EnhancedSyntaxTestCase extends AbstractControllerTestBase {
 
     private static ResourceDefinition createDummyProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(TEST_ADDRESS.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler() {
 
                     @Override

--- a/controller/src/test/java/org/jboss/as/controller/operation/global/StorageRuntimeCollectionOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operation/global/StorageRuntimeCollectionOperationsTestCase.java
@@ -59,7 +59,7 @@ public class StorageRuntimeCollectionOperationsTestCase extends AbstractCollecti
 
     protected ResourceDefinition createProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(TEST_ADDRESS.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler() {
 
                     @Override

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -670,7 +670,7 @@ public class PersistentResourceXMLParserTestCase {
                 .build();
 
 
-        static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -689,7 +689,7 @@ public class PersistentResourceXMLParserTestCase {
             }
         };
 
-        static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -702,7 +702,7 @@ public class PersistentResourceXMLParserTestCase {
             }
         };
 
-        static final PersistentResourceDefinition OBJECT_TYPE_TEST = new PersistentResourceDefinition(PathElement.pathElement("object-type-test"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition OBJECT_TYPE_TEST = new PersistentResourceDefinition(PathElement.pathElement("object-type-test"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -712,7 +712,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("server"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("server"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -732,7 +732,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition CUSTOM_SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("custom"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition CUSTOM_SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("custom"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -749,7 +749,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition SESSION_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("mail-session"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition SESSION_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("mail-session"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -765,7 +765,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE) {
 
             @Override
             public Collection<AttributeDefinition> getAttributes() {
@@ -1189,7 +1189,7 @@ public class PersistentResourceXMLParserTestCase {
         static final IIOPRootDefinition INSTANCE = new IIOPRootDefinition();
 
         private IIOPRootDefinition() {
-            super(PathElement.pathElement("subsystem", "orb"), new NonResolvingResourceDescriptionResolver());
+            super(PathElement.pathElement("subsystem", "orb"), NonResolvingResourceDescriptionResolver.INSTANCE);
         }
 
         @Override
@@ -1395,7 +1395,7 @@ public class PersistentResourceXMLParserTestCase {
                     .build();
         }
 
-    static final PersistentResourceDefinition SERVICE_PROCESS_RESOURCE = new PersistentResourceDefinition(PathElement.pathElement("service"), new NonResolvingResourceDescriptionResolver()) {
+    static final PersistentResourceDefinition SERVICE_PROCESS_RESOURCE = new PersistentResourceDefinition(PathElement.pathElement("service"), NonResolvingResourceDescriptionResolver.INSTANCE) {
         @Override
         public Collection<AttributeDefinition> getAttributes() {
             Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -1409,7 +1409,7 @@ public class PersistentResourceXMLParserTestCase {
 
     protected static final PathElement PROCESS_SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "process");
 
-    PersistentResourceDefinition PROCESS_SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(PROCESS_SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+    PersistentResourceDefinition PROCESS_SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(PROCESS_SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE) {
 
               @Override
               public Collection<AttributeDefinition> getAttributes() {

--- a/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
@@ -118,7 +118,7 @@ public class YamlConfigurationExtensionTest {
                 .setValidator(new StringLengthValidator(0, true, true))
                 .build();
         ManagementResourceRegistration connectorRegistration = root.registerSubModel(new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(
-                PathElement.pathElement("connector"), new NonResolvingResourceDescriptionResolver())
+                PathElement.pathElement("connector"), NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AbstractBoottimeAddStepHandler(connectorType) {
                 })
                 .setRemoveHandler(new AbstractRemoveStepHandler() {
@@ -127,7 +127,7 @@ public class YamlConfigurationExtensionTest {
         connectorRegistration.registerReadWriteAttribute(connectorType, null, new ModelOnlyWriteAttributeHandler(connectorType));
         ManagementResourceRegistration acceptorRegistration = connectorRegistration.registerSubModel(
                 new SimpleResourceDefinition(
-                        new SimpleResourceDefinition.Parameters(PathElement.pathElement("acceptor"), new NonResolvingResourceDescriptionResolver())
+                        new SimpleResourceDefinition.Parameters(PathElement.pathElement("acceptor"), NonResolvingResourceDescriptionResolver.INSTANCE)
                                 .setAddHandler(new AbstractBoottimeAddStepHandler(connectorType) {
                                 })
                                 .setRemoveHandler(new AbstractRemoveStepHandler() {

--- a/controller/src/test/java/org/jboss/as/controller/registry/CoreManagementResourceRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/CoreManagementResourceRegistrationUnitTestCase.java
@@ -69,7 +69,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
 
     @Before
     public void setup() {
-        rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()));
+        rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
     @Test
     public void testHandlersOnChildResource() throws Exception {
 
-        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, NonResolvingResourceDescriptionResolver.INSTANCE));
         child.registerOperationHandler(getOpDef("one"), TestHandler.ONE);
         child.registerOperationHandler(getOpDef("two", OperationEntry.Flag.READ_ONLY), TestHandler.TWO);
 
@@ -126,11 +126,11 @@ public class CoreManagementResourceRegistrationUnitTestCase {
         rootRegistration.registerOperationHandler(getOpDef("three", OperationEntry.Flag.READ_ONLY), TestHandler.PARENT, true);
         rootRegistration.registerOperationHandler(getOpDef("four", OperationEntry.Flag.READ_ONLY), TestHandler.PARENT, false);
 
-        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, NonResolvingResourceDescriptionResolver.INSTANCE));
         child.registerOperationHandler(getOpDef("one"), TestHandler.CHILD, true);
         child.registerOperationHandler(getOpDef("two", OperationEntry.Flag.MASTER_HOST_CONTROLLER_ONLY), TestHandler.CHILD, true);
 
-        ManagementResourceRegistration grandchild = child.registerSubModel(new SimpleResourceDefinition(grandchildElement, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration grandchild = child.registerSubModel(new SimpleResourceDefinition(grandchildElement, NonResolvingResourceDescriptionResolver.INSTANCE));
 
         OperationStepHandler oneHandler = child.getOperationHandler(PathAddress.EMPTY_ADDRESS, "one");
         assertSame(TestHandler.CHILD, oneHandler);
@@ -206,7 +206,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
     @Test
     public void testFlagsOnChildResource() throws Exception {
 
-        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, NonResolvingResourceDescriptionResolver.INSTANCE));
         child.registerOperationHandler(getOpDef("one"), TestHandler.INSTANCE);
         child.registerOperationHandler(getOpDef("two", OperationEntry.Flag.READ_ONLY), TestHandler.INSTANCE, false);
 
@@ -243,11 +243,11 @@ public class CoreManagementResourceRegistrationUnitTestCase {
         rootRegistration.registerOperationHandler(getOpDef("three", OperationEntry.Flag.READ_ONLY), TestHandler.INSTANCE, true);
         rootRegistration.registerOperationHandler(getOpDef("four", OperationEntry.Flag.READ_ONLY), TestHandler.INSTANCE, false);
 
-        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration child = rootRegistration.registerSubModel(new SimpleResourceDefinition(childElement, NonResolvingResourceDescriptionResolver.INSTANCE));
         child.registerOperationHandler(getOpDef("one"), TestHandler.INSTANCE, true);
         child.registerOperationHandler(getOpDef("two", OperationEntry.Flag.MASTER_HOST_CONTROLLER_ONLY), TestHandler.INSTANCE, true);
 
-        ManagementResourceRegistration grandchild = child.registerSubModel(new SimpleResourceDefinition(grandchildElement, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration grandchild = child.registerSubModel(new SimpleResourceDefinition(grandchildElement, NonResolvingResourceDescriptionResolver.INSTANCE));
 
         Set<OperationEntry.Flag> oneFlags = child.getOperationFlags(PathAddress.EMPTY_ADDRESS, "one");
         assertNotNull(oneFlags);
@@ -335,7 +335,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
     @Test
     public void testInheritedAccessConstraints() {
 
-        ResourceDefinition rootRd = new SimpleResourceDefinition(new Parameters(null, new NonResolvingResourceDescriptionResolver())
+        ResourceDefinition rootRd = new SimpleResourceDefinition(new Parameters(null, NonResolvingResourceDescriptionResolver.INSTANCE)
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.EXTENSIONS, ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
         ManagementResourceRegistration root = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootRd);
 
@@ -345,7 +345,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
         assertTrue(acds.contains(ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
 
         ResourceDefinition childRd = new SimpleResourceDefinition(
-                new Parameters(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver())
+                new Parameters(PathElement.pathElement("child"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN, ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
         ManagementResourceRegistration child = root.registerSubModel(childRd);
         acds = child.getAccessConstraints();
@@ -372,7 +372,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
     }
 
     static OperationDefinition getOpDef(String name, OperationEntry.Flag... flags) {
-        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
+        return new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .withFlags(flags)
                 .build();
     }

--- a/controller/src/test/java/org/jboss/as/controller/registry/ExtendWildCardRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/ExtendWildCardRegistrationUnitTestCase.java
@@ -90,31 +90,31 @@ public class ExtendWildCardRegistrationUnitTestCase {
 
     @BeforeClass
     public static void setup() {
-        registration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(PathElement.pathElement("root","root"), new NonResolvingResourceDescriptionResolver()));
+        registration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(PathElement.pathElement("root","root"), NonResolvingResourceDescriptionResolver.INSTANCE));
 
-        parentWildReg = registration.registerSubModel(new SimpleResourceDefinition(parentWild, new NonResolvingResourceDescriptionResolver()));
+        parentWildReg = registration.registerSubModel(new SimpleResourceDefinition(parentWild, NonResolvingResourceDescriptionResolver.INSTANCE));
         parentWildReg.registerReadOnlyAttribute(wildAttr, parentWildAttr);
         parentWildReg.registerOperationHandler(getOpDef("wildOp"), parentWildOp);
         parentWildReg.registerReadOnlyAttribute(overrideAttr, parentWildOverrideAttr);
         parentWildReg.registerOperationHandler(getOpDef("overrideOp"), parentWildOverrideOp);
 
-        parentExtReg = registration.registerSubModel(new SimpleResourceDefinition(parentExt, new NonResolvingResourceDescriptionResolver()));
+        parentExtReg = registration.registerSubModel(new SimpleResourceDefinition(parentExt, NonResolvingResourceDescriptionResolver.INSTANCE));
         parentExtReg.registerReadOnlyAttribute(extAttr, parentExtAttr);
         parentExtReg.registerOperationHandler(getOpDef("extOp"), parentExtOp);
         parentExtReg.registerReadOnlyAttribute(overrideAttr, parentExtOverrideAttr);
         parentExtReg.registerOperationHandler(getOpDef("overrideOp"), parentExtOverrideOp);
 
-        childWildReg = parentWildReg.registerSubModel(new SimpleResourceDefinition(childWild, new NonResolvingResourceDescriptionResolver()));
+        childWildReg = parentWildReg.registerSubModel(new SimpleResourceDefinition(childWild, NonResolvingResourceDescriptionResolver.INSTANCE));
         childWildReg.registerReadOnlyAttribute(wildAttr, childWildAttr);
         childWildReg.registerOperationHandler(getOpDef("wildOp"), childWildOp);
         childWildReg.registerReadOnlyAttribute(overrideAttr, childWildOverrideAttr);
         childWildReg.registerOperationHandler(getOpDef("overrideOp"), childWildOverrideOp);
 
-        childWildExtReg = parentWildReg.registerSubModel(new SimpleResourceDefinition(childWildExt, new NonResolvingResourceDescriptionResolver()));
+        childWildExtReg = parentWildReg.registerSubModel(new SimpleResourceDefinition(childWildExt, NonResolvingResourceDescriptionResolver.INSTANCE));
         childWildExtReg.registerReadOnlyAttribute(wildExtAttr, childWildExtAttr);
         childWildExtReg.registerOperationHandler(getOpDef("wildExtOp"), childWildExtOp);
 
-        childExtReg = parentExtReg.registerSubModel(new SimpleResourceDefinition(childExt, new NonResolvingResourceDescriptionResolver()));
+        childExtReg = parentExtReg.registerSubModel(new SimpleResourceDefinition(childExt, NonResolvingResourceDescriptionResolver.INSTANCE));
         childExtReg.registerReadOnlyAttribute(extAttr, childExtAttr);
         childExtReg.registerOperationHandler(getOpDef("extOp"), childExtOp);
         childExtReg.registerReadOnlyAttribute(overrideAttr, childExtOverrideAttr);
@@ -336,21 +336,21 @@ public class ExtendWildCardRegistrationUnitTestCase {
     @Test
     public void testDuplicateSubModel() {
         try {
-            parentExtReg.registerSubModel(new SimpleResourceDefinition(childWildExt, new NonResolvingResourceDescriptionResolver()));
+            parentExtReg.registerSubModel(new SimpleResourceDefinition(childWildExt, NonResolvingResourceDescriptionResolver.INSTANCE));
             fail("Duplicate child not rejected");
         } catch (Exception good) {
             //
         }
 
         try {
-            parentExtReg.registerSubModel(new SimpleResourceDefinition( childWild, new NonResolvingResourceDescriptionResolver()));
+            parentExtReg.registerSubModel(new SimpleResourceDefinition( childWild, NonResolvingResourceDescriptionResolver.INSTANCE));
             fail("Duplicate child not rejected");
         } catch (Exception good) {
             //
         }
 
         try {
-            parentWildReg.registerSubModel(new SimpleResourceDefinition(childWild, new NonResolvingResourceDescriptionResolver()));
+            parentWildReg.registerSubModel(new SimpleResourceDefinition(childWild, NonResolvingResourceDescriptionResolver.INSTANCE));
             fail("Duplicate child not rejected");
         } catch (Exception good) {
             //
@@ -364,9 +364,9 @@ public class ExtendWildCardRegistrationUnitTestCase {
         PathElement grandchildExt = PathElement.pathElement("grandchild", "ext");
         PathElement anotherGranchild = PathElement.pathElement("another", "grandchild");
 
-        childWildReg.registerSubModel(new SimpleResourceDefinition(grandchildWild, new NonResolvingResourceDescriptionResolver()));
-        childWildExtReg.registerSubModel(new SimpleResourceDefinition(grandchildExt, new NonResolvingResourceDescriptionResolver()));
-        childWildExtReg.registerSubModel(new SimpleResourceDefinition(anotherGranchild, new NonResolvingResourceDescriptionResolver()));
+        childWildReg.registerSubModel(new SimpleResourceDefinition(grandchildWild, NonResolvingResourceDescriptionResolver.INSTANCE));
+        childWildExtReg.registerSubModel(new SimpleResourceDefinition(grandchildExt, NonResolvingResourceDescriptionResolver.INSTANCE));
+        childWildExtReg.registerSubModel(new SimpleResourceDefinition(anotherGranchild, NonResolvingResourceDescriptionResolver.INSTANCE));
 
         // Confirm setup.
 
@@ -416,7 +416,7 @@ public class ExtendWildCardRegistrationUnitTestCase {
         assertTrue(grandchildren.toString(), grandchildren.contains(anotherGranchild));
 
         // Restore state
-        childWildReg.registerSubModel(new SimpleResourceDefinition(grandchildWild, new NonResolvingResourceDescriptionResolver()));
+        childWildReg.registerSubModel(new SimpleResourceDefinition(grandchildWild, NonResolvingResourceDescriptionResolver.INSTANCE));
 
         // 4) Removing a higher level override does not remove children of the related wildcard
         parentWildReg.unregisterSubModel(childWildExt);

--- a/controller/src/test/java/org/jboss/as/controller/registry/ProxyControllerRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/ProxyControllerRegistrationUnitTestCase.java
@@ -45,7 +45,7 @@ public class ProxyControllerRegistrationUnitTestCase {
 
     @Before
     public void setup() {
-        root = ManagementResourceRegistration.Factory.forProcessType(ProcessType.HOST_CONTROLLER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()));
+        root = ManagementResourceRegistration.Factory.forProcessType(ProcessType.HOST_CONTROLLER).createRegistration(new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE));
         proxyController = new ProxyController() {
             @Override
             public PathAddress getProxyNodeAddress() {

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -207,7 +207,7 @@ public abstract class AbstractControllerTestBase {
 
         public ModelControllerService(final ProcessType processType, RunningModeControl runningModeControl, Supplier<ExecutorService> executorService) {
             super(processType, runningModeControl, executorService, new EmptyConfigurationPersister(), new ControlledProcessState(true),
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build()
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build()
             );
         }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
@@ -161,7 +161,7 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         );
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addReadOnlyAttribute(SimpleAttributeDefinitionBuilder.create("name", ModelType.STRING, false).setMinSize(1).build())
                 .build();
 
@@ -171,7 +171,7 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         ManagementResourceRegistration profileSub1Reg = profileReg.registerSubModel(new Subsystem1RootResource());
 
         ManagementResourceRegistration profileASub2Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem2"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem2"), NonResolvingResourceDescriptionResolver.INSTANCE));
         AttributeDefinition longAttr = TestUtils.createAttribute("long", ModelType.LONG, "number");
         profileASub2Reg.registerReadWriteAttribute(longAttr, null, new ModelOnlyWriteAttributeHandler(longAttr));
         profileASub2Reg.registerReadOnlyAttribute(TestUtils.createAttribute("type", ModelType.TYPE), null);
@@ -195,7 +195,7 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
                 .setCapabilityReference("org.wildfly.test.capability", att1, att2)
                 .build();
         ManagementResourceRegistration profileBSub3Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem3"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem3"), NonResolvingResourceDescriptionResolver.INSTANCE));
         profileBSub3Reg.registerReadOnlyAttribute(att1, null);
         profileBSub3Reg.registerReadOnlyAttribute(att2, null);
         profileBSub3Reg.registerReadOnlyAttribute(ref, null);
@@ -229,11 +229,11 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
                 .setCapabilityReference("org.wildfly.test.capability")
                 .build();
         ManagementResourceRegistration profileCSub4Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem4"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem4"), NonResolvingResourceDescriptionResolver.INSTANCE));
         profileCSub4Reg.registerReadOnlyAttribute(simpleRef, null);
 
         ManagementResourceRegistration profileCSub5Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem5"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem5"), NonResolvingResourceDescriptionResolver.INSTANCE));
         profileCSub5Reg.registerReadOnlyAttribute(TestUtils.createAttribute("name", ModelType.STRING, "varchar"), new OperationStepHandler() {
 
             @Override
@@ -249,13 +249,13 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
                                 "org.wildfly.test.capability.req")));
 
         ResourceDefinition profileCSub5Type1RegDef = ResourceBuilder.Factory.create(PathElement.pathElement("type1"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .build();
 
         ManagementResourceRegistration profileCSub5Type1Reg = profileCSub5Reg.registerSubModel(profileCSub5Type1RegDef);
 
         ManagementResourceRegistration profileCSub6Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem6"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem6"), NonResolvingResourceDescriptionResolver.INSTANCE));
 
         profileCSub6Reg.registerOperationHandler(TestUtils.createOperationDefinition("testA", true),
                 new OperationStepHandler() {

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -632,7 +632,7 @@ public abstract class AbstractProxyControllerTest {
 
         MainModelControllerService(final Supplier<ModelController> proxy, ControlledProcessState processState) {
             super(ProcessType.EMBEDDED_SERVER, new NullConfigurationPersister(), processState,
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build());
             this.proxy = proxy;
         }
 
@@ -653,7 +653,7 @@ public abstract class AbstractProxyControllerTest {
                 }
             });
 
-            rootRegistration.registerSubModel(ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"), new NonResolvingResourceDescriptionResolver())
+            rootRegistration.registerSubModel(ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .addReadOnlyAttribute(TestUtils.createNillableAttribute("name",ModelType.STRING))
                     .build());
 
@@ -667,7 +667,7 @@ public abstract class AbstractProxyControllerTest {
 
         ProxyModelControllerService(final ControlledProcessState processState) {
             super(ProcessType.EMBEDDED_SERVER, new NullConfigurationPersister(), processState,
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build());
         }
 
         @Override
@@ -705,7 +705,7 @@ public abstract class AbstractProxyControllerTest {
             );
 
             ManagementResourceRegistration serverReg = rootRegistration.registerSubModel(
-                    new SimpleResourceDefinition(PathElement.pathElement("serverchild", "*"),new NonResolvingResourceDescriptionResolver()));
+                    new SimpleResourceDefinition(PathElement.pathElement("serverchild", "*"),NonResolvingResourceDescriptionResolver.INSTANCE));
             serverReg.registerReadOnlyAttribute(createAttribute("name", ModelType.STRING), null);
             /*ManagementResourceRegistration serverReg = rootRegistration.registerSubModel(PathElement.pathElement("serverchild", "*"), new DescriptionProvider() {
 
@@ -726,7 +726,7 @@ public abstract class AbstractProxyControllerTest {
 
 
             ManagementResourceRegistration serverChildReg = serverReg.registerSubModel(
-                    new SimpleResourceDefinition(PathElement.pathElement("child", "*"),new NonResolvingResourceDescriptionResolver()));
+                    new SimpleResourceDefinition(PathElement.pathElement("child", "*"),NonResolvingResourceDescriptionResolver.INSTANCE));
 
             /*ManagementResourceRegistration serverChildReg = serverReg.registerSubModel(PathElement.pathElement("child", "*"), new DescriptionProvider() {
 

--- a/controller/src/test/java/org/jboss/as/controller/test/AliasContextTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AliasContextTestCase.java
@@ -171,7 +171,7 @@ public class AliasContextTestCase extends AbstractControllerTestBase {
     private class MainResourceDefinition extends SimpleResourceDefinition {
 
         public MainResourceDefinition() {
-            super(PathElement.pathElement(MAIN), new NonResolvingResourceDescriptionResolver(), null, new ModelOnlyRemoveStepHandler());
+            super(PathElement.pathElement(MAIN), NonResolvingResourceDescriptionResolver.INSTANCE, null, new ModelOnlyRemoveStepHandler());
         }
 
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/BadReadHandlerAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/BadReadHandlerAttributeTestCase.java
@@ -132,7 +132,7 @@ public class BadReadHandlerAttributeTestCase extends AbstractControllerTestBase 
     private static class TestResource extends SimpleResourceDefinition {
 
         public TestResource() {
-            super(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver(),
+            super(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE,
                     new TestResourceAddHandler(), new AbstractRemoveStepHandler() {
                     });
         }

--- a/controller/src/test/java/org/jboss/as/controller/test/CastAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/CastAttributeOperationTestCase.java
@@ -77,7 +77,7 @@ public class CastAttributeOperationTestCase extends AbstractControllerTestBase {
     private static final String BIGINT_ATT_NAME = "bigint-att";
     private static final String BIGDEC_ATT_NAME = "bigdec-att";
 
-    private static final OperationDefinition SETUP_OP_DEF = new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+    private static final OperationDefinition SETUP_OP_DEF = new SimpleOperationDefinitionBuilder("setup", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setPrivateEntry()
             .build();
 
@@ -175,7 +175,7 @@ public class CastAttributeOperationTestCase extends AbstractControllerTestBase {
         GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addReadOnlyAttribute(SimpleAttributeDefinitionBuilder.create(NAME, ModelType.STRING, false).setMinSize(1).build())
                 .pushChild(PathElement.pathElement("subsystem", "subsystem1"))
                 .addReadWriteAttribute(BOOLEAN_ATT, null, handler)

--- a/controller/src/test/java/org/jboss/as/controller/test/DefaultAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DefaultAttributeTestCase.java
@@ -83,7 +83,7 @@ public class DefaultAttributeTestCase extends AbstractControllerTestBase {
 
     private static class TestResource extends SimpleResourceDefinition {
         public TestResource() {
-            super(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver(), new TestResourceAddHandler(), new AbstractRemoveStepHandler() {});
+            super(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE, new TestResourceAddHandler(), new AbstractRemoveStepHandler() {});
         }
 
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/DisappearingResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DisappearingResourceTestCase.java
@@ -319,11 +319,11 @@ public class DisappearingResourceTestCase extends AbstractControllerTestBase {
         GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         ManagementResourceRegistration subsystemRegistration = registration.registerSubModel(
-                new SimpleResourceDefinition(SUBSYSTEM_ELEMENT, new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(SUBSYSTEM_ELEMENT, NonResolvingResourceDescriptionResolver.INSTANCE));
         ManagementResourceRegistration parentReg = subsystemRegistration.registerSubModel(
-                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PARENT_ELEMENT, new NonResolvingResourceDescriptionResolver()).setRuntime()));
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PARENT_ELEMENT, NonResolvingResourceDescriptionResolver.INSTANCE).setRuntime()));
         ManagementResourceRegistration runtimeResource = parentReg.registerSubModel(
-                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(CHILD_WILDCARD_ELEMENT, new NonResolvingResourceDescriptionResolver()).setRuntime()));
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(CHILD_WILDCARD_ELEMENT, NonResolvingResourceDescriptionResolver.INSTANCE).setRuntime()));
         AttributeDefinition runtimeAttr = TestUtils.createAttribute(ATTR, ModelType.LONG, GROUP);
         runtimeResource.registerReadOnlyAttribute(runtimeAttr, new OperationStepHandler() {
             @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsAliasesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsAliasesTestCase.java
@@ -143,7 +143,7 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
         );
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addReadOnlyAttribute(SimpleAttributeDefinitionBuilder.create("name", ModelType.STRING, false).setMinSize(1).build())
                 .build();
 
@@ -192,21 +192,21 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
                 });
 
         ManagementResourceRegistration profileASub2Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem2"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem2"), NonResolvingResourceDescriptionResolver.INSTANCE));
         AttributeDefinition longAttr = TestUtils.createAttribute("long", ModelType.LONG);
         profileASub2Reg.registerReadWriteAttribute(longAttr, null, new ModelOnlyWriteAttributeHandler(longAttr));
 
         ManagementResourceRegistration profileBSub3Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem3"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem3"), NonResolvingResourceDescriptionResolver.INSTANCE));
         ManagementResourceRegistration squatter1Reg = profileBSub3Reg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("service", "squatter1"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("service", "squatter1"), NonResolvingResourceDescriptionResolver.INSTANCE));
         AttributeDefinition squatter1Name = TestUtils.createAttribute("name", ModelType.STRING);
         squatter1Reg.registerReadWriteAttribute(squatter1Name, null, new ModelOnlyWriteAttributeHandler(squatter1Name));
         AttributeDefinition squatter1Thing = TestUtils.createAttribute("thing1", ModelType.STRING);
         squatter1Reg.registerReadWriteAttribute(squatter1Thing, null, new ModelOnlyWriteAttributeHandler(squatter1Thing));
 
         ManagementResourceRegistration squatter3Reg = profileBSub3Reg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("service", "squatter3"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("service", "squatter3"), NonResolvingResourceDescriptionResolver.INSTANCE));
         AttributeDefinition squatter3Name = TestUtils.createAttribute("name", ModelType.STRING);
         squatter3Reg.registerReadWriteAttribute(squatter3Name, null, new ModelOnlyWriteAttributeHandler(squatter3Name));
         AttributeDefinition squatter3Thing = TestUtils.createAttribute("thing3", ModelType.LONG);
@@ -269,10 +269,10 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
         );
 
         ManagementResourceRegistration profileCSub4Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem4"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem4"), NonResolvingResourceDescriptionResolver.INSTANCE));
 
         ManagementResourceRegistration profileCSub5Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem5"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem5"), NonResolvingResourceDescriptionResolver.INSTANCE));
         profileCSub5Reg.registerReadOnlyAttribute(TestUtils.createAttribute("name", ModelType.STRING), new OperationStepHandler() {
 
             @Override
@@ -282,12 +282,12 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
         });
 
         ResourceDefinition profileCSub5Type1RegDef = ResourceBuilder.Factory.create(PathElement.pathElement("type1", "thing1"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .build();
         ManagementResourceRegistration profileCSub5Type1Reg = profileCSub5Reg.registerSubModel(profileCSub5Type1RegDef);
 
         ManagementResourceRegistration profileCSub6Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem6"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem6"), NonResolvingResourceDescriptionResolver.INSTANCE));
 
         profileCSub6Reg.registerOperationHandler(TestUtils.createOperationDefinition("testA", true),
                 new OperationStepHandler() {
@@ -299,11 +299,11 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
         );
 
         ManagementResourceRegistration profileESub7Reg = profileReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem7"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem7"), NonResolvingResourceDescriptionResolver.INSTANCE));
         ManagementResourceRegistration profileESub7TypeReg = profileESub7Reg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("type"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("type"), NonResolvingResourceDescriptionResolver.INSTANCE));
         ManagementResourceRegistration profileESub7TypeSquatterOneReg = profileESub7TypeReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("squatter", "one"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("squatter", "one"), NonResolvingResourceDescriptionResolver.INSTANCE));
         profileESub7TypeReg.registerAlias(PathElement.pathElement("squatter-alias", "ONE"), new AliasEntry(profileESub7TypeSquatterOneReg) {
             @Override
             public PathAddress convertToTargetAddress(PathAddress address, AliasContext aliasContext) {
@@ -321,7 +321,7 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
 
         });
         ManagementResourceRegistration profileESub7TypeWildcardReg = profileESub7TypeReg.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("wildcard"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("wildcard"), NonResolvingResourceDescriptionResolver.INSTANCE));
         profileESub7TypeReg.registerAlias(PathElement.pathElement("wildcard-alias"), new AliasEntry(profileESub7TypeWildcardReg) {
             @Override
             public PathAddress convertToTargetAddress(PathAddress address, AliasContext aliasContext) {

--- a/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
@@ -336,7 +336,7 @@ public class OperationTransformationTestCase {
         }
     };
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 
     private static final ExpressionResolver resolver = new ExpressionResolver() {
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
@@ -157,7 +157,7 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
 
         public ParentResourceDefinition() {
             super(PARENT_MAIN,
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
                     new ModelOnlyRemoveStepHandler());
         }
@@ -176,7 +176,7 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
     private static class OrderedChildResourceDefinition extends SimpleResourceDefinition {
 
         public OrderedChildResourceDefinition() {
-            super(new Parameters(CHILD, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(CHILD, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler(REQUEST_ATTRIBUTES))
                     .setRemoveHandler(new ModelOnlyRemoveStepHandler())
                     .setOrderedChild());

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadAttributeGroupTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadAttributeGroupTestCase.java
@@ -160,7 +160,7 @@ public class ReadAttributeGroupTestCase extends AbstractControllerTestBase {
         GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         ManagementResourceRegistration basicResourceRegistration = registration.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "basicSubsystem"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "basicSubsystem"), NonResolvingResourceDescriptionResolver.INSTANCE));
         basicResourceRegistration.registerReadOnlyAttribute(TestUtils.createAttribute("first", ModelType.STRING, "group1", false), null);
         basicResourceRegistration.registerReadOnlyAttribute(TestUtils.createAttribute("second", ModelType.STRING, "group1", false), null);
         basicResourceRegistration.registerReadOnlyAttribute(TestUtils.createAttribute("third", ModelType.STRING, "group2", false), null);

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadConfigAsFeaturesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadConfigAsFeaturesTestCase.java
@@ -218,7 +218,7 @@ public class ReadConfigAsFeaturesTestCase extends AbstractControllerTestBase {
         this.registration = registration;
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
 
-        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder("setup", NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setPrivateEntry()
                 .build()
                 , new OperationStepHandler() {

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
@@ -131,7 +131,7 @@ public class ReadResourceChildOrderingTestCase extends AbstractControllerTestBas
     protected void initModel(ManagementModel managementModel) {
         ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
-        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder("setup", NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setPrivateEntry()
                 .build()
                 , new OperationStepHandler() {
@@ -143,7 +143,7 @@ public class ReadResourceChildOrderingTestCase extends AbstractControllerTestBas
 
         GlobalNotifications.registerGlobalNotifications(registration, processType);
 
-        ManagementResourceRegistration child = registration.registerSubModel(new SimpleResourceDefinition(testSubsystem, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration child = registration.registerSubModel(new SimpleResourceDefinition(testSubsystem, NonResolvingResourceDescriptionResolver.INSTANCE));
         child.registerReadOnlyAttribute(TestUtils.createNillableAttribute("prop", ModelType.STRING), null);
 
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
@@ -130,13 +130,13 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
         GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         ManagementResourceRegistration subsystemRegistration = registration.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "mysubsystem"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "mysubsystem"), NonResolvingResourceDescriptionResolver.INSTANCE));
         // /subsystem=mysubsystem/resource=A is a regular resource
         subsystemRegistration.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("resource", "A"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(PathElement.pathElement("resource", "A"), NonResolvingResourceDescriptionResolver.INSTANCE));
         // /subsystem=mysubsystem/resource=B is a runtime-only resource
         ManagementResourceRegistration runtimeResource = subsystemRegistration.registerSubModel(
-                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("resource", "B"), new NonResolvingResourceDescriptionResolver()).setRuntime()));
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("resource", "B"), NonResolvingResourceDescriptionResolver.INSTANCE).setRuntime()));
         AttributeDefinition runtimeAttr = TestUtils.createAttribute("attr", ModelType.LONG);
         runtimeResource.registerReadOnlyAttribute(runtimeAttr, new OperationStepHandler() {
             @Override
@@ -147,7 +147,7 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
 
         // /subsystem=mysubsystem/resource=D is a runtime-only resource fail at Stage.Runtime
         ManagementResourceRegistration runtimeResourceD = subsystemRegistration.registerSubModel(
-                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("resource", "D"), new NonResolvingResourceDescriptionResolver()).setRuntime()));
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("resource", "D"), NonResolvingResourceDescriptionResolver.INSTANCE).setRuntime()));
         AttributeDefinition runtimeAttrD = TestUtils.createAttribute("attrD", ModelType.LONG);
         runtimeResourceD.registerReadOnlyAttribute(runtimeAttrD, new OperationStepHandler() {
             @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
@@ -224,7 +224,7 @@ public class RegistryProxyControllerTestCase {
     }
 
     private ManagementResourceRegistration registerSubModel(final ManagementResourceRegistration parent, final PathElement address) {
-        return parent.registerSubModel(new SimpleResourceDefinition(address, new NonResolvingResourceDescriptionResolver()));
+        return parent.registerSubModel(new SimpleResourceDefinition(address, NonResolvingResourceDescriptionResolver.INSTANCE));
     }
 
     static class TestProxyController implements ProxyController {

--- a/controller/src/test/java/org/jboss/as/controller/test/RevertReloadRequiredTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RevertReloadRequiredTestCase.java
@@ -78,7 +78,7 @@ public class RevertReloadRequiredTestCase extends AbstractControllerTestBase {
 
         public TestResource() {
             super(PathElement.pathElement("test"),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new TestResourceAddHandler(),
                     new AbstractRemoveStepHandler() {
                     });

--- a/controller/src/test/java/org/jboss/as/controller/test/Subsystem1RootResource.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/Subsystem1RootResource.java
@@ -47,7 +47,7 @@ import org.jboss.dmr.ModelType;
 public class Subsystem1RootResource extends SimpleResourceDefinition {
 
     public Subsystem1RootResource() {
-        super(PathElement.pathElement("subsystem", "subsystem1"), new NonResolvingResourceDescriptionResolver());
+        super(PathElement.pathElement("subsystem", "subsystem1"), NonResolvingResourceDescriptionResolver.INSTANCE);
     }
 
     @Override
@@ -69,14 +69,14 @@ public class Subsystem1RootResource extends SimpleResourceDefinition {
     public void registerChildren(ManagementResourceRegistration profileSub1Reg) {
         super.registerChildren(profileSub1Reg);
         ResourceDefinition profileSub1RegType1Def = ResourceBuilder.Factory.create(PathElement.pathElement("type1", "*"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addReadOnlyAttribute(createAttribute("name", ModelType.STRING))
                 .addReadOnlyAttribute(createAttribute("value", ModelType.INT))
                 .build();
         profileSub1Reg.registerSubModel(profileSub1RegType1Def);
 
         ResourceDefinition profileSub1RegType2Def = ResourceBuilder.Factory.create(PathElement.pathElement("type2", "other"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addReadOnlyAttribute(createAttribute("name", ModelType.STRING))
                 .addReadOnlyAttribute(SimpleAttributeDefinitionBuilder.create("default", ModelType.STRING).setRequired(false).setDefaultValue(new ModelNode("Default string")).build())
                 .build();

--- a/controller/src/test/java/org/jboss/as/controller/test/TestUtils.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/TestUtils.java
@@ -38,7 +38,7 @@ import org.jboss.dmr.ModelType;
  */
 public class TestUtils {
 
-    static final OperationDefinition SETUP_OPERATION_DEF = new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+    static final OperationDefinition SETUP_OPERATION_DEF = new SimpleOperationDefinitionBuilder("setup", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setPrivateEntry()
             .build();
 
@@ -108,13 +108,13 @@ public class TestUtils {
     }
 
     public static OperationDefinition createOperationDefinition(String name, AttributeDefinition... parameters) {
-        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
+        return new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(parameters)
                 .build();
     }
 
     public static OperationDefinition createOperationDefinition(String name, boolean runtimeOnly, AttributeDefinition... parameters) {
-        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(parameters);
         if (runtimeOnly) {
             builder.setRuntimeOnly();

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceDescriptionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceDescriptionUnitTestCase.java
@@ -406,13 +406,13 @@ public class WildcardReadResourceDescriptionUnitTestCase  extends AbstractContro
         root.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         root.registerOperationHandler(SimpleOperationDefinitionBuilder.of("setup",
-                new NonResolvingResourceDescriptionResolver()).build(), NoopOperationStepHandler.WITHOUT_RESULT);
+                NonResolvingResourceDescriptionResolver.INSTANCE).build(), NoopOperationStepHandler.WITHOUT_RESULT);
 
         GlobalNotifications.registerGlobalNotifications(root, processType);
 
 
-        final ManagementResourceRegistration subsystemW = root.registerSubModel(new SimpleResourceDefinition(webSubsystem, new NonResolvingResourceDescriptionResolver()));
-        final ManagementResourceRegistration connectors = subsystemW.registerSubModel(new SimpleResourceDefinition(connector, new NonResolvingResourceDescriptionResolver()));
+        final ManagementResourceRegistration subsystemW = root.registerSubModel(new SimpleResourceDefinition(webSubsystem, NonResolvingResourceDescriptionResolver.INSTANCE));
+        final ManagementResourceRegistration connectors = subsystemW.registerSubModel(new SimpleResourceDefinition(connector, NonResolvingResourceDescriptionResolver.INSTANCE));
         connectors.registerReadOnlyAttribute(TestUtils.createNillableAttribute("1", ModelType.STRING), null);
         connectors.registerReadOnlyAttribute(TestUtils.createNillableAttribute("2", ModelType.STRING), null);
         connectors.registerReadOnlyAttribute(TestUtils.createNillableAttribute("3", ModelType.STRING), null);
@@ -438,12 +438,12 @@ public class WildcardReadResourceDescriptionUnitTestCase  extends AbstractContro
         });
         final ManagementResourceRegistration stats = specialConnectors.registerSubModel(
                 new SimpleResourceDefinition(statistics,
-                        new NonResolvingResourceDescriptionResolver()));
+                        NonResolvingResourceDescriptionResolver.INSTANCE));
         stats.registerReadOnlyAttribute(TestUtils.createNillableAttribute("7", ModelType.STRING), null);
 
-        ManagementResourceRegistration otherSubsystemModel = root.registerSubModel(new SimpleResourceDefinition(otherSubsystem, new NonResolvingResourceDescriptionResolver()));
-        ManagementResourceRegistration serverModel = otherSubsystemModel.registerSubModel(new SimpleResourceDefinition(server, new NonResolvingResourceDescriptionResolver()));
-        serverModel.registerSubModel(new SimpleResourceDefinition(resource, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration otherSubsystemModel = root.registerSubModel(new SimpleResourceDefinition(otherSubsystem, NonResolvingResourceDescriptionResolver.INSTANCE));
+        ManagementResourceRegistration serverModel = otherSubsystemModel.registerSubModel(new SimpleResourceDefinition(server, NonResolvingResourceDescriptionResolver.INSTANCE));
+        serverModel.registerSubModel(new SimpleResourceDefinition(resource, NonResolvingResourceDescriptionResolver.INSTANCE));
 
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceUnitTestCase.java
@@ -133,7 +133,7 @@ public class WildcardReadResourceUnitTestCase extends AbstractControllerTestBase
         root.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         root.registerOperationHandler(SimpleOperationDefinitionBuilder.of("setup",
-                new NonResolvingResourceDescriptionResolver()).build(), new OperationStepHandler() {
+                NonResolvingResourceDescriptionResolver.INSTANCE).build(), new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
@@ -155,10 +155,10 @@ public class WildcardReadResourceUnitTestCase extends AbstractControllerTestBase
         GlobalNotifications.registerGlobalNotifications(root, processType);
 
 
-        final ManagementResourceRegistration hosts = root.registerSubModel(new SimpleResourceDefinition(host, new NonResolvingResourceDescriptionResolver()));
-        final ManagementResourceRegistration servers = hosts.registerSubModel(new SimpleResourceDefinition(server, new NonResolvingResourceDescriptionResolver()));
-        final ManagementResourceRegistration subsystems = servers.registerSubModel(new SimpleResourceDefinition(subsystem, new NonResolvingResourceDescriptionResolver()));
-        final ManagementResourceRegistration connectors = subsystems.registerSubModel(new SimpleResourceDefinition(connector, new NonResolvingResourceDescriptionResolver()));
+        final ManagementResourceRegistration hosts = root.registerSubModel(new SimpleResourceDefinition(host, NonResolvingResourceDescriptionResolver.INSTANCE));
+        final ManagementResourceRegistration servers = hosts.registerSubModel(new SimpleResourceDefinition(server, NonResolvingResourceDescriptionResolver.INSTANCE));
+        final ManagementResourceRegistration subsystems = servers.registerSubModel(new SimpleResourceDefinition(subsystem, NonResolvingResourceDescriptionResolver.INSTANCE));
+        final ManagementResourceRegistration connectors = subsystems.registerSubModel(new SimpleResourceDefinition(connector, NonResolvingResourceDescriptionResolver.INSTANCE));
         connectors.registerReadOnlyAttribute(TestUtils.createNillableAttribute("1", ModelType.STRING), null);
         connectors.registerReadOnlyAttribute(TestUtils.createNillableAttribute("2", ModelType.STRING), null);
         connectors.registerReadOnlyAttribute(TestUtils.createNillableAttribute("3", ModelType.STRING), null);
@@ -184,7 +184,7 @@ public class WildcardReadResourceUnitTestCase extends AbstractControllerTestBase
         });
         final ManagementResourceRegistration stats = specialConnectors.registerSubModel(
                 new SimpleResourceDefinition(PathElement.pathElement("statistics", "test"),
-                        new NonResolvingResourceDescriptionResolver()));
+                        NonResolvingResourceDescriptionResolver.INSTANCE));
         stats.registerReadOnlyAttribute(TestUtils.createNillableAttribute("7", ModelType.STRING), null);
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
@@ -74,7 +74,7 @@ public class WriteAttributeOperationTestCase extends AbstractControllerTestBase 
     private static final String BIGINT_ATT_NAME = "bigint-att";
     private static final String BIGDEC_ATT_NAME = "bigdec-att";
 
-    private static final OperationDefinition SETUP_OP_DEF = new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+    private static final OperationDefinition SETUP_OP_DEF = new SimpleOperationDefinitionBuilder("setup", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setPrivateEntry()
             .build();
 
@@ -179,7 +179,7 @@ public class WriteAttributeOperationTestCase extends AbstractControllerTestBase 
         GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addReadOnlyAttribute(SimpleAttributeDefinitionBuilder.create(NAME, ModelType.STRING, false).setMinSize(1).build())
                 .pushChild(PathElement.pathElement("subsystem", "subsystem1"))
                 .addReadWriteAttribute(BOOLEAN_ATT, null, handler)

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/AliasTransformerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/AliasTransformerTestCase.java
@@ -183,7 +183,7 @@ public class AliasTransformerTestCase {
         return getTransfomers(target).transformOperation(context, operation);
     }
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 
     private static ModelNode success() {
         final ModelNode result = new ModelNode();
@@ -203,7 +203,7 @@ public class AliasTransformerTestCase {
 
     static class AbstractChildResourceDefinition extends SimpleResourceDefinition {
         public AbstractChildResourceDefinition(PathElement element) {
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new ModelOnlyAddStepHandler())
                     .setRemoveHandler(new ModelOnlyRemoveStepHandler())
                     .setOrderedChild());

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/AttributesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/AttributesTestCase.java
@@ -864,7 +864,7 @@ public class AttributesTestCase {
         return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
     }
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 
     private static ModelNode success() {
         final ModelNode result = new ModelNode();

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/BasicResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/BasicResourceTestCase.java
@@ -647,7 +647,7 @@ public class BasicResourceTestCase {
         return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
     }
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 
     private static ModelNode success() {
         final ModelNode result = new ModelNode();

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedOperationBuilderTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedOperationBuilderTestCase.java
@@ -65,7 +65,7 @@ public class ChainedOperationBuilderTestCase {
 
     private static PathElement PATH = PathElement.pathElement("toto", "testSubsystem");
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE);
     private static final ModelVersion V1_0_0 = ModelVersion.create(1, 0, 0);
     private static final ModelVersion V2_0_0 = ModelVersion.create(2, 0, 0);
     private static final ModelVersion V3_0_0 = ModelVersion.create(3, 0, 0);

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedResourceBuilderTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedResourceBuilderTestCase.java
@@ -59,7 +59,7 @@ public class ChainedResourceBuilderTestCase {
 
     private static PathElement PATH = PathElement.pathElement("toto", "testSubsystem");
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE);
     private static final ModelVersion V1_0_0 = ModelVersion.create(1, 0, 0);
     private static final ModelVersion V2_0_0 = ModelVersion.create(2, 0, 0);
     private static final ModelVersion V3_0_0 = ModelVersion.create(3, 0, 0);

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChildRedirectTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChildRedirectTestCase.java
@@ -211,7 +211,7 @@ public class ChildRedirectTestCase {
         return getTransfomers(target).transformOperation(context, operation);
     }
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 
     private static ModelNode success() {
         final ModelNode result = new ModelNode();

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/RecursiveDiscardAndRemoveTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/RecursiveDiscardAndRemoveTestCase.java
@@ -243,7 +243,7 @@ public class RecursiveDiscardAndRemoveTestCase {
         return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
     }
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 
     protected void assertRejected(final ModelNode original, final TransformedOperation transformed) {
         Assert.assertNotNull(transformed);

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -731,7 +731,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
     private static class AddMissingHostSchemaLocationsAttributeForValidationHandler implements OperationStepHandler {
         static final OperationStepHandler INSTANCE = new AddMissingHostSchemaLocationsAttributeForValidationHandler();
         static final String NAME = "add-missing-schema-locations-attribute-for-validation-handler";
-        static final OperationDefinition DEF = new SimpleOperationDefinitionBuilder(NAME, new NonResolvingResourceDescriptionResolver()).build();
+        static final OperationDefinition DEF = new SimpleOperationDefinitionBuilder(NAME, NonResolvingResourceDescriptionResolver.INSTANCE).build();
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel().get(SCHEMA_LOCATIONS).setEmptyList();
@@ -741,7 +741,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
     private static class AddMissingHostNamespacesAttributeForValidationHandler implements OperationStepHandler {
         static final OperationStepHandler INSTANCE = new AddMissingHostNamespacesAttributeForValidationHandler();
         static final String NAME = "add-missing-namespaces-attribute-for-validation-handler";
-        static final OperationDefinition DEF = new SimpleOperationDefinitionBuilder(NAME, new NonResolvingResourceDescriptionResolver()).build();
+        static final OperationDefinition DEF = new SimpleOperationDefinitionBuilder(NAME, NonResolvingResourceDescriptionResolver.INSTANCE).build();
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel().get(NAMESPACES).setEmptyList();

--- a/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/TestModelControllerService.java
+++ b/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/TestModelControllerService.java
@@ -49,7 +49,7 @@ public abstract class TestModelControllerService extends AbstractControllerServi
     private final CapabilityRegistry capabilityRegistry;
 
     protected TestModelControllerService(ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
-        this(processType, configurationPersister, processState, ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+        this(processType, configurationPersister, processState, ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build());
     }
 
     protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/util/AbstractControllerTestBase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/util/AbstractControllerTestBase.java
@@ -161,7 +161,7 @@ public abstract class AbstractControllerTestBase {
 
         ModelControllerService(final ProcessType processType, final ManagedAuditLogger auditLogger) {
             super(processType, new EmptyConfigurationPersister(), new ControlledProcessState(true),
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(),
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     auditLogger);
         }
 

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/util/TestModelControllerService.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/util/TestModelControllerService.java
@@ -66,13 +66,13 @@ public abstract class TestModelControllerService extends AbstractControllerServi
 
     protected TestModelControllerService(final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
         this(ProcessType.EMBEDDED_SERVER, configurationPersister, processState,
-                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(),
+                ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                 AuditLogger.NO_OP_LOGGER);
     }
 
     protected TestModelControllerService(final ConfigurationPersister configurationPersister, final ControlledProcessState processState, ManagedAuditLogger auditLogger) {
         this(ProcessType.EMBEDDED_SERVER, configurationPersister, processState,
-                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(),
+                ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                 auditLogger);
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -935,7 +935,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
         boolean ok = boot(Collections.singletonList(registerModelControllerServiceInitializationBootStep(context)), true, true);
         // until a host is added with the host add op, there is no root description provider delegate. We just install a non-resolving one for now, so the
         // CLI doesn't get a lot of NPEs from :read-resource-description etc.
-        SimpleResourceDefinition def = new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(null, new NonResolvingResourceDescriptionResolver()));
+        SimpleResourceDefinition def = new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(null, NonResolvingResourceDescriptionResolver.INSTANCE));
         rootResourceDefinition.setFakeDelegate(def);
         // just initialize the persister and return, we have to wait for /host=foo:add()
         hostControllerConfigurationPersister.initializeDomainConfigurationPersister(false);

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
@@ -96,7 +96,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
     static final PathElement EXTRA_CHILD = PathElement.pathElement("extra-child");
     static final AttributeDefinition ATTR = new SimpleAttributeDefinitionBuilder("attr", ModelType.STRING, true).build();
     static final AttributeDefinition[] REQUEST_ATTRIBUTES = new AttributeDefinition[]{ATTR};
-    static final OperationDefinition TRIGGER_SYNC = new SimpleOperationDefinitionBuilder("trigger-sync", new NonResolvingResourceDescriptionResolver())
+    static final OperationDefinition TRIGGER_SYNC = new SimpleOperationDefinitionBuilder("trigger-sync", NonResolvingResourceDescriptionResolver.INSTANCE)
             .addParameter(ATTR)
             .build();
 
@@ -277,7 +277,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
         public SubsystemResourceDefinition() {
             super(SUBSYSTEM_ELEMENT,
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
                     new ModelOnlyRemoveStepHandler());
         }
@@ -298,7 +298,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
     static class NonOrderedChildResourceDefinition extends SimpleResourceDefinition {
 
         public NonOrderedChildResourceDefinition() {
-            super(NON_ORDERED_CHILD, new NonResolvingResourceDescriptionResolver(), new ModelOnlyAddStepHandler(REQUEST_ATTRIBUTES), new ModelOnlyRemoveStepHandler());
+            super(NON_ORDERED_CHILD, NonResolvingResourceDescriptionResolver.INSTANCE, new ModelOnlyAddStepHandler(REQUEST_ATTRIBUTES), new ModelOnlyRemoveStepHandler());
         }
 
 
@@ -309,7 +309,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
     abstract class AbstractChildResourceDefinition extends SimpleResourceDefinition {
         public AbstractChildResourceDefinition(PathElement element, OperationStepHandler addHandler) {
-            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(addHandler)
                     .setRemoveHandler(new ModelOnlyRemoveStepHandler())
                     .setOrderedChild());

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandlerTestCase.java
@@ -148,5 +148,5 @@ public class ReadMasterDomainModelHandlerTestCase {
         return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTargetType.DOMAIN);
     }
 
-    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());
+    private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE);
 }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
@@ -116,7 +116,7 @@ import org.junit.Test;
 public class SyncModelServerStateTestCase extends AbstractControllerTestBase  {
 
     static final AttributeDefinition ATTR = new SimpleAttributeDefinitionBuilder("attr", ModelType.STRING, true).build();
-    static final OperationDefinition TRIGGER_SYNC = new SimpleOperationDefinitionBuilder("trigger-sync", new NonResolvingResourceDescriptionResolver())
+    static final OperationDefinition TRIGGER_SYNC = new SimpleOperationDefinitionBuilder("trigger-sync", NonResolvingResourceDescriptionResolver.INSTANCE)
             .addParameter(ATTR)
             .build();
 

--- a/host-controller/src/test/java/org/jboss/as/host/controller/util/AbstractControllerTestBase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/util/AbstractControllerTestBase.java
@@ -280,7 +280,7 @@ public abstract class AbstractControllerTestBase {
 
         public ModelControllerService(final ManagedAuditLogger auditLogger) {
             super(AbstractControllerTestBase.this.processType, new EmptyConfigurationPersister(), new ControlledProcessState(true),
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(),
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     auditLogger, initializer, capabilityRegistry);
         }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ComplexRuntimeAttributesExtension.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ComplexRuntimeAttributesExtension.java
@@ -91,7 +91,7 @@ class ComplexRuntimeAttributesExtension implements Extension {
 
         final SubsystemRegistration subsystem = context.registerSubsystem("test", ModelVersion.create(1));
 
-        ResourceBuilder builder = ResourceBuilder.Factory.create(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver())
+        ResourceBuilder builder = ResourceBuilder.Factory.create(SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(TestSubystemAdd.INSTANCE)
                 .addMetric(MAP_OF_MAPS, new OperationStepHandler() {
                     @Override

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerResourceDefinition.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerResourceDefinition.java
@@ -84,7 +84,7 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
 
         complex = new ObjectTypeAttributeDefinition.Builder("complex", intValue, bigDecimal).build();
         AttributeDefinition param1 = new ObjectTypeAttributeDefinition.Builder("param1", intValue, bigDecimal).build();
-        COMPLEX_OP_DEF = new SimpleOperationDefinitionBuilder("complex", new NonResolvingResourceDescriptionResolver())
+        COMPLEX_OP_DEF = new SimpleOperationDefinitionBuilder("complex", NonResolvingResourceDescriptionResolver.INSTANCE)
                 .addParameter(param1)
                 .setReplyType(ModelType.OBJECT)
                 .setReplyParameters(complex)
@@ -96,7 +96,7 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
 
 
     public ModelControllerResourceDefinition(boolean allowExpressions, boolean forStandalone) {
-        super(PathElement.pathElement("subsystem", "test"), new NonResolvingResourceDescriptionResolver(),
+        super(PathElement.pathElement("subsystem", "test"), NonResolvingResourceDescriptionResolver.INSTANCE,
                 TestSubystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE
         );
@@ -178,10 +178,10 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
     static class VoidOperationNoParams implements OperationStepHandler {
         static final String OPERATION_NAME = "void-no-params";
 
-        static final OperationDefinition DEFINITION_STANDALONE = new SimpleOperationDefinitionBuilder(VoidOperationNoParams.OPERATION_NAME, new NonResolvingResourceDescriptionResolver())
+        static final OperationDefinition DEFINITION_STANDALONE = new SimpleOperationDefinitionBuilder(VoidOperationNoParams.OPERATION_NAME, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setReadOnly()
                 .build();
-        static final OperationDefinition DEFINITION_DOMAIN = new SimpleOperationDefinitionBuilder(VoidOperationNoParams.OPERATION_NAME, new NonResolvingResourceDescriptionResolver())
+        static final OperationDefinition DEFINITION_DOMAIN = new SimpleOperationDefinitionBuilder(VoidOperationNoParams.OPERATION_NAME, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setReadOnly()
                 .setRuntimeOnly()
                 .build();
@@ -214,11 +214,11 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
                 .setValidator(new IntAllowedValuesValidator(3, 5, 7))
                 .build();
 
-        final OperationDefinition DEFINITION_STANDALONE = new SimpleOperationDefinitionBuilder(IntOperationWithParams.OPERATION_NAME, new NonResolvingResourceDescriptionResolver())
+        final OperationDefinition DEFINITION_STANDALONE = new SimpleOperationDefinitionBuilder(IntOperationWithParams.OPERATION_NAME, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(param1, param2, param3, param4, param5)
                 .setReplyType(ModelType.STRING)
                 .build();
-        final OperationDefinition DEFINITION_DOMAIN = new SimpleOperationDefinitionBuilder(IntOperationWithParams.OPERATION_NAME, new NonResolvingResourceDescriptionResolver())
+        final OperationDefinition DEFINITION_DOMAIN = new SimpleOperationDefinitionBuilder(IntOperationWithParams.OPERATION_NAME, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(param1, param2, param3, param4, param5)
                 .setReplyType(ModelType.STRING)
                 .setRuntimeOnly()

--- a/jmx/src/test/java/org/jboss/as/jmx/SubsystemWithChildrenExtension.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/SubsystemWithChildrenExtension.java
@@ -69,7 +69,7 @@ class SubsystemWithChildrenExtension implements Extension {
 
         final SubsystemRegistration subsystem = context.registerSubsystem("test", ModelVersion.create(1));
 
-        ResourceBuilder builder = ResourceBuilder.Factory.create(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver())
+        ResourceBuilder builder = ResourceBuilder.Factory.create(SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(TestSubystemAdd.INSTANCE)
                 .pushChild(getChildElement())
                 .setAddOperation(TestChildAdd.INSTANCE)

--- a/jmx/src/test/java/org/jboss/as/jmx/model/ExpressionTypeConverterUnitTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/ExpressionTypeConverterUnitTestCase.java
@@ -859,7 +859,7 @@ public class ExpressionTypeConverterUnitTestCase {
                                         .build()
                         ).build())
                         .build();
-        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), new NonResolvingResourceDescriptionResolver(), Locale.ENGLISH, null);
+        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), NonResolvingResourceDescriptionResolver.INSTANCE, Locale.ENGLISH, null);
         TypeConverter converter = getConverter(def, desc);
 
         ModelNode node = new ModelNode();
@@ -901,7 +901,7 @@ public class ExpressionTypeConverterUnitTestCase {
                                         .build()
                         ).build())
                         .build();
-        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), new NonResolvingResourceDescriptionResolver(), Locale.ENGLISH, null);
+        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), NonResolvingResourceDescriptionResolver.INSTANCE, Locale.ENGLISH, null);
         TypeConverter converter = getConverter(def, desc);
 
         ModelNode node = new ModelNode();

--- a/jmx/src/test/java/org/jboss/as/jmx/model/LegacyTypeConverterUnitTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/LegacyTypeConverterUnitTestCase.java
@@ -919,7 +919,7 @@ public class LegacyTypeConverterUnitTestCase {
                                         .build()
                         ).build())
                 .build();
-        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), new NonResolvingResourceDescriptionResolver(), Locale.ENGLISH, null);
+        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), NonResolvingResourceDescriptionResolver.INSTANCE, Locale.ENGLISH, null);
         TypeConverter converter = getConverter(def, desc);
 
         ModelNode node = new ModelNode();
@@ -961,7 +961,7 @@ public class LegacyTypeConverterUnitTestCase {
                                         .build()
                         ).build())
                         .build();
-        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), new NonResolvingResourceDescriptionResolver(), Locale.ENGLISH, null);
+        ModelNode desc = def.addResourceAttributeDescription(new ModelNode(), NonResolvingResourceDescriptionResolver.INSTANCE, Locale.ENGLISH, null);
         TypeConverter converter = getConverter(def, desc);
 
         ModelNode node = new ModelNode();

--- a/jmx/src/test/java/org/jboss/as/jmx/model/ObjectNameAddressUtilTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/ObjectNameAddressUtilTestCase.java
@@ -100,7 +100,7 @@ public class ObjectNameAddressUtilTestCase {
     @Test
     public void testToPathAddress() {
 
-        NonResolvingResourceDescriptionResolver resolver = new NonResolvingResourceDescriptionResolver();
+        NonResolvingResourceDescriptionResolver resolver = NonResolvingResourceDescriptionResolver.INSTANCE;
 
         ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootResourceDef);
         ManagementResourceRegistration subsystemRegistration = rootRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("subsystem", "foo"), resolver));

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -867,7 +867,7 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
 
     private static class TestResourceDefinition extends SimpleResourceDefinition {
         TestResourceDefinition(PathElement pathElement, AccessConstraintDefinition...constraints) {
-            super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler() {})
                     .setRemoveHandler(new AbstractRemoveStepHandler() {})
                     .setAccessConstraints(constraints));
@@ -893,7 +893,7 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
         }
 
         void addOperation(String name, boolean readOnly, boolean runtimeOnly, SimpleAttributeDefinition[] parameters, AccessConstraintDefinition...constraints) {
-            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver());
+            SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE);
             if (constraints != null) {
                 builder.setAccessConstraints(constraints);
             }

--- a/jmx/src/test/java/org/jboss/as/jmx/test/util/AbstractControllerTestBase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/test/util/AbstractControllerTestBase.java
@@ -172,7 +172,7 @@ public abstract class AbstractControllerTestBase {
 
         ModelControllerService(final ProcessType processType, final ManagedAuditLogger auditLogger, final DelegatingConfigurableAuthorizer authorizer) {
             super(processType, new EmptyConfigurationPersister(), new ControlledProcessState(true),
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(),
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     auditLogger, authorizer);
         }
 

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
@@ -62,7 +62,7 @@ public class PlatformMBeanTestModelControllerService extends AbstractControllerS
      */
     protected PlatformMBeanTestModelControllerService() {
         super(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), new NullConfigurationPersister(), new ControlledProcessState(true),
-        ResourceBuilder.Factory.create(PathElement.pathElement("root"),new NonResolvingResourceDescriptionResolver()).build(), null, ExpressionResolver.TEST_RESOLVER,
+        ResourceBuilder.Factory.create(PathElement.pathElement("root"),NonResolvingResourceDescriptionResolver.INSTANCE).build(), null, ExpressionResolver.TEST_RESOLVER,
         AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer(), new ManagementSecurityIdentitySupplier(), new CapabilityRegistry(true));
     }
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TransformerAttachmentGrabber.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TransformerAttachmentGrabber.java
@@ -48,7 +48,7 @@ public class TransformerAttachmentGrabber implements OperationStepHandler {
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.VALUE, ModelType.OBJECT).build();
 
     static final OperationDefinition DESC =
-            new SimpleOperationDefinitionBuilder("execute-grab-attachment-and-transform", new NonResolvingResourceDescriptionResolver())
+            new SimpleOperationDefinitionBuilder("execute-grab-attachment-and-transform", NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setParameters(VALUE)
                     .build();
 

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/extrasubsystem/subsystem/dependency/DependencySubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/extrasubsystem/subsystem/dependency/DependencySubsystemExtension.java
@@ -56,7 +56,7 @@ public class DependencySubsystemExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new SimpleResourceDefinition(
                 PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME),
-                new NonResolvingResourceDescriptionResolver(),
+                NonResolvingResourceDescriptionResolver.INSTANCE,
                 DependencySubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE
         ));

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/extrasubsystem/subsystem/main/MainSubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/extrasubsystem/subsystem/main/MainSubsystemExtension.java
@@ -55,7 +55,7 @@ public class MainSubsystemExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new SimpleResourceDefinition(
                 PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME),
-                new NonResolvingResourceDescriptionResolver(),
+                NonResolvingResourceDescriptionResolver.INSTANCE,
                 MainSubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE
         ));

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/otherservices/subsystem/OtherServicesSubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/otherservices/subsystem/OtherServicesSubsystemExtension.java
@@ -66,7 +66,7 @@ public class OtherServicesSubsystemExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new SimpleResourceDefinition(
                 PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME),
-                new NonResolvingResourceDescriptionResolver(),
+                NonResolvingResourceDescriptionResolver.INSTANCE,
                 addHandler,
                 ReloadRequiredRemoveStepHandler.INSTANCE
         ));

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/simple/subsystem/SimpleSubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/simple/subsystem/SimpleSubsystemExtension.java
@@ -54,7 +54,7 @@ public class SimpleSubsystemExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new SimpleResourceDefinition(
                 PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME),
-                new NonResolvingResourceDescriptionResolver(),
+                NonResolvingResourceDescriptionResolver.INSTANCE,
                 SimpleSubsystemAdd.INSTANCE,
                 SimpleSubsystemRemove.INSTANCE
         ));

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/NewExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/NewExtension.java
@@ -165,7 +165,7 @@ public class NewExtension implements Extension {
     protected static class TestResourceDefinition extends SimpleResourceDefinition {
         protected TestResourceDefinition() {
             super(SUBSYSTEM_PATH,
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new ModelOnlyAddStepHandler(ATTRIBUTES),
                     ModelOnlyRemoveStepHandler.INSTANCE);
         }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/OldExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/OldExtension.java
@@ -95,7 +95,7 @@ public class OldExtension implements Extension {
     protected static class TestResourceDefinition extends SimpleResourceDefinition {
         protected TestResourceDefinition() {
             super(SUBSYSTEM_PATH,
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new ModelOnlyAddStepHandler(TEST),
                     ModelOnlyRemoveStepHandler.INSTANCE);
         }
@@ -114,7 +114,7 @@ public class OldExtension implements Extension {
     protected static class PropertyResourceDefinition extends SimpleResourceDefinition {
         protected PropertyResourceDefinition() {
             super(PathElement.pathElement("property"),
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new ModelOnlyAddStepHandler(VALUE),
                     ModelOnlyRemoveStepHandler.INSTANCE);
         }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/similarity/RootSubsystemResource.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/similarity/RootSubsystemResource.java
@@ -36,7 +36,7 @@ public class RootSubsystemResource extends SimpleResourceDefinition {
 
     private RootSubsystemResource() {
         super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test-subsystem"),
-                new NonResolvingResourceDescriptionResolver(),
+                NonResolvingResourceDescriptionResolver.INSTANCE,
                 NoopOperationStepHandler.WITHOUT_RESULT,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
     }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/similarity/SessionDefinition.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/similarity/SessionDefinition.java
@@ -40,7 +40,7 @@ public class SessionDefinition extends SimpleResourceDefinition {
     public static SessionDefinition INSTANCE = new SessionDefinition();
 
     private SessionDefinition() {
-        super(PathElement.pathElement("session"), new NonResolvingResourceDescriptionResolver());
+        super(PathElement.pathElement("session"), NonResolvingResourceDescriptionResolver.INSTANCE);
     }
 
     protected static final SimpleAttributeDefinition JNDI_NAME =
@@ -77,7 +77,7 @@ public class SessionDefinition extends SimpleResourceDefinition {
     }
 
     private static OperationDefinition createOperationDefinition(String name, AttributeDefinition... parameters) {
-        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
+        return new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(parameters)
                 .build();
     }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/validation/subsystem/ValidateSubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/validation/subsystem/ValidateSubsystemExtension.java
@@ -64,7 +64,7 @@ public class ValidateSubsystemExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
         SimpleResourceDefinition subsystemResource = new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(
                 PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME),
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
         );
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(subsystemResource);
         //We always need to add an 'add' operation

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
@@ -71,7 +71,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
 
 
     public ConstrainedResource(PathElement pathElement) {
-        super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+        super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN, AUTHENTICATION_INFLOW))
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("datasources", "datasource"))));

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
@@ -93,7 +93,7 @@ public class OrderedChildResourceExtension implements Extension {
 
         public SubsystemResourceDefinition() {
             super(SUBSYSTEM_PATH,
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
                     new ModelOnlyRemoveStepHandler());
         }
@@ -118,7 +118,7 @@ public class OrderedChildResourceExtension implements Extension {
     private static class OrderedChildResourceDefinition extends SimpleResourceDefinition {
 
         public OrderedChildResourceDefinition() {
-            super(new Parameters(CHILD, new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(CHILD, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AbstractAddStepHandler())
                     .setRemoveHandler(new ModelOnlyRemoveStepHandler())
                     .setOrderedChild());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/RootResourceDefinition.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/RootResourceDefinition.java
@@ -50,7 +50,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
     private static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder("name", ModelType.STRING, false).build();
 
     public RootResourceDefinition(String name) {
-        super(PathElement.pathElement(SUBSYSTEM, name), new NonResolvingResourceDescriptionResolver(),
+        super(PathElement.pathElement(SUBSYSTEM, name), NonResolvingResourceDescriptionResolver.INSTANCE,
                 new AddSubsystemHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SensitiveResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SensitiveResource.java
@@ -40,7 +40,7 @@ import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResol
 public class SensitiveResource extends SimpleResourceDefinition {
 
     public SensitiveResource(PathElement pathElement) {
-        super(new  Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+        super(new  Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AbstractAddStepHandler())
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestAliasReadResourceDescriptionAddressExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestAliasReadResourceDescriptionAddressExtension.java
@@ -76,7 +76,7 @@ public class TestAliasReadResourceDescriptionAddressExtension implements Extensi
     private static class AbstractResourceDefinition extends SimpleResourceDefinition {
         public AbstractResourceDefinition(PathElement pathElement) {
             super(pathElement,
-                    new NonResolvingResourceDescriptionResolver(),
+                    NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(),
                     new ModelOnlyRemoveStepHandler());
         }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
@@ -106,10 +106,10 @@ public class TestHostCapableExtension implements Extension {
                 new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, true)
                 .setCapabilityReference(SOCKET_CAPABILITY_NAME, TEST_CAPABILITY_NAME)
                 .build();
-        private static final OperationDefinition TEST_OP = new SimpleOperationDefinitionBuilder("test-op", new NonResolvingResourceDescriptionResolver()).build();
+        private static final OperationDefinition TEST_OP = new SimpleOperationDefinitionBuilder("test-op", NonResolvingResourceDescriptionResolver.INSTANCE).build();
 
         public RootResourceDefinition(String name) {
-            super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SUBSYSTEM, name), new NonResolvingResourceDescriptionResolver())
+            super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SUBSYSTEM, name), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AddSubsystemHandler())
                     .setRemoveHandler(new RemoveSubsystemHandler())
                     .addCapabilities(TEST_CAPABILITY));

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtensionCommon.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtensionCommon.java
@@ -49,13 +49,13 @@ public abstract class VersionedExtensionCommon implements Extension {
     static AttributeDefinition TEST_ATTRIBUTE = SimpleAttributeDefinitionBuilder.create("test-attribute", ModelType.STRING, true).build();
 
     protected static ResourceDefinition createResourceDefinition(final PathElement element) {
-        return new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(element, new NonResolvingResourceDescriptionResolver())
+        return new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
         .setAddHandler(new AbstractAddStepHandler())
         .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
     }
 
     static OperationDefinition getOperationDefinition(String name) {
-        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
+        return new SimpleOperationDefinitionBuilder(name, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setReadOnly()
                 .build();
     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/module/TestSecureExpressionsExtension.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/module/TestSecureExpressionsExtension.java
@@ -87,14 +87,14 @@ public class TestSecureExpressionsExtension implements Extension {
             .setAllowExpression(true)
             .build();
 
-    public static final OperationDefinition RESOLVE = new SimpleOperationDefinitionBuilder("resolve", new NonResolvingResourceDescriptionResolver())
+    public static final OperationDefinition RESOLVE = new SimpleOperationDefinitionBuilder("resolve", NonResolvingResourceDescriptionResolver.INSTANCE)
             .addParameter(PARAM_EXPRESSION)
             .build();
 
     public static final AttributeDefinition PARAM_SYS_PROP = SimpleAttributeDefinitionBuilder.create("system-property", ModelType.STRING, false)
             .build();
 
-    public static final OperationDefinition READ_SYS_PROP = new SimpleOperationDefinitionBuilder("read-system-property", new NonResolvingResourceDescriptionResolver())
+    public static final OperationDefinition READ_SYS_PROP = new SimpleOperationDefinitionBuilder("read-system-property", NonResolvingResourceDescriptionResolver.INSTANCE)
             .addParameter(PARAM_SYS_PROP)
             .build();
 
@@ -127,7 +127,7 @@ public class TestSecureExpressionsExtension implements Extension {
     public static class ResourceDescription extends PersistentResourceDefinition {
 
         public ResourceDescription() {
-            super(new SimpleResourceDefinition.Parameters(PATH, new NonResolvingResourceDescriptionResolver())
+            super(new SimpleResourceDefinition.Parameters(PATH, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new AddHandler())
                     .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
         }

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
@@ -103,7 +103,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
             .build();
 
     public ConstrainedResource(PathElement pathElement) {
-        super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+        super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN, AUTHENTICATION_INFLOW))
                 .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "datasource"))));

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/RootResourceDefinition.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/RootResourceDefinition.java
@@ -48,7 +48,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
     private static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder("name", ModelType.STRING, false).build();
 
     public RootResourceDefinition(String name) {
-        super(PathElement.pathElement(SUBSYSTEM, name), new NonResolvingResourceDescriptionResolver(),
+        super(PathElement.pathElement(SUBSYSTEM, name), NonResolvingResourceDescriptionResolver.INSTANCE,
                 new AddSubsystemHandler(), ModelOnlyRemoveStepHandler.INSTANCE);
     }
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
@@ -40,7 +40,7 @@ import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResol
 public class SensitiveResource extends SimpleResourceDefinition {
 
     public SensitiveResource(PathElement pathElement) {
-        super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+        super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AbstractAddStepHandler())
                 .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -108,7 +108,7 @@ public class BlockerExtension implements Extension {
 
         private final boolean forHost;
         private BlockerSubsystemResourceDefinition(boolean forHost) {
-            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
+            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(),
                     ModelOnlyRemoveStepHandler.INSTANCE);
             this.forHost = forHost;
@@ -144,7 +144,7 @@ public class BlockerExtension implements Extension {
 
     private static class BlockHandler implements OperationStepHandler {
 
-        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
+        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(CALLER, TARGET_HOST, TARGET_SERVER, BLOCK_POINT, BLOCK_TIME)
                 .setRuntimeOnly()
                 .build();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/customcontext/CustomContextExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/customcontext/CustomContextExtension.java
@@ -87,7 +87,7 @@ public class CustomContextExtension implements Extension {
     private static class CustomContextSubsystemResourceDefinition extends SimpleResourceDefinition {
 
         private CustomContextSubsystemResourceDefinition() {
-            super(new Parameters(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(ADD_HANDLER)
                     .setRemoveHandler(REMOVE_HANDLER)
                     .setCapabilities(CAP)

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
@@ -69,7 +69,7 @@ public class RootResourceDefinition extends PersistentResourceDefinition {
     static final PersistentResourceDefinition INSTANCE = new RootResourceDefinition();
 
     private RootResourceDefinition() {
-        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(AddSubsystemHandler.INSTANCE)
                 .setRemoveHandler(new ServiceRemoveStepHandler(AddSubsystemHandler.INSTANCE, RUNTIME_CAPABILITY))
                 .setCapabilities(RUNTIME_CAPABILITY));

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
@@ -108,7 +108,7 @@ public class ErrorExtension implements Extension {
 
         private final boolean forHost;
         private BlockerSubsystemResourceDefinition(boolean forHost) {
-            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
+            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(), ErrorRemovingBlockingSubsystemStepHandler.REMOVE_SUBSYSTEM_INSTANCE);
             this.forHost = forHost;
         }
@@ -147,7 +147,7 @@ public class ErrorExtension implements Extension {
 
     private static class ErroringHandler implements OperationStepHandler {
 
-        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("error", new NonResolvingResourceDescriptionResolver())
+        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("error", NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setParameters(CALLER, TARGET_HOST, TARGET_SERVER, ERROR_POINT)
                 .build();
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
@@ -127,7 +127,7 @@ public class OpTypesExtension implements Extension {
         private final ProcessType processType;
 
         private OperationTypesSubsystemResourceDefinition(ProcessType processType) {
-            super(new Parameters(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+            super(new Parameters(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setAddHandler(new ModelOnlyAddStepHandler())
                     .setRemoveHandler(new ModelOnlyRemoveStepHandler())
             );

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
@@ -97,7 +97,7 @@ public class LogStreamExtension implements Extension {
 
         private final OperationStepHandler handler;
         private LogStreamSubsystemResourceDefinition() {
-            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
+            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE,
                     new AbstractAddStepHandler(),
                     ModelOnlyRemoveStepHandler.INSTANCE);
             this.handler = new LogStreamHandler();
@@ -123,7 +123,7 @@ public class LogStreamExtension implements Extension {
     private static class LogStreamHandler implements OperationStepHandler {
 
         private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(STREAM_LOG_FILE,
-                new NonResolvingResourceDescriptionResolver())
+                NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setReplyType(ModelType.INT)
                 .build();
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandsSubsystemResourceDescription.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandsSubsystemResourceDescription.java
@@ -41,7 +41,7 @@ public class CliExtCommandsSubsystemResourceDescription extends SimpleResourceDe
     public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, CliExtCommandsExtension.SUBSYSTEM_NAME);
 
     public CliExtCommandsSubsystemResourceDescription() {
-        super(PATH, new NonResolvingResourceDescriptionResolver(), new ModelOnlyAddStepHandler(), new AbstractRemoveStepHandler(){});
+        super(PATH, NonResolvingResourceDescriptionResolver.INSTANCE, new ModelOnlyAddStepHandler(), new AbstractRemoveStepHandler(){});
     }
 
     @Override

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/DuplicateExtCommandSubsystemResourceDescription.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/DuplicateExtCommandSubsystemResourceDescription.java
@@ -38,7 +38,7 @@ public class DuplicateExtCommandSubsystemResourceDescription extends SimpleResou
     public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, DuplicateExtCommandsExtension.SUBSYSTEM_NAME);
 
     public DuplicateExtCommandSubsystemResourceDescription() {
-        super(PATH, new NonResolvingResourceDescriptionResolver(), new ModelOnlyAddStepHandler(), new AbstractRemoveStepHandler() {
+        super(PATH, NonResolvingResourceDescriptionResolver.INSTANCE, new ModelOnlyAddStepHandler(), new AbstractRemoveStepHandler() {
         });
     }
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/booterror/RootResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/booterror/RootResourceDefinition.java
@@ -76,7 +76,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
     static String bootError = null;
 
     RootResourceDefinition() {
-        super(new Parameters(PathElement.pathElement(SUBSYSTEM, TestExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+        super(new Parameters(PathElement.pathElement(SUBSYSTEM, TestExtension.SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AddSubsystemHandler())
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setCapabilities(CAPABILITY)
@@ -101,7 +101,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerSubModel(new SimpleResourceDefinition(new Parameters(PathElement.pathElement("key", "value"), new NonResolvingResourceDescriptionResolver())
+        resourceRegistration.registerSubModel(new SimpleResourceDefinition(new Parameters(PathElement.pathElement("key", "value"), NonResolvingResourceDescriptionResolver.INSTANCE)
         .setAddHandler(new AbstractAddStepHandler() {
 
             @Override

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ChildResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ChildResourceDefinition.java
@@ -46,7 +46,7 @@ public class ChildResourceDefinition extends SimpleResourceDefinition {
     private static final SimpleAttributeDefinition CHILD_ATTRIBUTE = new SimpleAttributeDefinitionBuilder("child-attr", ModelType.STRING, true).build();
 
     ChildResourceDefinition() {
-        super(new Parameters(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver())
+        super(new Parameters(PathElement.pathElement("child"), NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AddChildHandler())
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setIncorporatingCapabilities(Collections.singleton(RootResourceDefinition.CAPABILITY))

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/RootResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/RootResourceDefinition.java
@@ -51,7 +51,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
     private static final SimpleAttributeDefinition ATTRIBUTE = new SimpleAttributeDefinitionBuilder("attribute", ModelType.STRING, true).build();
 
     RootResourceDefinition() {
-        super(new Parameters(PathElement.pathElement(SUBSYSTEM, TestExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+        super(new Parameters(PathElement.pathElement(SUBSYSTEM, TestExtension.SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddHandler(new AddSubsystemHandler())
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setCapabilities(CAPABILITY)


### PR DESCRIPTION
…e used instead of creating new instances

Although there are 128 changed files, the majority of changes were in test code.

Changes in `NonResolvingResourceDescriptionResolver.java`:
- changed `INSTANCE` variable to final
- deprecated no arg constructor

Changes in other files:
- `new NonResolvingResourceDescriptionResolver()` --> `NonResolvingResourceDescriptionResolver.INSTANCE`

`subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemDescriptionDump.java` and `subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/VersionedExtensionCommon.java` were not changed since `NonResolvingResourceDescriptionResolver.INSTANCE` did not exist when they were written, which would cause issues with tests.

https://issues.redhat.com/browse/WFCORE-5808 
