### PR TITLE
[WFCORE-5881] Use JPMS properties from launcher optionally

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -62,20 +62,22 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         // Additions to these should include good explanations why in the relevant JIRA
         // Keep them alphabetical to avoid the code history getting confused by reordering commits
         final ArrayList<String> modularJavaOpts = new ArrayList<>();
-        modularJavaOpts.add("--add-exports=java.desktop/sun.awt=ALL-UNNAMED");
-        modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.io=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.security=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.util=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
-        modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
-        // As of jboss-modules 1.9.1.Final the java.se module is no longer required to be added. However as this API is
-        // designed to work with older versions of the server we still need to add this argument of modular JVM's.
-        modularJavaOpts.add("--add-modules=java.se");
+        if (!Boolean.parseBoolean(System.getProperty("launcher.skip.jpms.properties", "false"))) {
+            modularJavaOpts.add("--add-exports=java.desktop/sun.awt=ALL-UNNAMED");
+            modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.io=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.security=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.util=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
+            modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
+            // As of jboss-modules 1.9.1.Final the java.se module is no longer required to be added. However as this API is
+            // designed to work with older versions of the server we still need to add this argument of modular JVM's.
+            modularJavaOpts.add("--add-modules=java.se");
+        }
         DEFAULT_MODULAR_VM_ARGUMENTS = Collections.unmodifiableList(modularJavaOpts);
     }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5881

The details from jira:

JPMS properties are currently [hardcoded in a launcher](https://github.com/wildfly/wildfly-core/blob/main/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java#L65-L78). Launcher is used by [arquillian container](https://mvnrepository.com/artifact/org.wildfly.arquillian/wildfly-arquillian-container-managed). But latest version of arquillian container uses wf-core 16.0.0.Final. So if we depend on old wf-core launcher, we can't ensure that proper JPMS settings would be used. Fortunately, it's quite easy to propagate correct JPMS properties to arquillian directly. This would be useful only if hard-coded properties from Launcher won't be used. This task adds option to not use hard-coded properties from launcher.

The default settings will be still the same - hardcoded JPMS properties would be used by default.

cc: @jamezp @bstansberry 