### PR TITLE
[WFCORE-6035] Eliminating deprecated and unused CapabilityServiceBuilder.addDependency(ServiceName,Class,Injector) method

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
@@ -84,14 +84,6 @@ public interface CapabilityServiceBuilder<T> extends ServiceBuilder<T> {
     /**
      * {@inheritDoc}
      * @return this builder
-     * @deprecated Use {@link ServiceBuilder#requires(ServiceName)} instead. This method will be removed in a future release.
-     */
-    @Deprecated
-    <I> CapabilityServiceBuilder<T> addDependency(ServiceName dependency, Class<I> type, Injector<I> target);
-
-    /**
-     * {@inheritDoc}
-     * @return this builder
      */
     @Override
     CapabilityServiceBuilder<T> setInitialMode(ServiceController.Mode mode);

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2635,12 +2635,6 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
 
         @Override
-        public <I> CapabilityServiceBuilder<T> addDependency(ServiceName dependency, Class<I> type, Injector<I> target){
-            super.addDependency(dependency, type, target);
-            return this;
-        }
-
-        @Override
         public CapabilityServiceBuilder<T> setInitialMode(ServiceController.Mode mode) {
             super.setInitialMode(mode);
             return this;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6035
