### PR TITLE
[WFCORE-6241] Adding 'quickly' profile for fast maven builds with quick profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2507,5 +2507,26 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <license.skip>true</license.skip>
+                <skipTests>true</skipTests>
+                <enforcer.skip>true</enforcer.skip>
+                <checkstyle.skip>true</checkstyle.skip>
+                <skipITs>true</skipITs>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <maven.buildNumber.skip>true</maven.buildNumber.skip>
+            </properties>
+            <build>
+                <defaultGoal>clean install</defaultGoal>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -40,8 +40,6 @@
         <wildfly.home>${project.basedir}${file.separator}target${file.separator}${server.name}</wildfly.home>
         <test.log.level>INFO</test.log.level>
         <test.log.file>${project.build.directory}${file.separator}test.log</test.log.file>
-        <maven.test.skip>false</maven.test.skip>
-        <skipTests>${maven.test.skip}</skipTests>
     </properties>
 
     <build>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6241

My machine:

mvn clean install -DskipTests -> 02:00 min
mvn -Dquickly -> 01:24 min
mvnd -Dquickly -> 46.530 s (7 threads)