### PR TITLE
[19.x][WFCORE-6168] Write server configuration files using UTF-8 encoding a…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/AbstractConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/AbstractConfigurationPersister.java
@@ -25,6 +25,7 @@ package org.jboss.as.controller.persistence;
 import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,7 +82,7 @@ public abstract class AbstractConfigurationPersister implements ExtensibleConfig
         try {
             XMLStreamWriter streamWriter = null;
             try {
-                streamWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(output);
+                streamWriter = new UTF8XmlStringWriterDelegate(XMLOutputFactory.newInstance().createXMLStreamWriter(output, StandardCharsets.UTF_8.name()));
                 final ModelMarshallingContext extensibleModel = new ModelMarshallingContext() {
 
                     @Override

--- a/controller/src/main/java/org/jboss/as/controller/persistence/UTF8XmlStringWriterDelegate.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/UTF8XmlStringWriterDelegate.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller.persistence;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * An {@link XMLStreamWriter} implementation delegate that always adds an XML encoding header with UTF-8 value
+ */
+final class UTF8XmlStringWriterDelegate implements XMLStreamWriter {
+    private final XMLStreamWriter delegate;
+    private static final String ENCODING_HEADER = StandardCharsets.UTF_8.name();
+    private static final String VERSION_HEADER = "1.0";
+
+    UTF8XmlStringWriterDelegate(XMLStreamWriter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void writeStartElement(String localName) throws XMLStreamException {
+        delegate.writeStartElement(localName);
+    }
+
+    @Override
+    public void writeStartElement(String namespaceURI, String localName) throws XMLStreamException {
+        delegate.writeStartElement(namespaceURI, localName);
+    }
+
+    @Override
+    public void writeStartElement(String prefix, String localName, String namespaceURI) throws XMLStreamException {
+        delegate.writeStartElement(prefix, localName, namespaceURI);
+    }
+
+    @Override
+    public void writeEmptyElement(String namespaceURI, String localName) throws XMLStreamException {
+        delegate.writeEmptyElement(namespaceURI, localName);
+    }
+
+    @Override
+    public void writeEmptyElement(String prefix, String localName, String namespaceURI) throws XMLStreamException {
+        delegate.writeEmptyElement(prefix, localName, namespaceURI);
+    }
+
+    @Override
+    public void writeEmptyElement(String localName) throws XMLStreamException {
+        delegate.writeEmptyElement(localName);
+    }
+
+    @Override
+    public void writeEndElement() throws XMLStreamException {
+        delegate.writeEndElement();
+    }
+
+    @Override
+    public void writeEndDocument() throws XMLStreamException {
+        delegate.writeEndDocument();
+    }
+
+    @Override
+    public void close() throws XMLStreamException {
+        delegate.close();
+    }
+
+    @Override
+    public void flush() throws XMLStreamException {
+        delegate.flush();
+    }
+
+    @Override
+    public void writeAttribute(String localName, String value) throws XMLStreamException {
+        delegate.writeAttribute(localName, value);
+    }
+
+    @Override
+    public void writeAttribute(String prefix, String namespaceURI, String localName, String value) throws XMLStreamException {
+        delegate.writeAttribute(prefix, namespaceURI, localName, value);
+    }
+
+    @Override
+    public void writeAttribute(String namespaceURI, String localName, String value) throws XMLStreamException {
+        delegate.writeAttribute(namespaceURI, localName, value);
+    }
+
+    @Override
+    public void writeNamespace(String prefix, String namespaceURI) throws XMLStreamException {
+        delegate.writeNamespace(prefix, namespaceURI);
+    }
+
+    @Override
+    public void writeDefaultNamespace(String namespaceURI) throws XMLStreamException {
+        delegate.writeDefaultNamespace(namespaceURI);
+    }
+
+    @Override
+    public void writeComment(String data) throws XMLStreamException {
+        delegate.writeComment(data);
+    }
+
+    @Override
+    public void writeProcessingInstruction(String target) throws XMLStreamException {
+        delegate.writeProcessingInstruction(target);
+    }
+
+    @Override
+    public void writeProcessingInstruction(String target, String data) throws XMLStreamException {
+        delegate.writeProcessingInstruction(target, data);
+    }
+
+    @Override
+    public void writeCData(String data) throws XMLStreamException {
+        delegate.writeCData(data);
+    }
+
+    @Override
+    public void writeDTD(String dtd) throws XMLStreamException {
+        delegate.writeDTD(dtd);
+    }
+
+    @Override
+    public void writeEntityRef(String name) throws XMLStreamException {
+        delegate.writeEntityRef(name);
+    }
+
+    @Override
+    public void writeStartDocument() throws XMLStreamException {
+        this.writeStartDocument(ENCODING_HEADER, VERSION_HEADER);
+    }
+
+    @Override
+    public void writeStartDocument(String version) throws XMLStreamException {
+        this.writeStartDocument(ENCODING_HEADER, version);
+    }
+
+    @Override
+    public void writeStartDocument(String encoding, String version) throws XMLStreamException {
+        delegate.writeStartDocument(encoding, version);
+    }
+
+    @Override
+    public void writeCharacters(String text) throws XMLStreamException {
+        delegate.writeCharacters(text);
+    }
+
+    @Override
+    public void writeCharacters(char[] text, int start, int len) throws XMLStreamException {
+        delegate.writeCharacters(text, start, len);
+    }
+
+    @Override
+    public String getPrefix(String uri) throws XMLStreamException {
+        return delegate.getPrefix(uri);
+    }
+
+    @Override
+    public void setPrefix(String prefix, String uri) throws XMLStreamException {
+        delegate.setPrefix(prefix, uri);
+    }
+
+    @Override
+    public void setDefaultNamespace(String uri) throws XMLStreamException {
+        delegate.setDefaultNamespace(uri);
+    }
+
+    @Override
+    public void setNamespaceContext(NamespaceContext context) throws XMLStreamException {
+        delegate.setNamespaceContext(context);
+    }
+
+    @Override
+    public NamespaceContext getNamespaceContext() {
+        return delegate.getNamespaceContext();
+    }
+
+    @Override
+    public Object getProperty(String name) throws IllegalArgumentException {
+        return delegate.getProperty(name);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/EncodingPersistenceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/EncodingPersistenceTestCase.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.manualmode.management.persistence;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+import jakarta.inject.Inject;
+import org.apache.commons.io.FileUtils;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildFlyRunner;
+
+import static org.jboss.as.domain.management.ModelDescriptionConstants.VALUE;
+
+@RunWith(WildFlyRunner.class)
+@ServerControl(manual = true)
+public class EncodingPersistenceTestCase {
+    static final PathAddress PROPERTY_ADDR = PathAddress.pathAddress(ModelDescriptionConstants.SYSTEM_PROPERTY, "test_property");
+    @Inject
+    private ServerController serverController;
+
+    /**
+     * Tests that we can write and read the persistence XML when the server is launched using an encoding different that UTF-8
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEncodingManagementClient() throws Exception {
+        String originalArgs = System.getProperty("jvm.args");
+        try {
+            System.setProperty("jvm.args", originalArgs + " -Dfile.encoding=windows-1250");
+            serverController.start();
+
+            final ManagementClient client = serverController.getClient();
+
+            ModelNode op = Util.createAddOperation(PROPERTY_ADDR);
+            op.get(ModelDescriptionConstants.VALUE).set("áéíóú");
+
+            client.executeForResult(op);
+
+            serverController.stop();
+            serverController.start();
+
+            op = Util.getReadResourceOperation(PROPERTY_ADDR);
+            ModelNode result = client.executeForResult(op);
+            Assert.assertEquals("áéíóú", result.get(VALUE).asString());
+        } finally {
+            System.setProperty("jvm.args", originalArgs);
+            if (serverController.isStarted()) {
+                serverController.stop();
+            }
+        }
+    }
+
+    /**
+     * Verifies all the persistence XML files explicitly have an encoding header as UTF-8
+     *
+     * @throws IOException
+     */
+    @Test
+    public void checkUtf8HeaderOnXmlConfigurationFiles() throws IOException {
+        final Path jbossHome = Paths.get(TestSuiteEnvironment.getJBossHome());
+
+        final Path standalone = jbossHome.resolve("standalone").resolve("configuration");
+        try (Stream<Path> file = Files.list(standalone)) {
+            file.filter(p -> p.toString().endsWith(".xml")).forEach(this::checkXmlHeader);
+        }
+
+        final Path domain = jbossHome.resolve("domain").resolve("configuration");
+        if (Files.exists(domain)) {
+            try (Stream<Path> file = Files.list(domain)) {
+                file.filter(p -> p.toString().endsWith(".xml")).forEach(this::checkXmlHeader);
+            }
+        }
+
+    }
+
+    private void checkXmlHeader(Path f) {
+        try {
+            Assert.assertTrue("XML encoding header not found in " + f.toAbsolutePath(),
+                    FileUtils.readFileToString(f.toFile(), Charset.forName("utf-8"))
+                            .contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
…nd force to write the XML encoding header

Jira issue: https://issues.redhat.com/browse/WFCORE-6168

