### PR TITLE
[18.x][WFCORE-5861] Add the standard server JPMS settings to jboss-cli-clie…

### DIFF
--- a/bootable-jar/boot/pom.xml
+++ b/bootable-jar/boot/pom.xml
@@ -56,9 +56,9 @@
                         </manifest>
                         <manifestEntries>
                             <Multi-Release>true</Multi-Release>
-                            <!-- NB: In case an update is made to these exports and opens, make sure that common.sh script is in sync. -->
-                            <Add-Exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</Add-Exports>
-                            <Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.io java.base/java.security java.base/java.util java.base/java.util.concurrent java.management/javax.management java.naming/javax.naming</Add-Opens>
+                            <!-- Use sharable JPMS settings declared in the root pom -->
+                            <Add-Exports>${embedding.jar.jpms.exports}</Add-Exports>
+                            <Add-Opens>${embedding.jar.jpms.opens}</Add-Opens>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -68,6 +68,9 @@
                                     <mainClass>org.jboss.as.cli.CommandLineMain</mainClass>
                                     <manifestEntries>
                                         <Multi-Release>true</Multi-Release>
+                                        <!-- Use sharable JPMS settings declared in the root pom -->
+                                        <Add-Exports>${embedding.jar.jpms.exports}</Add-Exports>
+                                        <Add-Opens>${embedding.jar.jpms.opens}</Add-Opens>
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
         <module.jakarta.classifier></module.jakarta.classifier>
         <module.jakarta.suffix></module.jakarta.suffix>
 
+        <!-- JPMS settings for use in MANIFEST.MF files of jars that can 'embed' a Wildfly server,
+             e.g. a bootable jar or a jboss-cli-client.jar.
+             NB: In case an update is made to these exports and opens, make sure that the common.sh script is in sync.
+        -->
+        <embedding.jar.jpms.exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</embedding.jar.jpms.exports>
+        <embedding.jar.jpms.opens>java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.io java.base/java.security java.base/java.util java.base/java.util.concurrent java.management/javax.management java.naming/javax.naming</embedding.jar.jpms.opens>
+
         <!--
             Dependency versions. Please keep alphabetical.
             you can automatically sort it by running


### PR DESCRIPTION
…nt.jar so it can embed the server on SE 16+

Configure the settings in properties in the root pom so they can be shared between the bootable-jar/boot/pom.xml and the cli/pom.xml

Issue: https://issues.redhat.com/browse/WFCORE-5861
Upstream: #5028