### PR TITLE
[18.x][WFCORE-5828] WildFly-Common 1.6 depends on java.xml

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/common/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/common/main/module.xml
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="java.management"/>
+        <module name="java.xml"/>
         <module name="org.jboss.logging"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFCORE-5828

Upstream https://github.com/wildfly/wildfly-core/pull/4999