### PR TITLE
[WFCORE-5863] LdapSecurityRealmBuilder should warn that direct verification and user password mapper are incompatible

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
@@ -26,6 +26,7 @@ import static org.wildfly.extension.elytron.ElytronDefinition.commonDependencies
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.BASE64;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HEX;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.UTF_8;
+import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -454,6 +455,10 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
             final LdapSecurityRealmBuilder builder = LdapSecurityRealmBuilder.builder();
 
             if (DIRECT_VERIFICATION.resolveModelAttribute(context, model).asBoolean()) {
+                ModelNode identityMappingNode = IdentityMappingObjectDefinition.OBJECT_DEFINITION.resolveModelAttribute(context, model);
+                if (UserPasswordCredentialMappingObjectDefinition.OBJECT_DEFINITION.resolveModelAttribute(context, identityMappingNode).isDefined()) {
+                    ROOT_LOGGER.ldapRealmDirectVerificationAndUserPasswordMapper();
+                }
                 boolean allowBlankPassword = ALLOW_BLANK_PASSWORD.resolveModelAttribute(context, model).asBoolean();
                 builder.addDirectEvidenceVerification(allowBlankPassword);
             }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -342,6 +342,10 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 46, value = "Provided path '%s' to JAAS configuration file does not exist.")
     StartException jaasFileDoesNotExist(final String path);
 
+    @LogMessage(level = WARN)
+    @Message(id = 47, value = "LDAP Realm is configured to use direct-verification and user-password-mapper which is invalid configuration.")
+    void ldapRealmDirectVerificationAndUserPasswordMapper();
+
     /*
      * Credential Store Section.
      */


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5863
