### PR TITLE
[WFCORE-5948]: Upgrade JGit to 6.2.0.202206071550-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,10 +194,10 @@
         <version.org.apache.logging.log4j>2.17.2</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
-        <version.org.apache.sshd>2.7.0</version.org.apache.sshd>
+        <version.org.apache.sshd>2.8.0</version.org.apache.sshd>
         <version.org.bouncycastle>1.71</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>
-        <version.org.eclipse.jgit>5.13.0.202109080827-r</version.org.eclipse.jgit>
+        <version.org.eclipse.jgit>6.2.0.202206071550-r</version.org.eclipse.jgit>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-5948

* Upgrading JGit to to 6.2.0.202206071550-r
* Upgrading Apache SSHD to 2.8.0

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>
