### PR TITLE
[WFCORE-5866] Upgrade Jackson to 2.12.6

### DIFF
--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -41,7 +41,8 @@
 
     <properties>
         <version.ch.qos.reload4j>1.2.18.5</version.ch.qos.reload4j>
-        <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.12.6.1</version.com.fasterxml.jackson.databind>
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.71.Final</version.io.netty>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
@@ -96,7 +97,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
+                <version>${version.com.fasterxml.jackson.databind}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Upgrade jackson-databind to 2.12.6.1
Upgrade other jackson components to 2.12.6

Upstream PR: #5040
JIRA: https://issues.redhat.com/browse/WFCORE-5866

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
