### PR TITLE
[18.x][WFCORE-5909] Upgrade WildFly OpenSSL to 2.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>2.2.0.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.2.1.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5909
Upstream: https://github.com/wildfly/wildfly-core/pull/5099


        Release Notes - WildFly OpenSSL - Version 2.2.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-93'>WFSSL-93</a>] -         Set the natives version used to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-94'>WFSSL-94</a>] -         java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer; on JDK8
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-95'>WFSSL-95</a>] -         Release WildFly OpenSSL 2.2.1.Final
</li>
</ul>
                                                                                                                                                                                                                                        