### PR TITLE
[WFCORE-6124] Remove deprecated SocketBinding and OutboundSocketBinding members

### DIFF
--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -31,6 +31,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 
 import java.io.IOException;
 import java.util.List;
@@ -53,7 +54,6 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
-import org.jboss.as.network.SocketBinding;
 import org.jboss.as.remoting.EndpointService;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
@@ -672,7 +672,7 @@ public class JMXSubsystemTestCase extends AbstractSubsystemBaseTest {
             ManagementRemotingServices.installRemotingManagementEndpoint(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT, "localhost", EndpointService.EndpointType.MANAGEMENT);
 
             RemotingServices.installConnectorServicesForSocketBinding(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
-                    "remote", SocketBinding.JBOSS_BINDING_NAME.append("remote"), OptionMap.EMPTY,
+                    "remote", SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("remote"), OptionMap.EMPTY,
                     null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"));
         }
     }

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.jmx;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -88,7 +89,6 @@ import org.jboss.as.controller.operations.common.ResolveExpressionHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.jmx.model.ModelControllerMBeanHelper;
-import org.jboss.as.network.SocketBinding;
 import org.jboss.as.remoting.EndpointService;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
@@ -1681,7 +1681,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
             ServiceName tmpDirPath = ServiceName.JBOSS.append("server", "path", "jboss.controller.temp.dir");
 
             RemotingServices.installConnectorServicesForSocketBinding(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
-                    "server", SocketBinding.JBOSS_BINDING_NAME.append("server"), OptionMap.EMPTY,
+                    "server", SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("server"), OptionMap.EMPTY,
                     null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"));
         }
 

--- a/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.network;
 
-import org.jboss.msc.service.ServiceName;
 import org.wildfly.common.Assert;
 
 import java.io.IOException;
@@ -41,10 +40,6 @@ import java.net.UnknownHostException;
  * @author Jaikiran Pai
  */
 public class OutboundSocketBinding {
-
-    /** @deprecated use capability based injection */
-    @Deprecated
-    public static final ServiceName OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME = ServiceName.JBOSS.append("outbound-socket-binding");
 
     private final String name;
     private final SocketBindingManager socketBindingManager;
@@ -157,15 +152,6 @@ public class OutboundSocketBinding {
             return this.resolvedDestinationAddress;
         }
         return InetAddress.getByName(this.unresolvedDestinationAddress);
-    }
-
-    /**
-     * @deprecated Use {@link #getResolvedDestinationAddress()} instead to get the resolved destination address
-     * or {@link #getUnresolvedDestinationAddress()} to get the unresolved destination address.
-     */
-    @Deprecated
-    public synchronized InetAddress getDestinationAddress() throws UnknownHostException {
-        return getResolvedDestinationAddress();
     }
 
     /**

--- a/network/src/main/java/org/jboss/as/network/SocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBinding.java
@@ -31,8 +31,6 @@ import java.net.SocketException;
 import java.util.Collections;
 import java.util.List;
 
-import org.jboss.msc.service.ServiceName;
-
 import static org.jboss.as.network.logging.NetworkMessages.MESSAGES;
 
 /**
@@ -41,10 +39,6 @@ import static org.jboss.as.network.logging.NetworkMessages.MESSAGES;
  * @author Emanuel Muckenhuber
  */
 public final class SocketBinding {
-
-    /** @deprecated use capability injection */
-    @Deprecated
-    public static final ServiceName JBOSS_BINDING_NAME = ServiceName.JBOSS.append("binding");
 
     private final String name;
     private volatile int port;

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingAddHandler.java
@@ -107,7 +107,7 @@ public class BindingAddHandler extends SocketBindingAddHandler {
         final Supplier<SocketBindingManager> sbSupplier = builder.requiresCapability("org.wildfly.management.socket-binding-manager", SocketBindingManager.class);
         final SocketBindingService service = new SocketBindingService(sbConsumer, ibSupplier, sbSupplier, name, port, fixedPort, mcastInet, mcastPort, clientMappings);
         builder.setInstance(service);
-        builder.addAliases(SocketBinding.JBOSS_BINDING_NAME.append(name));
+        builder.addAliases(SOCKET_BINDING_CAPABILITY.getCapabilityServiceName((name)));
         builder.setInitialMode(Mode.ON_DEMAND);
         builder.install();
     }

--- a/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingAddHandler.java
@@ -155,7 +155,7 @@ public class LocalDestinationOutboundSocketBindingAddHandler extends AbstractAdd
         final Supplier<SocketBinding> sbSupplier = builder.requiresCapability(SOCKET_BINDING_CAPABILITY_NAME, SocketBinding.class, socketBindingRef);
         builder.setInstance(new LocalDestinationOutboundSocketBindingService(osbConsumer, sbmSupplier, nibSupplier, sbSupplier, outboundSocketName, sourcePort, fixedSourcePort));
         builder.setInitialMode(ServiceController.Mode.ON_DEMAND);
-        builder.addAliases(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketName));
+        builder.addAliases(OUTBOUND_SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(outboundSocketName));
         builder.install();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingAddHandler.java
@@ -155,7 +155,8 @@ public class RemoteDestinationOutboundSocketBindingAddHandler extends AbstractAd
         final Supplier<NetworkInterfaceBinding> nibSupplier = sourceInterfaceName != null ? builder.requiresCapability("org.wildfly.network.interface", NetworkInterfaceBinding.class, sourceInterfaceName) : null;
         builder.setInstance(new RemoteDestinationOutboundSocketBindingService(osbConsumer, sbmSupplier, nibSupplier, outboundSocketName, destinationHost, destinationPort, sourcePort, fixedSourcePort));
         builder.setInitialMode(ServiceController.Mode.ON_DEMAND);
-        builder.addAliases(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketName));
+
+        builder.addAliases(OUTBOUND_SOCKET_BINDING_CAPABILITY.getCapabilityServiceName((outboundSocketName)));
         builder.install();
     }
 }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/otherservices/subsystem/SubsystemAddWithSocketBindingUserService.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/otherservices/subsystem/SubsystemAddWithSocketBindingUserService.java
@@ -7,6 +7,8 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
+
 /**
  * Handler responsible for adding the subsystem resource to the model
  *
@@ -32,7 +34,7 @@ public class SubsystemAddWithSocketBindingUserService extends AbstractBoottimeAd
 
         SocketBindingUserService mine = new SocketBindingUserService();
         context.getServiceTarget().addService(SocketBindingUserService.NAME, mine)
-            .addDependency(SocketBinding.JBOSS_BINDING_NAME.append("test2"), SocketBinding.class, mine.socketBindingValue)
+            .addDependency(SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("test2"), SocketBinding.class, mine.socketBindingValue)
             .install();
 
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6124

[WFCORE-6124] Remove deprecated SocketBinding and OutboundSocketBinding members