### PR TITLE
[WFCORE-6076] Upgrade JBoss Remoting to 5.0.26.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.1.1.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.0.3.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.13.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.25.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.26.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

https://issues.redhat.com/browse/WFCORE-6076


        Release Notes - JBoss Remoting (3+) - Version 5.0.26.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-394'>REM3-394</a>] -         JBoss Remoting must not depend on org.wildfly.security:wildfly-elytron
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-395'>REM3-395</a>] -         Fix the CI and enable it on all branches
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-398'>REM3-398</a>] -         Upgrade dependencies to latest minor versions
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-396'>REM3-396</a>] -         Fix test failure &quot;Bind address already in use&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/REM3-397'>REM3-397</a>] -         Fix test failure for RemoteChannelTest.testRefused on Windows
</li>
</ul>
                                                                                                                                            