### PR TITLE
[WFCORE-6160] Upgrade JBoss Remoting to 5.0.27.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.1.1.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.1.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.5.0.Beta4</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.26.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.27.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-6160

        Release Notes - JBoss Remoting (3+) - Version 5.0.27.Final
                                                                                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-393'>REM3-393</a>] -         Endpoint parsing: add support for max-inbound-channels and max-outbound-channels
</li>
</ul>
                                                                                                                                                