### PR TITLE
[WFCORE-5805] HostControllerBootOperationsTestCase fails intermittent…

### DIFF
--- a/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
+++ b/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
@@ -3,7 +3,7 @@ CLASS org.jboss.as.server.mgmt.domain.HostControllerConnection$ServerRegisterReq
 METHOD sendRequest
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 25*1000)
+DO waitFor($this, 45*1000)
 ENDRULE
 
 RULE Delay Server finish boot
@@ -11,5 +11,5 @@ CLASS org.jboss.as.server.ServerService
 METHOD finishBoot
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 25*1000)
+DO waitFor($this, 45*1000)
 ENDRULE


### PR DESCRIPTION
…ly when Security Manager is enabled

Jira issue: https://issues.redhat.com/browse/WFCORE-5805

This PR follow-ups on https://github.com/wildfly/wildfly-core/pull/4961. 

It adds 40 seconds more to the overall test to ensure we are not hitting failures when CI is pretty busy :(. Ideally, we should be able to unlock the Byte man rule by issuing `signalWake` when the test condition is satisfied, but it is really difficult to find a condition that can be used to trigger the awake by using the same identifier ($this). So I'm trying this with the hope that this additional time is acceptable. It is a workaround though, it won't ensure we will never going to pass the limit that ensures the test can be run, but for the last failures, it looks enough.
