### PR TITLE
[18.x] [WFCORE-5810] Fix license in wildfly-cli jar.

### DIFF
--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -208,6 +208,11 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
           <distribution>repo</distribution>
         </license>
+        <license>
+          <name>Eclipse Public License - v 1.0</name>
+          <url>https://www.eclipse.org/legal/epl-v10.html</url>
+          <distribution>repo</distribution>
+        </license>
       </licenses>
     </dependency>
     <dependency>
@@ -561,6 +566,11 @@
         <license>
           <name>Apache License 2.0</name>
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>Eclipse Public License - v 1.0</name>
+          <url>https://www.eclipse.org/legal/epl-v10.html</url>
           <distribution>repo</distribution>
         </license>
       </licenses>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-5810

https://github.com/wildfly/wildfly-core/pull/4970 backporting to 18.x
