### PR TITLE
[WFCORE-6132] Upgrade sshd-common to 2.9.2 to address CVE-2022-45047

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.apache.logging.log4j>2.19.0</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
-        <version.org.apache.sshd>2.8.0</version.org.apache.sshd>
+        <version.org.apache.sshd>2.9.2</version.org.apache.sshd>
         <version.org.bouncycastle>1.72</version.org.bouncycastle>
         <version.org.bouncycastle.bcpg-jdk18on>1.72.1</version.org.bouncycastle.bcpg-jdk18on>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6132 
