### PR TITLE
[WFCORE-6091] Drop suffix from transformed wildfly-elytron-integration artifact

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -262,7 +262,7 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -33,7 +33,7 @@
     </exports>
 
     <resources>
-        <artifact name="${org.wildfly.core:wildfly-elytron-integration-jakarta}"/>
+        <artifact name="${org.wildfly.core:wildfly-elytron-integration}"/>
     </resources>
 
     <dependencies>

--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -26,7 +26,7 @@
         <version>19.0.0.Final-SNAPSHOT</version>
     </parent>
 
-    <artifactId>wildfly-elytron-integration</artifactId>
+    <artifactId>wildfly-elytron-integration-legacy-namespace</artifactId>
 
     <name>WildFly: Elytron Subsystem</name>
 

--- a/jakartaee/elytron-jakarta/pom.xml
+++ b/jakartaee/elytron-jakarta/pom.xml
@@ -29,9 +29,9 @@
         <version>19.0.0.Final-SNAPSHOT</version>
     </parent>
 
-    <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+    <artifactId>wildfly-elytron-integration</artifactId>
 
-    <name>WildFly: WildFly Elytron Subsystem (Jakarta Namespace)</name>
+    <name>WildFly: WildFly Elytron Subsystem</name>
 
     <properties>
         <transformer-input-dir>${project.basedir}/../../elytron</transformer-input-dir>

--- a/pom.xml
+++ b/pom.xml
@@ -1583,12 +1583,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-elytron-integration</artifactId>
+                <artifactId>wildfly-elytron-integration-legacy-namespace</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+                <artifactId>wildfly-elytron-integration</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -101,7 +101,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6091

Drop -jakarta suffix from the transformed artifact and use new suffix for original artifact instead, until it is properly migrated to Jakarta namespace.

This change would require change in wildfly to use the dependency without suffix.