### PR TITLE
[WFCORE-5931] Upgrade JBoss Remoting to 5.0.25.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.0.12.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.0.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.13.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.24.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.25.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Jira:  https://issues.redhat.com/browse/WFCORE-5931

Main PR: #5129 

        Release Notes - JBoss Remoting (3+) - Version 5.0.25.Final
                                                                                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-391'>REM3-391</a>] -         Remove the lock around Endpoint connection creation
</li>
</ul>
                                                                                                                                    