### PR TITLE
[WFCORE-6048] Add license entries for the artifacts that are fully dr…

### DIFF
--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -200,6 +200,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <licenses>
+        <license>
+          <name>Eclipse Distribution License, Version 1.0</name>
+          <url>https://repository.jboss.org/licenses/edl-1.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>https://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
       <licenses>
@@ -1898,6 +1914,28 @@
     <dependency>
       <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-x500-principal</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security.jakarta</groupId>
+      <artifactId>jakarta-authentication</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security.jakarta</groupId>
+      <artifactId>jakarta-authorization</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/core-feature-pack/ee-10-api/src/main/resources/license/core-feature-pack-ee-10-api-licenses.xml
+++ b/core-feature-pack/ee-10-api/src/main/resources/license/core-feature-pack-ee-10-api-licenses.xml
@@ -2,8 +2,8 @@
 <licenseSummary>
   <dependencies>
     <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
+      <groupId>jakarta.authentication</groupId>
+      <artifactId>jakarta.authentication-api</artifactId>
       <licenses>
         <license>
           <name>Eclipse Public License 2.0</name>
@@ -15,9 +15,52 @@
           <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
           <distribution>repo</distribution>
         </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.authorization</groupId>
+      <artifactId>jakarta.authorization-api</artifactId>
+      <licenses>
         <license>
-          <name>Eclipse Distribution License, Version 1.0</name>
-          <url>http://repository.jboss.org/licenses/edl-1.0.txt</url>
+          <name>Eclipse Public License 2.0</name>
+          <url>http://www.eclipse.org/legal/epl-v20.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.interceptor</groupId>
+      <artifactId>jakarta.interceptor-api</artifactId>
+      <licenses>
+        <license>
+          <name>Eclipse Public License 2.0</name>
+          <url>http://www.eclipse.org/legal/epl-v20.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <licenses>
+        <license>
+          <name>Eclipse Public License 2.0</name>
+          <url>http://www.eclipse.org/legal/epl-v20.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
           <distribution>repo</distribution>
         </license>
       </licenses>


### PR DESCRIPTION
…iven by WildFly Core

Jira issue: https://issues.redhat.com/browse/WFCORE-6048

- [WFCORE-6048] Fix jakarta.json-api removing the Eclipse Distribution License
- [WFCORE-6048] Add jakarta.interceptor-api license entry
- [WFCORE-6048] Add jakarta.authentication-api license entry
- [WFCORE-6048] Add jakarta.authorization-api license entry
- [WFCORE-6048] Add org.eclipse.parsson license entry
- [WFCORE-6048] Add org.wildfly.security.jakarta:jakarta-authentication license entry
- [WFCORE-6048] Add org.wildfly.security.jakarta:jakarta-authorization license entry

