### PR TITLE
Yaml backport

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
@@ -245,6 +245,8 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
                                 } else {
                                     if (value != null) {
                                         MGMT_OP_LOGGER.unexpectedValueForResource(value, address.toCLIStyleString(), name);
+                                    } else {// ADD operation without parameters
+                                        processAttributes(address, rootRegistration, operationEntry, null, postExtensionOps);
                                     }
                                 }
                             }
@@ -326,21 +328,23 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
         }
         attributes.addAll(Arrays.asList(operationEntry.getOperationDefinition().getParameters()));
         ModelNode op = createOperation(address, operationEntry);
-        for (AttributeDefinition att : attributes) {
-            if (map.containsKey(att.getName())) {
-                Object value = map.get(att.getName());
-                map.remove(att.getName());
-                switch (att.getType()) {
-                    case OBJECT:
-                        op.get(att.getName()).set(processObjectAttribute((ObjectTypeAttributeDefinition) att, (Map<String, Object>) value));
-                        break;
-                    case LIST:
-                        ModelNode list = op.get(att.getName()).setEmptyList();
-                        processListAttribute((ListAttributeDefinition) att, list, value);
-                        break;
-                    default:
-                        op.get(att.getName()).set(value.toString());
-                        break;
+        if (map != null) {
+            for (AttributeDefinition att : attributes) {
+                if (map.containsKey(att.getName())) {
+                    Object value = map.get(att.getName());
+                    map.remove(att.getName());
+                    switch (att.getType()) {
+                        case OBJECT:
+                            op.get(att.getName()).set(processObjectAttribute((ObjectTypeAttributeDefinition) att, (Map<String, Object>) value));
+                            break;
+                        case LIST:
+                            ModelNode list = op.get(att.getName()).setEmptyList();
+                            processListAttribute((ListAttributeDefinition) att, list, value);
+                            break;
+                        default:
+                            op.get(att.getName()).set(value.toString());
+                            break;
+                    }
                 }
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
@@ -288,6 +288,8 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
                             op.get(NAME).set(attributeName);
                             ModelNode list = op.get(VALUE).setEmptyList();
                             processListAttribute((ListAttributeDefinition) att, list, value);
+                            MGMT_OP_LOGGER.debugf("Updating attribute %s for resource %s with operation %s", attributeName, address, op);
+                            postExtensionOps.add(new ParsedBootOp(op, operationEntry.getOperationHandler()));
                         }
                     }
                     break;

--- a/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.MapAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.ParsedBootOp;
 import org.jboss.as.controller.PathAddress;
@@ -352,7 +353,11 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
                     map.remove(att.getName());
                     switch (att.getType()) {
                         case OBJECT:
-                            op.get(att.getName()).set(processObjectAttribute((ObjectTypeAttributeDefinition) att, (Map<String, Object>) value));
+                            if (att instanceof MapAttributeDefinition) {
+                                processMapAttribute((MapAttributeDefinition) att, op, (Map<String, Object>) value);
+                            } else {
+                                op.get(att.getName()).set(processObjectAttribute((ObjectTypeAttributeDefinition) att, (Map<String, Object>) value));
+                            }
                             break;
                         case LIST:
                             ModelNode list = op.get(att.getName()).setEmptyList();
@@ -385,7 +390,11 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
                 Object value = map.get(child.getName());
                 switch (child.getType()) {
                     case OBJECT:
-                        objectNode.get(child.getName()).set(processObjectAttribute((ObjectTypeAttributeDefinition) child, (Map<String, Object>) value));
+                        if(child instanceof MapAttributeDefinition) {
+                            processMapAttribute((MapAttributeDefinition)child, objectNode, (Map<String, Object>)value);
+                        } else {
+                            objectNode.get(child.getName()).set(processObjectAttribute((ObjectTypeAttributeDefinition) child, (Map<String, Object>) value));
+                        }
                         break;
                     case LIST:
                         ModelNode list = objectNode.get(child.getName()).setEmptyList();
@@ -413,6 +422,13 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
             } else {
                 list.add(entry.toString());
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void processMapAttribute(MapAttributeDefinition att, ModelNode map, Map<String, Object> value) {
+        for (Map.Entry<String, Object> entry : value.entrySet()) {
+            map.get(att.getName()).get(entry.getKey()).set(entry.getValue().toString());
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
@@ -107,11 +107,21 @@ public class YamlConfigurationExtensionTest {
                 resourceRegistration.registerReadWriteAttribute(listAtt, null, new ModelOnlyWriteAttributeHandler(valueAtt));
             }
         };
+        SimpleResourceDefinition basicResource = new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("basic"), descriptionResolver)
+                .setAddHandler(new AbstractBoottimeAddStepHandler(valueAtt) {
+                })) {
+            @Override
+            public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+                super.registerAttributes(resourceRegistration);
+                resourceRegistration.registerReadWriteAttribute(valueAtt, null, new ModelOnlyWriteAttributeHandler(valueAtt));
+            }
+        };
         ManagementResourceRegistration root = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootResource);
         GlobalOperationHandlers.registerGlobalOperations(root, ProcessType.EMBEDDED_SERVER);
         root.registerSubModel(systemPropertyResource);
         root.registerSubModel(extensionResource);
         root.registerSubModel(listResource);
+        root.registerSubModel(basicResource);
         AttributeDefinition connectorType = SimpleAttributeDefinitionBuilder.create("type", STRING, true)
                 .setAllowExpression(true)
                 .setValidator(new StringLengthValidator(0, true, true))
@@ -147,19 +157,22 @@ public class YamlConfigurationExtensionTest {
         ConfigurationExtension instance = ConfigurationExtensionFactory.createConfigurationExtension(Paths.get(this.getClass().getResource("simple.yml").toURI()));
         instance.processOperations(rootRegistration, postExtensionOps);
         assertFalse(postExtensionOps.isEmpty());
-        assertEquals(3, postExtensionOps.size());
+        assertEquals(4, postExtensionOps.size());
         assertEquals(ADD, postExtensionOps.get(0).operationName);
-        assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(0).address);
-        assertTrue(postExtensionOps.get(0).operation.hasDefined("value"));
-        assertEquals("foo", postExtensionOps.get(0).operation.get("value").asString());
+        assertEquals(PathAddress.pathAddress("basic", "test"), postExtensionOps.get(0).address);
+        assertFalse(postExtensionOps.get(0).operation.hasDefined("value"));
         assertEquals(ADD, postExtensionOps.get(1).operationName);
-        assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(1).address);
+        assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(1).address);
         assertTrue(postExtensionOps.get(1).operation.hasDefined("value"));
-        assertEquals("bar", postExtensionOps.get(1).operation.get("value").asString());
+        assertEquals("foo", postExtensionOps.get(1).operation.get("value").asString());
         assertEquals(ADD, postExtensionOps.get(2).operationName);
-        assertEquals(PathAddress.pathAddress("system-property", "ccc"), postExtensionOps.get(2).address);
+        assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(2).address);
         assertTrue(postExtensionOps.get(2).operation.hasDefined("value"));
-        assertEquals("test", postExtensionOps.get(2).operation.get("value").asString());
+        assertEquals("bar", postExtensionOps.get(2).operation.get("value").asString());
+        assertEquals(ADD, postExtensionOps.get(3).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "ccc"), postExtensionOps.get(3).address);
+        assertTrue(postExtensionOps.get(3).operation.hasDefined("value"));
+        assertEquals("test", postExtensionOps.get(3).operation.get("value").asString());
     }
 
     /**
@@ -217,23 +230,28 @@ public class YamlConfigurationExtensionTest {
         ConfigurationExtension instance = ConfigurationExtensionFactory.createConfigurationExtension(Paths.get(this.getClass().getResource("simple.yml").toURI()));
         instance.processOperations(rootRegistration, postExtensionOps);
         assertFalse(postExtensionOps.isEmpty());
-        assertEquals(5, postExtensionOps.size());
+        assertEquals(6, postExtensionOps.size());
         assertEquals(ADD, postExtensionOps.get(0).operationName);
         assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(0).address);
         assertFalse(postExtensionOps.get(0).operation.hasDefined("value"));
         assertEquals(ADD, postExtensionOps.get(1).operationName);
         assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(1).address);
         assertFalse(postExtensionOps.get(1).operation.hasDefined("value"));
-        assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(2).address);
-        assertEquals(WRITE_ATTRIBUTE_OPERATION, postExtensionOps.get(2).operationName);
-        assertEquals("foo", postExtensionOps.get(2).operation.get("value").asString());
-        assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(3).address);
+        assertEquals(ADD, postExtensionOps.get(2).operationName);
+        assertEquals(PathAddress.pathAddress("basic", "test"), postExtensionOps.get(2).address);
+        assertFalse(postExtensionOps.get(2).operation.hasDefined("value"));
+        assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(3).address);
         assertEquals(WRITE_ATTRIBUTE_OPERATION, postExtensionOps.get(3).operationName);
-        assertEquals("bar", postExtensionOps.get(3).operation.get("value").asString());
-        assertEquals(ADD, postExtensionOps.get(4).operationName);
-        assertEquals(PathAddress.pathAddress("system-property", "ccc"), postExtensionOps.get(4).address);
+        assertTrue(postExtensionOps.get(3).operation.hasDefined("value"));
+        assertEquals("foo", postExtensionOps.get(3).operation.get("value").asString());
+        assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(4).address);
+        assertEquals(WRITE_ATTRIBUTE_OPERATION, postExtensionOps.get(4).operationName);
         assertTrue(postExtensionOps.get(4).operation.hasDefined("value"));
-        assertEquals("test", postExtensionOps.get(4).operation.get("value").asString());
+        assertEquals("bar", postExtensionOps.get(4).operation.get("value").asString());
+        assertEquals(ADD, postExtensionOps.get(5).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "ccc"), postExtensionOps.get(5).address);
+        assertTrue(postExtensionOps.get(5).operation.hasDefined("value"));
+        assertEquals("test", postExtensionOps.get(5).operation.get("value").asString());
     }
 
     /**

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/yaml/simple.yml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/yaml/simple.yml
@@ -10,6 +10,8 @@ wildfly-configuration:
     system-property:
       ccc:
         value: test
+    basic:
+      test:
 #User defined elements, must be ignored.
 org:
     foo:


### PR DESCRIPTION
PR combining all the YAML fixes:

- [WFCORE-5953]: List attribute are not properly updated with the YamlConfigurationExtesnion
- [WFCORE-5954]: Yaml Extension doesn't add empty resources.
- [WFCORE-5918]: Adding SSO to application security domain via YamlConfigurationExtesnion
- [WFCORE-5949]: Adding meta-data to json-logger via YamlConfigurationExtesnion

Jira: 
https://issues.redhat.com/browse/WFCORE-5953
https://issues.redhat.com/browse/WFCORE-5954
https://issues.redhat.com/browse/WFCORE-5918
https://issues.redhat.com/browse/WFCORE-5949

Supersedes: 
https://github.com/wildfly/wildfly-core/pull/5134
https://github.com/wildfly/wildfly-core/pull/5135
https://github.com/wildfly/wildfly-core/pull/5145