### PR TITLE
[WFCORE-5805] HostControllerBootOperationsTestCase fails intermittent…

### DIFF
--- a/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
+++ b/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
@@ -3,7 +3,7 @@ CLASS org.jboss.as.server.mgmt.domain.HostControllerConnection$ServerRegisterReq
 METHOD sendRequest
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 25*1000)
+DO waitFor($this, 45*1000)
 ENDRULE
 
 RULE Delay Server finish boot
@@ -11,5 +11,5 @@ CLASS org.jboss.as.server.ServerService
 METHOD finishBoot
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 25*1000)
+DO waitFor($this, 45*1000)
 ENDRULE


### PR DESCRIPTION
…ly when Security Manager is enabled

Jira issue: https://issues.redhat.com/browse/WFCORE-5805

Backporting https://github.com/wildfly/wildfly-core/pull/5032 to 18.x. It just adds more stability to the testsuite in case of a busy CI. 
