### PR TITLE
[WFCORE-5958] The warning message when changing worker of remoting endpoint is not fully correct

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
@@ -122,7 +122,7 @@ public interface RemotingLogger extends BasicLogger {
     @Message(id = 25, value = "Can't remove %s as JMX uses it as a remoting endpoint")
     OperationFailedException couldNotRemoveResource(PathAddress address);
 
-    @Message(id = 26, value = "Change of worker to '%s' in remoting might require the same change in resources depending on remoting.")
+    @Message(id = 26, value = "Change of worker to '%s' in remoting might require the same change in linked resources depending on remoting and in definition of http(s) listeners.")
     String warningOnWorkerChange(String worker);
 
     @Message(id = 27, value = "Failed to obtain SSLContext")


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5958