### PR TITLE
[WFCORE-6204] Upgrade SLF4J from 1.7.36 to 2.0.6.

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
@@ -28,6 +28,6 @@
     </resources>
 
     <dependencies>
-        <module name="org.slf4j.impl"/>
+        <module name="org.slf4j.impl" services="import"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <version.org.jboss.remoting>5.0.27.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
-        <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.1.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>
+        <version.org.jboss.slf4j.slf4j-jboss-logmanager>2.0.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
@@ -250,7 +250,7 @@
         <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mockito>3.10.0</version.org.mockito>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
-        <version.org.slf4j>1.7.36</version.org.slf4j>
+        <version.org.slf4j>2.0.6</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>

--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -38,7 +38,7 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
-        <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
+        <version.ch.qos.logback>1.4.5</version.ch.qos.logback>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6204

According to https://www.slf4j.org/manual.html SLF4J should be backwards compatible. This does however require changes to the implementation of `org.jboss.logging:slf4j-jboss-logmanager`. We also need to upgrade logback for testing.

We do not support logback so any user using logback would be required to provide their own version of the `slf4j-api`. We should be able to safely upgrade. Tests passed for me locally and the full test suite of WildFly.