### PR TITLE
[WFCORE-6175] move the plexus-utils dependency to testbom and upgrade

### DIFF
--- a/model-test/pom.xml
+++ b/model-test/pom.xml
@@ -96,10 +96,6 @@
             <groupId>org.apache.maven.resolver</groupId>
             <artifactId>maven-resolver-transport-http</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-        </dependency>
         <!-- slf4j needed for aether -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
         <version.org.apache.sshd>2.9.2</version.org.apache.sshd>
         <version.org.bouncycastle>1.72</version.org.bouncycastle>
         <version.org.bouncycastle.bcpg-jdk18on>1.72.1</version.org.bouncycastle.bcpg-jdk18on>
-        <version.org.codehaus.plexus.plexus-utils>3.1.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.2.0.202206071550-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.1</version.org.eclipse.parsson>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
@@ -990,11 +989,6 @@
                 <version>${version.org.apache.maven.resolver}</version>
             </dependency>
             <!-- This dependency needs to be managed due to the dependency convergence enforcer rule -->
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>${version.org.codehaus.plexus.plexus-utils}</version>
-            </dependency>
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>

--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -49,6 +49,7 @@
         <version.io.netty>4.1.77.Final</version.io.netty>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
+        <version.org.codehaus.plexus.plexus-utils>3.5.0</version.org.codehaus.plexus.plexus-utils>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>
         <version.xom.xom>1.3.7</version.xom.xom>
@@ -204,6 +205,12 @@
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity-engine-scripting</artifactId>
                 <version>${version.org.apache.velocity}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${version.org.codehaus.plexus.plexus-utils}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6175

related WFLY PR: https://github.com/wildfly/wildfly/pull/16380 Full integration Test failures are expected until WFLY PR is merged.
