### PR TITLE
WFCORE-2852/WFCORE-5853: CLI autocomplete suggests non-existent subsystems

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -231,7 +231,7 @@ public class LoggingExtension implements Extension {
 
         // Register deployment resources
         if (context.isRuntimeOnlyRegistrationValid()) {
-            final SimpleResourceDefinition deploymentSubsystem = new SimpleResourceDefinition(new Parameters(LoggingResourceDefinition.SUBSYSTEM_PATH, getResourceDescriptionResolver("deployment")).setFeature(false));
+            final SimpleResourceDefinition deploymentSubsystem = new SimpleResourceDefinition(new Parameters(LoggingResourceDefinition.SUBSYSTEM_PATH, getResourceDescriptionResolver("deployment")).setFeature(false).setRuntime());
             final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(deploymentSubsystem);
             final ManagementResourceRegistration configurationResource = deployments.registerSubModel(LoggingDeploymentResources.CONFIGURATION);
             configurationResource.registerSubModel(LoggingDeploymentResources.HANDLER);


### PR DESCRIPTION
* Removing the child names for runtime resource definitions when the
  resource is not present for completion.
* Setting the logging deployment submodel to runtime

Jira: https://issues.redhat.com/browse/WFCORE-5852
        https://issues.redhat.com/browse/WFCORE-5853