### PR TITLE
[WFCORE-6251] Use standard java.xml JPMS module instead of deprecated javax.xml.stream.api

### DIFF
--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/security-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/expressions/module/security-module.xml
@@ -30,6 +30,6 @@
         <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.picketbox"/>
-        <module name="javax.xml.stream.api"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6251