### PR TITLE
[WFCORE-6078] Upgrade jboss-logmanager to 2.1.19.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <version.org.jboss.logging.jboss-logging>3.4.3.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.18.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.19.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.1.1.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.1.1.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.0.3.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6078
Signed-off-by: James R. Perkins <jperkins@redhat.com>
----

Tag: https://github.com/jboss-logging/jboss-logmanager/releases/tag/2.1.19.Final
Diff: https://github.com/jboss-logging/jboss-logmanager/compare/2.1.18.Final...2.1.19.Final