### PR TITLE
[WFCORE-6106] Bump Management API to 21.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -84,7 +84,8 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY23("WildFly23.0", KernelAPIVersion.VERSION_16_0),
         WILDFLY24("WildFly24.0", KernelAPIVersion.VERSION_17_0),
         WILDFLY25("WildFly25.0", KernelAPIVersion.VERSION_18_0),
-        WILDFLY26("WildFly26.0", KernelAPIVersion.VERSION_19_0);
+        WILDFLY26("WildFly26.0", KernelAPIVersion.VERSION_19_0),
+        WILDFLY27("WildFly27.0", KernelAPIVersion.VERSION_20_0);
 
         private static final Map<String, KnownRelease> map = new HashMap<>();
         static {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -78,6 +78,8 @@ public enum KernelAPIVersion {
     VERSION_18_0(18, 0, 0),
     // WildFLy 26.0.0
     VERSION_19_0(19, 0, 0),
+    // WildFLy 27.0.0
+    VERSION_20_0(20, 0, 0),
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);
 

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -35,7 +35,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 20;
+    public static final int MANAGEMENT_MAJOR_VERSION = 21;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6106

The XSD version stays at urn:jboss:domain:20.0 until there is an actual
change change in the XML schema.