### PR TITLE
[WFCORE-5943] Exclude undertow-servlet transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -792,6 +792,14 @@
                         <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
                         <artifactId>jboss-jsp-api_2.2_spec</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.servlet</groupId>
+                        <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
These changes resolve convergence errors produced during the
productized build of the server.

Issue: https://issues.redhat.com/browse/WFCORE-5943