### PR TITLE
[WFCORE-5945][WFCORE-5941] upgraded WildFly OpenSSL to 2.2.3.Final an…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>2.2.1.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.2.3.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>

--- a/pom.xml
+++ b/pom.xml
@@ -239,8 +239,8 @@
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.2.3.Final</version.org.wildfly.openssl>
-        <version.org.wildfly.openssl.natives>2.2.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
+        <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>


### PR DESCRIPTION
…d OpenSSL Natives to 2.2.2.Final

Issue: 
https://issues.redhat.com/browse/WFCORE-5941
https://issues.redhat.com/browse/WFCORE-5945