### PR TITLE
[WFCORE-6182] Await service container stability before KernelServices are provided

### DIFF
--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -593,7 +593,7 @@ final class SubsystemTestDelegate {
                 LegacyControllerKernelServicesProxy legacyServices = legacyInitializer.install(kernelServices, transformedBootOperations);
                 kernelServices.addLegacyKernelService(entry.getKey(), legacyServices);
             }
-
+            kernelServices.getContainer().awaitStability();
             return kernelServices;
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6182
