### PR TITLE
[WFCORE-5966] Switch uses of deprecated WildflyTestRunner to WildFlyR…

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/expression/SystemPropertyExpressionTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/expression/SystemPropertyExpressionTestCase.java
@@ -56,7 +56,7 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.server.IdentityCredentials;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.SecretKeyCredential;
@@ -65,7 +65,7 @@ import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
 import org.wildfly.security.encryption.SecretKeyUtil;
 import org.wildfly.security.password.interfaces.ClearPassword;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(SystemPropertyExpressionTestCase.ServerSetup.class)
 public class SystemPropertyExpressionTestCase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AnonymousMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AnonymousMgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ AnonymousMgmtSaslTestCase.ServerSetup.class })
 public class AnonymousMgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
@@ -26,7 +26,7 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.AggregateRoleDecoder;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
@@ -50,7 +50,7 @@ import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ AuthenticationWithSourceAddressRoleDecoderMatchTestCase.ServerSetup.class })
 public class AuthenticationWithSourceAddressRoleDecoderMatchTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.AggregateRoleDecoder;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
@@ -47,7 +47,7 @@ import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.ServerSetup.class })
 public class AuthenticationWithSourceAddressRoleDecoderMismatchTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DefaultRealmDigestMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DefaultRealmDigestMgmtSaslTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -56,7 +56,7 @@ import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
  * @see <a href="https://issues.jboss.org/browse/ELY-1186">ELY-1186</a>
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ DefaultRealmDigestMgmtSaslTestCase.ServerSetup.class })
 public class DefaultRealmDigestMgmtSaslTestCase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestMd5MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestMd5MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ DigestMd5MgmtSaslTestCase.ServerSetup.class })
 public class DigestMd5MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha256MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha256MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ DigestSha256MgmtSaslTestCase.ServerSetup.class })
 public class DigestSha256MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha384MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha384MgmtSaslTestCase.java
@@ -19,7 +19,7 @@ package org.wildfly.test.integration.elytron.sasl.mgmt;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -31,7 +31,7 @@ import java.util.List;
  * @author Josef Cacek
  * @author Yeray Borges
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ DigestSha384MgmtSaslTestCase.ServerSetup.class })
 public class DigestSha384MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha512MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha512MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ DigestSha512MgmtSaslTestCase.ServerSetup.class })
 public class DigestSha512MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestShaMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestShaMgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ DigestShaMgmtSaslTestCase.ServerSetup.class })
 public class DigestShaMgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ExternalMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ExternalMgmtSaslTestCase.java
@@ -60,7 +60,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.SecurityFactory;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
@@ -95,7 +95,7 @@ import org.wildfly.test.security.common.other.SimpleSocketBinding;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ ExternalMgmtSaslTestCase.KeyMaterialSetup.class, ExternalMgmtSaslTestCase.ServerSetup.class })
 public class ExternalMgmtSaslTestCase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.CliPath;
@@ -65,7 +65,7 @@ import org.wildfly.test.security.common.other.SimpleSocketBinding;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @org.wildfly.core.testrunner.ServerSetup({ AbstractKerberosMgmtSaslTestBase.Krb5ConfServerSetupTask.class, //
         KerberosSystemPropertiesSetupTask.class, //
         AbstractKerberosMgmtSaslTestBase.DirectoryServerSetupTask.class, //

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
@@ -31,7 +31,7 @@ import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.CliPath;
@@ -63,7 +63,7 @@ import org.wildfly.test.security.common.other.SimpleSocketBinding;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @org.wildfly.core.testrunner.ServerSetup({ AbstractKerberosMgmtSaslTestBase.Krb5ConfServerSetupTask.class, //
         KerberosSystemPropertiesSetupTask.class, //
         AbstractKerberosMgmtSaslTestBase.DirectoryServerSetupTask.class, //

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/OauthbearerMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/OauthbearerMgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -35,7 +35,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ OauthbearerMgmtSaslTestCase.ServerSetup.class })
 public class OauthbearerMgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/PlainMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/PlainMgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ PlainMgmtSaslTestCase.ServerSetup.class })
 public class PlainMgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramPlusMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramPlusMgmtSaslTestCase.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.SecurityFactory;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
@@ -96,7 +96,7 @@ import org.wildfly.test.security.common.other.SimpleSocketBinding;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ ScramPlusMgmtSaslTestCase.KeyMaterialSetup.class, ScramPlusMgmtSaslTestCase.ServerSetup.class })
 public class ScramPlusMgmtSaslTestCase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha1MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha1MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ ScramSha1MgmtSaslTestCase.ServerSetup.class })
 public class ScramSha1MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha256MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha256MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ ScramSha256MgmtSaslTestCase.ServerSetup.class })
 public class ScramSha256MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha384MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha384MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ ScramSha384MgmtSaslTestCase.ServerSetup.class })
 public class ScramSha384MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha512MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramSha512MgmtSaslTestCase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
@@ -30,7 +30,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ ScramSha512MgmtSaslTestCase.ServerSetup.class })
 public class ScramSha512MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/OpenSslTlsTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/OpenSslTlsTestCase.java
@@ -73,7 +73,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.extension.elytron.ElytronExtension;
 import org.wildfly.openssl.OpenSSLProvider;
 import org.wildfly.security.ssl.CipherSuiteSelector;
@@ -97,7 +97,7 @@ import org.xnio.Xnio;
 
 import io.undertow.protocols.ssl.UndertowXnioSsl;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @org.wildfly.core.testrunner.ServerSetup({ OpenSslTlsTestCase.KeyMaterialSetup.class, OpenSslTlsTestCase.ServerSetup.class })
 public class OpenSslTlsTestCase {
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/ServerSslSniContextTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/ServerSslSniContextTestCase.java
@@ -25,12 +25,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ServerSslSniContextTestCase {
     CLIWrapper cli;
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/CasePrincipalTransformerTest.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/CasePrincipalTransformerTest.java
@@ -26,10 +26,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CasePrincipalTransformerTest {
 
     CLIWrapper cli;

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/RegexRoleMapperTest.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/RegexRoleMapperTest.java
@@ -7,11 +7,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.hamcrest.core.StringContains.containsString;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class RegexRoleMapperTest {
     CLIWrapper cli;
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SecurityDomainTest.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/SecurityDomainTest.java
@@ -23,11 +23,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class SecurityDomainTest {
     CLIWrapper cli;
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/adminonly/auditlog/AdminOnlyAuditLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/adminonly/auditlog/AdminOnlyAuditLogTestCase.java
@@ -40,13 +40,13 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
 /**
  * @author Kabir Khan
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class AdminOnlyAuditLogTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingLogTestCase.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
 /**
@@ -63,7 +63,7 @@ import org.xnio.IoUtils;
  *          Test that attribute log-boot of audit-log in Management and
  *          audit-log in JMX works right
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class AuditLogBootingLogTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
@@ -43,14 +43,14 @@ import org.junit.runner.RunWith;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
 /**
  *
  * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class AuditLogBootingSyslogTest {
     private final ModelNode userAuthAddress = Operations.createAddress("subsystem", "elytron", "configurable-sasl-server-factory", "configured");

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
@@ -50,7 +50,7 @@ import org.junit.runner.RunWith;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
 /**
@@ -59,7 +59,7 @@ import org.xnio.IoUtils;
  * @author Ondrej Lukas
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 @Category(CommonCriteria.class)
 public class AuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCase {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
 /**
@@ -37,7 +37,7 @@ import org.xnio.IoUtils;
  *
  *          Test that fields of Audit log from JMX have right content
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class JmxAuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCase {
     @Inject

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/cli/boot/ops/CliBootOperationsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/cli/boot/ops/CliBootOperationsTestCase.java
@@ -42,13 +42,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CliBootOperationsTestCase {
     // Taken from org.wildfly.core.testrunner.Server

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerNotificationUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerNotificationUnitTestCase.java
@@ -41,12 +41,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Emanuel Muckenhuber
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class DeploymentScannerNotificationUnitTestCase extends AbstractDeploymentScannerBasedTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationRollbackTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationRollbackTestCase.java
@@ -45,13 +45,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Testing the rollback of a composite operation with a manual scan.
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class DeploymentScannerOperationRollbackTestCase extends AbstractDeploymentScannerBasedTestCase {
     private static final int FAILING_TIMEOUT = 3000;

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationTestCase.java
@@ -39,13 +39,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Testing operation with a manual scan.
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class DeploymentScannerOperationTestCase extends AbstractDeploymentScannerBasedTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerRedeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerRedeploymentTestCase.java
@@ -33,9 +33,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class DeploymentScannerRedeploymentTestCase extends AbstractDeploymentScannerBasedTestCase {
     private static final int DELAY = 100;

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerShutdownTestCase.java
@@ -68,14 +68,14 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests server reload during a deployment or undeployment to a wildfly core server by the filesystem scanner.
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 @Ignore("this test relies too much on hacking internals (see the byteman script) so it's only here to allow " +
         "custom use if there is a need to diagnose a problem in this area")

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerUnitTestCase.java
@@ -59,12 +59,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Emanuel Muckenhuber
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBasedTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/InterdependentDeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/InterdependentDeploymentTestCase.java
@@ -51,7 +51,7 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test of deployment ops for deployments that depend on other deployments.
@@ -60,7 +60,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Brian Stansberry
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class InterdependentDeploymentTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/elytron/CustomCredentialSecurityFactoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/elytron/CustomCredentialSecurityFactoryTestCase.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test for authentication through http-interface secured by Elytron http-authentication-factory where we test that
@@ -50,7 +50,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author olukas
  * @author Hynek Švábek <hsvabek@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CustomCredentialSecurityFactoryTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/CredentialStoreExpressionsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/expressions/CredentialStoreExpressionsTestCase.java
@@ -24,14 +24,14 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CredentialStoreExpressionsTestCase extends AbstractSecureExpressionsTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingDependenciesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingDependenciesTestCase.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Create a deployment with dependency to log4j module.
@@ -45,7 +45,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class LoggingDependenciesTestCase extends AbstractLoggingTestCase {
     private static final Logger log = Logger.getLogger(LoggingDependenciesTestCase.class.getName());

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingPreferencesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingPreferencesTestCase.java
@@ -43,7 +43,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Create a deployment with both per-deploy logging configuration file and logging profile.
@@ -52,7 +52,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class LoggingPreferencesTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/PerDeployLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/PerDeployLoggingTestCase.java
@@ -42,7 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Create a deployment with per-deploy logging configuration file.
@@ -51,7 +51,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PerDeployLoggingTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
@@ -37,7 +37,7 @@ import org.productivity.java.syslog4j.SyslogConstants;
 import org.productivity.java.syslog4j.server.SyslogServer;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test case whether logging to syslog through UDP and TCP is possible if syslog server is restarted once and twice.
@@ -46,7 +46,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author olukas
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ReconnectSyslogServerTestCase extends AbstractSyslogReconnectionTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SizeAppenderRestartTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SizeAppenderRestartTestCase.java
@@ -44,14 +44,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test to confirm rotate-on-boot works.
  *
  * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class SizeAppenderRestartTestCase extends AbstractLoggingTestCase {
     private static final String FILE_NAME = "sizeAppenderRestartTestCase.log";

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
@@ -37,7 +37,7 @@ import org.productivity.java.syslog4j.SyslogConstants;
 import org.productivity.java.syslog4j.server.SyslogServer;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test whether application server can log into UDP and TCP syslog server even if this server is not available during server
@@ -47,7 +47,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author olukas
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class SyslogIsNotAvailableDuringServerBootTestCase extends AbstractSyslogReconnectionTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/capabilities/FilterCapabilityTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/capabilities/FilterCapabilityTestCase.java
@@ -28,12 +28,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class FilterCapabilityTestCase extends CapabilityTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/capabilities/HandlerCapabilityTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/capabilities/HandlerCapabilityTestCase.java
@@ -24,12 +24,12 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class HandlerCapabilityTestCase extends CapabilityTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/capabilities/LoggerCapabilityTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/capabilities/LoggerCapabilityTestCase.java
@@ -26,12 +26,12 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class LoggerCapabilityTestCase extends CapabilityTestCase {
     private static final String LOGGER_NAME = LoggerCapabilityTestCase.class.getName();

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/AbstractCustomModuleTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/module/AbstractCustomModuleTestCase.java
@@ -42,12 +42,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public abstract class AbstractCustomModuleTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/ReadOnlyModeTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/ReadOnlyModeTestCase.java
@@ -44,13 +44,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ReadOnlyModeTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/ServerServiceThreadPoolTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/ServerServiceThreadPoolTestCase.java
@@ -32,14 +32,14 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests the configuration of Server Service Thread Pool CorePoolSize and MaxPoolSize by using system properties.
  *
  * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ServerServiceThreadPoolTestCase {
     // There are the current default values, must be in sync with ServerService.ServerExecutorService field values

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIAuthenticationTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIAuthenticationTestCase.java
@@ -35,13 +35,13 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CLIAuthenticationTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Jean-Francois Denise (jdenise@redhat.com)
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CLIScriptSupportTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CommandTimeoutHandlerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CommandTimeoutHandlerTestCase.java
@@ -51,7 +51,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import static org.junit.Assert.assertEquals;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
@@ -60,7 +60,7 @@ import org.wildfly.core.testrunner.ServerController;
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CommandTimeoutHandlerTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/DeploymentOverlayTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/DeploymentOverlayTestCase.java
@@ -35,14 +35,14 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.jmx.ServiceActivatorDeployment;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentOverlayTestCase {
 
     private interface TestOperations {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/GlobalOpsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/GlobalOpsTestCase.java
@@ -39,12 +39,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author baranowb
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class GlobalOpsTestCase extends AbstractCliTestBase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ManagementOpTimeoutTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ManagementOpTimeoutTestCase.java
@@ -48,7 +48,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Integration test of management op timeout handling. This test focuses on the CLI handling
@@ -57,7 +57,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Brian Stansberry (c) 2014 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ManagementOpTimeoutTestCase extends AbstractCliTestBase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadOpsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadOpsTestCase.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2013 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ReloadOpsTestCase extends AbstractCliTestBase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
@@ -44,13 +44,13 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ReloadRedirectTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/RemoveManagementRealmTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/RemoveManagementRealmTestCase.java
@@ -44,13 +44,13 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RemoveManagementRealmTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ShutdownTestCase.java
@@ -30,13 +30,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ShutdownTestCase {
     @Inject

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
@@ -31,9 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class GitRepositoryTestCase extends AbstractGitRepositoryTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
@@ -38,9 +38,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteHttpGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteHttpGitRepositoryTestCase.java
@@ -36,12 +36,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RemoteHttpGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteSshGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteSshGitRepositoryTestCase.java
@@ -61,7 +61,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.common.annotation.NotNull;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.server.IdentityCredentials;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.KeyPairCredential;
@@ -74,7 +74,7 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 /**
  * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RemoteSshGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/YamlExtensionTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/YamlExtensionTestCase.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.Server;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -47,7 +47,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * Testing the cli ops are compatible with the YAML changes.
  * @author Emmanuel Hugonnet (c) 2021 Red Hat, Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 @Ignore
 public class YamlExtensionTestCase {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests for authentication through the http-interface secured by an Elytron http-authentication-factory
@@ -47,7 +47,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class  AuthenticationWithSourceAddressRoleDecoderMatchTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests for authentication through the http-interface secured by an Elytron http-authentication-factory
@@ -47,7 +47,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class AuthenticationWithSourceAddressRoleDecoderMismatchTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/ElytronModelControllerClientTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/ElytronModelControllerClientTestCase.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -54,7 +54,7 @@ import org.wildfly.security.auth.principal.NamePrincipal;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ElytronModelControllerClientTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/HttpMgmtInterfaceElytronAuthenticationTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/HttpMgmtInterfaceElytronAuthenticationTestCase.java
@@ -38,14 +38,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test for authentication through http-interface secured by Elytron http-authentication-factory.
  *
  * @author olukas
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class HttpMgmtInterfaceElytronAuthenticationTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/secman/PermissionsDeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/secman/PermissionsDeploymentTestCase.java
@@ -42,7 +42,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -52,7 +52,7 @@ import java.io.File;
  *
  * @author Jaikiran Pai
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PermissionsDeploymentTestCase extends AbstractDeploymentScannerBasedTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/StartSuspendedTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/StartSuspendedTestCase.java
@@ -51,7 +51,7 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.Server;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.suspendresumeendpoint.SuspendResumeHandler;
 import org.wildfly.test.suspendresumeendpoint.TestSuspendServiceActivator;
 import org.wildfly.test.suspendresumeendpoint.TestUndertowService;
@@ -60,7 +60,7 @@ import org.xnio.IoUtils;
 /**
  * Tests for suspend/resume functionality
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class StartSuspendedTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnShutdownTestCase.java
@@ -54,7 +54,7 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.suspendresumeendpoint.SuspendResumeHandler;
 import org.wildfly.test.suspendresumeendpoint.TestSuspendServiceActivator;
 import org.wildfly.test.suspendresumeendpoint.TestUndertowService;
@@ -65,7 +65,7 @@ import org.xnio.IoUtils;
  *
  * @author Yeray Borges
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class SuspendOnShutdownTestCase {
     public static final String WEB_SUSPEND_JAR = "web-suspend.jar";

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
@@ -57,7 +57,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.suspendresumeendpoint.SuspendResumeHandler;
 import org.wildfly.test.suspendresumeendpoint.TestSuspendServiceActivator;
 import org.wildfly.test.suspendresumeendpoint.TestUndertowService;
@@ -68,7 +68,7 @@ import org.xnio.IoUtils;
  *
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class SuspendOnSoftKillTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
@@ -57,7 +57,7 @@ import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Testing https connection to the http management interface with cli console
@@ -68,7 +68,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Filip Bogyai
  */
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class HTTPSConnectionWithCLITestCase {
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -45,13 +45,13 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PreparedResponseTestCase {
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsInStaticModuleTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsInStaticModuleTestCase.java
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.Server;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.jmx.ControlledStateNotificationListener;
 import org.wildfly.test.jmx.staticmodule.JMXFacadeListenerInStaticModuleSetupTask;
 
@@ -54,7 +54,7 @@ import static org.wildfly.test.jmx.ControlledStateNotificationListener.JMX_FACAD
 /**
  * @author Jan Martiska
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class JmxControlledStateNotificationsInStaticModuleTestCase {
     static final Path DATA = Paths.get("target/notifications/data");

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsTestCase.java
@@ -48,7 +48,7 @@ import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.jmx.JMXListenerDeploymentSetupTask;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -56,7 +56,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 /**
  * @author Emmanuel Hugonnet (c) 2016 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class JmxControlledStateNotificationsTestCase {
     static final Path DATA = Paths.get("target/notifications/data");

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/ProcessStateListenerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/ProcessStateListenerTestCase.java
@@ -59,14 +59,14 @@ import org.wildfly.core.testrunner.Server;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.extension.core.management.client.Process;
 import org.wildfly.test.events.provider.TestListener;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2016 Red Hat inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ProcessStateListenerTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/AgeOutHistoryUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/AgeOutHistoryUnitTestCase.java
@@ -52,12 +52,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class AgeOutHistoryUnitTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/BasicOneOffPatchingScenariosTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/BasicOneOffPatchingScenariosTestCase.java
@@ -69,7 +69,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import com.google.common.base.Joiner;
 
@@ -77,7 +77,7 @@ import com.google.common.base.Joiner;
 /**
  * @author Jan Martiska
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class BasicOneOffPatchingScenariosTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/BootLoggingPatchingStateTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/BootLoggingPatchingStateTestCase.java
@@ -49,13 +49,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class BootLoggingPatchingStateTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/CPRollingbackOneOffTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/CPRollingbackOneOffTestCase.java
@@ -59,13 +59,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CPRollingbackOneOffTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/CumulativePatchingScenariosTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/CumulativePatchingScenariosTestCase.java
@@ -60,12 +60,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Martin Simka
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class CumulativePatchingScenariosTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/GalleonSlimmedOneOffPatchingScenariosTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/GalleonSlimmedOneOffPatchingScenariosTestCase.java
@@ -23,7 +23,7 @@ package org.jboss.as.test.patching;
 import com.google.common.base.Joiner;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.jboss.as.test.patching.PatchingTestUtil.AS_DISTRIBUTION;
 import static org.jboss.as.test.patching.PatchingTestUtil.FILE_SEPARATOR;
@@ -32,7 +32,7 @@ import static org.jboss.as.test.patching.PatchingTestUtil.FILE_SEPARATOR;
  * Overrides the superclass just so it can be run in a separate execution without polluting the output from
  * the superclass version of the test.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class GalleonSlimmedOneOffPatchingScenariosTestCase extends BasicOneOffPatchingScenariosTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/MergedCpWithSubmoduleTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/MergedCpWithSubmoduleTestCase.java
@@ -39,12 +39,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class MergedCpWithSubmoduleTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/MergedPatchesTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/MergedPatchesTestCase.java
@@ -47,12 +47,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Martin Simka, updated for WildFly 10 by Jan Martiska
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class MergedPatchesTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/NativeApiPatchingTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/NativeApiPatchingTestCase.java
@@ -49,14 +49,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Smoke test to cover patching through the native API.
  *
  * @author Jan Martiska
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class NativeApiPatchingTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/NonStandardSituationsTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/NonStandardSituationsTestCase.java
@@ -48,12 +48,12 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Jan Martiska
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class NonStandardSituationsTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/OverridePreserveTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/OverridePreserveTestCase.java
@@ -50,12 +50,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Jan Martiska
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class OverridePreserveTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchBundleTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchBundleTestCase.java
@@ -29,12 +29,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Martin Simka
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PatchBundleTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchInfoTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchInfoTestCase.java
@@ -49,13 +49,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PatchInfoTestCase extends PatchInfoTestBase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchOpInputStreamIndexAsFSPathUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchOpInputStreamIndexAsFSPathUnitTestCase.java
@@ -52,13 +52,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PatchOpInputStreamIndexAsFSPathUnitTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchStreamsUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchStreamsUnitTestCase.java
@@ -58,13 +58,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class PatchStreamsUnitTestCase extends PatchInfoTestBase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoPatchIdUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoPatchIdUnitTestCase.java
@@ -59,13 +59,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RemotePatchInfoPatchIdUnitTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoUnitTestCase.java
@@ -49,7 +49,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.jboss.as.patching.Constants.BASE;
 import static org.jboss.as.patching.IoUtils.mkdir;
@@ -67,7 +67,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RemotePatchInfoUnitTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RollbackLastUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RollbackLastUnitTestCase.java
@@ -53,13 +53,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class RollbackLastUnitTestCase extends AbstractPatchingTestCase {
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/ShowHistoryUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/ShowHistoryUnitTestCase.java
@@ -41,12 +41,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class ShowHistoryUnitTestCase extends PatchInfoTestBase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractPropertiesRoleMappingTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractPropertiesRoleMappingTestCase.java
@@ -47,14 +47,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * This class is also used in the LDAP test cases.
  *
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 abstract class AbstractPropertiesRoleMappingTestCase extends AbstractRbacTestCase {
     @Inject

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ApplicationTypeTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ApplicationTypeTestCase.java
@@ -50,12 +50,12 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, StandardExtensionSetupTask.class})
 public class ApplicationTypeTestCase extends AbstractRbacTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/CliInterfaceStandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/CliInterfaceStandardRolesBasicTestCase.java
@@ -31,14 +31,14 @@ import org.jboss.as.test.integration.management.interfaces.ManagementInterface;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.WildFlyElytronProvider;
 
 /**
  * @author jcechace
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, StandardExtensionSetupTask.class})
 public class CliInterfaceStandardRolesBasicTestCase extends StandardRolesBasicTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ConfigurationChangesHistoryTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ConfigurationChangesHistoryTestCase.java
@@ -87,13 +87,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ServerReload.SetupTask.class, StandardUsersSetupTask.class})
 public class ConfigurationChangesHistoryTestCase extends AbstractManagementInterfaceRbacTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/DeploymentScannerTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/DeploymentScannerTestCase.java
@@ -53,14 +53,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test that the deployment scanner still works even with RBAC enabled.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({DeploymentScannerSetupTask.class})
 public class DeploymentScannerTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/HttpInterfaceStandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/HttpInterfaceStandardRolesBasicTestCase.java
@@ -27,13 +27,13 @@ import org.jboss.as.test.integration.management.interfaces.HttpManagementInterfa
 import org.jboss.as.test.integration.management.interfaces.ManagementInterface;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author jcechace
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, StandardExtensionSetupTask.class})
 public class HttpInterfaceStandardRolesBasicTestCase extends StandardRolesBasicTestCase {
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/InMemoryAuditReportTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/InMemoryAuditReportTestCase.java
@@ -48,7 +48,6 @@ import static org.jboss.as.test.integration.management.rbac.RbacUtil.MAINTAINER_
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.MONITOR_USER;
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.OPERATOR_USER;
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.SUPERUSER_USER;
-import static org.jboss.as.test.integration.mgmt.access.AbstractManagementInterfaceRbacTestCase.getManagementClient;
 import static org.jboss.as.test.integration.mgmt.access.InMemoryAuditReportSetupTask.IN_MEMORY_HANDLER_ADDR;
 import static org.productivity.java.syslog4j.impl.message.pci.PCISyslogMessage.USER_ID;
 
@@ -66,7 +65,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
@@ -81,7 +80,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({InMemoryAuditReportSetupTask.class, StandardUsersSetupTask.class})
 public class InMemoryAuditReportTestCase extends AbstractManagementInterfaceRbacTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/IncludeAllRoleTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/IncludeAllRoleTestCase.java
@@ -44,12 +44,12 @@ import org.jboss.as.test.integration.management.rbac.RbacUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class})
 public class IncludeAllRoleTestCase extends AbstractRbacTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/Jmx2ndInterfaceStandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/Jmx2ndInterfaceStandardRolesBasicTestCase.java
@@ -24,13 +24,13 @@ package org.jboss.as.test.integration.mgmt.access;
 
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author jcechace
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardExtensionSetupTask.class, StandardUsersSetupTask.class})
 public class Jmx2ndInterfaceStandardRolesBasicTestCase extends JmxInterfaceStandardRolesBasicTestCase {
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/JmxInterfaceStandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/JmxInterfaceStandardRolesBasicTestCase.java
@@ -44,13 +44,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author jcechace
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, StandardExtensionSetupTask.class})
 public class JmxInterfaceStandardRolesBasicTestCase extends StandardRolesBasicTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/JmxNonSensitiveTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/JmxNonSensitiveTestCase.java
@@ -26,12 +26,12 @@ import org.jboss.as.test.integration.management.rbac.RbacUtil;
 import org.wildfly.test.jmx.JMXServiceDeploymentSetupTask;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardExtensionSetupTask.class, StandardUsersSetupTask.class, JMXServiceDeploymentSetupTask.class})
 public class JmxNonSensitiveTestCase extends AbstractJmxNonCoreMBeansSensitivityTestCase {
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/JmxSensitiveTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/JmxSensitiveTestCase.java
@@ -26,12 +26,12 @@ import org.jboss.as.test.integration.management.rbac.RbacUtil;
 import org.wildfly.test.jmx.JMXServiceDeploymentSetupTask;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardExtensionSetupTask.class, StandardUsersSetupTask.class, JMXServiceDeploymentSetupTask.class})
 public class JmxSensitiveTestCase extends AbstractJmxNonCoreMBeansSensitivityTestCase {
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/LegacyConfigurationChangesHistoryTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/LegacyConfigurationChangesHistoryTestCase.java
@@ -88,13 +88,13 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({ServerReload.SetupTask.class, StandardUsersSetupTask.class})
 public class LegacyConfigurationChangesHistoryTestCase extends AbstractManagementInterfaceRbacTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/NativeInterfaceStandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/NativeInterfaceStandardRolesBasicTestCase.java
@@ -27,13 +27,13 @@ import org.jboss.as.test.integration.management.interfaces.ManagementInterface;
 import org.jboss.as.test.integration.management.interfaces.NativeManagementInterface;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author jcechace
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, StandardExtensionSetupTask.class})
 public class NativeInterfaceStandardRolesBasicTestCase extends StandardRolesBasicTestCase {
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/PermissionsCoverageTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/PermissionsCoverageTestCase.java
@@ -29,12 +29,12 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class PermissionsCoverageTestCase {
     @Inject
     private ManagementClient managementClient;

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ReadAttributeGroupTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ReadAttributeGroupTestCase.java
@@ -54,13 +54,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test to check RABC access on reading attributes per group name.
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, BasicExtensionSetupTask.class})
 public class ReadAttributeGroupTestCase extends AbstractRbacTestCase {
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ReadResourceDescriptionVsActualOperationTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ReadResourceDescriptionVsActualOperationTestCase.java
@@ -49,12 +49,12 @@ import org.jboss.dmr.Property;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author jcechace
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({StandardUsersSetupTask.class, BasicExtensionSetupTask.class})
 public class ReadResourceDescriptionVsActualOperationTestCase extends AbstractRbacTestCase {
     private static final String TEST_DS = "subsystem=rbac/rbac-constrained=default";

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/RejectingCombinationPolicyTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/RejectingCombinationPolicyTestCase.java
@@ -38,14 +38,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test {@link org.jboss.as.controller.access.CombinationPolicy#REJECTING}.
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class RejectingCombinationPolicyTestCase extends AbstractRbacTestCase {
 
     private static final PathAddress AC_ADDRESS =

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/RoleMappingRuntimeReconfigurationTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/RoleMappingRuntimeReconfigurationTestCase.java
@@ -61,14 +61,14 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.WildFlyElytronProvider;
 
 /**
  * @author jcechace
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(RoleMappingRuntimeReconfigurationTestCase.BasicUsersSetup.class)
 public class RoleMappingRuntimeReconfigurationTestCase {
     private static final String ROLE_MAPPING_ADDRESS_BASE = "core-service=management/access=authorization/role-mapping=";

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/RolesIntegrityCheckingTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/RolesIntegrityCheckingTestCase.java
@@ -43,14 +43,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * WFLY-2270
  *
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(StandardUsersSetupTask.class)
 public class RolesIntegrityCheckingTestCase {
     @Inject

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ValidateAddressOrOperationTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ValidateAddressOrOperationTestCase.java
@@ -68,12 +68,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({BasicExtensionSetupTask.class, StandardUsersSetupTask.class})
 public class ValidateAddressOrOperationTestCase extends AbstractRbacTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogTestCase.java
@@ -36,7 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * The actual contents of what is being logged is tested in
@@ -46,7 +46,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Kabir Khan
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 //@RunAsClient
 public class AuditLogTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToTCPSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToTCPSyslogTestCase.java
@@ -24,7 +24,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.syslogserver.TCPSyslogServerConfig;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.jboss.dmr.ModelNode;
 import org.junit.runner.RunWith;
 import org.productivity.java.syslog4j.SyslogConstants;
@@ -36,7 +36,7 @@ import org.productivity.java.syslog4j.server.SyslogServerConfigIF;
  * @author Ondrej Lukas
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 //@RunAsClient
 @ServerSetup(AuditLogToTCPSyslogTestCase.AuditLogToTCPSyslogTestCaseSetup.class)
 public class AuditLogToTCPSyslogTestCase extends AuditLogToSyslogTestCase {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToTLSSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToTLSSyslogTestCase.java
@@ -20,7 +20,7 @@ package org.jboss.as.test.integration.auditlog;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.junit.runner.RunWith;
 
 /**
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 //@RunAsClient
 @ServerSetup(AuditLogToTLSSyslogSetup.class)
 public class AuditLogToTLSSyslogTestCase extends AuditLogToSyslogTestCase {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToUDPSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToUDPSyslogTestCase.java
@@ -21,14 +21,14 @@ import org.jboss.as.test.categories.CommonCriteria;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests UDP protocol of auditlog-to-syslog handler.
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(AuditLogToUDPSyslogSetup.class)
 @Category(CommonCriteria.class)
 public class AuditLogToUDPSyslogTestCase extends AuditLogToSyslogTestCase {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/JmxAuditLogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/JmxAuditLogTestCase.java
@@ -50,10 +50,10 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 //@RunAsClient
 @ServerSetup(JmxAuditLogTestCase.JmxAuditLogSetup.class)
 public class JmxAuditLogTestCase {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/TLSAuditLogToTCPSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/TLSAuditLogToTCPSyslogTestCase.java
@@ -45,7 +45,7 @@ import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.productivity.java.syslog4j.server.SyslogServerIF;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests that plain TCP messages are not sent when TLS syslog-handler is selected in Audit Log settings. <br>
@@ -53,7 +53,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author: Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(TLSAuditLogToTCPSyslogTestCase.AuditLogToTCPSyslogTestCaseSetup.class)
 public class TLSAuditLogToTCPSyslogTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/JmxControlledStateNotificationsTestCase.java
@@ -47,13 +47,13 @@ import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.jmx.JMXListenerDeploymentSetupTask;
 
 /**
  * @author Emmanuel Hugonnet (c) 2016 Red Hat, inc.; Jan Martiska (c) 2017 Red Hat, inc
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({JMXListenerDeploymentSetupTask.class})
 public class JmxControlledStateNotificationsTestCase {
     static final Path DATA = Paths.get("target/notifications/data");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
@@ -61,7 +61,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.jmx.Dynamic;
 import org.wildfly.test.jmx.ServiceActivatorDeploymentUtil;
 import org.xnio.IoUtils;
@@ -70,7 +70,7 @@ import org.xnio.IoUtils;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModelControllerMBeanTestCase {
 
     private static final String RESOLVED_DOMAIN = "jboss.as";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/DeploymentResourceTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/DeploymentResourceTestCase.java
@@ -35,12 +35,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(DeploymentResourceTestCase.LoggingProfileSetup.class)
 public class DeploymentResourceTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/filters/FilterTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/filters/FilterTestCase.java
@@ -53,7 +53,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -61,7 +61,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class FilterTestCase extends AbstractLoggingTestCase {
 
     private static final String FILE_NAME = "json-file-filter.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/formatters/JsonFormatterTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/formatters/JsonFormatterTestCase.java
@@ -55,14 +55,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests output from the JSON formatter to ensure that integration between the subsystem and the log manager is correct.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class JsonFormatterTestCase extends AbstractLoggingTestCase {
 
     private static final String FILE_NAME = "json-file-handler.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/formatters/XmlFormatterTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/formatters/XmlFormatterTestCase.java
@@ -57,7 +57,7 @@ import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xml.sax.InputSource;
 
 /**
@@ -65,7 +65,7 @@ import org.xml.sax.InputSource;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class XmlFormatterTestCase extends AbstractLoggingTestCase {
 
     private static final String FILE_NAME = "xml-file-handler.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/RotatingFileHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/RotatingFileHandlerTestCase.java
@@ -47,12 +47,12 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(RotatingFileHandlerTestCase.ConfigureSubsystem.class)
 public class RotatingFileHandlerTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/SocketHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/SocketHandlerTestCase.java
@@ -68,13 +68,13 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(SocketHandlerTestCase.ConfigureSubsystem.class)
 public class SocketHandlerTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
@@ -46,13 +46,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CustomFormattersTestCase extends AbstractLoggingOperationsTestCase {
 
     private static final String CUSTOM_FORMATTER_NAME = "customFormatter";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
@@ -32,13 +32,13 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerTestCase.java
@@ -39,13 +39,13 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @ServerSetup(CustomHandlerTestCase.CustomHandlerSetUp.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CustomHandlerTestCase extends AbstractLoggingOperationsTestCase {
 
     private static final String FILE_NAME = "custom-handler-file.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLoggingPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLoggingPropertiesTestCase.java
@@ -40,12 +40,12 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Petr Křemenský <pkremens@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class JBossLoggingPropertiesTestCase extends DeploymentBaseTestCase {
 
     private static final Path logFile = getAbsoluteLogFilePath("jboss-logging-properties-test.log");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LoggingPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LoggingPropertiesTestCase.java
@@ -40,12 +40,12 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Petr Křemenský <pkremens@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class LoggingPropertiesTestCase extends DeploymentBaseTestCase {
 
     private static final Path logFile = getAbsoluteLogFilePath("logging-properties-test.log");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/PeriodicSizeRotatingFileHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/PeriodicSizeRotatingFileHandlerTestCase.java
@@ -29,12 +29,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class PeriodicSizeRotatingFileHandlerTestCase extends AbstractRotatingFileHandlerTestCase {
 
     private static final String FILE_NAME = "config-periodic-size-rotating.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/SizeRotatingFileHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/SizeRotatingFileHandlerTestCase.java
@@ -29,12 +29,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class SizeRotatingFileHandlerTestCase extends AbstractRotatingFileHandlerTestCase {
 
     private static final String FILE_NAME = "config-size-rotating.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/CommonsLoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/CommonsLoggingProfilesTestCase.java
@@ -21,12 +21,12 @@ package org.jboss.as.test.integration.logging.profiles;
 
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
 public class CommonsLoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Log4j2LoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Log4j2LoggingProfilesTestCase.java
@@ -28,12 +28,12 @@ import org.jboss.as.test.integration.logging.Log4j2ServiceActivator;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
 public class Log4j2LoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
@@ -22,12 +22,12 @@ package org.jboss.as.test.integration.logging.profiles;
 import org.jboss.as.test.integration.logging.LoggingServiceActivator;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
 public class LoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/NonExistingProfileTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/NonExistingProfileTestCase.java
@@ -44,13 +44,13 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Petr Křemenský <pkremens@redhat.com>
  */
 @ServerSetup(NonExistingProfileTestCase.NonExistingProfileTestCaseSetup.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class NonExistingProfileTestCase extends AbstractLoggingTestCase {
 
     private static final String LOG_FILE_NAME = "non-existing-profile-test.log";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Slf4jLoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Slf4jLoggingProfilesTestCase.java
@@ -21,12 +21,12 @@ package org.jboss.as.test.integration.logging.profiles;
 
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
 public class Slf4jLoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -63,7 +63,7 @@ import org.productivity.java.syslog4j.server.SyslogServer;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * A SyslogHandlerTestCase for testing that logs are logged to syslog
@@ -73,7 +73,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Ondrej Lukas
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(SyslogHandlerTestCase.SyslogHandlerTestCaseSetup.class)
 public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
@@ -31,7 +31,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Emanuel Muckenhuber
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(ClientCompatibilityUnitTestCase.ClientCompatibilityUnitTestCaseServerSetup.class)
 public class ClientCompatibilityUnitTestCase extends ClientCompatibilityUnitTestBase {
     static class ClientCompatibilityUnitTestCaseServerSetup extends ClientCompatibilityUnitTestBase.ClientCompatibilityServerSetup implements ServerSetupTask {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
@@ -31,13 +31,13 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class AttachmentTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BasicOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BasicOpsTestCase.java
@@ -33,7 +33,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -43,7 +43,7 @@ import org.wildfly.security.sasl.SaslMechanismSelector;
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BasicOpsTestCase {
     @Inject
     protected ManagementClient managementClient;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchFileTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchFileTestCase.java
@@ -43,13 +43,13 @@ import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BatchFileTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchTestCase.java
@@ -39,13 +39,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BatchTestCase extends AbstractCliTestBase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchWithHeadersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchWithHeadersTestCase.java
@@ -34,13 +34,13 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BatchWithHeadersTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CdTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CdTestCase.java
@@ -30,13 +30,13 @@ import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CdTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliAliasTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliAliasTestCase.java
@@ -22,7 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
  *
  * @author Martin Schvarcbacher mschvarc@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliAliasTestCase {
 
     private static final String VALID_ALIAS_NAME = "DEBUG123_ALIAS";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
@@ -34,14 +34,14 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliArgumentsTestCase {
 
     private static final String tempDir = TestSuiteEnvironment.getTmpDir();

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCapabilityCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCapabilityCompletionTestCase.java
@@ -42,13 +42,13 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliCapabilityCompletionTestCase {
 
     private static CommandContext ctx;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCommentsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCommentsTestCase.java
@@ -27,13 +27,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliCommentsTestCase {
 
     @Rule

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
@@ -42,7 +42,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliCompletionTestCase {
 
     private static CommandContext ctx;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
@@ -45,13 +45,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliConfigTestCase  {
 
     private final String LINE_SEPARATOR = System.getProperty("line.separator");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliControllerConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliControllerConfigTestCase.java
@@ -23,7 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
  *
  * @author Martin Schvarcbacher
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliControllerConfigTestCase {
 
     private static final Protocol TEST_RUNNER_PROTOCOL = HTTP_REMOTING;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliSpecialCharactersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliSpecialCharactersTestCase.java
@@ -29,7 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.junit.Assert.assertTrue;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -40,7 +40,7 @@ import org.wildfly.core.testrunner.ManagementClient;
  *
  * @author Martin Schvarcbacher
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliSpecialCharactersTestCase {
     private static final String TEST_RESOURCE_NAME = "test_resource_special_chars";
     private CLIWrapper cli;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliVariablesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliVariablesTestCase.java
@@ -26,7 +26,7 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.parsing.UnresolvedVariableException;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertNotNull;
  *
  * @author Martin Schvarcbacher
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliVariablesTestCase {
 
     private static final String JBOSS_CLI_RC_PROP = "jboss.cli.rc";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ColorOutputTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ColorOutputTestCase.java
@@ -31,9 +31,9 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ColorOutputTestCase {
 
     private static CliProcessWrapper cli;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CommandSubstitutionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CommandSubstitutionTestCase.java
@@ -33,13 +33,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CommandSubstitutionTestCase {
 
     private static final String ADD = "add";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CommandsExitCodeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CommandsExitCodeTestCase.java
@@ -28,14 +28,14 @@ import static org.junit.Assert.assertTrue;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import java.io.IOException;
 
 /**
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CommandsExitCodeTestCase {
 
     private static final String PROP_NAME = "cli-arg-test";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CtrlCTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CtrlCTestCase.java
@@ -30,9 +30,9 @@ import java.io.IOException;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CtrlCTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
@@ -56,12 +56,12 @@ import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeployTestCase extends AbstractCliTestBase{
 
     private static final String WRONG_PATH_PART = "216561-d.war";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentInfoTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentInfoTestCase.java
@@ -34,14 +34,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author baranowb
  *
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentInfoTestCase extends AbstractCliTestBase {
 
     private CommandContext ctx;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
@@ -28,13 +28,13 @@ import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentOverlayTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/EchoTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/EchoTestCase.java
@@ -33,13 +33,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  *
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class EchoTestCase {
 
     private static ByteArrayOutputStream cliOut;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/EscapingArgumentValuesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/EscapingArgumentValuesTestCase.java
@@ -32,13 +32,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  *
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class EscapingArgumentValuesTestCase {
 
     private static final String VALUE = "value";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ExplodedDeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ExplodedDeploymentTestCase.java
@@ -37,13 +37,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ExplodedDeploymentTestCase {
 
     @Rule

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
@@ -35,13 +35,13 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class FileArgumentTestCase {
 
     private static final String PROP_NAME = "cli-arg-test";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileInputTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileInputTestCase.java
@@ -29,14 +29,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Emulate jboss-cli.sh process with input coming from a file. This activates
  * aesh-readline ExtTerminal in an intensive multi-thread context.
  *
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class FileInputTestCase {
 
     @Rule

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileWithPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileWithPropertiesTestCase.java
@@ -40,13 +40,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class FileWithPropertiesTestCase {
 
     private static final String SERVER_PROP_NAME = "cli-arg-test";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
@@ -24,13 +24,13 @@ import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ForLoopTestCase extends AbstractCliTestBase {
 
     @BeforeClass

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
@@ -29,13 +29,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test generic command features of CLI.
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class GenericCommandTestCase extends AbstractCliTestBase {
 
     @BeforeClass

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
@@ -35,13 +35,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class GlobalOpsTestCase extends AbstractCliTestBase {
 
     @BeforeClass

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/HelpTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/HelpTestCase.java
@@ -31,13 +31,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HelpTestCase extends AbstractCliTestBase {
 
     private static final String[] COMMANDS = {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/InvalidAddressOperationTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/InvalidAddressOperationTestCase.java
@@ -44,7 +44,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * The test makes sure the outcome of an operation with a non-existing address
@@ -52,7 +52,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class InvalidAddressOperationTestCase {
 
     private static Path jbossCliOriginalCopy = Paths.get(TestSuiteEnvironment.getTmpDir(), "tmp-jboss-cli.xml");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
@@ -38,14 +38,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.launcher.CliCommandBuilder;
 import org.wildfly.core.launcher.Launcher;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Jean-François Denise <jdenise@redhat.com>
  */
 // Required by Bootable JAR in order to create the installation directory
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class JBossCliXmlConfigTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlValidationTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlValidationTestCase.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -46,7 +46,7 @@ import org.xml.sax.SAXParseException;
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
 // Required by Bootable JAR in order to create the installation directory
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class JBossCliXmlValidationTestCase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/LongOutputTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/LongOutputTestCase.java
@@ -17,7 +17,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 import java.io.BufferedReader;
@@ -45,10 +45,10 @@ import java.util.regex.Pattern;
  * This test covers the minimal use-cases.
  * @author eduda@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class LongOutputTestCase {
 
-    private static final Logger log = Logger.getLogger(WildflyTestRunner.class);
+    private static final Logger log = Logger.getLogger(WildFlyRunner.class);
 
     private static final String LINE_SEP = System.getProperty("line.separator");
     private static final Pattern morePattern = Pattern.compile(".*--More\\(\\d+%\\)--$");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/LsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/LsTestCase.java
@@ -42,13 +42,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class LsTestCase extends AbstractCliTestBase {
 
     private static final String MSG_SHOULD_FAIL = " command should fail.";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ModuleOpsCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ModuleOpsCompletionTestCase.java
@@ -32,7 +32,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 
 
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModuleOpsCompletionTestCase {
 
     private static final String MODULE_NAME = "org.jboss.test.cli.climoduletest";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ModuleTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ModuleTestCase.java
@@ -57,7 +57,7 @@ import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.xnio.IoUtils;
 
 /**
@@ -65,7 +65,7 @@ import org.xnio.IoUtils;
  *
  * @author Ivo Studensky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModuleTestCase extends AbstractCliTestBase {
 
     private static final String MODULE_NAME = "org.jboss.test.cli.climoduletest";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/MultipleLinesCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/MultipleLinesCommandsTestCase.java
@@ -27,13 +27,13 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class MultipleLinesCommandsTestCase {
 
     private static String[] operation;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/RcFileTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/RcFileTestCase.java
@@ -42,14 +42,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  *
  */
 // Required by Bootable JAR in order to create the installation directory
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class RcFileTestCase {
 
     private static final String JBOSS_CLI_RC_PROP = "jboss.cli.rc";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/RealValueExpressionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/RealValueExpressionTestCase.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * CLI should show the real value of expression properties in addition to the expression
@@ -40,7 +40,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Marek Kopecky <mkopecky@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class RealValueExpressionTestCase extends AbstractCliTestBase {
 
     private static Logger log = Logger.getLogger(RealValueExpressionTestCase.class);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ReloadSASLFactoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ReloadSASLFactoryTestCase.java
@@ -34,13 +34,13 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ReloadSASLFactoryTestCase {
 
     private static final String MANAGEMENT_NATIVE_PORT = "9999";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
@@ -42,13 +42,13 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class SecurityAuthCommandsTestCase {
 
     private static final ByteArrayOutputStream consoleOutput = new ByteArrayOutputStream();

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -58,14 +58,14 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockserver.integration.ClientAndServer;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.x500.cert.acme.CertificateAuthority;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class SecurityCommandsTestCase {
 
     private static final String DEFAULT_KEY_STORE = "applicationKS";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SilentModeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SilentModeTestCase.java
@@ -36,14 +36,14 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class SilentModeTestCase {
 
     private static ByteArrayOutputStream cliOut;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/StringValuesParsedAsNonObjectsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/StringValuesParsedAsNonObjectsTestCase.java
@@ -32,13 +32,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Alexey Loubyansky
  *
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class StringValuesParsedAsNonObjectsTestCase {
 
     private static final String VALUE = "value";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
@@ -32,13 +32,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class TryCatchFinallyTestCase extends CLISystemPropertyTestBase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/VariablesCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/VariablesCompletionTestCase.java
@@ -19,7 +19,7 @@ package org.jboss.as.test.integration.management.cli;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertNotNull;
  *
  * @author wangc
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class VariablesCompletionTestCase {
 
     private static final String FOO_NAME = "foo";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandsTestCase.java
@@ -52,14 +52,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Testing commands loaded from the available management model extensions.
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CliExtCommandsTestCase {
 
     private static final String MODULE_NAME = "test.cli.extension.commands";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/DuplicateExtCommandTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/DuplicateExtCommandTestCase.java
@@ -54,12 +54,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Petr Kremensky pkremens@redhat.com
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DuplicateExtCommandTestCase {
 
     private static final String MODULE_NAME = "test.cli.extension.duplicate";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
@@ -31,13 +31,13 @@ import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BasicIfElseTestCase extends CLISystemPropertyTestBase {
     @Inject
     protected ManagementClient managementClient;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BatchesInIfElseTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BatchesInIfElseTestCase.java
@@ -32,13 +32,13 @@ import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BatchesInIfElseTestCase extends CLISystemPropertyTestBase {
     @Inject
     protected ManagementClient managementClient;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/NonExistingPathComparisonTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/NonExistingPathComparisonTestCase.java
@@ -30,13 +30,13 @@ import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class NonExistingPathComparisonTestCase extends CLISystemPropertyTestBase {
     @Inject
     protected ManagementClient managementClient;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/modules/ModuleResourceRootPathsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/modules/ModuleResourceRootPathsTestCase.java
@@ -43,14 +43,14 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test module add command and loading of modules with resources with absolute/relative paths (MODULES-218)
  *
  * @author Martin Simka
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModuleResourceRootPathsTestCase extends AbstractCliTestBase {
     private static final String MODULE_RESOURCE_MODULE_NAME = "module.resource.test";
     private static final String ABSOLUTE_RESOURCE_MODULE_NAME = "absolute.resource.test";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/console/WebConsoleRedirectionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/console/WebConsoleRedirectionTestCase.java
@@ -32,14 +32,14 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Since console is not loaded in core dist, in both modes the server is supposed to return 404.
  *
  * @author Tomas Hofman (thofman@redhat.com)
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class WebConsoleRedirectionTestCase {
 
     @SuppressWarnings("unused")

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/CustomManagementContextTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/CustomManagementContextTestCase.java
@@ -22,14 +22,14 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.test.integration.management.extension.customcontext.testbase.CustomManagementContextTestBase;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test of integrating a custom management context on the http interface on a standalone server.
  *
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CustomManagementContextTestCase extends CustomManagementContextTestBase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpDeploymentUploadUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpDeploymentUploadUnitTestCase.java
@@ -67,7 +67,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test the HTTP API upload functionality to ensure that a deployment is successfully
@@ -75,7 +75,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Jonathan Pearlin
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HttpDeploymentUploadUnitTestCase {
 
     private static final String BOUNDARY_PARAM = "NeAG1QNIHHOyB5joAS7Rox!!";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpGenericOperationUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpGenericOperationUnitTestCase.java
@@ -89,12 +89,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Emanuel Muckenhuber
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HttpGenericOperationUnitTestCase {
 
     private static final int RANDOM_FILE_SIZE = 10 * 1024 * 1024;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
@@ -52,14 +52,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests all management operation types which are available via HTTP GET requests.
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HttpGetMgmtOpsTestCase {
 
     private static final int MGMT_PORT = 9990;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpManagementConstantHeadersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpManagementConstantHeadersTestCase.java
@@ -53,7 +53,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -67,7 +67,7 @@ import static org.junit.Assert.assertNull;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  * @author <a href="mailto:tterem@redhat.com">Tomas Terem</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HttpManagementConstantHeadersTestCase {
 
     private static final int MGMT_PORT = 9990;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpMgmtPrettyTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpMgmtPrettyTestCase.java
@@ -30,14 +30,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests all management operation types which are available via HTTP GET requests.
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HttpMgmtPrettyTestCase {
 
     private static final int MGMT_PORT = 9990;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpPostMgmtOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpPostMgmtOpsTestCase.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class HttpPostMgmtOpsTestCase {
 
     private static final int MGMT_PORT = 9990;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/XCorrelationIdTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/XCorrelationIdTestCase.java
@@ -51,14 +51,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests X-Correlation-Id header handling.
  *
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class XCorrelationIdTestCase {
 
     private static final int MGMT_PORT = 9990;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
@@ -27,14 +27,14 @@ import org.jboss.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * This class contains a check that CLI access is secured.
  *
  * @author <a href="mailto:jlanik@redhat.com">Jan Lanik</a>.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(DisableLocalAuthServerSetupTask.class)
 public class CLISecurityTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/DMRSecurityTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/DMRSecurityTestCase.java
@@ -27,14 +27,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * This class contains a check that the management api access is secured.
  *
  * @author <a href="mailto:jlanik@redhat.com">Jan Lanik</a>.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(DisableLocalAuthServerSetupTask.class)
 public class DMRSecurityTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/WebConsoleSecurityTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/WebConsoleSecurityTestCase.java
@@ -35,7 +35,7 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test verifies that the web management console is secured
@@ -43,7 +43,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author jlanik@redhat.com
  */
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class WebConsoleSecurityTestCase {
 
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
@@ -79,7 +79,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.x500.cert.X509CertificateBuilder;
 import org.wildfly.test.undertow.UndertowSSLService;
 import org.wildfly.test.undertow.UndertowSSLServiceActivator;
@@ -102,7 +102,7 @@ import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
 import io.undertow.util.StringReadChannelListener;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(SNICombinedWithALPNTestCase.Setup.class)
 public class SNICombinedWithALPNTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/warning/OperationWarningTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/warning/OperationWarningTestCase.java
@@ -57,10 +57,10 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 @ServerSetup({OperationWarningTestCase.SetupExtensions.class,OperationWarningTestCase.SetupWorkers.class})
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class OperationWarningTestCase extends AbstractMgmtTestBase {
     @Inject
     private static ServerController serverController;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/deployment/JandexIndexCachingTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/deployment/JandexIndexCachingTestCase.java
@@ -52,9 +52,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @org.wildfly.core.testrunner.ServerSetup(JandexIndexCachingTestCase.LogHandlerSetup.class)
 public class JandexIndexCachingTestCase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/booterror/OperationFailuresDuringBootTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/booterror/OperationFailuresDuringBootTestCase.java
@@ -54,12 +54,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(ServerReload.SetupTask.class)
 public class OperationFailuresDuringBootTestCase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ExtensionRemoveTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ExtensionRemoveTestCase.java
@@ -56,12 +56,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(ServerReload.SetupTask.class)
 public class ExtensionRemoveTestCase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -103,7 +103,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Basic management operation unit test.
@@ -111,7 +111,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Emanuel Muckenhuber
  */
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class BasicOperationsUnitTestCase {
     private static final DateTimeFormatter DATE_FORMAT = new DateTimeFormatterBuilder().appendInstant().appendZoneId().toFormatter(Locale.ENGLISH);
     private static final ZoneId ZONE_ID = ZoneId.of(Calendar.getInstance().getTimeZone().getID());

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/CapabilityReloadRequiredUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/CapabilityReloadRequiredUnitTestCase.java
@@ -57,7 +57,7 @@ import org.junit.runner.RunWith;
 import org.jboss.as.test.integration.management.extension.dependent.DependentExtension;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test of WFCORE-1106 behavior.
@@ -65,7 +65,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Brian Stansberry
  */
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CapabilityReloadRequiredUnitTestCase {
 
     private static final String WFCORE1106 = "WFCORE-1106";

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DefaultSaslConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DefaultSaslConfigTestCase.java
@@ -40,7 +40,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -51,7 +51,7 @@ import org.wildfly.security.sasl.SaslMechanismSelector;
  *
  * @author Josef Cacek
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DefaultSaslConfigTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DescribeOperationUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DescribeOperationUnitTestCase.java
@@ -42,7 +42,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test validating that subsystems register a "describe" operation in order to be able
@@ -50,7 +50,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Emanuel Muckenhuber
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DescribeOperationUnitTestCase {
 
     private static final Set<String> ignored = new HashSet<String>();

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ExtensionSubsystemCompositeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ExtensionSubsystemCompositeTestCase.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ExtensionSubsystemCompositeTestCase {
 
     private static final PathAddress EXT = PathAddress.pathAddress("extension", OpTypesExtension.EXTENSION_NAME);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/PlatformMBeansUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/PlatformMBeansUnitTestCase.java
@@ -43,14 +43,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test validating that the platform mbean resources exist and are reachable.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class PlatformMBeansUnitTestCase {
 
     private static final Set<String> ignored = new HashSet<String>();

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/PrivateHiddenOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/PrivateHiddenOperationsTestCase.java
@@ -37,14 +37,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests invocations of private and hidden operations.
  *
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class PrivateHiddenOperationsTestCase {
 
     private static final PathAddress EXT = PathAddress.pathAddress("extension", OpTypesExtension.EXTENSION_NAME);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ReloadWithConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ReloadWithConfigTestCase.java
@@ -41,14 +41,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *  Tests using server-config parameter in the :reload operation
  *
  * @author Kabir Khan
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ReloadWithConfigTestCase {
     private static final String RELOAD_TEST_CASE_ONE = "reload-test-case-one";
     private static final String RELOAD_TEST_CASE_TWO = "reload-test-case-two";

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ResolveExpressionFromEnvironmentVariableTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ResolveExpressionFromEnvironmentVariableTestCase.java
@@ -32,14 +32,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * This uses the TEST_ENVIRONMENT_VARIABLE environment variable set up in pom.xml
  *
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ResolveExpressionFromEnvironmentVariableTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/CoreServerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/CoreServerTestCase.java
@@ -48,14 +48,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Simple test to validate the server's model availability and reading it as XML or from the root.
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class CoreServerTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentContentRemovalTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentContentRemovalTestCase.java
@@ -64,12 +64,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Tomas Hofman (thofman@redhat.com)
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentContentRemovalTestCase {
 
     private static String DEPLOYMENT_ONE_NAME = "deployment-one.jar";

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentOverlayTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentOverlayTestCase.java
@@ -62,13 +62,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author Emmanuel Hugonnet (c) 2016 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentOverlayTestCase {
 
     // Max time to wait for some action to complete, in ms

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentScannerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentScannerTestCase.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 
 /**
@@ -52,7 +52,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Dominik Pospisil <dpospisi@redhat.com>
  * @author Jaikiran Pai - Updated to fix intermittent failures as reported in https://issues.jboss.org/browse/WFLY-1554
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({DeploymentScannerSetupTask.class})
 public class DeploymentScannerTestCase extends ContainerResourceMgmtTestBase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentTestCase.java
@@ -87,14 +87,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests deployment to a wildfly core server, both via the client API and by the filesystem scanner.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup({DeploymentScannerSetupTask.class})
 public class DeploymentTestCase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ExplodedDeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ExplodedDeploymentTestCase.java
@@ -77,13 +77,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ExplodedDeploymentTestCase {
 
     // Max time to wait for some action to complete, in ms

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ModelPersistenceTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ModelPersistenceTestCase.java
@@ -39,14 +39,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests both automated and manual configuration model persistence snapshot generation.
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModelPersistenceTestCase extends ContainerResourceMgmtTestBase {
 
     private class CfgFileDescription {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ReadFeatureDescriptionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ReadFeatureDescriptionTestCase.java
@@ -42,14 +42,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test of read-feature-description handling.
  *
  * @author Brian Stansberry
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ReadFeatureDescriptionTestCase {
 
     @SuppressWarnings("unused")

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateAddressOperationTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateAddressOperationTestCase.java
@@ -30,7 +30,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROBLEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALID;
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author <a href="alex@jboss.org">Alexey Loubyansky</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ValidateAddressOperationTestCase extends ContainerResourceMgmtTestBase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateModelTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateModelTestCase.java
@@ -51,12 +51,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ValidateModelTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateOperationOperationTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateOperationOperationTestCase.java
@@ -36,14 +36,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests that the validate-operation operation works as it should
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ValidateOperationOperationTestCase extends ContainerResourceMgmtTestBase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
@@ -58,7 +58,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test the configuration changes history command.
@@ -66,7 +66,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ConfigurationChangesHistoryTestCase extends AbstractConfigurationChangesTestCase {
 
     private static final PathAddress ADDRESS = PathAddress.pathAddress()

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentModulesListTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentModulesListTestCase.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -61,7 +61,7 @@ import static org.wildfly.common.Assert.assertTrue;
  * /deployment=application_war_ear_name:list-modules(verbose=false|true)
  * @author <a href="mailto:szhantem@redhat.com">Sultan Zhantemirov</a> (c) 2019 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentModulesListTestCase {
 
     private JavaArchive archive;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
@@ -98,13 +98,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests to check hard requirements and extreme cases for deployment operations.
  * @author <a href="mailto:mjurc@redhat.com">Michal Jurc</a> (c) 2016 Red Hat, Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class DeploymentOperationsTestCase {
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/JdkModuleDependencyTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/JdkModuleDependencyTestCase.java
@@ -39,7 +39,7 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import javax.inject.Inject;
 import java.io.InputStream;
@@ -57,7 +57,7 @@ import java.util.stream.Stream;
  *
  * @author <a href="mailto:mjurc@redhat.com">Michal Jurc</a> (c) 2018 Red Hat, Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class JdkModuleDependencyTestCase {
 
     public static final String DEPLOYMENT_NAME_SUFFIX = "-test-dep.jar";

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/LegacyConfigurationChangesHistoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/LegacyConfigurationChangesHistoryTestCase.java
@@ -41,7 +41,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.wildfly.core.test.standalone.mgmt.api.core.AbstractConfigurationChangesTestCase.MAX_HISTORY_SIZE;
 
 import java.io.IOException;
 import java.util.List;
@@ -60,7 +59,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test the configuration changes history command.
@@ -68,7 +67,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
 @ServerSetup(ServerReload.SetupTask.class)
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class LegacyConfigurationChangesHistoryTestCase extends AbstractConfigurationChangesTestCase {
 
     private static final PathAddress ADDRESS = PathAddress.pathAddress()

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ManagementVersionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ManagementVersionTestCase.java
@@ -30,7 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 
@@ -39,7 +39,7 @@ import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNo
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ManagementVersionTestCase extends ContainerResourceMgmtTestBase {
 
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ModuleInfoTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ModuleInfoTestCase.java
@@ -36,7 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,7 +55,7 @@ import static org.jboss.as.test.integration.domain.management.util.DomainTestSup
  *
  * @author <a href="mailto:msimka@redhat.com">Martin Simka</a> (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModuleInfoTestCase extends ContainerResourceMgmtTestBase {
     private static final PathAddress RESOURCE = PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MODULE_LOADING));
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ModuleLoadingManagementTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ModuleLoadingManagementTestCase.java
@@ -39,14 +39,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Tests of the core-service=module-loading resource.
  *
  * @author Brian Stansberry (c) 2012 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ModuleLoadingManagementTestCase extends ContainerResourceMgmtTestBase {
     private static final PathAddress RESOURCE = PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MODULE_LOADING));
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/PatchInfoUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/PatchInfoUnitTestCase.java
@@ -43,12 +43,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * @author Emanuel Muckenhuber
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class PatchInfoUnitTestCase extends ContainerResourceMgmtTestBase {
 
     private static final PathAddress ROOT_RESOURCE = PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, "patching"));

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ProductInfoUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ProductInfoUnitTestCase.java
@@ -54,13 +54,13 @@ import org.jboss.dmr.Property;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Testing the product-info operation on a standalone instance.
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ProductInfoUnitTestCase extends ContainerResourceMgmtTestBase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ReadConfigAsFeaturesStandaloneTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ReadConfigAsFeaturesStandaloneTestCase.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.UnsuccessfulOperationException;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -48,7 +48,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
  *
  * @author <a href="mailto:rjanik@redhat.com">Richard Janík</a>
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ReadConfigAsFeaturesStandaloneTestCase extends ReadConfigAsFeaturesTestBase {
 
     private File defaultConfig;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ResolveExpressionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ResolveExpressionTestCase.java
@@ -34,14 +34,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test for functionality added with AS7-2139.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ResolveExpressionTestCase extends ContainerResourceMgmtTestBase {
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ResponseAttachmentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ResponseAttachmentTestCase.java
@@ -85,14 +85,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test of streams attached to a standalone server management op response.
  *
  * @author Brian Stansberry (c) 2014 Red Hat Inc.
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class ResponseAttachmentTestCase extends ContainerResourceMgmtTestBase {
 
     private static final Logger log = Logger.getLogger(ResponseAttachmentTestCase.class);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/secmgr/InvalidPermissionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/secmgr/InvalidPermissionTestCase.java
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.ServerSetupTask;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.undertow.UndertowServiceActivator;
 
 /**
@@ -60,7 +60,7 @@ import org.wildfly.test.undertow.UndertowServiceActivator;
  *
  * @author rmartinc
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 @ServerSetup(InvalidPermissionTestCase.Setup.class)
 public class InvalidPermissionTestCase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
@@ -46,7 +46,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.core.testrunner.WildFlyRunner;
 import org.wildfly.test.suspendresumeendpoint.SuspendResumeHandler;
 import org.wildfly.test.suspendresumeendpoint.TestSuspendServiceActivator;
 import org.wildfly.test.suspendresumeendpoint.TestUndertowService;
@@ -56,7 +56,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
 /**
  * Tests for suspend/resume functionality
  */
-@RunWith(WildflyTestRunner.class)
+@RunWith(WildFlyRunner.class)
 public class SuspendResumeTestCase {
 
     public static final String WEB_SUSPEND_JAR = "web-suspend.jar";


### PR DESCRIPTION
…unner

Follow-on to https://issues.redhat.com/browse/WFCORE-5966 to switch WF Core use to the new name. Since WFCORE-5966 isn't in a release yet I'll just reuse its JIRA for this change.