### PR TITLE
[WFCORE-6144] JmxFacadeRbacEnabledTestCase tests fail intermittently due to an NPE

### DIFF
--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -1199,7 +1199,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
     public void testAttributeChangeNotificationUsingMSc() throws Exception {
         KernelServices kernelServices = setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new TestExtension()));
         ServiceController<?> service = kernelServices.getContainer().getService(MBeanServerService.SERVICE_NAME);
-        MBeanServer mbeanServer = MBeanServer.class.cast(service.getValue());
+        MBeanServer mbeanServer = MBeanServer.class.cast(service.awaitValue(5, TimeUnit.MINUTES));
 
         doTestAttributeChangeNotification(mbeanServer, true);
     }
@@ -1356,7 +1356,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
     public void testMBeanServerNotification_UNREGISTRATION_NOTIFICATIONUsingMsc() throws Exception {
         KernelServices kernelServices = setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
         ServiceController<?> service = kernelServices.getContainer().getService(MBeanServerService.SERVICE_NAME);
-        MBeanServer mBeanServer = MBeanServer.class.cast(service.getValue());
+        MBeanServer mBeanServer = MBeanServer.class.cast(service.awaitValue(5, TimeUnit.MINUTES));
 
         doTestMBeanServerNotification_UNREGISTRATION_NOTIFICATION(mBeanServer, true);
     }

--- a/jmx/src/test/java/org/jboss/as/jmx/PluggableMBeanServerTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/PluggableMBeanServerTestCase.java
@@ -53,6 +53,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -81,7 +82,7 @@ public class PluggableMBeanServerTestCase extends AbstractSubsystemTest {
         KernelServices services = builder.build();
 
         ServiceController<?> controller = services.getContainer().getRequiredService(MBeanServerService.SERVICE_NAME);
-        server = (PluggableMBeanServer)controller.getValue();
+        server = (PluggableMBeanServer)controller.awaitValue(5, TimeUnit.MINUTES);
     }
 
     @Test

--- a/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
@@ -610,7 +610,7 @@ public class JmxAuditLogHandlerTestCase extends AbstractControllerTestBase {
 
     private MBeanServer getMBeanServer() throws Exception {
         ServiceController controller = getContainer().getRequiredService(MBeanServerService.SERVICE_NAME);
-        return (PluggableMBeanServer)controller.getValue();
+        return (PluggableMBeanServer) controller.awaitValue(5, TimeUnit.MINUTES);
     }
 
     private ModelNode createAddFileHandlerOperation(String handlerName, String formatterName, String fileName) {

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -732,7 +732,7 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
 
     private MBeanServer getMBeanServer() throws Exception {
         ServiceController<?> controller = getContainer().getRequiredService(MBeanServerService.SERVICE_NAME);
-        return (PluggableMBeanServer)controller.getValue();
+        return (PluggableMBeanServer) controller.awaitValue(5, TimeUnit.MINUTES);
     }
 
     @Override

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
@@ -599,7 +599,7 @@ public abstract class JmxRbacTestCase extends AbstractControllerTestBase {
 
     private MBeanServer getMBeanServer() throws Exception {
         ServiceController controller = getContainer().getRequiredService(MBeanServerService.SERVICE_NAME);
-        return (PluggableMBeanServer)controller.getValue();
+        return (PluggableMBeanServer) controller.awaitValue(5, TimeUnit.MINUTES);
     }
 
     protected void initModel(ManagementModel managementModel) {

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/otherservices/OtherServicesSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/otherservices/OtherServicesSubsystemTestCase.java
@@ -88,7 +88,7 @@ public class OtherServicesSubsystemTestCase extends AbstractSubsystemTest {
 
         Assert.assertNotNull(services.getContainer().getService(OtherService.NAME));
         Assert.assertNotNull(services.getContainer().getService(MyService.NAME));
-        MyService myService = (MyService)services.getContainer().getService(MyService.NAME).getValue();
+        MyService myService = (MyService)services.getContainer().getService(MyService.NAME).awaitValue();
         Assert.assertNotNull(myService.otherValue.getValue());
     }
 
@@ -144,7 +144,7 @@ public class OtherServicesSubsystemTestCase extends AbstractSubsystemTest {
 
         ServiceController<?> controller = services.getContainer().getService(SocketBindingUserService.NAME);
         Assert.assertNotNull(controller);
-        SocketBindingUserService service = (SocketBindingUserService)controller.getValue();
+        SocketBindingUserService service = (SocketBindingUserService)controller.awaitValue();
         SocketBinding socketBinding = service.socketBindingValue.getValue();
         Assert.assertEquals(8000, socketBinding.getSocketBindings().getPortOffset());
         Assert.assertFalse("fixed port", socketBinding.isFixedPort());
@@ -189,7 +189,7 @@ public class OtherServicesSubsystemTestCase extends AbstractSubsystemTest {
 
         ServiceController<?> controller = services.getContainer().getService(SocketBindingUserService.NAME);
         Assert.assertNotNull(controller);
-        SocketBindingUserService service = (SocketBindingUserService)controller.getValue();
+        SocketBindingUserService service = (SocketBindingUserService)controller.awaitValue();
         SocketBinding socketBinding = service.socketBindingValue.getValue();
         Assert.assertEquals(234, socketBinding.getPort());
         Assert.assertEquals("127.0.0.1", socketBinding.getAddress().getHostAddress());
@@ -226,7 +226,7 @@ public class OtherServicesSubsystemTestCase extends AbstractSubsystemTest {
 
         ServiceController<?> controller = services.getContainer().getService(PathUserService.NAME);
         Assert.assertNotNull(controller);
-        PathUserService service = (PathUserService)controller.getValue();
+        PathUserService service = (PathUserService)controller.awaitValue();
         Assert.assertEquals(new File(".", "target").getAbsolutePath(), service.pathValue.getValue());
     }
 


### PR DESCRIPTION
Built on top of #5299

Jira issue: https://issues.redhat.com/browse/WFCORE-6144

Ensures the Service is up before initializing the MBeanServer instance value