### PR TITLE
[WFCORE-5887] Upgrade XNIO to 3.8.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.6.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.7.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-5887

18.x PR: #5072 

        Release Notes - XNIO - Version 3.8.7.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-403'>XNIO-403</a>] -         Channels/Conduits.drain do not check for -1 when transferring bytes
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-404'>XNIO-404</a>] -         Channels cannot open file &quot;NUL:&quot; on Windows 
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-406'>XNIO-406</a>] -         javax.net.ssl.SSLHandshakeException: Insufficient buffer remaining for AEAD cipher fragment (2)
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-409'>XNIO-409</a>] -         Channels.drain(FileChannel, long, long) should increment position
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-410'>XNIO-410</a>] -         Add a test for Conduits class
</li>
</ul>
                                                                                                            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-402'>XNIO-402</a>] -         Log Xnio thread size config at debug
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-405'>XNIO-405</a>] -         Add ConduitStreamSinkChannel.toString
</li>
<li>[<a href='https://issues.redhat.com/browse/XNIO-408'>XNIO-408</a>] -         Channels.drain(FileChannel, long, long) does not need to check for StreamSourceChannel
</li>
</ul>
                                                                                                                            