### PR TITLE
[WFCORE-5893] Testsuite uses 1024 RSA keys - they are disabled in new…

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/auditlog/AuditLogToTLSSyslogSetup.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/auditlog/AuditLogToTLSSyslogSetup.java
@@ -89,7 +89,7 @@ public class AuditLogToTLSSyslogSetup extends AuditLogToSyslogSetup {
                 .setKeyAlgorithmName("RSA")
                 .setSignatureAlgorithmName("SHA256withRSA")
                 .setDn(principal)
-                .setKeySize(1024)
+                .setKeySize(2048)
                 .build();
         X509Certificate certificate = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
@@ -109,7 +109,7 @@ public class CoreUtils {
                 .setKeyAlgorithmName("RSA")
                 .setSignatureAlgorithmName("SHA256withRSA")
                 .setDn(principal)
-                .setKeySize(1024)
+                .setKeySize(2048)
                 .build();
         X509Certificate certificate = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
 


### PR DESCRIPTION
…er JDKs by default

https://issues.redhat.com/browse/WFCORE-5893
