### PR TITLE
[WFCORE-6142] Remove deprecated AbstractAddStepHandler methods

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractBoottimeAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractBoottimeAddStepHandler.java
@@ -23,13 +23,9 @@
 package org.jboss.as.controller;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
 
 /**
  * Base class for {@link OperationStepHandler} implementations that add managed resources and also perform runtime
@@ -66,40 +62,8 @@ public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHand
     /**
      * {@inheritDoc}
      */
-    @Deprecated
-    protected AbstractBoottimeAddStepHandler(RuntimeCapability capability, Collection<? extends AttributeDefinition> attributes) {
-        super(capability, attributes);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    protected AbstractBoottimeAddStepHandler(Set<RuntimeCapability> capabilities, Collection<? extends AttributeDefinition> attributes) {
-        super(capabilities, attributes);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    protected AbstractBoottimeAddStepHandler(RuntimeCapability capability, AttributeDefinition... attributes) {
-        super(capability, attributes);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected AbstractBoottimeAddStepHandler(AttributeDefinition... attributes) {
         super(attributes);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    protected AbstractBoottimeAddStepHandler(Set<RuntimeCapability> capabilities, AttributeDefinition... attributes) {
-        super(capabilities, attributes);
     }
 
     public AbstractBoottimeAddStepHandler(Parameters parameters) {
@@ -170,19 +134,6 @@ public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHand
      */
     @Override
     protected void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
-        revertReload(context);
-    }
-
-    /**
-     * <strong>Deprecated</strong>. Overrides the superclass to call {@link OperationContext#revertReloadRequired()}
-     * if {@link OperationContext#isBooting()} returns {@code false}.
-     *
-     * {@inheritDoc}
-     */
-    @Deprecated
-    @Override
-    @SuppressWarnings("deprecation")
-    protected void rollbackRuntime(OperationContext context, ModelNode operation, ModelNode model, List<ServiceController<?>> controllers) {
         revertReload(context);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.controller;
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -46,22 +47,24 @@ import org.jboss.dmr.ModelNode;
  */
 public abstract class AbstractRemoveStepHandler implements OperationStepHandler {
 
+    static final Set<RuntimeCapability> NULL_CAPABILITIES = Collections.emptySet();
+
     private static final OperationContext.AttachmentKey<Set<PathAddress>> RECURSION = OperationContext.AttachmentKey.create(Set.class);
 
     private final Set<RuntimeCapability> capabilities;
 
     protected AbstractRemoveStepHandler() {
-        this.capabilities = AbstractAddStepHandler.NULL_CAPABILITIES;
+        this.capabilities = NULL_CAPABILITIES;
     }
 
     @Deprecated
     protected AbstractRemoveStepHandler(RuntimeCapability... capabilities) {
-        this(capabilities.length == 0 ? AbstractAddStepHandler.NULL_CAPABILITIES : new HashSet<RuntimeCapability>(Arrays.asList(capabilities)));
+        this(capabilities.length == 0 ? NULL_CAPABILITIES : new HashSet<RuntimeCapability>(Arrays.asList(capabilities)));
     }
 
     @Deprecated
     protected AbstractRemoveStepHandler(Set<RuntimeCapability> capabilities) {
-        this.capabilities = capabilities == null ? AbstractAddStepHandler.NULL_CAPABILITIES : capabilities;
+        this.capabilities = capabilities == null ? NULL_CAPABILITIES : capabilities;
     }
 
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredAddStepHandler.java
@@ -23,9 +23,7 @@
 package org.jboss.as.controller;
 
 import java.util.Collection;
-import java.util.Set;
 
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 
@@ -53,16 +51,6 @@ public class ReloadRequiredAddStepHandler extends AbstractAddStepHandler {
 
     public ReloadRequiredAddStepHandler(Collection<AttributeDefinition> attributes) {
         super(attributes);
-    }
-
-    @Deprecated
-    public ReloadRequiredAddStepHandler(RuntimeCapability capability, AttributeDefinition... attributes) {
-        super(capability, attributes);
-    }
-
-    @Deprecated
-    public ReloadRequiredAddStepHandler(Set<RuntimeCapability> capabilities, Collection<AttributeDefinition> attributes) {
-        super(capabilities, attributes);
     }
 
     public ReloadRequiredAddStepHandler(Parameters parameters) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceAddHandler.java
@@ -23,7 +23,6 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.interfaces.ParsedInterfaceCriteria;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.resource.InterfaceDefinition;
@@ -42,8 +41,8 @@ public class InterfaceAddHandler extends AbstractAddStepHandler {
     /**
      * Create the InterfaceAddHandler
      */
-    protected InterfaceAddHandler(boolean specified, RuntimeCapability capability) {
-        super(capability);
+    protected InterfaceAddHandler(boolean specified) {
+        super();
         this.specified = specified;
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -25,9 +25,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +90,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
     private static final RuntimeCapability<Void> TEST_CAPABILITY1 = RuntimeCapability.Builder.of("org.wildfly.test.capability1", true, Void.class).build();
     private static final RuntimeCapability<Void> TEST_CAPABILITY2 = RuntimeCapability.Builder.of("org.wildfly.test.capability2", true, Void.class).build();
     private static final RuntimeCapability<Void> TEST_CAPABILITY3 = RuntimeCapability.Builder.of("org.wildfly.test.capability3", true, Void.class).build();
+    private static final RuntimeCapability<Void> TEST_CAPABILITY5 = RuntimeCapability.Builder.of("org.wildfly.test.capability5", true, Void.class).build();
     private static final RuntimeCapability<Void> PROFILE_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.profile-capability", true, Void.class).build();
     private static final RuntimeCapability<Void> HOST_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.host-capability", true, Void.class).build();
     private static final RuntimeCapability<Void> RELOADED_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.reloaded-capability", true, Void.class).build();
@@ -102,26 +101,26 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
     private static final RuntimeCapability<Void> TRANS_DEP_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.trans-dep-capability", false, Void.class)
             .addRequirements(DEPENDENT_CAPABILITY.getName()).build();
 
-    private static PathAddress TEST_ADDRESS1 = PathAddress.pathAddress("subsystem", "test1");
-    private static PathAddress TEST_ADDRESS2 = PathAddress.pathAddress("subsystem", "test2");
-    private static PathAddress TEST_ADDRESS3 = PathAddress.pathAddress("sub", "resource");
-    private static PathAddress TEST_ADDRESS4 = PathAddress.pathAddress("subsystem", "test4");
-    private static PathAddress TEST_ADDRESS5 = PathAddress.pathAddress("subsystem", "broken");
+    private static final PathAddress TEST_ADDRESS1 = PathAddress.pathAddress("subsystem", "test1");
+    private static final PathAddress TEST_ADDRESS2 = PathAddress.pathAddress("subsystem", "test2");
+    private static final PathAddress TEST_ADDRESS3 = PathAddress.pathAddress("sub", "resource");
+    private static final PathAddress TEST_ADDRESS4 = PathAddress.pathAddress("subsystem", "test4");
+    private static final PathAddress TEST_ADDRESS5 = PathAddress.pathAddress("subsystem", "broken");
 
-    private static PathElement RELOAD_ELEMENT = PathElement.pathElement("subsystem", "reload");
-    private static PathElement CIRCULAR_CAP_ELEMENT = PathElement.pathElement("subsystem", "circular");
-    private static PathElement CHILD_ELEMENT = PathElement.pathElement("child", "test");
-    private static PathElement GRANDCHILD_ELEMENT = PathElement.pathElement("grandchild", "test");
-    private static PathElement INFANT_ELEMENT = PathElement.pathElement("infant", "test");
-    private static PathElement INDEPENDENT_ELEMENT = PathElement.pathElement("independent", "test");
-    private static PathElement UNINCORPORATED_ELEMENT = PathElement.pathElement("unincorporated", "test");
-    private static PathElement HOST_ELEMENT = PathElement.pathElement("host", "test");
+    private static final PathElement RELOAD_ELEMENT = PathElement.pathElement("subsystem", "reload");
+    private static final PathElement CIRCULAR_CAP_ELEMENT = PathElement.pathElement("subsystem", "circular");
+    private static final PathElement CHILD_ELEMENT = PathElement.pathElement("child", "test");
+    private static final PathElement GRANDCHILD_ELEMENT = PathElement.pathElement("grandchild", "test");
+    private static final PathElement INFANT_ELEMENT = PathElement.pathElement("infant", "test");
+    private static final PathElement INDEPENDENT_ELEMENT = PathElement.pathElement("independent", "test");
+    private static final PathElement UNINCORPORATED_ELEMENT = PathElement.pathElement("unincorporated", "test");
+    private static final PathElement HOST_ELEMENT = PathElement.pathElement("host", "test");
 
 
-    private static PathElement PROFILE_ELEMENT = PathElement.pathElement("profile", "test");
-    private static PathElement NO_CAP_ELEMENT = PathElement.pathElement("subsystem", "no-cap");
-    private static PathElement DEP_CAP_ELEMENT = PathElement.pathElement("subsystem", "dep-cap");
-    private static PathElement DEP_CAP_ELEMENT_2 = PathElement.pathElement("subsystem", "dep-cap-2");
+    private static final PathElement PROFILE_ELEMENT = PathElement.pathElement("profile", "test");
+    private static final PathElement NO_CAP_ELEMENT = PathElement.pathElement("subsystem", "no-cap");
+    private static final PathElement DEP_CAP_ELEMENT = PathElement.pathElement("subsystem", "dep-cap");
+    private static final PathElement DEP_CAP_ELEMENT_2 = PathElement.pathElement("subsystem", "dep-cap-2");
 
 
     private static final RuntimeCapability<Void> CIRCULAR_PARENT_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.circular-parent-capability", false, Void.class)
@@ -148,10 +147,10 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     private static final OperationDefinition RESTART_DEFINITION = SimpleOperationDefinitionBuilder.of(RESTART, NonResolvingResourceDescriptionResolver.INSTANCE).build();
 
-    private static ResourceDefinition TEST_RESOURCE1 = ResourceBuilder.Factory.create(TEST_ADDRESS1.getElement(0),
+    private static final ResourceDefinition TEST_RESOURCE1 = ResourceBuilder.Factory.create(TEST_ADDRESS1.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(new HashSet<>(Arrays.asList(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY)), ad, other))
-            .setRemoveOperation(new AbstractRemoveStepHandler(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY) {})
+            .setAddOperation(new AbstractAddStepHandler(ad, other))
+            .setRemoveOperation(new AbstractRemoveStepHandler() {})
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
             .addOperation(SimpleOperationDefinitionBuilder.of("add-cap",
@@ -167,17 +166,17 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     private static final ResourceDefinition SUB_RESOURCE = ResourceBuilder.Factory.create(TEST_ADDRESS3.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddOperation(new AbstractAddStepHandler(Collections.singleton(TEST_CAPABILITY3)))
-                .setRemoveOperation(new ReloadRequiredRemoveStepHandler(TEST_CAPABILITY3))
+                .setAddOperation(new AbstractAddStepHandler())
+                .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
                 .addCapability(TEST_CAPABILITY3)
                 .build();
 
 
-    private static ResourceDefinition TEST_RESOURCE2 = ResourceBuilder.Factory.create(TEST_ADDRESS2.getElement(0),
+    private static final ResourceDefinition TEST_RESOURCE2 = ResourceBuilder.Factory.create(TEST_ADDRESS2.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(Collections.singleton(TEST_CAPABILITY2), ad, other))
-            .setRemoveOperation(new ReloadRequiredRemoveStepHandler(TEST_CAPABILITY2))
+            .setAddOperation(new AbstractAddStepHandler(ad, other))
+            .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
             .addCapability(TEST_CAPABILITY2)
@@ -196,9 +195,9 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
                     })
             .build();
 
-    private static ResourceDefinition TEST_RESOURCE4 = ResourceBuilder.Factory.create(TEST_ADDRESS4.getElement(0),
+    private static final ResourceDefinition TEST_RESOURCE4 = ResourceBuilder.Factory.create(TEST_ADDRESS4.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(new HashSet<>(Arrays.asList(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY)), ad, other) {
+            .setAddOperation(new AbstractAddStepHandler(ad, other) {
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
             if(operation.hasDefined("fail")) {
@@ -211,7 +210,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             return true;
         }
             })
-            .setRemoveOperation(new ReloadRequiredRemoveStepHandler(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY))
+            .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
             .addCapability(IO_POOL_RUNTIME_CAPABILITY)
@@ -219,8 +218,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .build();
 
     private static class RuntimeReportAddHandler extends AbstractAddStepHandler {
-        private RuntimeReportAddHandler(Set<RuntimeCapability> caps) {
-            super(caps);
+        private RuntimeReportAddHandler() {
         }
 
         @Override
@@ -230,8 +228,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
     }
 
     private static class RuntimeReportRemoveHandler extends AbstractRemoveStepHandler {
-        private RuntimeReportRemoveHandler(Set<RuntimeCapability> caps) {
-            super(caps);
+        private RuntimeReportRemoveHandler() {
         }
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
@@ -295,20 +292,19 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
                 .addOperation(RUNTIME_ONLY_DEFINITION, RUNTIME_MOD_HANDLER);
 
         if (caps != null && caps.length > 0) {
-            Set<RuntimeCapability> capsSet = new HashSet<>(Arrays.asList(caps));
             result = result.addCapabilities(caps)
-                    .setAddOperation(new RuntimeReportAddHandler(capsSet))
-                    .setRemoveOperation(new RuntimeReportRemoveHandler(capsSet));
+                    .setAddOperation(new RuntimeReportAddHandler())
+                    .setRemoveOperation(new RuntimeReportRemoveHandler());
         }
         else {
-            result = result.setAddOperation(new RuntimeReportAddHandler(Collections.emptySet()))
-                    .setRemoveOperation(new RuntimeReportRemoveHandler(Collections.emptySet()));
+            result = result.setAddOperation(new RuntimeReportAddHandler())
+                    .setRemoveOperation(new RuntimeReportRemoveHandler());
         }
 
         return result;
     }
 
-    private static ResourceDefinition RELOAD_PARENT = createReloadRestartTestResourceBuilder(RELOAD_ELEMENT, RELOADED_CAPABILITY)
+    private static final ResourceDefinition RELOAD_PARENT = createReloadRestartTestResourceBuilder(RELOAD_ELEMENT, RELOADED_CAPABILITY)
             .pushChild(createReloadRestartTestResourceBuilder(INDEPENDENT_ELEMENT, INDEPENDENT_CAPABILITY))
                 .pushChild(createReloadRestartTestResourceBuilder(CHILD_ELEMENT)).pop()
             .pop()
@@ -329,38 +325,38 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
             .build();
 
-    private static ResourceDefinition CIRCULAR_CAP_RESOURCE = createReloadRestartTestResourceBuilder(CIRCULAR_CAP_ELEMENT)
+    private static final ResourceDefinition CIRCULAR_CAP_RESOURCE = createReloadRestartTestResourceBuilder(CIRCULAR_CAP_ELEMENT)
             .pushChild(createReloadRestartTestResourceBuilder(INDEPENDENT_ELEMENT, INDEPENDENT_CAPABILITY)).pop()
             .pushChild(createReloadRestartTestResourceBuilder(CHILD_ELEMENT, CIRCULAR_PARENT_CAPABILITY))
                 .pushChild(createReloadRestartTestResourceBuilder(GRANDCHILD_ELEMENT, CIRCULAR_CHILD_CAPABILITY)).pop()
             .pop()
             .build();
 
-    private static ResourceDefinition HOST_RESOURCE = createReloadRestartTestResourceBuilder(HOST_ELEMENT, HOST_CAPABILITY)
+    private static final ResourceDefinition HOST_RESOURCE = createReloadRestartTestResourceBuilder(HOST_ELEMENT, HOST_CAPABILITY)
             .pushChild(createReloadRestartTestResourceBuilder(CHILD_ELEMENT)).pop()
             .build();
 
-    private static ResourceDefinition PROFILE_RESOURCE = createReloadRestartTestResourceBuilder(PROFILE_ELEMENT, PROFILE_CAPABILITY)
+    private static final ResourceDefinition PROFILE_RESOURCE = createReloadRestartTestResourceBuilder(PROFILE_ELEMENT, PROFILE_CAPABILITY)
             .pushChild(createReloadRestartTestResourceBuilder(NO_CAP_ELEMENT))
                 .pushChild(createReloadRestartTestResourceBuilder(CHILD_ELEMENT)).pop()
             .pop()
             .build();
 
-    private static ResourceDefinition NO_CAP_RESOURCE = createReloadRestartTestResourceBuilder(CHILD_ELEMENT)
+    private static final ResourceDefinition NO_CAP_RESOURCE = createReloadRestartTestResourceBuilder(CHILD_ELEMENT)
             .build();
 
-    private static ResourceDefinition DEP_CAP_RESOURCE = createReloadRestartTestResourceBuilder(DEP_CAP_ELEMENT, DEPENDENT_CAPABILITY)
+    private static final ResourceDefinition DEP_CAP_RESOURCE = createReloadRestartTestResourceBuilder(DEP_CAP_ELEMENT, DEPENDENT_CAPABILITY)
             .pushChild(createReloadRestartTestResourceBuilder(CHILD_ELEMENT, TRANS_DEP_CAPABILITY)).pop()
             .build();
 
-    private static ResourceDefinition DEP_CAP_RESOURCE_2 = createReloadRestartTestResourceBuilder(DEP_CAP_ELEMENT_2, TRANS_DEP_CAPABILITY)
+    private static final ResourceDefinition DEP_CAP_RESOURCE_2 = createReloadRestartTestResourceBuilder(DEP_CAP_ELEMENT_2, TRANS_DEP_CAPABILITY)
             .build();
 
     private static final AtomicReference<CountDownLatch> readLatchHolder = new AtomicReference<>();
     private static final AtomicReference<CountDownLatch> failLatchHolder = new AtomicReference<>();
     private static final ResourceDefinition BAD_RESOURCE = ResourceBuilder.Factory.create(TEST_ADDRESS5.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(Collections.singleton(TEST_CAPABILITY1)) {
+            .setAddOperation(new AbstractAddStepHandler() {
                 @Override
                 protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
 
@@ -381,12 +377,13 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
                     context.getFailureDescription().set("failed per design");
                 }
             })
-            .setRemoveOperation(new ReloadRequiredRemoveStepHandler(TEST_CAPABILITY3))
+            .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
             .addOperation(SimpleOperationDefinitionBuilder.of("read", NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     ((context, operation) -> context.getResult().set(true)))
+            .addCapability(TEST_CAPABILITY5)
             .build();
 
-    private static final int RELOAD_CAP_COUNT = 8;
+    private static final int RELOAD_CAP_COUNT = 9;
 
     private ManagementModel managementModel;
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/BaseAddHandler.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/BaseAddHandler.java
@@ -57,7 +57,7 @@ class BaseAddHandler extends AbstractAddStepHandler implements ElytronOperationS
      * @param attributes the {@link AttributeDefinition} instances associated with this resource.
      */
     BaseAddHandler(RuntimeCapability<?> runtimeCapability, AttributeDefinition... attributes) {
-        super(runtimeCapability, attributes);
+        super(attributes);
         this.runtimeCapabilities = Collections.singleton(runtimeCapability);
     }
 
@@ -70,7 +70,7 @@ class BaseAddHandler extends AbstractAddStepHandler implements ElytronOperationS
      * @param attributes the {@link AttributeDefinition} instances associated with this resource.
      */
     BaseAddHandler(Set<RuntimeCapability> capabilities, AttributeDefinition... attributes) {
-        super(capabilities, attributes);
+        super(attributes);
         this.runtimeCapabilities = capabilities;
     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -440,7 +440,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
     private static class ElytronAdd extends AbstractBoottimeAddStepHandler implements ElytronOperationStepHandler {
 
         private ElytronAdd() {
-            super(ELYTRON_RUNTIME_CAPABILITY, DEFAULT_AUTHENTICATION_CONTEXT, INITIAL_PROVIDERS, FINAL_PROVIDERS, DISALLOWED_PROVIDERS, SECURITY_PROPERTIES, REGISTER_JASPI_FACTORY, DEFAULT_SSL_CONTEXT);
+            super(DEFAULT_AUTHENTICATION_CONTEXT, INITIAL_PROVIDERS, FINAL_PROVIDERS, DISALLOWED_PROVIDERS, SECURITY_PROPERTIES, REGISTER_JASPI_FACTORY, DEFAULT_SSL_CONTEXT);
         }
 
         @Override

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileAddHandler.java
@@ -37,7 +37,7 @@ public class ProfileAddHandler extends AbstractAddStepHandler {
     public static final ProfileAddHandler INSTANCE = new ProfileAddHandler();
 
     ProfileAddHandler() {
-        super(ProfileResourceDefinition.PROFILE_CAPABILITY, ProfileResourceDefinition.ATTRIBUTES);
+        super(ProfileResourceDefinition.ATTRIBUTES);
     }
 
     protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupAddHandler.java
@@ -35,7 +35,7 @@ public class ServerGroupAddHandler extends AbstractAddStepHandler {
     public static OperationStepHandler INSTANCE = new ServerGroupAddHandler();
 
     ServerGroupAddHandler() {
-        super(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY, ServerGroupResourceDefinition.ADD_ATTRIBUTES);
+        super(ServerGroupResourceDefinition.ADD_ATTRIBUTES);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
@@ -60,7 +60,7 @@ public class ServerAddHandler extends AbstractAddStepHandler {
      * Create the ServerAddHandler
      */
     private ServerAddHandler(LocalHostControllerInfo hostControllerInfo, ServerInventory serverInventory, ControlledProcessState processState, File domainDataDir) {
-        super(ServerConfigResourceDefinition.SERVER_CONFIG_CAPABILITY, ServerConfigResourceDefinition.WRITABLE_ATTRIBUTES);
+        super(ServerConfigResourceDefinition.WRITABLE_ATTRIBUTES);
         this.hostControllerInfo = hostControllerInfo;
         this.serverInventory = serverInventory;
         this.processState = processState;

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemAdd.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemAdd.java
@@ -52,7 +52,7 @@ class JMXSubsystemAdd extends AbstractAddStepHandler {
     private final RuntimeHostControllerInfoAccessor hostInfoAccessor;
 
     JMXSubsystemAdd(ManagedAuditLogger auditLoggerInfo, JmxAuthorizer authorizer, Supplier<SecurityIdentity> securityIdentitySupplier,  RuntimeHostControllerInfoAccessor hostInfoAccessor) {
-        super(JMXSubsystemRootResource.JMX_CAPABILITY, JMXSubsystemRootResource.NON_CORE_MBEAN_SENSITIVITY);
+        super(JMXSubsystemRootResource.NON_CORE_MBEAN_SENSITIVITY);
         this.auditLoggerInfo = auditLoggerInfo;
         this.authorizer = authorizer;
         this.securityIdentitySupplier = securityIdentitySupplier;

--- a/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorAdd.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorAdd.java
@@ -44,7 +44,7 @@ class RemotingConnectorAdd extends AbstractAddStepHandler {
     static final RemotingConnectorAdd INSTANCE = new RemotingConnectorAdd();
 
     private RemotingConnectorAdd() {
-        super(RemotingConnectorResource.REMOTE_JMX_CAPABILITY, RemotingConnectorResource.USE_MANAGEMENT_ENDPOINT);
+        super(RemotingConnectorResource.USE_MANAGEMENT_ENDPOINT);
     }
 
     @Override

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemAdd.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemAdd.java
@@ -24,10 +24,11 @@
 
 package org.wildfly.extension.requestcontroller;
 
-import static org.jboss.as.server.Services.JBOSS_SUSPEND_CONTROLLER;
+import static org.wildfly.extension.requestcontroller.RequestControllerRootDefinition.REQUEST_CONTROLLER_CAPABILITY;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
@@ -38,6 +39,7 @@ import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.dmr.ModelNode;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 
 /**
@@ -48,7 +50,7 @@ import java.util.Collection;
 class RequestControllerSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     RequestControllerSubsystemAdd(Collection<AttributeDefinition> attributeDefinitions) {
-        super(RequestControllerRootDefinition.REQUEST_CONTROLLER_CAPABILITY, attributeDefinitions);
+        super(attributeDefinitions);
     }
 
     /**
@@ -69,12 +71,13 @@ class RequestControllerSubsystemAdd extends AbstractBoottimeAddStepHandler {
         int maxRequests = RequestControllerRootDefinition.MAX_REQUESTS.resolveModelAttribute(context, resource.getModel()).asInt();
         boolean trackIndividual = RequestControllerRootDefinition.TRACK_INDIVIDUAL_ENDPOINTS.resolveModelAttribute(context, resource.getModel()).asBoolean();
 
-        RequestController requestController = new RequestController(trackIndividual);
 
+
+        CapabilityServiceBuilder<?> svcBuilder = context.getCapabilityServiceTarget().addCapability(REQUEST_CONTROLLER_CAPABILITY);
+        Supplier<SuspendController> supplier = svcBuilder.requiresCapability("org.wildfly.server.suspend-controller", SuspendController.class);
+        RequestController requestController = new RequestController(trackIndividual, supplier);
         requestController.setMaxRequestCount(maxRequests);
-
-        context.getServiceTarget().addService(RequestController.SERVICE_NAME, requestController)
-                .addDependency(JBOSS_SUSPEND_CONTROLLER, SuspendController.class, requestController.getShutdownControllerInjectedValue())
+        svcBuilder.setInstance(requestController)
                 .install();
 
     }

--- a/request-controller/src/test/java/org/wildfly/extension/requestcontroller/WFCORE4967_TestCase.java
+++ b/request-controller/src/test/java/org/wildfly/extension/requestcontroller/WFCORE4967_TestCase.java
@@ -43,7 +43,7 @@ public class WFCORE4967_TestCase {
     }
 
     private RequestController suspendedRCWithQueuedTasks(int i, Runnable whenExecuted) {
-        RequestController requestController = new RequestController(false);
+        RequestController requestController = new RequestController(false, () -> null);
         requestController.suspended(() -> {
         });
 

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceAddHandler.java
@@ -35,13 +35,11 @@ public class InterfaceAddHandler extends org.jboss.as.controller.operations.comm
     /**
      * Create the InterfaceAddHandler
      *
-     * @param specified
+     * @param specified {@code true} if the interface is expected to have a specified interface selection criteria;
+     *                  {@code false} if the interface can simply be a named placeholder
      */
     InterfaceAddHandler(boolean specified) {
-        // Pass the capability through the OSH constructor rather than relying
-        // on the MRR, as in some subsystem test stuff due to restrictions for
-        // legacy controllers the MRR can't record the cap
-        super(specified, InterfaceResourceDefinition.INTERFACE_CAPABILITY);
+        super(specified);
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingAddHandler.java
@@ -63,7 +63,7 @@ public class LocalDestinationOutboundSocketBindingAddHandler extends AbstractAdd
     static final LocalDestinationOutboundSocketBindingAddHandler INSTANCE = new LocalDestinationOutboundSocketBindingAddHandler();
 
     private LocalDestinationOutboundSocketBindingAddHandler() {
-        super(LocalDestinationOutboundSocketBindingResourceDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY, LocalDestinationOutboundSocketBindingResourceDefinition.ATTRIBUTES);
+        super(LocalDestinationOutboundSocketBindingResourceDefinition.ATTRIBUTES);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingResourceDefinition.java
@@ -56,11 +56,11 @@ public class LocalDestinationOutboundSocketBindingResourceDefinition extends Out
     public static final LocalDestinationOutboundSocketBindingResourceDefinition INSTANCE = new LocalDestinationOutboundSocketBindingResourceDefinition();
 
     private LocalDestinationOutboundSocketBindingResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING),
-                ControllerResolver.getResolver(ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING),
-                LocalDestinationOutboundSocketBindingAddHandler.INSTANCE,
-                new ServiceRemoveStepHandler(LocalDestinationOutboundSocketBindingAddHandler.INSTANCE,
-                        OUTBOUND_SOCKET_BINDING_CAPABILITY));
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING),
+                ControllerResolver.getResolver(ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING))
+                .setAddHandler(LocalDestinationOutboundSocketBindingAddHandler.INSTANCE)
+                .setRemoveHandler(new ServiceRemoveStepHandler(LocalDestinationOutboundSocketBindingAddHandler.INSTANCE))
+        );
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
@@ -22,14 +22,11 @@
 
 package org.jboss.as.server.services.net;
 
-import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -70,11 +67,7 @@ public abstract class OutboundSocketBindingResourceDefinition extends SimpleReso
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
-    protected OutboundSocketBindingResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver,
-                                                      final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
-        super(new SimpleResourceDefinition.Parameters(pathElement, descriptionResolver)
-                .setAddHandler(addHandler)
-                .setRemoveHandler(removeHandler)
-                .addCapabilities(OUTBOUND_SOCKET_BINDING_CAPABILITY));
+    protected OutboundSocketBindingResourceDefinition(final Parameters parameters) {
+        super(parameters.addCapabilities(OUTBOUND_SOCKET_BINDING_CAPABILITY));
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingAddHandler.java
@@ -61,7 +61,7 @@ public class RemoteDestinationOutboundSocketBindingAddHandler extends AbstractAd
     static final RemoteDestinationOutboundSocketBindingAddHandler INSTANCE = new RemoteDestinationOutboundSocketBindingAddHandler();
 
     private RemoteDestinationOutboundSocketBindingAddHandler() {
-        super(OutboundSocketBindingResourceDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY, RemoteDestinationOutboundSocketBindingResourceDefinition.ATTRIBUTES);
+        super(RemoteDestinationOutboundSocketBindingResourceDefinition.ATTRIBUTES);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingResourceDefinition.java
@@ -60,11 +60,10 @@ public class RemoteDestinationOutboundSocketBindingResourceDefinition extends Ou
     public static final RemoteDestinationOutboundSocketBindingResourceDefinition INSTANCE = new RemoteDestinationOutboundSocketBindingResourceDefinition();
 
     private RemoteDestinationOutboundSocketBindingResourceDefinition() {
-        super(PATH,
-                ControllerResolver.getResolver(ModelDescriptionConstants.REMOTE_DESTINATION_OUTBOUND_SOCKET_BINDING),
-                RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE,
-                new ServiceRemoveStepHandler(RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE,
-                        OUTBOUND_SOCKET_BINDING_CAPABILITY));
+        super(new Parameters(PATH, ControllerResolver.getResolver(ModelDescriptionConstants.REMOTE_DESTINATION_OUTBOUND_SOCKET_BINDING))
+                .setAddHandler(RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE)
+                .setRemoveHandler(new ServiceRemoveStepHandler(RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE))
+        );
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingAddHandler.java
@@ -85,8 +85,7 @@ public class SocketBindingAddHandler extends AbstractAddStepHandler {
      * Create the SocketBindingAddHandler
      */
     protected SocketBindingAddHandler() {
-        super(SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY,
-                AbstractSocketBindingResourceDefinition.INTERFACE,
+        super(  AbstractSocketBindingResourceDefinition.INTERFACE,
                 AbstractSocketBindingResourceDefinition.PORT,
                 AbstractSocketBindingResourceDefinition.FIXED_PORT,
                 AbstractSocketBindingResourceDefinition.MULTICAST_ADDRESS,


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6142

This had been sitting bit-rotting on my laptop for a couple months; I'm not sure why I didn't send it up. We'll see if CI tells me why.

I may have been thinking about doing AbstractRemoveStepHandler in the same PR, but if so a 2 month pointless delay is a good sign that it's better to do things one step at a time.
