### PR TITLE
Fix for WFCORE-6228, Upgrade galleon-plugins to 6.3.0.Final

### DIFF
--- a/core-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/core-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -61,10 +61,6 @@
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>
     </plugins>
 
-    <resources>
-        <copy artifact="org.wildfly.galleon-plugins:wildfly-config-gen" to="wildfly/wildfly-config-gen.jar"/>
-    </resources>
-
     <generate-feature-specs>
         <extensions>
             <standalone>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <version.org.jboss.galleon>5.0.7.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>6.2.3.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.3.0.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.wildfly.plugin>2.0.2.Final</version.wildfly.plugin>
         <version.org.wildfly.jar.plugin>8.1.0.Final</version.org.wildfly.jar.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6228
Upgrade galleon-plugins and remove the copy of wildfly-config-gen artifact inside the feature-pack. It is now resolved from maven.
