### PR TITLE
[18.x][WFCORE-5766] Upgrading to JBoss Modules 2.0.1.Final

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/javax/sql/api/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/javax/sql/api/main/module.xml
@@ -32,5 +32,6 @@
     <dependencies>
         <module name="java.sql" export="true"/>
         <module name="java.sql.rowset" export="true"/>
+        <module name="java.transaction.xa" export="true"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.legacy.test>6.0.1.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.2.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.3.0.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.1.1.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.modules.jboss-modules>2.0.0.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>2.0.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.13.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.23.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.5.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.6.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>5.2.7.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.2.10.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <version.org.wildfly.jar.plugin>7.0.0.Final</version.org.wildfly.jar.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <version.org.jboss.byteman>4.0.18</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.jandex>2.4.1.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.4.2.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.16.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
         <version.org.jboss.jandex>2.4.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
-        <version.org.jboss.jboss-vfs>3.2.15.Final</version.org.jboss.jboss-vfs>
+        <version.org.jboss.jboss-vfs>3.2.16.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>
         <version.org.jboss.logging.jboss-logging>3.4.3.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5766

Based on #4985 as I'd prefer to minimize the number of PRs related to micro component upgrades in 18.x.

See discussion leading up to https://wildfly.zulipchat.com/#narrow/stream/174184-wildfly-developers/topic/WFCORE-5777.20JBoss.20Modules.202.2E0.2E2/near/274313586 for why this isn't a move to MSC 2.0.2.