### PR TITLE
[18.x][WFCORE-5939] Upgrade WildFly Elytron to 1.19.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.19.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.19.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-5939
Upstream: https://github.com/wildfly/wildfly-core/pull/5181


        Release Notes - WildFly Elytron - Version 1.19.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2304'>ELY-2304</a>] -         Location is required even for non-filebased type e.g. PKCS11
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2326'>ELY-2326</a>] -         Elytron GSSCredentialSecurityFactory does not check validity of KerberosTicket.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2347'>ELY-2347</a>] -         parseKeyStoreType crashes if type and wrap attributes not set
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2360'>ELY-2360</a>] -         Sporadic &quot;Invalid format of OIDC_STATE cookie&quot; warnings in log file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2371'>ELY-2371</a>] -         Fix bug in searching for identity in filesystem realm
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2353'>ELY-2353</a>] -         Add trace logging in org.wildfly.security.http.oidc.TokenValidator#parseAndVerifyToken
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2356'>ELY-2356</a>] -         Revisit org.wildfly.security.http.oidc.OidcClientConfigurationBuilder#sanitizeProviderUrl
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2357'>ELY-2357</a>] -         Update the issuer URL for OIDC based on discovery
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2362'>ELY-2362</a>] -         Add support for the bearer-only option when using the OIDC HTTP mechanism
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2374'>ELY-2374</a>] -         Support forwarding of domain_hint query parameter
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2386'>ELY-2386</a>] -         Release WildFly Elytron 1.19.1.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2331'>ELY-2331</a>] -         Upgrade FasterXML/Jackson to 2.13.1
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2352'>ELY-2352</a>] -         Upgrade Jackson (Databind) to resolve CVE-2020-36518
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2363'>ELY-2363</a>] -         Upgrade keycloak to 18.0.2 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2372'>ELY-2372</a>] -         Upgrade jose4j to 0.7.11
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2373'>ELY-2373</a>] -         Upgrade jboss-logging to 3.4.3.Final
</li>
</ul>
                   
