### PR TITLE
[WFCORE-5837] AttributeMarshallers.SimpleListAttributeMarshaller needs to flag isMarshallableAsElement as true

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
@@ -283,11 +283,15 @@ public abstract class AttributeMarshaller {
     }
 
     static class WrappedSimpleAttributeMarshaller extends AttributeElementMarshaller {
+        final boolean unwrap;
+        WrappedSimpleAttributeMarshaller(boolean unwrap) {
+            this.unwrap = unwrap;
+        }
 
           @Override
           public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
               writer.writeStartElement(attribute.getXmlName());
-              marshallElementContent(resourceModel.get(attribute.getName()).asString(), writer);
+              marshallElementContent(unwrap ? resourceModel.asString() : resourceModel.get(attribute.getName()).asString(), writer);
               writer.writeEndElement();
           }
       }

--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshallers.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshallers.java
@@ -169,6 +169,11 @@ public interface AttributeMarshallers {
         }
 
         @Override
+        public boolean isMarshallableAsElement() {
+            return true;
+        }
+
+        @Override
         public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
             assert attribute instanceof SimpleListAttributeDefinition;
             SimpleListAttributeDefinition attr = (SimpleListAttributeDefinition) attribute;
@@ -177,7 +182,7 @@ public interface AttributeMarshallers {
                     writer.writeStartElement(attribute.getXmlName());
                 }
                 for (ModelNode handler : resourceModel.get(attribute.getName()).asList()) {
-                    attr.getValueType().getMarshaller().marshallAsElement(attribute, handler, true, writer);
+                    attr.getValueType().getMarshaller().marshallAsElement(attr.getValueType(), handler, true, writer);
                 }
                 if (wrap) {
                     writer.writeEndElement();
@@ -248,7 +253,12 @@ public interface AttributeMarshallers {
     /**
      * marshalls attributes to element where element name is attribute name and its content is value of attribute
      */
-    AttributeMarshaller SIMPLE_ELEMENT = new AttributeMarshaller.WrappedSimpleAttributeMarshaller();
+    AttributeMarshaller SIMPLE_ELEMENT = new AttributeMarshaller.WrappedSimpleAttributeMarshaller(false);
+
+    /**
+     * marshalls attributes to element where element name is attribute name and its content is value of resourceModel
+     */
+    AttributeMarshaller SIMPLE_ELEMENT_UNWRAP = new AttributeMarshaller.WrappedSimpleAttributeMarshaller(true);
 
     /**
      * space delimited list marshaller


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5837

This PR tries to:
* Implement `AttributeMarshallers.SimpleListAttributeMarshaller.isMarshallableAsElement()` to return `true`.
* Fixes the argument of calling sub element of the list to the `valueType` instead of the `SimpleListAttribute` itself.
* Adds a `SIMPLE_ELEMENT_UNWRAP` in `AttributeMarshallers` to render the simple element from resourceModel.
* Adds tests.