### PR TITLE
[WFCORE-6024]Upgrade Undertow to 2.2.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
-        <version.io.undertow>2.2.18.Final</version.io.undertow>
+        <version.io.undertow>2.2.19.Final</version.io.undertow>
         <version.jakarta.inject.jakarta.inject-api>1.0.5</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6024
18.x PR: #5170 


        Release Notes - Undertow - Version 2.2.19.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1790'>UNDERTOW-1790</a>] -         UT000010: Session is invalid due to concurrent calls changeSessionId() calls on same session
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1900'>UNDERTOW-1900</a>] -         InMemorySessionManager#SessionImpl.changeSessionId does not check if session exist before replacing
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1934'>UNDERTOW-1934</a>] -         onClose not called when network drops
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1997'>UNDERTOW-1997</a>] -         SecurityPathMatches fails to match default path (&#39;/&#39;) 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2031'>UNDERTOW-2031</a>] -         protocol error with HTTP/2 and Expect: 100-continue 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2064'>UNDERTOW-2064</a>] -         Revert HTTP2 Fix for  UT005085, it is causing issues with WildFly HTTP Client
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2083'>UNDERTOW-2083</a>] -         bad read timeout message
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2112'>UNDERTOW-2112</a>] -         Client Cert Renegotiation Test Case is failing
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2113'>UNDERTOW-2113</a>] -         Read Timeout Test Case Fail on Windows with JDK17 due to different exception message
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2116'>UNDERTOW-2116</a>] -         ServletOutputStreamImpl incorrectly sets Content-Length to 0
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2124'>UNDERTOW-2124</a>] -         ProgramaticLazyEndpointTest and BinaryEndpointTest failures with JDK-17
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2125'>UNDERTOW-2125</a>] -         ReadTimeoutStreamSourceConduit expires when connection is closed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2130'>UNDERTOW-2130</a>] -         Classes with annotation RunWith are triggered as TestCase.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2133'>UNDERTOW-2133</a>] -         CVE-2022-2053: Large AJP request may cause DoS
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2135'>UNDERTOW-2135</a>] -         Properly handle HTTP Continue with HTTP2 upgrade
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2063'>UNDERTOW-2063</a>] -         Review fix for UT005085, it is causing RST messages to be sent to client sometimes
</li>
</ul>
                                                                                                                                                                                                                                                        