### PR TITLE
[19.x] WFCORE-6132 Upgrade sshd-common to 2.9.2 to address CVE-2022-45047

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <version.org.apache.logging.log4j>2.19.0</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
-        <version.org.apache.sshd>2.8.0</version.org.apache.sshd>
+        <version.org.apache.sshd>2.9.2</version.org.apache.sshd>
         <version.org.bouncycastle>1.71</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.2.0.202206071550-r</version.org.eclipse.jgit>


### PR DESCRIPTION

https://issues.redhat.com/browse/WFCORE-6132