### PR TITLE
[WFCORE-6032] Ignore AdminOnlyPolicyTestCase

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -55,11 +55,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests of running domain hosts in admin-only move.
  */
+@Ignore("https://issues.redhat.com/browse/WFCORE-6032")
 public class AdminOnlyPolicyTestCase {
 
     private static DomainTestSupport testSupport;


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6032

This test case is failing very often and it is making the testsuite to hang. Ignore it temporarily until further investigation