### PR TITLE
[WFCORE-6166] max-outbound-channels setting in remoting subsystem is not honored

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/EndpointService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/EndpointService.java
@@ -66,6 +66,7 @@ public class EndpointService implements Service {
         final EndpointBuilder builder = Endpoint.builder();
         builder.setEndpointName(endpointName);
         builder.setXnioWorker(workerSupplier.get());
+        builder.setDefaultConnectionsOptionMap(optionMap);
         try {
             endpoint = builder.build();
         } catch (IOException e) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6166