### PR TITLE
[WFCORE-5975] Upgrade WildFly Elytron to 1.20.0.Final

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
@@ -109,6 +109,7 @@
         <module name="java.security.sasl"/>
         <module name="java.sql"/>
         <module name="java.xml"/>
+        <module name="java.xml.crypto"/>
         <module name="javax.json.api"/>
         <module name="jdk.security.auth"/>
         <module name="jdk.unsupported"/>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.19.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.20.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5975
https://issues.redhat.com/browse/WFCORE-5859

This PR also includes a change from https://github.com/wildfly/wildfly-core/pull/5048 which is needed to pass CI.

        Release Notes - WildFly Elytron - Version 1.20.0.Final
                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2320'>ELY-2320</a>] -         Add integrity support to FileSystemSecurityRealm
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2304'>ELY-2304</a>] -         Location is required even for non-filebased type e.g. PKCS11
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2322'>ELY-2322</a>] -         Duplicate dependency in auth/client/pom.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2326'>ELY-2326</a>] -         Elytron GSSCredentialSecurityFactory does not check validity of KerberosTicket.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2347'>ELY-2347</a>] -         parseKeyStoreType crashes if type and wrap attributes not set
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2360'>ELY-2360</a>] -         Sporadic &quot;Invalid format of OIDC_STATE cookie&quot; warnings in log file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2371'>ELY-2371</a>] -         Fix bug in searching for identity in filesystem realm
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2222'>ELY-2222</a>] -         Add a test case for TLS where the client and server have different TLS protocols configured
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2330'>ELY-2330</a>] -         Community users should use &#39;Start Progress&#39; instead of &#39;Assign to me&#39; 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2333'>ELY-2333</a>] -         Update README to include links where users can ask questions
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2335'>ELY-2335</a>] -         Add a test case for one-way TLS to TLS13AuthenticationTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2341'>ELY-2341</a>] -         Add appropriate exclusions to the org.apache.httpcomponents:httpclient dependency in the pom.xml file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2345'>ELY-2345</a>] -         New elytron-identity client schema version (1.2)
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2353'>ELY-2353</a>] -         Add trace logging in org.wildfly.security.http.oidc.TokenValidator#parseAndVerifyToken
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2362'>ELY-2362</a>] -         Add support for the bearer-only option when using the OIDC HTTP mechanism
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2375'>ELY-2375</a>] -         Release WildFly Elytron 1.20.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2331'>ELY-2331</a>] -         Upgrade FasterXML/Jackson to 2.13.1
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2363'>ELY-2363</a>] -         Upgrade keycloak to 18.0.2 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2372'>ELY-2372</a>] -         Upgrade jose4j to 0.7.11
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2373'>ELY-2373</a>] -         Upgrade jboss-logging to 3.4.3.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2312'>ELY-2312</a>] -         Update the --encrypt action of the credential-store command to support existing entries.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2352'>ELY-2352</a>] -         Upgrade Jackson (Databind) to resolve CVE-2020-36518
</li>
</ul>
