### PR TITLE
WFCORE-5765 Unable to check the result containing whitespace with the…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/ConditionArgument.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/ConditionArgument.java
@@ -289,7 +289,8 @@ public class ConditionArgument extends ArgumentWithValue {
         @Override
         public void character(ParsingContext ctx) throws CommandFormatException {
             //System.out.println(ctx.getState().getId() + ": " + ctx.getCharacter());
-            if(parenthesisState != ctx.getState() && !Character.isWhitespace(ctx.getCharacter())) {
+            if (parenthesisState != ctx.getState() && (!Character.isWhitespace(ctx.getCharacter())
+                    || ctx.getState().getId().equals(QuotesState.ID) || ctx.getState().getId().equals(EscapeCharacterState.ID))) {
                 buf.append(ctx.getCharacter());
             }
         }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/ifelse/test/EqualsTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/ifelse/test/EqualsTestCase.java
@@ -93,4 +93,14 @@ public class EqualsTestCase extends ComparisonTestBase {
         node.get("result").set("undefined");
         assertFalse(node, "result == undefined");
     }
+
+    @Test
+    public void testWhitespace() throws Exception {
+        ModelNode node = new ModelNode();
+        node.get("result").set("foo bar");
+        assertTrue(node, "result == \"foo bar\"");
+
+        node.get("result").set("foo\nbar");
+        assertTrue(node, "result == \"foo\\nbar\"");
+    }
 }


### PR DESCRIPTION
… equals to (==) comparison operator in the if-else control flow in JBoss-CLI

Issue: https://issues.redhat.com/browse/WFCORE-5765
Upstream: https://github.com/wildfly/wildfly-core/pull/4915