### PR TITLE
[WFCORE-5947] fix test for IBM JDK Semeru 11

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -346,11 +346,7 @@ public class TlsTestCase extends AbstractSubsystemTest {
     public void prepare() throws Throwable {
         if (services != null) return;
         String subsystemXml;
-        if (JdkUtils.isIbmJdk()) {
-            subsystemXml = "tls-ibm.xml";
-        } else {
-            subsystemXml = JdkUtils.getJavaSpecVersion() <= 12 ? "tls-sun.xml" : "tls-oracle13plus.xml";
-        }
+        subsystemXml = JdkUtils.getJavaSpecVersion() <= 12 ? "tls-sun.xml" : "tls-oracle13plus.xml";
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(subsystemXml).build();
         if (!services.isSuccessfulBoot()) {
             if (services.getBootError() != null) {
@@ -387,8 +383,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testSslServiceAuthSSLv2Hello() throws Throwable {
-        Assume.assumeFalse("Skipping testSslServiceAuthSSLv2Hello as IBM JDK does not support enabling SSLv2Hello " +
-                "in the client", JdkUtils.isIbmJdk());
         String[] enabledProtocols = new String[]{"SSLv2Hello", "TLSv1"};
 
         HashMap<String, String[]> protocolChecker = new HashMap<>();
@@ -403,8 +397,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testSslServiceAuthSSLv2HelloOneWay() throws Throwable {
-        Assume.assumeFalse("Skipping testSslServiceAuthSSLv2Hello as IBM JDK does not support enabling SSLv2Hello " +
-                "in the client", JdkUtils.isIbmJdk());
         String[] enabledProtocols = new String[]{"SSLv2Hello", "TLSv1"};
 
         HashMap<String, String[]> protocolChecker = new HashMap<>();
@@ -419,8 +411,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testSslServiceAuthProtocolMismatchSSLv2Hello() throws Throwable {
-        Assume.assumeFalse("Skipping testSslServiceAuthSSLv2Hello as IBM JDK does not support enabling SSLv2Hello " +
-                "in the client", JdkUtils.isIbmJdk());
         try {
             testCommunication("ServerSslContextTLS12Only", "ClientSslContextSSLv2Hello", false, "OU=Elytron,O=Elytron,C=CZ,ST=Elytron,CN=localhost",
                     "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly");
@@ -462,9 +452,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testSslServiceAuthSSLv2HelloOpenSsl() throws Throwable {
-        Assume.assumeFalse("Skipping testSslServiceAuthSSLv2Hello as IBM JDK does not support enabling SSLv2Hello " +
-                "in the client", JdkUtils.isIbmJdk());
-
         ServiceName serviceName = Capabilities.SSL_CONTEXT_RUNTIME_CAPABILITY.getCapabilityServiceName(
                 "SeverSslContextSSLv2HelloOpenSsl");
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
@@ -89,6 +89,7 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -145,6 +146,7 @@ public abstract class AbstractKerberosMgmtSaslTestBase {
     @BeforeClass
     public static void beforeClass() {
         KerberosTestUtils.assumeKerberosAuthenticationSupported();
+        Assume.assumeFalse("WFCORE-5947 temporary skip test until IBM JDK fixes are incorporated in elytron upgrade", CoreUtils.IBM_JDK);
     }
 
     /**

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KerberosTestUtils.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KerberosTestUtils.java
@@ -65,7 +65,7 @@ public final class KerberosTestUtils {
      * @throws AssumptionViolatedException
      */
     public static void assumeKerberosAuthenticationSupported() throws AssumptionViolatedException {
-        if (CoreUtils.IBM_JDK && isIPV6()) {
+        if (isIPV6()) {
             throw new AssumptionViolatedException(
                     "Kerberos tests are not supported on IBM Java with IPv6. Find more info in https://bugzilla.redhat.com/show_bug.cgi?id=1188632");
         }
@@ -98,13 +98,6 @@ public final class KerberosTestUtils {
     public static LoginContext loginWithKerberos(final Krb5LoginConfiguration krb5Configuration, final String user,
             final String pass) throws LoginException {
         LoginContext lc = new LoginContext(krb5Configuration.getName(), new UsernamePasswordHandler(user, pass));
-        if (CoreUtils.IBM_JDK) {
-            // workaround for IBM JDK on RHEL5 issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1206177
-            // The first negotiation always fail, so let's do a dummy login/logout round.
-            lc.login();
-            lc.logout();
-            lc = new LoginContext(krb5Configuration.getName(), new UsernamePasswordHandler(user, pass));
-        }
         lc.login();
         return lc;
     }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/Krb5LoginConfiguration.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/Krb5LoginConfiguration.java
@@ -30,9 +30,6 @@ import java.util.UUID;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
-import org.jboss.as.test.integration.security.common.CoreUtils;
-
-
 /**
  * Simple Krb5LoginModule configuration.
  *
@@ -84,25 +81,13 @@ public class Krb5LoginConfiguration extends Configuration {
      */
     public static Map<String, String> getOptions(final String principal, final File keyTab, final boolean acceptor) {
         final Map<String, String> res = new HashMap<String, String>();
-
-        if (CoreUtils.IBM_JDK) {
-            if (keyTab != null) {
-                res.put("useKeytab", keyTab.toURI().toString());
-            }
-            if (acceptor) {
-                res.put("credsType", "acceptor");
-            } else {
-                res.put("noAddress", "true");
-            }
-        } else {
-            if (keyTab != null) {
-                res.put("keyTab", keyTab.getAbsolutePath());
-                res.put("doNotPrompt", "true");
-                res.put("useKeyTab", "true");
-            }
-            if (acceptor) {
-                res.put("storeKey", "true");
-            }
+        if (keyTab != null) {
+            res.put("keyTab", keyTab.getAbsolutePath());
+            res.put("doNotPrompt", "true");
+            res.put("useKeyTab", "true");
+        }
+        if (acceptor) {
+            res.put("storeKey", "true");
         }
 
         res.put("refreshKrb5Config", "true");
@@ -121,11 +106,7 @@ public class Krb5LoginConfiguration extends Configuration {
      * @return class name
      */
     public static String getLoginModule() {
-        if (CoreUtils.IBM_JDK) {
-            return "com.ibm.security.auth.module.Krb5LoginModule";
-        } else {
-            return "com.sun.security.auth.module.Krb5LoginModule";
-        }
+        return "com.sun.security.auth.module.Krb5LoginModule";
     }
 
     /**

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
@@ -367,11 +367,7 @@ public class SNICombinedWithALPNTestCase {
      * @return IbmX509 in case of IBM JDK, SunX509 otherwise
      */
     private static String keyAlgorithm() {
-        if (isIbmJdk()) {
-            return "IbmX509";
-        } else {
-            return "SunX509";
-        }
+        return "SunX509";
     }
 
     /**


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5947

Making this Draft because this requires Elytorn upgrade to include fix in https://github.com/wildfly-security/wildfly-elytron/pull/1722. Otherwise,`KerberosNativeMgmtSaslTestCase` and `KerberosHttpMgmtSaslTestCase` fails on IBM JDK.

cc @Skyllarr 
