### PR TITLE
Fix for WFCORE-6068, CliCommandBuilder.of method must be added back

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
@@ -132,6 +132,28 @@ public class CliCommandBuilder implements CommandBuilder {
     }
 
     /**
+     * Creates a command builder for a modular CLI instance.
+     *
+     * @param wildflyHome the path to the WildFly home directory
+     *
+     * @return a new builder
+     */
+    public static CliCommandBuilder of(final Path wildflyHome) {
+        return asModularLauncher(wildflyHome);
+    }
+
+    /**
+     * Creates a command builder for a modular CLI instance.
+     *
+     * @param wildflyHome the path to the WildFly home directory
+     *
+     * @return a new builder
+     */
+    public static CliCommandBuilder of(final String wildflyHome) {
+        return asModularLauncher(wildflyHome);
+    }
+
+    /**
      * Creates a command builder for a non-modular CLI instance launched from wildflyHome/bin/client/jboss-client.jar.
      *
      * @param wildflyHome the path to the WildFly home directory


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6068

