### PR TITLE
[WFCORE-6226] Dropping tests for TransformerSubsystemTestCase using deprecated ModelTestControllerVersion and creating test case against EAP_7_4_0

### DIFF
--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/TransformerSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/TransformerSubsystemTestCase.java
@@ -84,15 +84,9 @@ public class TransformerSubsystemTestCase extends AbstractSubsystemBaseTest {
     public void testTransformersAS() throws Exception {
         testTransformers(ModelTestControllerVersion.MASTER);
     }
-
     @Test
-    public void testTransformersEAP640() throws Exception {
-        testTransformers(ModelTestControllerVersion.EAP_6_4_0);
-    }
-
-    @Test
-    public void testTransformersEAP700() throws Exception {
-        testTransformers(ModelTestControllerVersion.EAP_7_0_0);
+    public void testTransformersEAP740() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_4_0);
     }
 
     private void testTransformers(ModelTestControllerVersion controllerVersion) throws Exception {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6226
