### PR TITLE
[WFCORE-5936] Ldap autentication using referrals fails on JDK 17 with ApacheDS

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -42,6 +42,8 @@ goto :eof
       rem Needed to instantiate the default InitialContextFactory implementation used by the
       rem Elytron subsystem dir-context and core management ldap-connection resources
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
+      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED"
+      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED"
       rem Needed if Hibernate applications use Javassist
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.lang=ALL-UNNAMED"
       rem Needed by the MicroProfile REST Client subsystem

--- a/core-feature-pack/common/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.ps1
@@ -170,6 +170,8 @@ Param(
         # Needed to instantiate the default InitialContextFactory implementation used by the
         # Elytron subsystem dir-context and core management ldap-connection resources
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
+        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED"
+        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED"
         # Needed if Hibernate applications use Javassist
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.lang=ALL-UNNAMED"
         # Needed by the MicroProfile REST Client subsystem

--- a/core-feature-pack/common/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.sh
@@ -40,6 +40,8 @@ setDefaultModularJvmOptions() {
       # Needed to instantiate the default InitialContextFactory implementation used by the
       # Elytron subsystem dir-context and core management ldap-connection resources
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
+      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED"
+      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED"
       # Needed if Hibernate applications use Javassist
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
       # Needed by the MicroProfile REST Client subsystem

--- a/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
@@ -60,6 +60,8 @@ public final class JvmType {
         // Keep them alphabetical to avoid the code history getting confused by reordering commits
         modularJavaOpts.add("--add-exports=java.desktop/sun.awt=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -129,7 +129,7 @@ public class ManagedServerBootCmdFactoryTestCase {
         List<String> result = instance.getServerLaunchCommand();
         MatcherAssert.assertThat(result.size(), is(notNullValue()));
         if (result.size() > 18) {
-            MatcherAssert.assertThat(result.size(), is(29));
+            MatcherAssert.assertThat(result.size(), is(31));
         } else {
             MatcherAssert.assertThat(result.size(), is(18));
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -65,6 +65,8 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         if (!Boolean.parseBoolean(System.getProperty("launcher.skip.jpms.properties", "false"))) {
             modularJavaOpts.add("--add-exports=java.desktop/sun.awt=ALL-UNNAMED");
             modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
+            modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED");
+            modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED");
             modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
             modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
             modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -270,6 +270,8 @@ public class CommandBuilderTest {
         // Check exports and opens
         assertArgumentExists(command, "--add-exports=java.desktop/sun.awt=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED", expectedCount);
+        assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED", expectedCount);
+        assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.base/java.io=ALL-UNNAMED", expectedCount);

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
              e.g. a bootable jar or a jboss-cli-client.jar.
              NB: In case an update is made to these exports and opens, make sure that the common.sh script is in sync.
         -->
-        <embedding.jar.jpms.exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap</embedding.jar.jpms.exports>
+        <embedding.jar.jpms.exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap java.naming/com.sun.jndi.url.ldap java.naming/com.sun.jndi.url.ldaps</embedding.jar.jpms.exports>
         <embedding.jar.jpms.opens>java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.io java.base/java.security java.base/java.util java.base/java.util.concurrent java.management/javax.management java.naming/javax.naming</embedding.jar.jpms.opens>
 
         <!--


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5936

The elytron dir-context also needs exports for `com.sun.jndi.url.ldap` in order to follow referrals in JDK-17. There is a exception in `org.jboss.as.naming.context.ObjectFactoryBuilder` when trying to recreate the context for the referral now. Just adding the same exports that were added for `com.sun.jndi.ldap` in WFCORE-5438.

@bstansberry Take a look when you have time. If you want it in another branch (26.x) just let me know.

@fjuma I was thinking about adding a referral and `referral-mode=follow` ldap realm test but I see they are on [wildfly](https://github.com/wildfly/wildfly/blob/main/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java). I can create a followup JIRA for that if you think it's interesting.
