### PR TITLE
[HOLD] Fix for WFCORE-5835, Missing modular export when enabling dns.ping protocol

### DIFF
--- a/bootable-jar/boot/pom.xml
+++ b/bootable-jar/boot/pom.xml
@@ -57,7 +57,7 @@
                         <manifestEntries>
                             <Multi-Release>true</Multi-Release>
                             <!-- NB: In case an update is made to these exports and opens, make sure that common.sh script is in sync. -->
-                            <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</Add-Exports>
+                            <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap jdk.naming.dns/com.sun.jndi.dns</Add-Exports>
                             <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.io java.base/java.security java.base/java.util java.base/java.util.concurrent java.management/javax.management java.naming/javax.naming</Add-Opens>
                         </manifestEntries>
                     </archive>

--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -60,6 +60,8 @@ goto :eof
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.management/javax.management=ALL-UNNAMED"
       rem InitialContext proxy generation requires deep reflection in javax.naming
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.naming/javax.naming=ALL-UNNAMED"
+      rem Needed when enabling jgroups dns.DNS_PING protocol
+      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
     ) else (
       set "DEFAULT_MODULAR_JVM_OPTIONS="
     )

--- a/core-feature-pack/common/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.ps1
@@ -188,6 +188,8 @@ Param(
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.management/javax.management=ALL-UNNAMED"
         # InitialContext proxy generation requires deep reflection in javax.naming
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.naming/javax.naming=ALL-UNNAMED"
+        # Needed when enabling jgroups dns.DNS_PING protocol
+        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
     }
     return $DEFAULT_MODULAR_JVM_OPTIONS
 }

--- a/core-feature-pack/common/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.sh
@@ -58,6 +58,8 @@ setDefaultModularJvmOptions() {
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.management/javax.management=ALL-UNNAMED"
       # InitialContext proxy generation requires deep reflection in javax.naming
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.naming/javax.naming=ALL-UNNAMED"
+      # Needed when enabling jgroups dns.DNS_PING protocol
+      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
     else
       DEFAULT_MODULAR_JVM_OPTIONS=""
     fi

--- a/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
@@ -69,6 +69,7 @@ public final class JvmType {
         modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED");
         DEFAULT_MODULAR_JVM_ARGUMENTS = Collections.unmodifiableList(modularJavaOpts);
     }
 

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -129,7 +129,7 @@ public class ManagedServerBootCmdFactoryTestCase {
         List<String> result = instance.getServerLaunchCommand();
         MatcherAssert.assertThat(result.size(), is(notNullValue()));
         if (result.size() > 18) {
-            MatcherAssert.assertThat(result.size(), is(29));
+            MatcherAssert.assertThat(result.size(), is(30));
         } else {
             MatcherAssert.assertThat(result.size(), is(18));
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -73,6 +73,7 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED");
         // As of jboss-modules 1.9.1.Final the java.se module is no longer required to be added. However as this API is
         // designed to work with older versions of the server we still need to add this argument of modular JVM's.
         modularJavaOpts.add("--add-modules=java.se");

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -274,6 +274,7 @@ public class CommandBuilderTest {
         assertArgumentExists(command, "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.management/javax.management=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.naming/javax.naming=ALL-UNNAMED", expectedCount);
+        assertArgumentExists(command, "--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-modules=java.se", expectedCount);
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5835
This PR is on hold, do not merge. Fix could be applied differently.
