### PR TITLE
WFCORE-6037 Upgrade jandex to 3.0.0

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -80,11 +80,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
         </dependency>
 
-        <!-- TODO: why do we need jandex in minimal? -->
+        <!-- TODO: Remove once wildfly updates to io.smallrye:jandex -->
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>

--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -24,6 +24,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>jandex</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
       <licenses>
@@ -236,6 +247,7 @@
         </license>
       </licenses>
     </dependency>
+    <!-- TODO: Remove once wildfly migrates to io.smallrye:jandex -->
     <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jandex</artifactId>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/io/smallrye/jandex/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/io/smallrye/jandex/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,5 +21,16 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<!-- TODO: Remove once wildfly migrates to io.smallrye:jandex -->
-<module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.jandex" target-name="io.smallrye.jandex"/>
+
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.jandex">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <main-class name="org.jboss.jandex.Main"/>
+
+    <resources>
+        <artifact name="${io.smallrye:jandex}"/>
+    </resources>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
+        <version.io.smallrye.jandex>3.0.0</version.io.smallrye.jandex>
         <version.io.undertow>2.3.0.Alpha2</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.0</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
@@ -228,6 +229,7 @@
         <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
+        <!-- TODO: Remove once wildfly migrates to io.smallrye:jandex -->
         <version.org.jboss.jandex>2.4.3.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.17.Final</version.org.jboss.jboss-vfs>
@@ -778,6 +780,11 @@
                 <version>${version.commons-cli}</version>
             </dependency>
             <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex</artifactId>
+                <version>${version.io.smallrye.jandex}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-core</artifactId>
                 <version>${version.io.undertow}</version>
@@ -1042,6 +1049,7 @@
                 <version>${version.org.glassfish.jakarta.json}</version>
             </dependency>
 
+            <!-- TODO: Remove once wildfly migrates to io.smallrye:jandex -->
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jandex</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -94,7 +94,7 @@
             <artifactId>wildfly-version</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -124,7 +124,7 @@
             <artifactId>wildfly-host-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6037

@yersan @Ladicek 
This is an alternate approach to https://github.com/wildfly/wildfly-core/pull/5194 that retains the org.jboss:jandex artifact so that wildfly-core can upgrade without breaking wildfly full integration.
Once wildfly full pull in the requisite wildfly-core version, it can safely upgrade to io.smallrye:jandex.  The org.jboss:jandex artifact can then be removed from the core-feature-pack in a subsequent release.

I think this will be far simpler/faster than doing things in reverse order, as suggested in https://github.com/wildfly/wildfly-core/pull/5194
