### PR TITLE
[WFCORE-5718] Remoting: add an ability to configure protocol used by …

### DIFF
--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.remoting.EndpointService;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ServerEnvironmentResourceDescription;
@@ -673,7 +674,7 @@ public class JMXSubsystemTestCase extends AbstractSubsystemBaseTest {
 
             RemotingServices.installConnectorServicesForSocketBinding(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                     "remote", SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("remote"), OptionMap.EMPTY,
-                    null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"));
+                    null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"), Protocol.REMOTE.toString());
         }
     }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -90,6 +90,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.jmx.model.ModelControllerMBeanHelper;
 import org.jboss.as.remoting.EndpointService;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
@@ -1682,7 +1683,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
 
             RemotingServices.installConnectorServicesForSocketBinding(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                     "server", SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("server"), OptionMap.EMPTY,
-                    null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"));
+                    null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"), Protocol.REMOTE.toString());
         }
 
         @Override

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractStreamServerService.java
@@ -65,6 +65,8 @@ abstract class AbstractStreamServerService implements Service {
     private final Supplier<SocketBindingManager> socketBindingManagerSupplier;
     private final OptionMap connectorPropertiesOptionMap;
 
+    private final String protocol;
+
     private volatile AcceptingChannel<StreamConnection> streamServer;
     private volatile ManagedBinding managedBinding;
 
@@ -74,19 +76,21 @@ abstract class AbstractStreamServerService implements Service {
             final Supplier<SaslAuthenticationFactory> saslAuthenticationFactorySupplier,
             final Supplier<SSLContext> sslContextSupplier,
             final Supplier<SocketBindingManager> socketBindingManagerSupplier,
-            final OptionMap connectorPropertiesOptionMap) {
+            final OptionMap connectorPropertiesOptionMap,
+            final String protocol) {
         this.streamServerConsumer = streamServerConsumer;
         this.endpointSupplier = endpointSupplier;
         this.saslAuthenticationFactorySupplier = saslAuthenticationFactorySupplier;
         this.sslContextSupplier = sslContextSupplier;
         this.socketBindingManagerSupplier = socketBindingManagerSupplier;
         this.connectorPropertiesOptionMap = connectorPropertiesOptionMap;
+        this.protocol = protocol;
     }
 
     @Override
     public void start(final StartContext context) throws StartException {
         try {
-            NetworkServerProvider networkServerProvider = endpointSupplier.get().getConnectionProviderInterface("remoting", NetworkServerProvider.class);
+            NetworkServerProvider networkServerProvider = endpointSupplier.get().getConnectionProviderInterface(protocol, NetworkServerProvider.class);
 
             SSLContext sslContext = sslContextSupplier != null ? sslContextSupplier.get() : null;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
@@ -89,7 +89,9 @@ public class ConnectorAdd extends AbstractAddStepHandler {
 
         final ServiceName sbmName = context.getCapabilityServiceName(SOCKET_BINDING_MANAGER_CAPABILTIY, SocketBindingManager.class);
 
+        final String protocol = ConnectorResource.PROTOCOL.resolveModelAttribute(context, fullModel).asString();
+
         RemotingServices.installConnectorServicesForSocketBinding(target, RemotingServices.SUBSYSTEM_ENDPOINT, connectorName,
-                socketBindingName, optionMap, saslAuthenticationFactoryName, sslContextName, sbmName);
+                socketBindingName, optionMap, saslAuthenticationFactoryName, sslContextName, sbmName, protocol);
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
@@ -37,9 +37,11 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.network.ProtocolSocketBinding;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -96,8 +98,15 @@ public class ConnectorResource extends SimpleResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(CommonAttributes.PROTOCOL, ModelType.STRING)
+            .setDefaultValue(new ModelNode("remote"))
+            .setValidator(EnumValidator.create(Protocol.class))
+            .setRequired(false)
+            .setRestartAllServices()
+            .build();
+
     static final AttributeDefinition[] ATTRIBUTES  = {AUTHENTICATION_PROVIDER, SOCKET_BINDING, SECURITY_REALM,
-            SERVER_NAME, SASL_PROTOCOL, SASL_AUTHENTICATION_FACTORY, SSL_CONTEXT};
+            SERVER_NAME, SASL_PROTOCOL, SASL_AUTHENTICATION_FACTORY, SSL_CONTEXT, PROTOCOL};
 
     static final ConnectorResource INSTANCE = new ConnectorResource();
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedNetworkBindingStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedNetworkBindingStreamServerService.java
@@ -55,9 +55,10 @@ final class InjectedNetworkBindingStreamServerService extends AbstractStreamServ
             final Supplier<SSLContext> sslContextSupplier,
             final Supplier<SocketBindingManager> socketBindingManagerSupplier,
             final Supplier<NetworkInterfaceBinding> interfaceBindingSupplier,
-            final OptionMap connectorPropertiesOptionMap, int port) {
+            final OptionMap connectorPropertiesOptionMap, int port,
+            final String protocol) {
         super(streamServerConsumer, endpointSupplier, saslAuthenticationFactorySupplier,
-                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap);
+                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap, protocol);
         this.interfaceBindingSupplier = interfaceBindingSupplier;
         this.port = port;
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedSocketBindingStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedSocketBindingStreamServerService.java
@@ -50,6 +50,7 @@ final class InjectedSocketBindingStreamServerService extends AbstractStreamServe
 
     private final Supplier<SocketBinding> socketBindingSupplier;
     private final String remotingConnectorName;
+    private final Protocol protocol;
 
     InjectedSocketBindingStreamServerService(
             final Consumer<AcceptingChannel<StreamConnection>> streamServerConsumer,
@@ -59,17 +60,19 @@ final class InjectedSocketBindingStreamServerService extends AbstractStreamServe
             final Supplier<SocketBindingManager> socketBindingManagerSupplier,
             final Supplier<SocketBinding> socketBindingSupplier,
             final OptionMap connectorPropertiesOptionMap,
-            final String remotingConnectorName) {
+            final String remotingConnectorName,
+            final String protocol) {
         super(streamServerConsumer, endpointSupplier, saslAuthenticationFactorySupplier,
-                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap);
+                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap, protocol);
         this.socketBindingSupplier = socketBindingSupplier;
         this.remotingConnectorName = remotingConnectorName;
+        this.protocol = Protocol.forName(protocol);
     }
 
     @Override
     public void start(final StartContext context) throws StartException {
         super.start(context);
-        RemotingConnectorBindingInfoService.install(context.getChildTarget(), remotingConnectorName, getSocketBinding(), Protocol.REMOTE);
+        RemotingConnectorBindingInfoService.install(context.getChildTarget(), remotingConnectorName, getSocketBinding(), protocol);
     }
 
     @Override

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Namespace.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Namespace.java
@@ -40,13 +40,13 @@ public enum Namespace {
     REMOTING_2_0("urn:jboss:domain:remoting:2.0"),
     REMOTING_3_0("urn:jboss:domain:remoting:3.0"),
     REMOTING_4_0("urn:jboss:domain:remoting:4.0"),
-    REMOTING_5_0("urn:jboss:domain:remoting:5.0")
-    ;
+    REMOTING_5_0("urn:jboss:domain:remoting:5.0"),
+    REMOTING_6_0("urn:jboss:domain:remoting:6.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = REMOTING_5_0;
+    public static final Namespace CURRENT = REMOTING_6_0;
 
     private final String name;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Protocol.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Protocol.java
@@ -14,6 +14,7 @@ import org.jboss.dmr.ModelNode;
 public enum Protocol {
 
     REMOTE("remote"),
+    REMOTE_TLS("remote+tls"),
     REMOTE_HTTP("remote+http"),
     HTTP_REMOTING("http-remoting"),
     HTTPS_REMOTING("https-remoting"),

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -133,7 +133,9 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_4_0.getUriString(), RemotingSubsystem40Parser::new);
         // For the current version we don't use a Supplier as we want its description initialized
         // TODO if any new xsd versions are added, use a Supplier for the old version
+
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_5_0.getUriString(), new RemotingSubsystem50Parser());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_6_0.getUriString(), new RemotingSubsystem60Parser());
 
         // For servers only as a migration aid we'll install io if it is missing.
         // It is invalid to do this on an HC as the HC needs to support profiles running legacy

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -117,6 +117,7 @@ public class RemotingServices {
                                                                           final String connectorName,
                                                                           final ServiceName networkInterfaceBindingName,
                                                                           final int port,
+                                                                          final String protocol,
                                                                           final OptionMap connectorPropertiesOptionMap,
                                                                           final ServiceName saslAuthenticationFactory,
                                                                           final ServiceName sslContext,
@@ -130,7 +131,7 @@ public class RemotingServices {
         final Supplier<SocketBindingManager> sbmSupplier = socketBindingManager != null ? builder.requires(socketBindingManager) : null;
         final Supplier<NetworkInterfaceBinding> ibSupplier = builder.requires(networkInterfaceBindingName);
         builder.setInstance(new InjectedNetworkBindingStreamServerService(streamServerConsumer,
-                eSupplier, safSupplier, scSupplier, sbmSupplier, ibSupplier, connectorPropertiesOptionMap, port));
+                eSupplier, safSupplier, scSupplier, sbmSupplier, ibSupplier, connectorPropertiesOptionMap, port, protocol));
         builder.install();
     }
 
@@ -141,7 +142,8 @@ public class RemotingServices {
                                                                 final OptionMap connectorPropertiesOptionMap,
                                                                 final ServiceName saslAuthenticationFactory,
                                                                 final ServiceName sslContext,
-                                                                final ServiceName socketBindingManager) {
+                                                                final ServiceName socketBindingManager,
+                                                                final String protocol) {
         final ServiceName serviceName = serverServiceName(connectorName);
         final ServiceBuilder<?> builder = serviceTarget.addService(serviceName);
         final Consumer<AcceptingChannel<StreamConnection>> streamServerConsumer = builder.provides(serviceName);
@@ -151,7 +153,7 @@ public class RemotingServices {
         final Supplier<SocketBindingManager> sbmSupplier = builder.requires(socketBindingManager);
         final Supplier<SocketBinding> sbSupplier = builder.requires(socketBindingName);
         builder.setInstance(new InjectedSocketBindingStreamServerService(streamServerConsumer,
-                eSupplier, safSupplier, scSupplier, sbmSupplier, sbSupplier, connectorPropertiesOptionMap, connectorName));
+                eSupplier, safSupplier, scSupplier, sbmSupplier, sbSupplier, connectorPropertiesOptionMap, connectorName, protocol));
         builder.install();
     }
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem60Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem60Parser.java
@@ -1,0 +1,174 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.remoting;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.readStringAttributeElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.remoting.CommonAttributes.AUTHENTICATION_PROVIDER;
+import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
+import static org.jboss.as.remoting.CommonAttributes.CONNECTOR_REF;
+import static org.jboss.as.remoting.CommonAttributes.HTTP_CONNECTOR;
+import static org.jboss.as.remoting.CommonAttributes.PROTOCOL;
+import static org.jboss.as.remoting.CommonAttributes.SECURITY_REALM;
+import static org.jboss.as.remoting.CommonAttributes.SOCKET_BINDING;
+
+/**
+ * Parser for version 6.0 of the subsystem schema.
+ *
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+class RemotingSubsystem60Parser extends RemotingSubsystem50Parser {
+
+    @Override
+    void parseConnector(boolean http, XMLExtendedStreamReader reader, ModelNode address, List<ModelNode> list)
+            throws XMLStreamException {
+        final ModelNode connector = new ModelNode();
+        connector.get(OP).set(ADD);
+
+        String name = null;
+        String securityRealm = null;
+
+        String socketBinding = null; // Only for NON-HTTP
+        String connectorRef = null;  // Only for HTTP
+
+        String protocol = null; //Only for NON-HTTP
+
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, http ? Attribute.CONNECTOR_REF : Attribute.SOCKET_BINDING);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                case SASL_AUTHENTICATION_FACTORY: {
+                    ConnectorCommon.SASL_AUTHENTICATION_FACTORY.parseAndSetParameter(value, connector, reader);
+                    break;
+                }
+                case SASL_PROTOCOL: {
+                    ConnectorCommon.SASL_PROTOCOL.parseAndSetParameter(value, connector, reader);
+                    break;
+                }
+                case SECURITY_REALM: {
+                    securityRealm = value;
+                    break;
+                }
+                case SERVER_NAME: {
+                    ConnectorCommon.SERVER_NAME.parseAndSetParameter(value, connector, reader);
+                    break;
+                }
+                case SOCKET_BINDING: {
+                    if (http) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    socketBinding = value;
+                    break;
+                }
+                case SSL_CONTEXT: {
+                    if (http) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ConnectorResource.SSL_CONTEXT.parseAndSetParameter(value, connector, reader);
+                    break;
+                }
+                case CONNECTOR_REF: {
+                    if (http == false) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    connectorRef = value;
+                    break;
+                }
+                case PROTOCOL:
+                    if(http){
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    protocol = value;
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        assert name != null;
+        if (http) {
+            assert connectorRef != null;
+        } else {
+            assert socketBinding != null;
+        }
+
+        connector.get(OP_ADDR).set(address).add(http ? HTTP_CONNECTOR : CONNECTOR, name);
+        if (http) {
+            connector.get(CONNECTOR_REF).set(connectorRef);
+        } else {
+            connector.get(SOCKET_BINDING).set(socketBinding);
+            if(protocol !=null) {
+                connector.get(PROTOCOL).set(protocol);
+            }
+        }
+        if (securityRealm != null) {
+            connector.get(SECURITY_REALM).set(securityRealm);
+        }
+        list.add(connector);
+
+        // Handle nested elements.
+        final EnumSet<Element> visited = EnumSet.noneOf(Element.class);
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            if (visited.contains(element)) {
+                throw unexpectedElement(reader);
+            }
+            visited.add(element);
+            switch (element) {
+                case SASL: {
+                    parseSaslElement(reader, connector.get(OP_ADDR), list);
+                    break;
+                }
+                case PROPERTIES: {
+                    parseProperties(reader, connector.get(OP_ADDR), list);
+                    break;
+                }
+                case AUTHENTICATION_PROVIDER: {
+                    connector.get(AUTHENTICATION_PROVIDER).set(readStringAttributeElement(reader, "name"));
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
@@ -172,6 +172,9 @@ class RemotingSubsystemXMLPersister implements XMLStreamConstants, XMLElementWri
         if (node.hasDefined(SECURITY_REALM)) {
             writer.writeAttribute(Attribute.SECURITY_REALM.getLocalName(), node.require(SECURITY_REALM).asString());
         }
+        if (node.hasDefined(PROTOCOL)) {
+            writer.writeAttribute(Attribute.PROTOCOL.getLocalName(), node.require(PROTOCOL).asString());
+        }
         ConnectorCommon.SERVER_NAME.marshallAsAttribute(node, writer);
         ConnectorCommon.SASL_PROTOCOL.marshallAsAttribute(node, writer);
         ConnectorResource.SASL_AUTHENTICATION_FACTORY.marshallAsAttribute(node, writer);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFacto
 import org.jboss.as.controller.remote.ModelControllerOperationHandlerFactory;
 import org.jboss.as.network.SocketBindingManager;
 import org.jboss.as.protocol.mgmt.support.ManagementChannelInitialization;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.logging.RemotingLogger;
 import org.jboss.dmr.ModelNode;
@@ -102,7 +103,7 @@ public final class ManagementRemotingServices extends RemotingServices {
         ServiceName sbmName = context.hasOptionalCapability(sbmCap, NATIVE_MANAGEMENT_RUNTIME_CAPABILITY.getName(), null)
                 ? context.getCapabilityServiceName(sbmCap, SocketBindingManager.class) : null;
         installConnectorServicesForNetworkInterfaceBinding(serviceTarget, endpointName, MANAGEMENT_CONNECTOR,
-                networkInterfaceBinding, port, options, saslAuthenticationFactory, sslContext, sbmName);
+                networkInterfaceBinding, port, Protocol.REMOTE.toString(), options, saslAuthenticationFactory, sslContext, sbmName);
     }
 
     /**

--- a/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -74,6 +74,7 @@ connector.sasl-protocol=The protocol to pass into the SASL mechanisms used for a
 connector.ssl-context=Reference to the SSLContext to use for this connector.
 connector.security=Configuration of security for this connector.
 connector.property=Properties to further configure the connector.
+connector.protocol=Protocol used in the connection.
 
 remoting.http-connector=The remoting HTTP Upgrade connectors.
 http-connector=The configuration of a HTTP Upgrade based Remoting connector.

--- a/remoting/subsystem/src/main/resources/schema/wildfly-remoting_6_0.xsd
+++ b/remoting/subsystem/src/main/resources/schema/wildfly-remoting_6_0.xsd
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:remoting:6.0"
+            xmlns="urn:jboss:domain:remoting:6.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="6.0">
+
+    <!-- The remoting subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the Remoting subsystem.
+
+                The 'worker-thread-pool' element configures the worker thread pool.
+                The nested "connector" element(s) define connectors for this subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="worker-thread-pool" type="workerThreadsType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                   Deprecated and replaced with the 'endpoint' configuration that can reference a worker from the IO subsystem.
+                   This is only supported for use in managed domain profiles whose servers are all running on
+                   previous versions that do not support the 'endpoint' configuration. Use in a server
+                   running a version after the introduction of the 'endpoint' configuration will result
+                   in an error.
+               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="endpoint" type="endpointType"></xs:element>
+            </xs:choice>
+            <xs:element name="connector" type="connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="http-connector" type="http-connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="outbound-connections" minOccurs="0" type="outbound-connectionsType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workerThreadsType">
+           <xs:annotation>
+               <xs:documentation>
+                   <![CDATA[
+                   Deprecated configuration of the worker thread pool.
+
+                   Only supported for legacy servers in a managed domain.
+               ]]>
+               </xs:documentation>
+           </xs:annotation>
+           <xs:attribute name="read-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="write-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-core-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-max-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-keepalive" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-limit" type="xs:integer" use="optional"/>
+       </xs:complexType>
+
+
+    <xs:complexType name="endpointType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Configures the remoting endpoint.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="worker" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                The name of the IO subsystem worker the endpoint should use.
+            ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="authorize-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The SASL authorization ID.  Used as authentication user name to use if no authentication {@code CallbackHandler} is specified
+                                    and the selected SASL mechanism demands a user name.
+                       ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="auth-realm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    The authentication realm to use if no authentication {@code CallbackHandler} is specified.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote+http">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buffer-region-size" type="xs:positiveInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of allocated buffer regions.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of the largest buffer that this endpoint will accept over a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-retries" type="xs:positiveInteger" default="3">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Specify the number of times a client is allowed to retry authentication before closing the connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="transmit-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum window size of the transmit direction for connection channels, in bytes.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-messages" type="xs:positiveInteger" default="65535">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of concurrent outbound messages on a channel.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="send-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of the largest buffer that this endpoint will transmit over a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-messages" type="xs:positiveInteger" default="80">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of concurrent inbound messages on a channel.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum window size of the receive direction for connection channels, in bytes.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="heartbeat-interval" type="xs:positiveInteger" default="2147483647">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction\
+                    for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of outbound channels to support for a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of inbound channels to support for a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="server-name">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The server side of the connection passes it's name to the client in the initial greeting, by default the name is automatically discovered from the local address of the connection or it can be overridden using this.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="abstractConnector" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The base configuration of a Remoting connector.
+
+                The "name" attribute specifies the unique name of this connector.
+
+                The optional nested "sasl" element contains the SASL authentication configuration for this connector.
+
+                The optional nested "authentication-provider" element contains the name of the authentication provider to
+                use for incoming connections.
+
+                The optional server-name attribute specifies the server name that should be used in the initial exchange with
+                the client and within the SASL mechanisms used for authentication.
+
+                The optional sasl-protocol attribute specifies the protocol that should be used within the SASL mechanisms.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="sasl" type="sasl" minOccurs="0"/>
+            <xs:element name="authentication-provider" type="ref" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+        <xs:attribute name="server-name" type="xs:string" use="optional" />
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote" />
+        <xs:attribute name="sasl-authentication-factory" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the SASL authentication factory to use for authenticating requests to this connector.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="connector">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of a Remoting connector.
+
+                The "socket-binding" attribute specifies the name of the socket binding to attach to.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="socket-binding" type="xs:string" use="required"/>
+                <xs:attribute name="protocol" type="xs:string" use="optional"/>
+                <xs:attribute name="ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SSLContext to use for this connector.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-connector">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of a Remoting HTTP upgrade based connector.
+
+                The "connector-ref" specifies the name of the Undertow http connector to use.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="connector-ref" type="name-list" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sasl">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the SASL authentication layer for this server.
+
+                The optional nested "include-mechanisms" element contains a whitelist of allowed SASL mechanism names.
+                No mechanisms will be allowed which are not present in this list.
+
+                The optional nested "qop" element contains a list of quality-of-protection values, in decreasing order
+                of preference.
+
+                The optional nested "strength" element contains a list of cipher strength values, in decreasing order
+                of preference.
+
+                The optional nested "reuse-session" boolean element specifies whether or not the server should attempt
+                to reuse previously authenticated session information.  The mechanism may or may not support such reuse,
+                and other factors may also prevent it.
+
+                The optional nested "server-auth" boolean element specifies whether the server should authenticate to the
+                client.  Not all mechanisms may support this setting.
+
+                The optional nested "policy" boolean element specifies a policy to use to narrow down the available set
+                of mechanisms.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="include-mechanisms" type="name-listType" minOccurs="0"/>
+            <xs:element name="qop" type="qop-listType" minOccurs="0"/>
+            <xs:element name="strength" type="strength-listType" minOccurs="0"/>
+            <xs:element name="reuse-session" type="boolean-element" minOccurs="0"/>
+            <xs:element name="server-auth" type="boolean-element" minOccurs="0"/>
+            <xs:element name="policy" type="policy" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="policy">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Policy criteria items to use in order to choose a SASL mechanism.
+
+                The optional nested "forward-secrecy" element contains a boolean value which specifies whether mechanisms
+                that implement forward secrecy between sessions are required. Forward secrecy means that breaking into
+                one session will not automatically provide information for breaking into future sessions.
+
+                The optional nested "no-active" element contains a boolean value which specifies whether mechanisms
+                susceptible to active (non-dictionary) attacks are not permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-anonymous" element contains a boolean value which specifies whether mechanisms
+                that accept anonymous login are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-dictionary" element contains a boolean value which specifies whether mechanisms
+                susceptible to passive dictionary attacks are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-plain-text" element contains a boolean value which specifies whether mechanisms
+                susceptible to simple plain passive attacks (e.g., "PLAIN") are not permitted.    "false" to permit, "true" to deny.
+
+                The optional nested "pass-credentials" element contains a boolean value which specifies whether
+                mechanisms that pass client credentials are required.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="forward-secrecy" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-active" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-anonymous" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-dictionary" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-plain-text" type="boolean-element" minOccurs="0"/>
+            <xs:element name="pass-credentials" type="boolean-element" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="boolean-element">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a boolean value.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="name-listType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a string list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="name-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="name-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A set of string items.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="qop-listType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a qop list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="qop-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="qop-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The SASL quality-of-protection value list.  See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#QOP
+                for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="auth"/>
+                    <xs:enumeration value="auth-int"/>
+                    <xs:enumeration value="auth-conf"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="strength-listType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                An element specifying a strength list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="strength-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="strength-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The SASL strength value list.  See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#STRENGTH
+                for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="low"/>
+                    <xs:enumeration value="medium"/>
+                    <xs:enumeration value="high"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="properties">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A set of free-form properties.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="property">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A free-form property.  The name is required; the value is optional.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="ref">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A reference to another named service.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionsType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="local-outbound-connection" type="local-outbound-connectionType" />
+            <xs:element name="remote-outbound-connection" type="remote-outbound-connectionType" />
+            <xs:element name="outbound-connection" type="outbound-connectionType" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="base-outbound-connectionType">
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="local-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="remote-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+                <xs:attribute name="username" type="xs:string" use="optional"/>
+                <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+                <xs:attribute name="protocol" type="xs:string" use="optional"/>
+                <xs:attribute name="authentication-context" type="xs:string" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-4.0.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-4.0.xml
@@ -1,0 +1,74 @@
+<subsystem xmlns="urn:jboss:domain:remoting:4.0">
+    <endpoint
+            worker="default-remoting"
+            send-buffer-size="8191"
+            receive-buffer-size="8191"
+            buffer-region-size="10240"
+            transmit-window-size="131071"
+            receive-window-size="131071"
+            max-outbound-channels="41"
+            max-inbound-channels="41"
+            authorize-id="foo"
+            auth-realm="ApplicationRealm"
+            authentication-retries="4"
+            max-outbound-messages="65534"
+            max-inbound-messages="79"
+            heartbeat-interval="20000"
+            max-inbound-message-size="1000000"
+            max-outbound-message-size="1000000"
+            server-name="test"
+            sasl-protocol="bar"
+    />
+    <connector name="remoting-connector" socket-binding="remoting" sasl-protocol="myProto" server-name="myServer">
+        <authentication-provider name="blah"/>
+        <properties>
+            <property name="TCP_NODELAY" value="true"/>
+            <property name="KEEP_ALIVE" value="true"/>
+        </properties>
+        <sasl>
+            <include-mechanisms value="one two three"/>
+            <qop value="auth auth-int"/>
+            <strength value="low high"/>
+            <server-auth value="true"/>
+            <reuse-session value="true"/>
+            <policy>
+                <forward-secrecy value="true"/>
+                <no-active value="true"/>
+                <no-anonymous value="true"/>
+                <no-dictionary value="true"/>
+                <no-plain-text value="true"/>
+                <pass-credentials value="true"/>
+            </policy>
+            <properties>
+                <property name="SASL_SERVER_AUTH" value="true"/>
+                <property name="SASL_POLICY_NOACTIVE" value="false"/>
+            </properties>
+        </sasl>
+    </connector>
+    <http-connector name="http-connector" connector-ref="http" sasl-protocol="myProto" server-name="myServer">
+        <authentication-provider name="blah"/>
+        <properties>
+            <property name="TCP_NODELAY" value="true"/>
+            <property name="REUSE_ADDRESSES" value="true"/>
+        </properties>
+        <sasl>
+            <include-mechanisms value="one two three"/>
+            <qop value="auth auth-int"/>
+            <strength value="low high"/>
+            <server-auth value="true"/>
+            <reuse-session value="true"/>
+            <policy>
+                <forward-secrecy value="true"/>
+                <no-active value="true"/>
+                <no-anonymous value="true"/>
+                <no-dictionary value="true"/>
+                <no-plain-text value="true"/>
+                <pass-credentials value="true"/>
+            </policy>
+            <properties>
+                <property name="SASL_SERVER_AUTH" value="true"/>
+                <property name="SASL_POLICY_NOACTIVE" value="false"/>
+            </properties>
+        </sasl>
+    </http-connector>
+</subsystem>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:remoting:5.0">
+<subsystem xmlns="urn:jboss:domain:remoting:6.0">
     <endpoint
         worker="default-remoting"
         send-buffer-size="8191"
@@ -19,7 +19,7 @@
         server-name="test"
         sasl-protocol="bar"
     />
-    <connector name="remoting-connector" socket-binding="remoting" sasl-protocol="myProto" server-name="myServer">
+    <connector name="remoting-connector" socket-binding="remoting" sasl-protocol="myProto" server-name="myServer" protocol="remote">
         <authentication-provider name="blah"/>
         <properties>
            <property name="TCP_NODELAY" value="true"/>

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.management.BaseNativeInterfaceAddStepHandler;
 import org.jboss.as.controller.management.NativeInterfaceCommonPolicy;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.network.SocketBindingManager;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.logging.ServerLogger;
@@ -104,7 +105,7 @@ public class NativeManagementAddHandler extends BaseNativeInterfaceAddStepHandle
         ManagementRemotingServices.installConnectorServicesForSocketBinding(serviceTarget, endpointName,
                     ManagementRemotingServices.MANAGEMENT_CONNECTOR,
                     socketBindingServiceName, commonPolicy.getConnectorOptions(),
-                    saslAuthenticationFactoryName, sslContextName, sbmName);
+                    saslAuthenticationFactoryName, sslContextName, sbmName, Protocol.REMOTE.toString());
         return Arrays.asList(REMOTING_BASE.append("server", MANAGEMENT_CONNECTOR), socketBindingServiceName);
     }
 


### PR DESCRIPTION
…the remoting connector

…the remoting connector

https://issues.redhat.com/browse/EAP7-1672
https://issues.redhat.com/browse/WFCORE-5718
https://issues.redhat.com/browse/WFLY-13828

This is a configuration fix that allows for easy configuration of feature required by EAP7-1672, which is using "remote+tls" protocol from ejb client. The protocol is supported by jboss-remoting but simply adding it to the configuration doesn't work out of the box. I have noticed that no matter what the connector configuration is on the server side, the connector is hardcoded to use
a connection provider associated with "remoting" protocol. This provider is configured differently than "remote+tls" one and this lead to inability to establish a connection. With this change customer has an ability to configure "remote+tls" on both client and the server and establish a connection using "always SSL" protocol.

@fl4via could you please review?
