### PR TITLE
[WFCORE-6055] Make Galleon provisioning content zips unique per release

### DIFF
--- a/core-feature-pack/common/assembly.xml
+++ b/core-feature-pack/common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/core-feature-pack/ee-10-api/assembly.xml
+++ b/core-feature-pack/ee-10-api/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/core-feature-pack/galleon-common/assembly.xml
+++ b/core-feature-pack/galleon-common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>


### PR DESCRIPTION
This change does this by adding the maven module pom to the zip.

A reasonable alternative when we have a bit more time would be to convert these modules jar packaging.

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.redhat.com/browse/WFCORE-6055