### PR TITLE
[WFCORE-6237] Eliminating usage of deprecated javax.api aggregation module

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/wildflyee/api/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/wildflyee/api/main/module.xml
@@ -50,8 +50,5 @@
         <module name="org.glassfish.jakarta.el" export="true" optional="true" />
         <module name="javax.xml.rpc.api" export="true" optional="true" />
         <module name="org.omg.api" export="true" optional="true" />
-
-        <!-- This one always goes last. -->
-        <module name="javax.api" export="true" optional="true" />
     </dependencies>
 </module>

--- a/core-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/security/auth/message/api/main/module.xml
+++ b/core-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/security/auth/message/api/main/module.xml
@@ -25,12 +25,7 @@
 <module xmlns="urn:jboss:module:1.9" name="jakarta.security.auth.message.api">
 
     <resources>
-        <!--<artifact name="${org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec}"/>-->
         <artifact name="${jakarta.authentication:jakarta.authentication-api}"/>
     </resources>
 
-    <dependencies>
-        <!-- Needed for javax.security.auth -->
-        <module name="javax.api" export="false"/>
-     </dependencies>
 </module>

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
@@ -41,7 +41,7 @@ import org.jboss.modules.ModuleLoader;
 public class ServerDependenciesProcessor implements DeploymentUnitProcessor {
 
     private static ModuleIdentifier[] DEFAULT_MODULES = new ModuleIdentifier[] {
-        ModuleIdentifier.create("javax.api"),
+        ModuleIdentifier.create("java.se"),
         ModuleIdentifier.create("org.jboss.vfs"),
     };
 

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -38,6 +38,7 @@ public class LayersTestCase {
     private static final String[] NOT_USED = {
         // deprecated
         "org.jboss.as.threads",
+        "javax.api",
         // Un-used
         "javax.xml.stream.api",
         // Un-used

--- a/testsuite/shared/src/main/resources/jmx-listener-module.xml
+++ b/testsuite/shared/src/main/resources/jmx-listener-module.xml
@@ -10,7 +10,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="sun.jdk"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.as.server"/>

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/dependent/module.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/dependent/module.xml
@@ -29,7 +29,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>

--- a/testsuite/shared/src/main/resources/org/wildfly/test/jmx/events/module.xml
+++ b/testsuite/shared/src/main/resources/org/wildfly/test/jmx/events/module.xml
@@ -21,7 +21,6 @@ limitations under the License.
 
     <dependencies>
         <module name="org.wildfly.extension.core-management-client"/>
-        <module name="javax.api"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/testsuite/standalone/src/test/resources/org/wildfly/core/test/standalone/extension/booterror/module.xml
+++ b/testsuite/standalone/src/test/resources/org/wildfly/core/test/standalone/extension/booterror/module.xml
@@ -29,7 +29,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>

--- a/testsuite/standalone/src/test/resources/org/wildfly/core/test/standalone/extension/remove/module.xml
+++ b/testsuite/standalone/src/test/resources/org/wildfly/core/test/standalone/extension/remove/module.xml
@@ -29,7 +29,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6237
