### PR TITLE
[WFCORE-6161] Upgrade Undertow to 2.3.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.io.smallrye.jandex>3.0.3</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.0.Final</version.io.undertow>
+        <version.io.undertow>2.3.2.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.authentication.jakarta-authentication-api>3.0.0</version.jakarta.authentication.jakarta-authentication-api>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-6161


        Release Notes - Undertow - Version 2.3.2.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2209'>UNDERTOW-2209</a>] -         deny-uncovered-methods grants access to forbidden methods when default security is blank
</li>
</ul>
                                                                                                                                                                                                                                                                        
        Release Notes - Undertow - Version 2.3.1.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2054'>UNDERTOW-2054</a>] -         Buffer leak errors involving SslConduit on CI
</li>
</ul>
                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2198'>UNDERTOW-2198</a>] -         Add Option to force the SNIHostName 
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1988'>UNDERTOW-1988</a>] -         undertow-servlet-jakartaee9 has a Java EE 8 dependency
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2123'>UNDERTOW-2123</a>] -         AsyncContextImpl.dispatch  uses empty path sometimes
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2184'>UNDERTOW-2184</a>] -         SessionListenerBridge doesn&#39;t properly implement sessionIdChanged
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2186'>UNDERTOW-2186</a>] -         Application sub directories named WEB-INF or META-INF are no longer served
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2188'>UNDERTOW-2188</a>] -         Adjust corner case of covered methods if no methods are  present 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2189'>UNDERTOW-2189</a>] -         IOException thrown when trying to close already closed stream
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2190'>UNDERTOW-2190</a>] -         DefaultServlet serves CSS and JS blobs even if directory listing is disabled
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2202'>UNDERTOW-2202</a>] -         Cannot release the file handle in docker
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2206'>UNDERTOW-2206</a>] -         IAE trying to decode a requestPath 
</li>
</ul>
                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2185'>UNDERTOW-2185</a>] -         Upgrade Apache DS to 2.0.0.AM26
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2143'>UNDERTOW-2143</a>] -         DeflatingStreamSinkConduit should use jdk11 deflate(ByteBuffer) overloads
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2196'>UNDERTOW-2196</a>] -         Reduce allocations from HttpString inn various places
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2204'>UNDERTOW-2204</a>] -         Add CODE_OF_CONDUCT.md
</li>
</ul>
                                                                                                                                                