### PR TITLE
[WFCORE-6053] Upgrade XNIO to 3.8.8.Final. Fixes CVE-20022-0084.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.7.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.8.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jmockit>1.39</version.org.jmockit>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-6053)

Main PR: #5208 

        Release Notes - XNIO - Version 3.8.8.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-401'>XNIO-401</a>] -         CVE-2022-0084 StreamConnection.notifyRead/WriteClosed() invoke Throwable.printStackTrace()
</li>
</ul>