### PR TITLE
[WFCORE-5945][WFCORE-5941][WFCORE-5976] WildFly OpenSSL Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,8 +240,8 @@
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.2.4.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
-        <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.19.0.Final</version.org.wildfly.security.elytron>

--- a/pom.xml
+++ b/pom.xml
@@ -239,8 +239,8 @@
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.2.4.Final</version.org.wildfly.openssl>
-        <version.org.wildfly.openssl.natives>2.2.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
+        <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>2.2.1.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.2.4.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.0.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5945
https://issues.redhat.com/browse/WFCORE-5941
https://issues.redhat.com/browse/WFCORE-5976


        Release Notes - WildFly OpenSSL - Version 2.2.4.Final
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-100'>WFSSL-100</a>] -         Upgrade WildFly OpenSSL Linux Natives to 2.2.2.SP01
</li>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-101'>WFSSL-101</a>] -         Release WildFly OpenSSL 2.2.4.Final
</li>
</ul>


        Release Notes - WildFly OpenSSL Natives - Version 2.2.2.Final
                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-21'>SSLNTV-21</a>] -         Release WildFly OpenSSL Natives 2.2.2.Final
</li>
</ul>


        Release Notes - WildFly OpenSSL Natives - Version 2.2.2.SP01
                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/SSLNTV-22'>SSLNTV-22</a>] -         Release WildFly OpenSSL Natives 2.2.2.SP01
</li>
</ul>
                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                        
