### PR TITLE
[18.x][WFCORE-5827] Add elytron-tool to the core-tools layer definition

### DIFF
--- a/core-feature-pack/galleon-common/src/main/resources/layers/standalone/core-tools/layer-spec.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/layers/standalone/core-tools/layer-spec.xml
@@ -7,6 +7,7 @@
        <!-- required for CLI and users management -->
         <package name="org.jboss.as.cli"/>
         <package name="org.jboss.as.domain-add-user"/>
+        <package name="org.wildfly.security.elytron-tool"/>
         <package name="tools"/>
     </packages>
 </layer-spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5827
Upstream: https://github.com/wildfly/wildfly-core/pull/4996
