### PR TITLE
[18.x][WFCORE-5563] Remove commons-lang(2) usage, use commons-lang3.

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -255,12 +255,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.4</version.commons-cli>
-        <version.commons-lang>2.6</version.commons-lang>
         <version.commons-lang3>3.11</version.commons-lang3>
         <version.io.undertow>2.2.16.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
@@ -735,11 +734,6 @@
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>${version.commons-cli}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${version.commons-lang}</version>
             </dependency>
             <dependency>
                 <groupId>io.undertow</groupId>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderHostScopedRolesTestCase.java
@@ -45,7 +45,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.Operations;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderServerGroupScopedRolesTestCase.java
@@ -45,7 +45,8 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.Operations;

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
@@ -54,7 +54,7 @@ import javax.security.sasl.SaslException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractJmxNonCoreMBeansSensitivityTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractJmxNonCoreMBeansSensitivityTestCase.java
@@ -32,7 +32,7 @@ import javax.management.JMRuntimeException;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.jboss.as.test.integration.management.interfaces.JmxManagementInterface;
 import org.jboss.as.test.integration.management.rbac.RbacAdminCallbackHandler;
 import org.jboss.as.test.integration.management.rbac.RbacUtil;

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -71,11 +71,6 @@
     <dependencies>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>compile</scope>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
@@ -56,7 +56,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.operations.common.Util;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -6,7 +6,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.wildfly.test.api.Authentication;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
@@ -15,7 +15,7 @@ limitations under the License.
  */
 package org.jboss.as.test.integration.management.cli;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-5563

https://github.com/wildfly/wildfly-core/pull/4723 backporting to 18.x
