### PR TITLE
[WFLY-5950] Update client-side modular args to standard set that we s…

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -30,6 +30,14 @@
 
     <name>WildFly: Elytron Subsystem</name>
 
+    <properties>
+        <!-- TlsTestCase specifies use of sun.security.ssl.SunJSSE in the server config,
+             so make it available. -->
+        <modular.jdk.args>${standard.client.modular.jdk.args}
+            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
+        </modular.jdk.args>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/jakartaee/elytron-jakarta/pom.xml
+++ b/jakartaee/elytron-jakarta/pom.xml
@@ -35,6 +35,11 @@
 
     <properties>
         <transformer-input-dir>${project.basedir}/../../elytron</transformer-input-dir>
+        <!-- TlsTestCase specifies use of sun.security.ssl.SunJSSE in the server config,
+             so make it available. -->
+        <modular.jdk.args>${standard.client.modular.jdk.args}
+            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
+        </modular.jdk.args>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,26 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
 
-        <!-- Modularized JDK support (various workarounds) - activated via profile -->
-        <modular.jdk.args>
+        <!-- Standard client-side JPMS settings identified as meeting
+             the needs of WildFly libraries meant for use in clients. -->
+        <standard.client.modular.jdk.args>
+            --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+            --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+            --add-opens=java.base/java.io=ALL-UNNAMED
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
             --add-opens=java.base/java.security=ALL-UNNAMED
-            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-        </modular.jdk.args>
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.management/javax.management=ALL-UNNAMED
+            --add-opens=java.naming/javax.naming=ALL-UNNAMED
+        </standard.client.modular.jdk.args>
+        <!-- JPMS arguments used when launching processes during builds.
+             Defaults to the standard client-side args to cover client side cases (e.g. test clients).
+             By default server processes uses the union of whatever this property specifies
+             plus the internal args from the launcher library. -->
+        <modular.jdk.args>${standard.client.modular.jdk.args}</modular.jdk.args>
         <modular.jdk.props></modular.jdk.props>
 
         <!--


### PR DESCRIPTION
…uggest user's use.

Only use -add-opens=java.base/sun.security.ssl=ALL-UNNAMED in the elytron module which has a test that requires it.

https://issues.redhat.com/browse/WFCORE-5950