### PR TITLE
  [WFCORE-5946] Upgrade Undertow to 2.2.18.Final (fixes  CVE-2022-1319)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.11</version.commons-lang3>
-        <version.io.undertow>2.2.17.Final</version.io.undertow>
+        <version.io.undertow>2.2.18.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-5946
Fixes  CVE-2022-1319
Main PR: #5127 

        Release Notes - Undertow - Version 2.2.18.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1945'>UNDERTOW-1945</a>] -         ServletOutputStreamTestCase fails with Premature end of chunk coded message body
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2034'>UNDERTOW-2034</a>] -         Http2StreamSinkChannel.awaitWritable could throw &quot;Out of control window&quot; IOException before awaitWritable timeout has fully ellapsed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2035'>UNDERTOW-2035</a>] -         Http2StreamSinkChannel overrides awaitWritable() but does not override awaitWritable(long, TimeUnit)
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2036'>UNDERTOW-2036</a>] -         AbstractFramedChannel.awaitWritable does not guard against spurious wakes
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2060'>UNDERTOW-2060</a>] -         CVE-2022-1319 Double AJP response for 400 from EAP 7 results in CPING failures
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2061'>UNDERTOW-2061</a>] -         IP address filter with netmask not working as expected
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2066'>UNDERTOW-2066</a>] -         AbstractFramedChannel.freeNotifier checks for receivesSuspendedByUser instead of receivesSuspendedTooManyBuffers
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2068'>UNDERTOW-2068</a>] -         AbstractFramedStreamSourceChannel read listener prevents read from running again
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2070'>UNDERTOW-2070</a>] -         Empty reply from Undertow if sendRedirect is called after setting content length
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2073'>UNDERTOW-2073</a>] -         JDK 8 / 11 updates breaking Undertow
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2079'>UNDERTOW-2079</a>] -         CPU spinning in AbstractFramedStreamSinkChannel
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2080'>UNDERTOW-2080</a>] -         Use currentTimeMillis instead of nanoTime to measure times in awaitWritable
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2094'>UNDERTOW-2094</a>] -         Bad relative redirect is generated if app is mapped to trailing slash context
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2102'>UNDERTOW-2102</a>] -         ServletPrintWriterDelegate throws exception using OpenJDK 19 EA
</li>
</ul>
                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2074'>UNDERTOW-2074</a>] -         Upgrade XNIO to 3.8.7.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2067'>UNDERTOW-2067</a>] -         AbstractFramedChannel should hold from resuming reads immediately after max buffer queue is hit
</li>
</ul>
                                                                                                                                    
