### PR TITLE
[WFCORE-5922] Ignore RemotingLegacySubsystemTestCase#testSubsystemWit…

### DIFF
--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -68,6 +68,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceNotFoundException;
 import org.jboss.msc.service.ServiceTarget;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.extension.io.IOServices;
 import org.wildfly.extension.io.WorkerService;
@@ -189,6 +190,7 @@ public class RemotingLegacySubsystemTestCase extends AbstractRemotingSubsystemBa
     }
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WFCORE-5386")
     public void testSubsystemWithConnectorPropertyChange() throws Exception {
         KernelServices services = createKernelServicesBuilder(createRuntimeAdditionalInitialization(false))
                 .setSubsystemXmlResource("remoting-with-connector.xml")


### PR DESCRIPTION
…hConnectorPropertyChange test case

Jira issue: https://issues.redhat.com/browse/WFCORE-5922

See https://issues.redhat.com/browse/XNIO-385 to know more about the root cause.

We have already identified the root cause for the failures of this test case. However, lately, it is failing more often and always with the same error and not with others.

It looks reasonable to ignore it by now. We would need to unignore after this problem is fixed on XNIO together with the XNIO upgrade that brings in the fix.
