### PR TITLE
[WFCORE-6187] Remove use of deprecated builder methods in PersistentResourceXmlDescription

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -514,41 +514,6 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
     }
 
     /**
-     * @param resource resource for which path we are creating builder
-     * @return PersistentResourceXMLBuilder
-     * @deprecated please use {@linkplain PersistentResourceXMLBuilder(PathElement, String)} variant
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    public static PersistentResourceXMLBuilder builder(PersistentResourceDefinition resource) {
-        return new PersistentResourceXMLBuilder(resource.getPathElement());
-    }
-
-    /**
-     * @param resource resource for which path we are creating builder
-     * @return PersistentResourceXMLBuilder
-     * @deprecated please use {@linkplain PersistentResourceXMLBuilder(PathElement, String)} variant
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    public static PersistentResourceXMLBuilder builder(ResourceDefinition resource) {
-        return new PersistentResourceXMLBuilder(resource.getPathElement());
-    }
-
-    /**
-     *
-     * @param resource resource for which path we are creating builder
-     * @param namespaceURI xml namespace to use for this resource, usually used for top level elements such as subsystems
-     * @return PersistentResourceXMLBuilder
-     * @deprecated please use {@linkplain PersistentResourceXMLBuilder(PathElement, String)} variant
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    public static PersistentResourceXMLBuilder builder(PersistentResourceDefinition resource, String namespaceURI) {
-        return new PersistentResourceXMLBuilder(resource.getPathElement(), namespaceURI);
-    }
-
-    /**
      * Creates builder for passed path element
      * @param pathElement for which we are creating builder
      * @return PersistentResourceXMLBuilder

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemParser_1_0.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemParser_1_0.java
@@ -35,7 +35,7 @@ class RequestControllerSubsystemParser_1_0 extends PersistentResourceXMLParser {
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return builder(RequestControllerRootDefinition.INSTANCE, Namespace.CURRENT.getUriString())
+        return builder(RequestControllerRootDefinition.INSTANCE.getPathElement(), Namespace.CURRENT.getUriString())
                 .addAttributes(RequestControllerRootDefinition.MAX_REQUESTS, RequestControllerRootDefinition.TRACK_INDIVIDUAL_ENDPOINTS)
                 .build();
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/SubsystemParser.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/SubsystemParser.java
@@ -37,7 +37,7 @@ class SubsystemParser extends PersistentResourceXMLParser {
     private final PersistentResourceXMLDescription xmlDescription;
 
     private SubsystemParser() {
-        xmlDescription = builder(RootResourceDefinition.INSTANCE, DependentExtension.NAMESPACE)
+        xmlDescription = builder(RootResourceDefinition.INSTANCE.getPathElement(), DependentExtension.NAMESPACE)
                 .addAttributes(RootResourceDefinition.ATTRIBUTE)
                 .build();
     }

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsParser2_0.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsParser2_0.java
@@ -33,7 +33,7 @@ public class ThreadsParser2_0 extends PersistentResourceXMLParser {
 
 
     @SuppressWarnings("deprecation")
-    private final PersistentResourceXMLDescription xmlDescription = builder(new ThreadSubsystemResourceDefinition(false), Namespace.CURRENT.getUriString())
+    private final PersistentResourceXMLDescription xmlDescription = builder(new ThreadSubsystemResourceDefinition(false).getPathElement(), Namespace.CURRENT.getUriString())
             .addChild(THREAD_FACTORY_PARSER)
             .addChild(getUnboundedQueueThreadPoolParser(UnboundedQueueThreadPoolResourceDefinition.create(false)))
             .addChild(getBoundedQueueThreadPoolParser(BoundedQueueThreadPoolResourceDefinition.create(false, false)))


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6187
