### PR TITLE
[WFCORE-6090] Unexpected NullPointerException in Elytron tests when init capabilities are missing

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/AuthenticationClientTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/AuthenticationClientTestCase.java
@@ -30,7 +30,10 @@ public class AuthenticationClientTestCase extends AbstractSubsystemTest {
         }
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(subsystemXml).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/CertificateAuthoritiesTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CertificateAuthoritiesTestCase.java
@@ -133,7 +133,10 @@ public class CertificateAuthoritiesTestCase extends AbstractSubsystemTest {
         }
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(subsystemXml).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java
@@ -74,7 +74,10 @@ public class CredentialStoreTestCase extends AbstractSubsystemTest {
     public void init() throws Exception {
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(CONFIGURATION).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
     }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreUpdatesTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreUpdatesTestCase.java
@@ -100,7 +100,10 @@ public class CredentialStoreUpdatesTestCase extends AbstractSubsystemTest {
     public void init() throws Exception {
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("credential-store-updates.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         emptyCSUtil = new CredentialStoreUtility(EMPTY_CS_PATH, EMPTY_CS_PASSWORD);
         nonEmptyCSUtil = new CredentialStoreUtility(NON_EMPTY_CS_PATH, NON_EMPTY_CS_PASSWORD);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/DomainTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/DomainTestCase.java
@@ -97,7 +97,10 @@ public class DomainTestCase extends AbstractSubsystemTest {
         TestEnvironment.mockCallerModuleClassloader();
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("domain-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "MyDomain");

--- a/elytron/src/test/java/org/wildfly/extension/elytron/ExpressionResolutionTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/ExpressionResolutionTestCase.java
@@ -186,7 +186,10 @@ public class ExpressionResolutionTestCase extends AbstractElytronSubsystemBaseTe
     public void testExpressionEncryptionOperations() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXml(emptySubsystemXml()).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         String testStorePath = "target/secret-key-store.cs";
@@ -355,7 +358,10 @@ public class ExpressionResolutionTestCase extends AbstractElytronSubsystemBaseTe
 
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXml(emptySubsystemXml()).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ModelNode result = services.executeOperation(composite);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
@@ -365,7 +365,10 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         }
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(subsystemXml).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
@@ -172,7 +172,10 @@ public class LdapTestCase extends AbstractSubsystemTest {
     public void initializeSubsystem() throws Exception {
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("ldap.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/MappersTestCase.java
@@ -70,7 +70,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testPrincipalTransformerTree() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomain");
@@ -89,7 +92,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testCasePrincipalTransformerUpperCase() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomainUpperCase");
@@ -105,7 +111,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testCasePrincipalTransformerLowerCase() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomainLowerCase");
@@ -121,7 +130,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testEvidenceDecoder() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomain");
 
@@ -157,7 +169,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testCustomEvidenceDecoder() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "CustomTestingDomain");
 
@@ -175,7 +190,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testSourceAddressRoleDecoder() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomain");
 
@@ -196,7 +214,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testSourceAddressRoleDecoderWithIPv6() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomainIPv6");
 
@@ -217,7 +238,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testSourceAddressRoleDecoderWithRegex() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomainRegex");
 
@@ -246,7 +270,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testSourceAddressRoleDecoderWithRegexIPv6() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomainRegexIPv6");
 
@@ -276,7 +303,10 @@ public class MappersTestCase extends AbstractElytronSubsystemBaseTest {
     public void testAggregateRoleDecoder() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestingDomainAggregate");
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
@@ -120,7 +120,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testPropertyRealm() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         // hex encoded using UTF-8
@@ -238,7 +241,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testFilesystemRealm() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("FilesystemRealm");
@@ -260,7 +266,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testFileSystemRealmEncodingAndCharset() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         // Testing filesystem realm hex encoded using UTF-8 charset
@@ -286,7 +295,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testFilesystemRealmEncrypted() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("FilesystemRealm5");
@@ -366,7 +378,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testFilesystemRealmIntegrity() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("FilesystemRealmIntegrity");
         ModifiableSecurityRealm securityRealm = (ModifiableSecurityRealm) services.getContainer().getService(serviceName).getValue();
@@ -522,7 +537,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testJwtRealm() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("JwtRealm");
@@ -538,7 +556,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testOAuth2Realm() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("OAuth2Realm");
@@ -550,7 +571,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testAggregateRealm() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("AggregateRealmOne");
@@ -572,7 +596,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testAggregateRealmWithPrincipalTransformer() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName("AggregateRealmTwo");
@@ -647,7 +674,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testEntryInJAASConfigMustBeProvided() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR)
@@ -666,7 +696,10 @@ public class RealmsTestCase extends AbstractElytronSubsystemBaseTest {
     public void testPathToJAASConfigFileDoesNotExist() throws Exception {
         KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("realms-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR)

--- a/elytron/src/test/java/org/wildfly/extension/elytron/RoleMappersTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/RoleMappersTestCase.java
@@ -52,7 +52,10 @@ public class RoleMappersTestCase extends AbstractElytronSubsystemBaseTest {
     private void init(String... domainsToActivate) throws Exception {
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("role-mappers-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
 
         TestEnvironment.activateService(services, Capabilities.SECURITY_DOMAIN_RUNTIME_CAPABILITY, "TestDomain1");

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SaslTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SaslTestCase.java
@@ -68,7 +68,10 @@ public class SaslTestCase extends AbstractSubsystemTest {
         TestEnvironment.mockCallerModuleClassloader(); // to allow loading classes from testsuite
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("sasl-test.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SyslogAuditLogTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SyslogAuditLogTestCase.java
@@ -69,7 +69,10 @@ public class SyslogAuditLogTestCase extends AbstractSubsystemTest {
     public void init() throws Exception {
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("syslog-audit-logging.xml").build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
         udpOperation = createUdpSyslogOperation(SERVER_ADDRESS);
     }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -353,7 +353,10 @@ public class TlsTestCase extends AbstractSubsystemTest {
         }
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(subsystemXml).build();
         if (!services.isSuccessfulBoot()) {
-            Assert.fail(services.getBootError().toString());
+            if (services.getBootError() != null) {
+                Assert.fail(services.getBootError().toString());
+            }
+            Assert.fail("Failed to boot, no reason provided");
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6090
