### PR TITLE
[WFCORE-5838] Adapt host Controller environment properties and host-s…

### DIFF
--- a/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-slave.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-slave.xml
@@ -14,10 +14,10 @@
         <feature spec="host.core-service.discovery-options">
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
-                <param name="protocol" value="${jboss.domain.master.protocol:remote+http}"/>
-                <param name="host-feature" value="${jboss.domain.master.address}"/>
+                <param name="protocol" value="${jboss.domain.primary.protocol:remote+http}"/>
+                <param name="host-feature" value="${jboss.domain.primary.address}"/>
                 <param name="host" value="slave"/>
-                <param name="port" value="${jboss.domain.master.port:9990}"/>
+                <param name="port" value="${jboss.domain.primary.port:9990}"/>
             </feature>
         </feature>
 

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/access/host.xml
@@ -14,7 +14,7 @@
     <domain-controller>
         <local/>
         <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+        <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager-ac.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager-ac.xml
@@ -12,7 +12,7 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9990}" authentication-context="SlaveAC" protocol="remote+http" />
+       <remote host="${jboss.domain.primary.address:127.0.0.1}" port="${jboss.domain.primary.port:9990}" authentication-context="SlaveAC" protocol="remote+http" />
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
@@ -12,7 +12,7 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9990}" protocol="remote+http" />
+       <remote host="${jboss.domain.primary.address:127.0.0.1}" port="${jboss.domain.primary.port:9990}" protocol="remote+http" />
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-remote-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-remote-domain-manager.xml
@@ -12,7 +12,7 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9999}" protocol="remote" />
+       <remote host="${jboss.domain.primary.address:127.0.0.1}" port="${jboss.domain.primary.port:9999}" protocol="remote" />
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-default-interface.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-default-interface.xml
@@ -14,7 +14,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
@@ -14,7 +14,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host.xml
@@ -14,7 +14,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/host.xml
@@ -35,7 +35,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -427,10 +427,10 @@ public class EmbeddedHostControllerFactory {
 
             // these are for compatibility with Main.determineEnvironment / HostControllerEnvironment
             // Once WFCORE-938 is resolved, --admin-only will allow a connection back to the DC for slaves,
-            // and support a method for setting the domain master address outside of -Djboss.domain.master.address
+            // and support a method for setting the domain master address outside of -Djboss.domain.primary.address
             // so we'll probably need a command line argument for this if its not specified as a system prop
-            if (SecurityActions.getPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_ADDRESS, null) == null) {
-                SecurityActions.setPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_ADDRESS, "127.0.0.1");
+            if (SecurityActions.getPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_PRIMARY_ADDRESS, null) == null) {
+                SecurityActions.setPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_PRIMARY_ADDRESS, "127.0.0.1");
             }
             cmds.add(MODULE_PATH);
             cmds.add(SecurityActions.getPropertyPrivileged("module.path", ""));

--- a/embedded/src/main/java/org/wildfly/core/embedded/HostControllerSystemPropertyContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/HostControllerSystemPropertyContext.java
@@ -34,7 +34,7 @@ final class HostControllerSystemPropertyContext extends SystemPropertyContext {
     private static final String DOMAIN_DEPLOYMENT_DIR = "jboss.domain.deployment.dir";
     private static final String DOMAIN_LOG_DIR = "jboss.domain.log.dir";
     private static final String DOMAIN_TEMP_DIR = "jboss.domain.temp.dir";
-    private static final String JBOSS_DOMAIN_MASTER_ADDRESS = "jboss.domain.master.address";
+    private static final String JBOSS_DOMAIN_PRIMARY_ADDRESS = "jboss.domain.primary.address";
     private static final String DOMAIN_SERVERS_DIR = "jboss.domain.servers.dir";
 
     /**
@@ -58,7 +58,7 @@ final class HostControllerSystemPropertyContext extends SystemPropertyContext {
         addPropertyIfAbsent(DOMAIN_DEPLOYMENT_DIR, resolvePath(dataDir, "content"));
         addPropertyIfAbsent(DOMAIN_LOG_DIR, resolvePath(baseDir, "log"));
         addPropertyIfAbsent(DOMAIN_TEMP_DIR, resolvePath(baseDir, "tmp"));
-        checkProperty(JBOSS_DOMAIN_MASTER_ADDRESS);
+        checkProperty(JBOSS_DOMAIN_PRIMARY_ADDRESS);
         checkProperty(DOMAIN_SERVERS_DIR);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -189,15 +189,15 @@ public class HostControllerEnvironment extends ProcessEnvironment {
     public static final String JBOSS_DEFAULT_MULTICAST_ADDRESS = "jboss.default.multicast.address";
 
     /**
-     * The default system property used to store the master Host Controller's native management interface address
+     * The default system property used to store the primary Host Controller's native management interface address
      * from the command line.
      */
-    public static final String JBOSS_DOMAIN_MASTER_ADDRESS = "jboss.domain.master.address";
+    public static final String JBOSS_DOMAIN_PRIMARY_ADDRESS = "jboss.domain.primary.address";
 
     /**
-     * The default system property used to store the master Host Controller's native of the master port from the command line.
+     * The default system property used to store the primary Host Controller's native of the primary port from the command line.
      */
-    public static final String JBOSS_DOMAIN_MASTER_PORT = "jboss.domain.master.port";
+    public static final String JBOSS_DOMAIN_PRIMARY_PORT = "jboss.domain.primary.port";
 
     /**
      * The system property used to store the name of the default domain configuration file. If not set,

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -379,8 +379,8 @@ public final class Main {
                         return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     value = fixPossibleIPv6URL(value);
-                    hostSystemProperties.put(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_ADDRESS, value);
-                    WildFlySecurityManager.setPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_ADDRESS, value);
+                    hostSystemProperties.put(HostControllerEnvironment.JBOSS_DOMAIN_PRIMARY_ADDRESS, value);
+                    WildFlySecurityManager.setPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_PRIMARY_ADDRESS, value);
                 } else if (arg.startsWith(CommandLineConstants.PRIMARY_PORT)) {
 
                     int idx = arg.indexOf('=');
@@ -394,8 +394,8 @@ public final class Main {
                         return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
 
-                    hostSystemProperties.put(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_PORT, value);
-                    WildFlySecurityManager.setPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_PORT, value);
+                    hostSystemProperties.put(HostControllerEnvironment.JBOSS_DOMAIN_PRIMARY_PORT, value);
+                    WildFlySecurityManager.setPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_PRIMARY_PORT, value);
                 } else if (CommandLineConstants.ADMIN_ONLY.equals(arg)) {
                     initialRunningMode = RunningMode.ADMIN_ONLY;
                 } else if (arg.startsWith(CommandLineConstants.SYS_PROP)) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/StaticDiscoveryWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/StaticDiscoveryWriteAttributeHandler.java
@@ -41,7 +41,7 @@ import org.jboss.dmr.Property;
  * discovery-options/static-discovery=primary:write-attribute(name=port,value=9999)
  * should be treated like the following
  * /host=slave/core-service=discovery-options:write-attribute(name=options,value=[{static-discovery={name=primary,
- * protocol="${jboss.domain.master.protocol:remote+http}",host="${jboss.domain.master.address}",port=9999}}]
+ * protocol="${jboss.domain.primary.protocol:remote+http}",host="${jboss.domain.primary.address}",port=9999}}]
  *
  * @author tmiyar
  *

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -192,7 +192,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
     }
 
     /**
-     * Sets the system property {@code jboss.domain.master.address}. In a default slave host configuration this is used
+     * Sets the system property {@code jboss.domain.primary.address}. In a default slave host configuration this is used
      * to configure the address of the master host controller. Ignores {@code null} values.
      * <p/>
      * <b>Note:</b> This option only works if the standard system property has not been removed from the remote host.
@@ -210,7 +210,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
     }
 
     /**
-     * Sets the system property {@code jboss.domain.master.port}. In a default slave host configuration this is used
+     * Sets the system property {@code jboss.domain.primary.port}. In a default slave host configuration this is used
      * to configure the port of the master host controller. Ignores {@code null} values or values less than 0.
      * <p/>
      * <b>Note:</b> This option only works if the standard system property has not been removed from the remote host.
@@ -230,7 +230,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
     }
 
     /**
-     * Sets the system property {@code jboss.domain.master.port}. In a default slave host configuration this is used
+     * Sets the system property {@code jboss.domain.primary.port}. In a default slave host configuration this is used
      * to configure the port of the master host controller. Ignores values less than 0.
      * <p/>
      * <b>Note:</b> This option only works if the standard system property has not been removed from the remote host.

--- a/process-controller/src/main/java/org/jboss/as/process/logging/ProcessLogger.java
+++ b/process-controller/src/main/java/org/jboss/as/process/logging/ProcessLogger.java
@@ -441,7 +441,7 @@ public interface ProcessLogger extends BasicLogger {
      *
      * @return the message.
      */
-    @Message(id = Message.NONE, value = "Set system property jboss.domain.master.address to the given value. In a default slave Host Controller config, this is used to configure the address of the master Host Controller.")
+    @Message(id = Message.NONE, value = "Set system property jboss.domain.primary.address to the given value. In a default slave Host Controller config, this is used to configure the address of the master Host Controller.")
     String argMasterAddress();
 
     /**
@@ -449,7 +449,7 @@ public interface ProcessLogger extends BasicLogger {
      *
      * @return the message.
      */
-    @Message(id = Message.NONE, value = "Set system property jboss.domain.master.port to the given value. In a default slave Host Controller config, this is used to configure the port used for native management communication by the master Host Controller.")
+    @Message(id = Message.NONE, value = "Set system property jboss.domain.primary.port to the given value. In a default slave Host Controller config, this is used to configure the port used for native management communication by the master Host Controller.")
     String argMasterPort();
 
     /**


### PR DESCRIPTION
…lave.xml configuration variables to primary/secondary nomenclature

Jira issue: https://issues.redhat.com/browse/WFCORE-5838

Changes to rename the following environment properties:
jboss.domain.master.protocol, jboss.domain.master.address, jboss.domain.master.port