### PR TITLE
[WFCORE-5981] Upgrade WildFly OpenSSL to 2.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.openssl>2.2.4.Final</version.org.wildfly.openssl>
+        <version.org.wildfly.openssl>2.2.5.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5981


        Release Notes - WildFly OpenSSL - Version 2.2.5.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-102'>WFSSL-102</a>] -         OpenSSLContextSPI socket factory cannot create unbound server sockets
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFSSL-103'>WFSSL-103</a>] -         Release WildFly OpenSSL 2.2.5.Final
</li>
</ul>
                                                                                                                                                                                                                                                        
