### PR TITLE
[WFCORE-6231] Upgrade slf4j-jboss-logmanager to 2.0.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <version.org.jboss.remoting>5.0.27.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.4.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
-        <version.org.jboss.slf4j.slf4j-jboss-logmanager>2.0.0.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>
+        <version.org.jboss.slf4j.slf4j-jboss-logmanager>2.0.1.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6231

Tag: https://github.com/jboss-logging/slf4j-jboss-logmanager/releases/tag/2.0.1.Final
Diff: https://github.com/jboss-logging/slf4j-jboss-logmanager/compare/2.0.0.Final...2.0.1.Final
