### PR TITLE
Keeping the actions up to date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates

Configures Dependabot to check the GitHub action used on the GithubWorkflows