### PR TITLE
WFCORE-6100 reorder JVM modular options

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
@@ -330,8 +330,6 @@ public class ManagedServerBootCmdFactory implements ManagedServerBootConfigurati
 
         command.add(localJvmType.getJavaExecutable());
 
-        command.addAll(localJvmType.getDefaultArguments());
-
         command.add("-D[" + ManagedServer.getServerProcessName(serverName) + "]");
 
         if (includeProcessId) {
@@ -370,6 +368,8 @@ public class ManagedServerBootCmdFactory implements ManagedServerBootConfigurati
                 command.add(sb.toString());
             }
         }
+
+        command.addAll(localJvmType.getDefaultArguments());
 
         command.add(String.format("-D%s=%s", ServerEnvironment.SERVER_LOG_DIR, this.logDir));
         command.add(String.format("-D%s=%s", ServerEnvironment.SERVER_TEMP_DIR, this.tmpDir));


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6100

move the `-D[Server:XXX] `parameter ahead of  and `add-opens` modular JVM options 