### PR TITLE
[WFCORE-5854] Upgrade WildFly Elytron to 1.19.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.18.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.19.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5854


        Release Notes - WildFly Elytron - Version 1.19.0.Final
                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2078'>ELY-2078</a>] -         Add encryption support to FileSystemSecurityRealm
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2112'>ELY-2112</a>] -         Automatic registration of client side / JVM wide default SSLContext
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2067'>ELY-2067</a>] -         Elytron tool should log a warning that mask password command is not FIPS compliant 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2271'>ELY-2271</a>] -         IdentityCredentials should have a verify(Supplier&lt;Provider[]&gt;, evidence, hashCharset) method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2294'>ELY-2294</a>] -         Failures in the WFCORE test-suite with branch 1.x
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2295'>ELY-2295</a>] -         Algorithm alias &quot;Data&quot; generates errors in WFCORE test-suite with jdk-18
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2303'>ELY-2303</a>] -         OIDC Client realm roles do overwrite the resource roles if not explicitly disabled
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2308'>ELY-2308</a>] -         Digest authentication fails for encoded queries
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2262'>ELY-2262</a>] -         Add the ability to search for blog posts by tag names
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2270'>ELY-2270</a>] -         Update pr-ci.yaml to include the 2.x branch
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2272'>ELY-2272</a>] -         Ensure tests work without registering JVM Security providers
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2297'>ELY-2297</a>] -         Wrong path for Setup the JBoss Maven Repository
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2307'>ELY-2307</a>] -         Update the OIDC tests so that they can run with Keycloak 17.0.0 and later
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2315'>ELY-2315</a>] -         Digest authentication fails for encoded paths
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2318'>ELY-2318</a>] -         Release WildFly Elytron 1.19.0.Final
</li>
</ul>
                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2281'>ELY-2281</a>] -         Upgrade resteasy-client to 4.7.4.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2180'>ELY-2180</a>] -         The mask command should also prompt for the password if not specified.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2253'>ELY-2253</a>] -         Add a simple implementation of HttpServerCookie
</li>
</ul>
                                                                                                                            
