### PR TITLE
[WFCORE-6026][WFCORE-6027][WFCORE-6049][WFCORE-6050][WFCORE-6051] Elytron component upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>3.0.0.Beta1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>3.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta4</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <legacy.version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>2.0.1.Final</legacy.version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <legacy.version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>2.0.0.Final</legacy.version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
         <legacy.version.org.wildfly.security.elytron>1.20.2.Final</legacy.version.org.wildfly.security.elytron>
-        <legacy.version.org.wildfly.security.elytron-web>1.10.1.Final</legacy.version.org.wildfly.security.elytron-web>
+        <legacy.version.org.wildfly.security.elytron-web>1.10.2.Final</legacy.version.org.wildfly.security.elytron-web>
 
         <version.com.googlecode.javaewah>1.1.13</version.com.googlecode.javaewah>
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.0.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta4</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
          -->
         <legacy.version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>2.0.1.Final</legacy.version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <legacy.version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>2.0.0.Final</legacy.version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
-        <legacy.version.org.wildfly.security.elytron>1.20.1.Final</legacy.version.org.wildfly.security.elytron>
+        <legacy.version.org.wildfly.security.elytron>1.20.2.Final</legacy.version.org.wildfly.security.elytron>
         <legacy.version.org.wildfly.security.elytron-web>1.10.1.Final</legacy.version.org.wildfly.security.elytron-web>
 
         <version.com.googlecode.javaewah>1.1.13</version.com.googlecode.javaewah>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.0.0.Beta3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.0.Beta1</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta4</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>1.29</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6026
https://issues.redhat.com/browse/WFCORE-6027
https://issues.redhat.com/browse/WFCORE-6049
https://issues.redhat.com/browse/WFCORE-6050
https://issues.redhat.com/browse/WFCORE-6051


        Release Notes - WildFly Elytron - Version 2.0.0.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2413'>ELY-2413</a>] -         Re-authentication after reboot, even though HttpSession are persisted
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2417'>ELY-2417</a>] -         Release WildFly Elytron 2.0.0.Final
</li>
</ul>

        Release Notes - Elytron Web - Version 3.0.0.Final
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-195'>ELYWEB-195</a>] -         Add repositories section to pom.xml
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-189'>ELYWEB-189</a>] -         Re-authentication after reboot, even though HttpSession are persisted
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-193'>ELYWEB-193</a>] -         Release Elytron Web 3.0.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-175'>ELYWEB-175</a>] -         Upgrade httpcore to 4.4.15
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-185'>ELYWEB-185</a>] -         Fix testsuite failures on Windows
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-186'>ELYWEB-186</a>] -         Upgrade infinispan-core to 9.4.24.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-187'>ELYWEB-187</a>] -         Upgrade jboss-logging to 3.4.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-188'>ELYWEB-188</a>] -         Upgrade undertow-core to 2.2.18.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-192'>ELYWEB-192</a>] -         Upgrade WildFly Elytron to 2.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-194'>ELYWEB-194</a>] -         Upgrade WildFly Elytron EE to 3.0.0.Final
</li>
</ul>
                                                                                           

        Release Notes - WildFly Elytron EE - Version 3.0.0.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-27'>ELYEE-27</a>] -         Re-authentication after reboot, even though HttpSession are persisted
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-29'>ELYEE-29</a>] -         Release WildFly Elytron EE 3.0.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-28'>ELYEE-28</a>] -         Upgrade WildFly Elytron component versions
</li>
</ul>
                                                                                                                                                                                                                                                                                                


        Release Notes - WildFly Elytron - Version 1.20.2.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2390'>ELY-2390</a>] -         Initialize empty keystores using load(null, null) instead of load(null)
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2413'>ELY-2413</a>] -         Re-authentication after reboot, even though HttpSession are persisted
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2415'>ELY-2415</a>] -         Add link to Elytron OS setup guides in CONTRIBUTING.md
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2416'>ELY-2416</a>] -         Release WildFly Elytron 1.20.2.Final
</li>
</ul>


        Release Notes - Elytron Web - Version 1.10.2.Final
                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-189'>ELYWEB-189</a>] -         Re-authentication after reboot, even though HttpSession are persisted
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-191'>ELYWEB-191</a>] -         Release Elytron Web 1.10.2.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-174'>ELYWEB-174</a>] -         Upgrade undertow-core to 2.2.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-175'>ELYWEB-175</a>] -         Upgrade httpcore to 4.4.15
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-185'>ELYWEB-185</a>] -         Fix testsuite failures on Windows
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-186'>ELYWEB-186</a>] -         Upgrade infinispan-core to 9.4.24.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-187'>ELYWEB-187</a>] -         Upgrade jboss-logging to 3.4.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-188'>ELYWEB-188</a>] -         Upgrade undertow-core to 2.2.18.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-190'>ELYWEB-190</a>] -         Upgrade WildFly Elytron to 1.20.2.Final
</li>
</ul>
                                                                                                                                                            
