### PR TITLE
[WFCORE-6243] Upgrade WildFly Elytron to 2.1.0.Final

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -504,6 +504,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-ssh-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-util</artifactId>
         </dependency>
         <dependency>

--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -1825,6 +1825,17 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-ssh-util</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-ssl</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
@@ -94,6 +94,7 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-security-manager}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-security-manager-action}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-ssl}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron-ssh-util}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-util}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-x500}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-x500-cert}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1730,6 +1730,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-ssh-util</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-audit</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.1.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>1.33</version.org.yaml.snakeyaml>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -144,6 +144,10 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-sasl-scram</artifactId>
         </dependency>
+             <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-ssh-util</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-ssl</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6243

This PR also includes the changes from https://github.com/wildfly/wildfly-core/pull/5386 since this is needed to build successfully with Elytron 2.1.0.Final. See https://issues.redhat.com/browse/WFCORE-6239 for more details.

        Release Notes - WildFly Elytron - Version 2.1.0.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-317'>ELY-317</a>] -         OneTimePassword transformer
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2313'>ELY-2313</a>] -         Update the OIDC tests to use the 19.0.1 version of quay.io/keycloak/keycloak
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2383'>ELY-2383</a>] -         KeyStoreCredentialStoreTest fails in Windows without adminstrator privileges
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2468'>ELY-2468</a>] -         Update getRealmIdentity so that it attempts to convert the given Principal to NamePrincipal if necessary
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2469'>ELY-2469</a>] -         Update deprecated assertThat method in JACC and credential store test cases
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2478'>ELY-2478</a>] -         WildFlyElytronClientDefaultSSLContextProvider configure method does not use constants
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2502'>ELY-2502</a>] -         SASL authentication configured by the security command denies CLI connection
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2179'>ELY-2179</a>] -         Add logging to AggregateSecurityRealm
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2182'>ELY-2182</a>] -         LogManager warning when using the credential-store command
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2255'>ELY-2255</a>] -         Upgrade net.minidev:json-smart to 2.4.7
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2317'>ELY-2317</a>] -         Add a test case for static registration of WildFlyElytronClientDefaultSSLContextProvider
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2327'>ELY-2327</a>] -         Add gitleaks.toml file with allowlist
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2366'>ELY-2366</a>] -         Add the missing @deprecated Javadoc tag to ElytronAuthenticator
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2367'>ELY-2367</a>] -         DefaultSSLContextFromFileWorksAndHasPrecedenceTest, DefaultSSLContextProviderProgrammaticConfigurationTest.java has expected and actual value swaped
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2368'>ELY-2368</a>] -         Add Override annotations to AggregateSecurityRealm
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2369'>ELY-2369</a>] -         Add Override annotations to in DERDecoder
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2370'>ELY-2370</a>] -         Move appropriate methods to the JaasRealmIdentity class from JaasSecurityRealm class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2382'>ELY-2382</a>] -         Update message description so no it no longer uses problematic language
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2385'>ELY-2385</a>] -         RawSecretKeyFactoryTest uses deprecated Assert.assertThat method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2389'>ELY-2389</a>] -         Consistent expression resolution with WildFly
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2392'>ELY-2392</a>] -         Fix invalid tags on the Elytron Blogs page
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2395'>ELY-2395</a>] -         Add missing ranges for wildfly-elytron-auth-server to ELY_Messages.txt
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2396'>ELY-2396</a>] -         Update string to int conversion in ModularCrypt
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2397'>ELY-2397</a>] -         Update three test cases in DEREncoderTestCase to use a common helper method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2398'>ELY-2398</a>] -         Fix FileSystemEncryptRealmCommand.java so it uses logical OR instead of bitwise OR
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2399'>ELY-2399</a>] -         Remove invalid assertion from SaslServerBuilder#setPlainText 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2400'>ELY-2400</a>] -         Remove temporary variable assignment in Builder#addRealm
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2401'>ELY-2401</a>] -         Make ENV_BINARY_ATTRIBUTES variable static
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2402'>ELY-2402</a>] -         Make the NO_FILTER variable static
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2403'>ELY-2403</a>] -         Declare &quot;next&quot; on a separate line in DERDecoder#decodeBitStringAsString
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2404'>ELY-2404</a>] -         Update WildFlyElytronClientDefaultSSLContextProvider to use constants for the &quot;SSLContext&quot; and &quot;Default&quot; strings
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2405'>ELY-2405</a>] -         Use already defined constant X509_FORMAT instead of duplicating its value in FileSystemSecurityRealm#parseCertificate
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2406'>ELY-2406</a>] -         The error and status fields for the HttpFailure class should be declared as final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2407'>ELY-2407</a>] -         Use isEmpty method instead of size method in AcmeClientSpi
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2408'>ELY-2408</a>] -         Redundant static qualifier in HttpClientBuilder
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2409'>ELY-2409</a>] -         Redundant static qualifier in AuthenticationError
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2410'>ELY-2410</a>] -         Remove unnecessary null check in ServerAuthenticationContext
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2411'>ELY-2411</a>] -         Add a test case to MappedRegexRealmMapperTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2414'>ELY-2414</a>] -         Add additional constructor to BearerMechanismFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2419'>ELY-2419</a>] -         Update GeneralName to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2420'>ELY-2420</a>] -         Update MaskedPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2421'>ELY-2421</a>] -         Update DigestPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2422'>ELY-2422</a>] -         Update SaltedSimpleDigestPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2423'>ELY-2423</a>] -         Update SimpleDigestPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2424'>ELY-2424</a>] -         Update ScramDigestPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2425'>ELY-2425</a>] -         Update SunUnixMD5CryptPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2426'>ELY-2426</a>] -         Update UnixMD5CryptPassworldImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2427'>ELY-2427</a>] -         Update EncryptablePasswordSpec to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2428'>ELY-2428</a>] -         Update ClearPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2429'>ELY-2429</a>] -         Update RawClearPassword to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2430'>ELY-2430</a>] -         Update AbstractX509CertificateChainCredential to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2431'>ELY-2431</a>] -         Update X509EvidenceVerifier to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2432'>ELY-2432</a>] -         Update RawSaltedSimpleDigestPassword to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2433'>ELY-2433</a>] -         Update RawScramDigestPassword to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2434'>ELY-2434</a>] -         Update UnixSHACryptPasswordImpl to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2435'>ELY-2435</a>] -         Update RawDigestPassword to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2436'>ELY-2436</a>] -         Update HashPasswordSpec to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2437'>ELY-2437</a>] -         Update DigestPasswordSpec to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2438'>ELY-2438</a>] -         Update RawSimpleDigestPassword to make use of MessageDigest#isEqual to avoid a potential timing attack
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2439'>ELY-2439</a>] -         Add a test class for RegexNameValidatingRewriter
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2440'>ELY-2440</a>] -         Move JaasSecurityRealmTest and its test resources to the same module that JaasSecurityRealm resides in
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2441'>ELY-2441</a>] -         Move the expected exception assertion from an annotation to the test body in DefaultSSLContextEmptyPathTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2442'>ELY-2442</a>] -         Move the expected exception assertion from an annotation to the test body in DefaultSSLContextNonexistentConfigFileTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2443'>ELY-2443</a>] -         Extract the assignment from the return statement in AuthenticationConfiguration#toString to make it more readable
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2444'>ELY-2444</a>] -         Immediately return the value in SNISSLExplorer instead of assigning it to a temporary variable
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2446'>ELY-2446</a>] -         Add a test class for RegexNameRewriter
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2447'>ELY-2447</a>] -         Add missing throw in Oidc#sendJsonHttpRequest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2448'>ELY-2448</a>] -         Return false in OidcAccount#tryRefresh when securityContext is null
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2449'>ELY-2449</a>] -         Remove unneeded null check in OidcCookieTokenStore#logout
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2450'>ELY-2450</a>] -         Assign value to path in OidcCookieTokenStore#getContextPath
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2451'>ELY-2451</a>] -         Correct a typo in ServerAuthenticationContext.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2453'>ELY-2453</a>] -         Small updates in RegexNameRewriterTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2458'>ELY-2458</a>] -         Use already defined constant HttpConstants.DIGEST_NAME instead of hardcoding DIGEST multiple times in HttpAuthenticationFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2459'>ELY-2459</a>] -         Add Override annotation to DigestPassword#getParameterSpec
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2460'>ELY-2460</a>] -         Add Override annotation to BCryptPassword#getParameterSpec
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2461'>ELY-2461</a>] -         Add Override annotation to BSDUnixDESCryptPassword#getParameterSpec
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2463'>ELY-2463</a>] -         Add Override annotation to OneTimePassword#getParameterSpec
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2464'>ELY-2464</a>] -         RSAPublicJWK#setX509CertificateChain should throw its exception using ElytronMessages
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2465'>ELY-2465</a>] -         JsonSerialization#createObjectNode should throw its exception using ElytronMessages
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2466'>ELY-2466</a>] -         Replace Collections.EMPTY_MAP with Collections.emptyMap()
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2467'>ELY-2467</a>] -         Update test cases in CipherSuiteSelectorTest to use a common helper method where appropriate
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2470'>ELY-2470</a>] -         Extract the assignemt out of this expression
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2471'>ELY-2471</a>] -         Make public static fields in Command class final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2472'>ELY-2472</a>] -         Add Override annotation to FileSystemSecurityRealm.Identity methods
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2473'>ELY-2473</a>] -         Move method getEntry from KeyStoreBackedSecurityRealm to its inner class KeyStoreRealmIdentity
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2474'>ELY-2474</a>] -         Remove unnecessary boolean literal in LegacyPropertiesSecurityRealm
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2481'>ELY-2481</a>] -         Use assertNotEquals instead of using equals method in AcmeClientSpiTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2482'>ELY-2482</a>] -         Update LICENSE.txt file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2483'>ELY-2483</a>] -         Add CODE_OF_CONDUCT.md
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2484'>ELY-2484</a>] -         Add SECURITY.md file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2485'>ELY-2485</a>] -         Add a CODEOWNERS file to GitHub repository
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2506'>ELY-2506</a>] -         Provide a utility method to create a SSLContext from a pem file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2509'>ELY-2509</a>] -         Move HttpAuthenticator#isAuthenticated method to AuthenticationExchange class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2520'>ELY-2520</a>] -         Fix system property resolution in JSON files
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2526'>ELY-2526</a>] -         Release WildFly Elytron 1.20.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2527'>ELY-2527</a>] -         Release WildFly Elytron 2.1.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2492'>ELY-2492</a>] -         Upgrade sshd-common from 2.7.0 to 2.9.2
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2493'>ELY-2493</a>] -         Upgrade jackson-databind to 2.13.4 to address CVE-2022-42004
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2505'>ELY-2505</a>] -         Upgrade xnio to 3.8.8.Final
</li>
</ul>