### PR TITLE
[WFCORE-5930] Upgrade Undertow to 2.3.0.Alpha1, containing Jakarta EE…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.11</version.commons-lang3>
-        <version.io.undertow>2.2.17.Final</version.io.undertow>
+        <version.io.undertow>2.3.0.Alpha1</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
…10 specs implementation

Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-5930


        Release Notes - Undertow - Version 2.3.0.Alpha1
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2058'>UNDERTOW-2058</a>] -         Session.getRequestURI() must return full URI not just request path
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2065'>UNDERTOW-2065</a>] -         ServerEndpointConfig.getUserProperties() must be per connection
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2084'>UNDERTOW-2084</a>] -         Adjust ServletResponse.setCharacterEncoding() behavior after spec clarification
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2085'>UNDERTOW-2085</a>] -         Implement fallback locale to charset mapping if such mapping wasn&#39;t specified in DD
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2086'>UNDERTOW-2086</a>] -         ASYNC and REQUEST dispatch types must return redirected path -&gt; servlet mapping
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2087'>UNDERTOW-2087</a>] -         All ServletContext modification methods must throw UnsupportedOperationException
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2088'>UNDERTOW-2088</a>] -         All SessionCookieConfig modification methods must throw IllegalStateException
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2089'>UNDERTOW-2089</a>] -         RFC 6265 treats the attributes of an RFC 2109 cookie as a separate cookies
</li>
</ul>
                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1593'>UNDERTOW-1593</a>] -         Track processing time of in flight requests
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2051'>UNDERTOW-2051</a>] -         Upgrade WebSocket API to 2.1.0
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2052'>UNDERTOW-2052</a>] -         Upgrade Servlet API to 6.0
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2036'>UNDERTOW-2036</a>] -         AbstractFramedChannel.awaitWritable does not guard against spurious wakes
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2061'>UNDERTOW-2061</a>] -         IP address filter with netmask not working as expected
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2070'>UNDERTOW-2070</a>] -         Empty reply from Undertow if sendRedirect is called after setting content length
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2073'>UNDERTOW-2073</a>] -         JDK 8 / 11 updates breaking Undertow
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2081'>UNDERTOW-2081</a>] -         RejectedExecutionException occurs during shutdown if an open websocket session exists
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2091'>UNDERTOW-2091</a>] -         spotbugs-maven-plugin needs to be updated to work with JDK17
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2092'>UNDERTOW-2092</a>] -         Update GitHub CI configuration to JDK11+
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2093'>UNDERTOW-2093</a>] -         Fix spotbugs reported errors
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2049'>UNDERTOW-2049</a>] -         Move Undertow to JDK11
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2050'>UNDERTOW-2050</a>] -         Move Undertow to Jakarta Specs by Default
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2096'>UNDERTOW-2096</a>] -         Add Nexus repository to CI
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2074'>UNDERTOW-2074</a>] -         Upgrade XNIO to 3.8.7.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1879'>UNDERTOW-1879</a>] -         Utilize o.w.common.Assert class for Null-Checks
</li>
</ul>
                                                                                                                            