### PR TITLE
[WFCORE-6214] Fixed Flaky Test HelpSupportTestCase.testStandalone

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/SynopsisGenerator.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/SynopsisGenerator.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -180,8 +181,8 @@ class SynopsisGenerator {
             }
             synopsisBuilder.append(" |");
             // Keep the set of all conflicts, they will be removed from all conflicts, being handled at this level.
-            Set<SynopsisOption> conflicts = new HashSet<>(currentOption.conflictWith);
-            Set<SynopsisOption> conflicts2 = new HashSet<>(currentOption.conflictWith);
+            Set<SynopsisOption> conflicts = new LinkedHashSet<>(currentOption.conflictWith);
+            Set<SynopsisOption> conflicts2 = new LinkedHashSet<>(currentOption.conflictWith);
             // Conflicts can have dependencies that must be added prior to them
             for (SynopsisOption so : conflicts2) {
                 Set<SynopsisOption> conflictAndDependencies = retrieveAllDependencies(so);


### PR DESCRIPTION
### What is the purpose of this PR

- This PR fixes the error resulting from the flaky test `org.jboss.as.cli.impl.aesh.HelpSupportTestCase`
- The mentioned test may fail or pass without changes made to the source code when it is run in different JVMs due to `HashSet`'s non-deterministic iteration order.

### Why the test fails

- `HelpSupportTestCase` calls `SynopsisGenerator`, which uses a `HashSet` as its data structure for the conflicts object. As per Java 11 documentation, the ordering of `HashSet` is not constant, so assigning the same `HashSet` as an array to different objects can change the ordering. So, when comparing these two arrays with `assertEquals` the test may fail as the given order can be different from the expected order.

### Reproduce the test failure

- Run the test with `NonDex` maven plugin. The command to recreate the flaky test failure is
   `mvn -pl cli edu.illinois:nondex-maven-plugin:2.1.1:nondex - 
    Dtest=org.jboss.as.cli.impl.aesh.HelpSupportTestCase#testStandalone`
- Fixing the flaky test now may prevent flaky test failures in future Java versions.


### Expected result

- The tests should run successfully when run with `NonDex`.
- Expected: `<...server-groups] | [--[replace] | [--server-groups]] )>`


### Actual Result
- We get the failure:
- [ERROR] `testStandalone(org.jboss.as.cli.impl.aesh.HelpSupportTestCase)`  Time elapsed: 0.254 s  <<< FAILURE!
`org.junit.ComparisonFailure`: `org.jboss.as.cli.impl.aesh.Commands$Standalone$Command10`. EXPECTED `[command1 [<argument>] ( [--all-server-groups] | [--replace] | [--server-groups] )]`. FOUND `[command1 [<argument>] ( [--all-server-groups] | [--server-groups] | [--replace] )]` expected: `<...server-groups] | [--[replace] | [--server-groups]] )>` but was: `<...server-groups] | [--[server-groups] | [--replace]] )>`

### Fix
- Changed the `conflicts` and `conflicts2` objects from `HashSet` to `LinkedHashSet` in method `SynopsisGenerator.addSynopsisOption(SynopsisOption)` and imported `LinkedHashSet`.


This PR is similar to some merged PRs in other wildfly projects:

https://github.com/wildfly/wildfly/pull/13728
https://github.com/wildfly/wildfly/pull/11833
https://github.com/wildfly/jboss-ejb-client/pull/534


### Jira Issue: 
https://issues.redhat.com/browse/WFCORE-6214
