### PR TITLE
[WFCORE-6217] Upgrade Undertow to 2.3.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.0.Final</version.io.undertow>
+        <version.io.undertow>2.3.4.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.authentication.jakarta-authentication-api>3.0.0</version.jakarta.authentication.jakarta-authentication-api>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFCORE-6217


        Release Notes - Undertow - Version 2.3.1.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2054'>UNDERTOW-2054</a>] -         Buffer leak errors involving SslConduit on CI
</li>
</ul>
                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2198'>UNDERTOW-2198</a>] -         Add Option to force the SNIHostName 
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1988'>UNDERTOW-1988</a>] -         undertow-servlet-jakartaee9 has a Java EE 8 dependency
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2184'>UNDERTOW-2184</a>] -         SessionListenerBridge doesn&#39;t properly implement sessionIdChanged
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2186'>UNDERTOW-2186</a>] -         Application sub directories named WEB-INF or META-INF are no longer served
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2188'>UNDERTOW-2188</a>] -         Adjust corner case of covered methods if no methods are  present 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2189'>UNDERTOW-2189</a>] -         IOException thrown when trying to close already closed stream
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2190'>UNDERTOW-2190</a>] -         DefaultServlet serves CSS and JS blobs even if directory listing is disabled
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2202'>UNDERTOW-2202</a>] -         Cannot release the file handle in docker
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2206'>UNDERTOW-2206</a>] -         IAE trying to decode a requestPath 
</li>
</ul>
                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2185'>UNDERTOW-2185</a>] -         Upgrade Apache DS to 2.0.0.AM26
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2143'>UNDERTOW-2143</a>] -         DeflatingStreamSinkConduit should use jdk11 deflate(ByteBuffer) overloads
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2196'>UNDERTOW-2196</a>] -         Reduce allocations from HttpString inn various places
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2204'>UNDERTOW-2204</a>] -         Add CODE_OF_CONDUCT.md
</li>
</ul>
                                                                                                                                                

        Release Notes - Undertow - Version 2.3.2.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2209'>UNDERTOW-2209</a>] -         deny-uncovered-methods grants access to forbidden methods when default security is blank
</li>
</ul>
                                                                                                                                                                                                                                                                        


        Release Notes - Undertow - Version 2.3.3.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2213'>UNDERTOW-2213</a>] -         Revert deny-uncovered-methods fix for corner case
</li>
</ul>
                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2203'>UNDERTOW-2203</a>] -         Split README file into several others
</li>
</ul>
                                                                                                                                                


        Release Notes - Undertow - Version 2.3.4.Final
                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1875'>UNDERTOW-1875</a>] -         Matrix parameters with comma are not properly handled
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1885'>UNDERTOW-1885</a>] -         Predicate Language: Parsing mishandles escaped quotes in string literal
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2200'>UNDERTOW-2200</a>] -         Path and query parameters are not decoded properly due to flag switch.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2211'>UNDERTOW-2211</a>] -         deny-uncovered-methods regards omitted methods as covered
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2221'>UNDERTOW-2221</a>] -         Undertow can add unwanted semicolon to path parameter when client http request packets are separated in the middle of path parameter
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2234'>UNDERTOW-2234</a>] -         HttpClientSNITestCase fails with last jdk 11.0.18 and 17.0.6
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2208'>UNDERTOW-2208</a>] -         Enhance SNI hostname creation exception text
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2210'>UNDERTOW-2210</a>] -         Improved write ASCII path on ServletPrintWriter
</li>
</ul>
                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1890'>UNDERTOW-1890</a>] -         NetworkUtils throws IOException instead of IllegalArgumentException
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2218'>UNDERTOW-2218</a>] -         Add default MIME type for webp
</li>
</ul>
                                                                                                                                                