### PR TITLE
[WFCORE-6214] Fixed Flaky Tests in HelpSupportTestCase.testStandalone and BootScriptInvokerTestCase

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/SynopsisGenerator.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/SynopsisGenerator.java
@@ -17,6 +17,7 @@ package org.jboss.as.cli.impl.aesh;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.TreeSet;
 import org.aesh.command.activator.OptionActivator;
 import org.aesh.command.impl.internal.ProcessedOption;
 import org.wildfly.core.cli.command.aesh.activator.DependOptionActivator;
@@ -181,7 +183,8 @@ class SynopsisGenerator {
             synopsisBuilder.append(" |");
             // Keep the set of all conflicts, they will be removed from all conflicts, being handled at this level.
             Set<SynopsisOption> conflicts = new HashSet<>(currentOption.conflictWith);
-            Set<SynopsisOption> conflicts2 = new HashSet<>(currentOption.conflictWith);
+            Set<SynopsisOption> conflicts2 = new TreeSet<>(Comparator.comparing(SynopsisOption::getName));
+            conflicts2.addAll(currentOption.conflictWith);
             // Conflicts can have dependencies that must be added prior to them
             for (SynopsisOption so : conflicts2) {
                 Set<SynopsisOption> conflictAndDependencies = retrieveAllDependencies(so);

--- a/cli/src/test/java/org/jboss/as/cli/impl/BootScriptInvokerTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/impl/BootScriptInvokerTestCase.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -214,7 +215,7 @@ public class BootScriptInvokerTestCase {
         Set<String> operations = new HashSet<>();
         operations.add("op1");
         operations.add("op2");
-        Set<String> echos = new HashSet<>();
+        Set<String> echos = new LinkedHashSet<>();
         echos.add("echo TestWarning > ${" + propWarning + "}");
         echos.add("echo TestError > ${" + propError + "}");
         echos.add("echo TestFoo >> ${" + propFoo + "}");


### PR DESCRIPTION
### What is the purpose of this PR

- This PR fixes the error resulting from two flaky tests:  `org.jboss.as.cli.impl.aesh.HelpSupportTestCase` and  `org.jboss.as.cli.impl.BootScriptInvokerTestCase`
- The mentioned tests may fail or pass without changes made to the source code when it is run in different JVMs due to `HashSet`'s non-deterministic iteration order.

### Why the tests fail

- Test one fails because `HelpSupportTestCase` calls `SynopsisGenerator`, which uses a `HashSet` as its data structure for the conflicts object. As per Java 11 documentation, the ordering of `HashSet` is not constant. So, the test may fail as the given order can be different from the expected order. 
- Test two fails because `BootScriptInvokerTestCase#test` uses a `HashSet` as its data structure for the echos object. As per Java 11 documentation, the ordering of `HashSet` is not constant. So, the test may fail as the given order can be different from the expected order. 

### Reproduce the test failure

- Run the tests with `NonDex` maven plugin. The commands to recreate the flaky test failures are:

- `mvn -pl cli edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.jboss.as.cli.impl.aesh.HelpSupportTestCase#testStandalone`
-  `mvn -pl cli edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.jboss.as.cli.impl.BootScriptInvoker#test`

- Fixing the flaky test now may prevent flaky test failures in future Java versions.


### Expected results
- Both tests should run successfully when run with `NonDex`.




### Actual Result
- We get the following failure for test `org.jboss.as.cli.impl.aesh.HelpSupportTestCase#testStandalone` : 
[ERROR] `testStandalone(org.jboss.as.cli.impl.aesh.HelpSupportTestCase)`  Time elapsed: 0.254 s  <<< FAILURE!
`org.junit.ComparisonFailure`: `org.jboss.as.cli.impl.aesh.Commands$Standalone$Command10`. EXPECTED `[command1 [<argument>] ( [--all-server-groups] | [--replace] | [--server-groups] )]`. FOUND `[command1 [<argument>] ( [--all-server-groups] | [--server-groups] | [--replace] )]` expected: `<...server-groups] | [--[replace] | [--server-groups]] )>` but was: `<...server-groups] | [--[server-groups] | [--replace]] )>`

- We get the following failure for test `org.jboss.as.cli.impl.BootScriptInvokerTestCase#test`:
`<<< FAILURE!` - in `org.jboss.as.cli.impl.BootScriptInvokerTestCase`  [ERROR] `test(org.jboss.as.cli.impl.BootScriptInvokerTestCase)` Time elapsed: 0.066 s  `<<< FAILURE!`
`java.lang.AssertionError`


### Fix
- For test one: Changed the object type of  `conflicts2` from `HashSet` to `TreeSet` in method `org.jboss.as.cli.impl.aesh.SynopsisGenerator#addSynopsisOption(SynopsisOption)`.
- For test two: Changed the object type of echos from `HashSet` to `LinkedHashSet` in `org.jboss.as.cli.impl.BootScriptInvokerTestCase#test`

### Jira Issue: 
https://issues.redhat.com/browse/WFCORE-6214


This PR is similar to some merged PRs in other Wildfly projects:

https://github.com/wildfly/wildfly/pull/13728
https://github.com/wildfly/wildfly/pull/11833
https://github.com/wildfly/jboss-ejb-client/pull/534
