### PR TITLE
WFCORE-5903: fix remote host unregistration

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -413,13 +413,13 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 if (pinger != null) {
                     pinger.cancel();
                 }
+                final String address = hostRegistration.getAddress();
+                final Event event = cleanShutdown ? create(HostConnectionInfo.EventType.UNREGISTERED, address) : create(HostConnectionInfo.EventType.UNCLEAN_UNREGISTRATION, address);
+                slaveHostRegistrations.unregisterHost(id, event);
                 boolean registered = hostProxies.remove(id) != null;
-                modelNodeRegistration.unregisterProxyController(PathElement.pathElement(HOST, id));
 
                 if (registered) {
-                    final String address = hostRegistration.getAddress();
-                    final Event event = cleanShutdown ? create(HostConnectionInfo.EventType.UNREGISTERED, address) : create(HostConnectionInfo.EventType.UNCLEAN_UNREGISTRATION, address);
-                    slaveHostRegistrations.unregisterHost(id, event);
+                    modelNodeRegistration.unregisterProxyController(PathElement.pathElement(HOST, id));
                     if (!cleanShutdown) {
                         DOMAIN_LOGGER.lostConnectionToRemoteHost(id);
                     } else {


### PR DESCRIPTION
Issue: [WFCORE-5903](https://issues.redhat.com/browse/WFCORE-5903)

Given what is happening in the [registerRemoteHost method](https://github.com/michpetrov/wildfly-core/blob/373c285655e992c5ed857de055735269063d0516/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java#L390-L398) processing the `slaveHostRegistrations` conditionally seems wrong here.