### PR TITLE
[WFCORE-6155] systemd service file - warning PIDFile legacy path used

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/systemd/wildfly.service
+++ b/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/systemd/wildfly.service
@@ -8,7 +8,7 @@ Environment=LAUNCH_JBOSS_IN_BACKGROUND=1
 EnvironmentFile=-/etc/wildfly/wildfly.conf
 User=wildfly
 LimitNOFILE=102642
-PIDFile=/var/run/wildfly/wildfly.pid
+PIDFile=/run/wildfly/wildfly.pid
 ExecStart=/opt/wildfly/bin/launch.sh $WILDFLY_MODE $WILDFLY_CONFIG $WILDFLY_BIND
 StandardOutput=null
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6155

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

Remember to use the Jira issue ID in the PR title, and any commits.
