### PR TITLE
[WFCORE-6087] Adding --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED to default JPMS settings

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -44,6 +44,8 @@ goto :eof
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED"
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED"
+      rem Needed by Netty
+      set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
       rem Needed if Hibernate applications use Javassist
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.lang=ALL-UNNAMED"
       rem Needed by the MicroProfile REST Client subsystem

--- a/core-feature-pack/common/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.ps1
@@ -172,6 +172,8 @@ Param(
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED"
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED"
+        # Needed by Netty
+        $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
         # Needed if Hibernate applications use Javassist
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=java.base/java.lang=ALL-UNNAMED"
         # Needed by the MicroProfile REST Client subsystem

--- a/core-feature-pack/common/src/main/resources/content/bin/common.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.sh
@@ -42,6 +42,8 @@ setDefaultModularJvmOptions() {
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED"
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED"
+      # Needed by Netty
+      DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
       # Needed if Hibernate applications use Javassist
       DEFAULT_MODULAR_JVM_OPTIONS="$DEFAULT_MODULAR_JVM_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
       # Needed by the MicroProfile REST Client subsystem

--- a/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/jvm/JvmType.java
@@ -62,6 +62,7 @@ public final class JvmType {
         modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED");
         modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
         modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -129,7 +129,7 @@ public class ManagedServerBootCmdFactoryTestCase {
         List<String> result = instance.getServerLaunchCommand();
         MatcherAssert.assertThat(result.size(), is(notNullValue()));
         if (result.size() > 18) {
-            MatcherAssert.assertThat(result.size(), is(31));
+            MatcherAssert.assertThat(result.size(), is(32));
         } else {
             MatcherAssert.assertThat(result.size(), is(18));
         }

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -67,6 +67,7 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
             modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
             modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED");
             modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED");
+            modularJavaOpts.add("--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED");
             modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
             modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
             modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -272,6 +272,7 @@ public class CommandBuilderTest {
         assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED", expectedCount);
+        assertArgumentExists(command, "--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", expectedCount);
         assertArgumentExists(command, "--add-opens=java.base/java.io=ALL-UNNAMED", expectedCount);

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
             --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
             --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED
             --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED
+            --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
             --add-opens=java.base/java.io=ALL-UNNAMED
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
@@ -170,7 +171,7 @@
              e.g. a bootable jar or a jboss-cli-client.jar.
              NB: In case an update is made to these exports and opens, make sure that the common.sh script is in sync.
         -->
-        <embedding.jar.jpms.exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap java.naming/com.sun.jndi.url.ldap java.naming/com.sun.jndi.url.ldaps</embedding.jar.jpms.exports>
+        <embedding.jar.jpms.exports>java.desktop/sun.awt java.naming/com.sun.jndi.ldap java.naming/com.sun.jndi.url.ldap java.naming/com.sun.jndi.url.ldaps jdk.naming.dns/com.sun.jndi.dns</embedding.jar.jpms.exports>
         <embedding.jar.jpms.opens>java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.io java.base/java.security java.base/java.util java.base/java.util.concurrent java.management/javax.management java.naming/javax.naming</embedding.jar.jpms.opens>
 
         <!--


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6087