### PR TITLE
[WFCORE-6250] Don't include org.jboss.vfs module to all deployments by default

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
@@ -37,12 +37,12 @@ import org.jboss.modules.ModuleLoader;
  *
  * @author Stuart Douglas
  * @author Thomas.Diesler@jboss.com
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class ServerDependenciesProcessor implements DeploymentUnitProcessor {
 
     private static ModuleIdentifier[] DEFAULT_MODULES = new ModuleIdentifier[] {
         ModuleIdentifier.create("java.se"),
-        ModuleIdentifier.create("org.jboss.vfs"),
     };
 
     private static ModuleIdentifier[] DEFAULT_MODULES_WITH_SERVICE_IMPORTS = new ModuleIdentifier[] {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6250
