### PR TITLE
[18.x][WFCORE-5894] Disable JBossLog4jXmlTestCase when security manager is …

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLog4jXmlTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLog4jXmlTestCase.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 
 import org.apache.http.HttpStatus;
 import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.junit.AfterClass;
@@ -52,6 +53,7 @@ public class JBossLog4jXmlTestCase extends DeploymentBaseTestCase {
 
     @BeforeClass
     public static void deploy() throws Exception {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         deploy(createDeployment("jboss-log4j.xml"), DEPLOYMENT_NAME);
     }
 


### PR DESCRIPTION
…enabled because it makes JBossLoggingPropertiesTestCase and LoggingPropertiesTestCase logger tests fail on JDK8

A way to reproduce the failure is the following:

mvn clean install -Dtest=JBossLog4jXmlTestCase,JBossLoggingPropertiesTestCase,LoggingPropertiesTestCase -Dsecurity.manager -DfailIfNoTests=false -Dsurefire.runOrder=alphabetical

This is only reproducible on 18.x since the main branch uses JDK11.

Jira issue: https://issues.redhat.com/browse/WFCORE-5894