### PR TITLE
[WFCORE-6057] Upgrade Undertow to 2.3.0.Final (fixes CVE-2022-2764)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.io.smallrye.jandex>3.0.1</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.0.Beta1</version.io.undertow>
+        <version.io.undertow>2.3.0.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.authentication.jakarta-authentication-api>3.0.0</version.jakarta.authentication.jakarta-authentication-api>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-6057

Release notes containing just the diff between 2.3.0.Beta1 and 2.3.0.Final:


        Release Notes - Undertow - Version 2.3.0.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1818'>UNDERTOW-1818</a>] -         AbstractServletInputStreamTestCase.runTestParallel fails with bytes out of order
</li>
</ul>
                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2048'>UNDERTOW-2048</a>] -         CVE-2022-2764 UndertowInputStream.close() blocks waiting to read= -1
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2069'>UNDERTOW-2069</a>] -         Filter.destroy can deadlock with running filter on shutdown
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2082'>UNDERTOW-2082</a>] -         HTTP/2 doesn&#39;t reassemble cookie headers violating rfc7540 8.1.2.5
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2111'>UNDERTOW-2111</a>] -         rewrite() handler doesn&#39;t guard against missing leading slash
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2141'>UNDERTOW-2141</a>] -         NPE in ServletContextImpl after session timed out
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2162'>UNDERTOW-2162</a>] -         Query parameters should not be canonicalized in servlet path when get request dispatcher
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2163'>UNDERTOW-2163</a>] -         Predicate Language cannot set attribute to empty string
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2176'>UNDERTOW-2176</a>] -         ActiveRequestTrackerTest.testRequestTracking fails intermittently
</li>
</ul>
        
                                                                                                          
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2171'>UNDERTOW-2171</a>] -         Upgrade H2Database test dependency to 2.1.214
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2172'>UNDERTOW-2172</a>] -         Upgrade Easymock to 4.3
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2173'>UNDERTOW-2173</a>] -         Upgrade Jakarta Annotations API to 2.1.1
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2175'>UNDERTOW-2175</a>] -         Upgrade JUnit to 4.13.2
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2177'>UNDERTOW-2177</a>] -         Upgrade Netty to 4.1.82.final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2178'>UNDERTOW-2178</a>] -         Upgrade JBoss Class File Writer to 1.2.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2179'>UNDERTOW-2179</a>] -         Upgrade JBoss Logging to 3.4.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2180'>UNDERTOW-2180</a>] -         Upgrade JBoss LogManager to 2.1.19.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2181'>UNDERTOW-2181</a>] -         [CVE-2022-0084] Upgrade XNIO to 3.8.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2182'>UNDERTOW-2182</a>] -         Upgrade JBoss Threads to 3.5.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2183'>UNDERTOW-2183</a>] -         Upgrade WildFly Common to 1.6.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1971'>UNDERTOW-1971</a>] -         Change in handling of concurrent session creation with id reuse
</li>
</ul>
                                                                                                                                            