### PR TITLE
[WFCORE-6033] Upgrade WildFly Elytron to 1.20.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.20.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.20.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6033


        Release Notes - WildFly Elytron - Version 1.20.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2351'>ELY-2351</a>] -         ScramDigestPasswordImpl fails with PKCS#11 (FIPS)
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2356'>ELY-2356</a>] -         Revisit org.wildfly.security.http.oidc.OidcClientConfigurationBuilder#sanitizeProviderUrl
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2357'>ELY-2357</a>] -         Update the issuer URL for OIDC based on discovery
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2374'>ELY-2374</a>] -         Support forwarding of domain_hint query parameter
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2387'>ELY-2387</a>] -         Release WildFly Elytron 1.20.1.Final
</li>
</ul>