### PR TITLE
[WFCORE-5871] Replace invalid operator

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -309,7 +309,7 @@ fi
 SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "java\.security\.manager"`
 if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
     SECURITY_MANAGER_SET_TO_ALLOW=`echo $JAVA_OPTS | $GREP "java\.security\.manager=allow"`
-    if [ "x$SECURITY_MANAGER_SET_TO_ALLOW" == "x" ]; then
+    if [ "x$SECURITY_MANAGER_SET_TO_ALLOW" = "x" ]; then
         echo "ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable."
         exit 1
     fi


### PR DESCRIPTION
Invalid operator while comparing variable SECURITY_MANAGER_SET_TO_ALLOW to "x" caused bash message "unexpected operator".

Jira issue: https://issues.redhat.com/browse/WFCORE-5871