### PR TITLE
WFCORE-6221 Add formal experimental/preview mode to management model

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -90,6 +90,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
         result.removeExistingDomainConfig = new ArgumentWithoutValue(result, REMOVE_EXISTING_DOMAIN_CONFIG);
         result.emptyHostConfig = new ArgumentWithoutValue(result, EMPTY_HOST_CONFIG);
         result.removeExistingHostConfig = new ArgumentWithoutValue(result, REMOVE_EXISTING_HOST_CONFIG);
+        // TODO: Use ProductConfig.getStabilitySet()
         result.stability = new ArgumentWithValue(result, new SimpleTabCompleter(EnumSet.allOf(Stability.class)), "--stability");
         return result;
     }

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
@@ -81,6 +81,7 @@ class EmbedServerHandler extends CommandHandlerWithHelp {
         result.removeExisting = new ArgumentWithoutValue(result, "--remove-existing");
         result.removeExisting.addRequiredPreceding(result.emptyConfig);
         result.timeout = new ArgumentWithValue(result, "--timeout");
+        // TODO: Use ProductConfig.getStabilitySet()
         result.stability = new ArgumentWithValue(result, new SimpleTabCompleter(EnumSet.allOf(Stability.class)), "--stability");
 
         return result;

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -67,7 +67,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param resourceDefinition source for descriptive information describing this
      *                            portion of the model (must not be {@code null})
-     * @return a resource registration which may be used to add attributes, operations, notifications and sub-models
+     * @return a resource registration which may be used to add attributes, operations, notifications and sub-models,
+     *         or null, if this resource definition is not enabled by the current stability level.
      *
      * @throws IllegalArgumentException if a submodel is already registered at {@code address}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true}
@@ -103,7 +104,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param name the specific name of the resource. Cannot be {@code null} or {@link PathElement#WILDCARD_VALUE}
      * @param descriptionProvider provider for descriptions of the additional attributes or child types
      *
-     * @return a resource registration which may be used to add attributes, operations and sub-models
+     * @return a resource registration which may be used to add attributes, operations and sub-models.
      *
      * @throws IllegalArgumentException if either parameter is null or if there is already a registration under {@code name}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true} or if {@link #isAllowsOverride()} returns false
@@ -118,7 +119,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param registration the child registration of this registry that should no longer be available
      * @param descriptionProvider provider for descriptions of the additional attributes or child types
      *
-     * @return a resource registration which may be used to add attributes, operations and sub-models
+     * @return a resource registration which may be used to add attributes, operations and sub-models,
+     *         or null, if this resource definition is not enabled by the current stability level.
      *
      * @throws IllegalArgumentException if either parameter is null or if there is already a registration under {@code name}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true} or if {@link #isAllowsOverride()} returns false

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -485,7 +485,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         this.processType = processType;
 
         this.stability = getEnumProperty(hostSystemProperties, STABILITY, this.productConfig.getDefaultStability());
-        if (!this.productConfig.getMinimumStability().enables(this.stability)) {
+        if (!this.productConfig.getStabilitySet().contains(this.stability)) {
             throw HostControllerLogger.ROOT_LOGGER.unsupportedStability(this.stability, this.productConfig.getProductName());
         }
         if (!hostSystemProperties.containsKey(STABILITY)) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironmentWrapper.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironmentWrapper.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.host.controller;
 
+import org.jboss.as.version.ProductConfig;
+
 /**
  * @author wangc
  *
@@ -18,18 +20,20 @@ public final class HostControllerEnvironmentWrapper {
 
     private HostControllerEnvironment hostControllerEnvironment;
     private HostControllerEnvironmentStatus hostControllerEnvironmentStatus;
+    private ProductConfig productConfig;
 
-    private HostControllerEnvironmentWrapper(HostControllerEnvironment hostControllerEnvironment, HostControllerEnvironmentStatus hostControllerEnvironmentStatus) {
+    private HostControllerEnvironmentWrapper(HostControllerEnvironment hostControllerEnvironment, HostControllerEnvironmentStatus hostControllerEnvironmentStatus, ProductConfig productConfig) {
         this.hostControllerEnvironment = hostControllerEnvironment;
         this.hostControllerEnvironmentStatus = hostControllerEnvironmentStatus;
+        this.productConfig = productConfig;
     }
 
     HostControllerEnvironmentWrapper(HostControllerEnvironment hostControllerEnvironment) {
-        this(hostControllerEnvironment, null);
+        this(hostControllerEnvironment, null, hostControllerEnvironment.getProductConfig());
     }
 
-    HostControllerEnvironmentWrapper(HostControllerEnvironmentStatus hostControllerEnvironmentStatus) {
-        this(null, hostControllerEnvironmentStatus);
+    HostControllerEnvironmentWrapper(HostControllerEnvironmentStatus hostControllerEnvironmentStatus, ProductConfig productConfig) {
+        this(null, hostControllerEnvironmentStatus, productConfig);
     }
 
     public HostControllerEnvironment getHostControllerEnvironment() {
@@ -38,5 +42,9 @@ public final class HostControllerEnvironmentWrapper {
 
     public HostControllerEnvironmentStatus getHostControllerEnvironmentStatus() {
         return hostControllerEnvironmentStatus;
+    }
+
+    public ProductConfig getProductConfig() {
+        return this.productConfig;
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostInfo.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostInfo.java
@@ -133,6 +133,7 @@ public class HostInfo implements Transformers.ResourceIgnoredTransformationRegis
         productVersion = hostInfo.hasDefined(PRODUCT_VERSION) ? hostInfo.require(PRODUCT_VERSION).asString() : null;
         remoteConnectionId = hostInfo.hasDefined(RemoteDomainConnectionService.DOMAIN_CONNECTION_ID)
                 ? hostInfo.get(RemoteDomainConnectionService.DOMAIN_CONNECTION_ID).asLong() : null;
+        // Legacy hosts may return null - if so, assume default stability per our ProductConfig
         this.stability = Optional.ofNullable(hostInfo.get(ModelDescriptionConstants.STABILITY).asStringOrNull()).map(Stability::valueOf).orElse(productConfig.getDefaultStability());
 
         Set<String> domainIgnoredExtensions = null;

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsageImpl.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsageImpl.java
@@ -6,14 +6,13 @@
 package org.jboss.as.process;
 
 import java.io.PrintStream;
-import java.util.EnumSet;
 
 import org.jboss.as.process.logging.ProcessLogger;
-import org.jboss.as.version.Stability;
+import org.jboss.as.version.ProductConfig;
 
 public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
-    public static void init(){
+    public static void init(ProductConfig productConfig){
 
         addArguments(CommandLineConstants.ADMIN_ONLY);
         instructions.add(ProcessLogger.ROOT_LOGGER.argAdminOnly());
@@ -81,12 +80,14 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SECMGR);
         instructions.add(ProcessLogger.ROOT_LOGGER.argSecMgr());
 
-        addArguments(CommandLineConstants.STABILITY + "=<value>");
-        instructions.add(ProcessLogger.ROOT_LOGGER.argStability(EnumSet.allOf(Stability.class), Stability.DEFAULT));
+        if (productConfig.getStabilitySet().size() > 1) {
+            addArguments(CommandLineConstants.STABILITY + "=<value>");
+            instructions.add(ProcessLogger.ROOT_LOGGER.argStability(productConfig.getStabilitySet(), productConfig.getDefaultStability()));
+        }
     }
 
-    public static void printUsage(final PrintStream out) {
-        init();
+    public static void printUsage(ProductConfig productConfig, PrintStream out) {
+        init(productConfig);
         out.print(usage("domain"));
     }
 }

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
@@ -6,18 +6,17 @@
 package org.jboss.as.server;
 
 import java.io.PrintStream;
-import java.util.EnumSet;
 
 import org.jboss.as.controller.persistence.ConfigurationExtensionFactory;
 
 import org.jboss.as.process.CommandLineArgumentUsage;
 import org.jboss.as.process.CommandLineConstants;
 import org.jboss.as.server.logging.ServerLogger;
-import org.jboss.as.version.Stability;
+import org.jboss.as.version.ProductConfig;
 
 public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
-    public static void init(){
+    public static void init(ProductConfig productConfig){
 
         addArguments(CommandLineConstants.ADMIN_ONLY);
         instructions.add(ServerLogger.ROOT_LOGGER.argAdminOnly());
@@ -81,12 +80,14 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
             instructions.add(ConfigurationExtensionFactory.getCommandLineInstructions());
         }
 
-        addArguments(CommandLineConstants.STABILITY + "=<value>");
-        instructions.add(ServerLogger.ROOT_LOGGER.argStability(EnumSet.allOf(Stability.class), Stability.DEFAULT));
+        if (productConfig.getStabilitySet().size() > 1) {
+            addArguments(CommandLineConstants.STABILITY + "=<value>");
+            instructions.add(ServerLogger.ROOT_LOGGER.argStability(productConfig.getStabilitySet(), productConfig.getDefaultStability()));
+        }
     }
 
-    public static void printUsage(final PrintStream out) {
-        init();
+    public static void printUsage(ProductConfig productConfig, PrintStream out) {
+        init(productConfig);
         out.print(usage("standalone"));
     }
 

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -523,7 +523,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             }
 
             this.stability = getEnumProperty(props, ProcessEnvironment.STABILITY, productConfig.getDefaultStability());
-            if (!productConfig.getMinimumStability().enables(this.stability)) {
+            if (!productConfig.getStabilitySet().contains(this.stability)) {
                 throw ServerLogger.ROOT_LOGGER.unsupportedStability(this.stability, productConfig.getProductName());
             }
         }

--- a/version/src/main/java/org/jboss/as/version/ProductConfig.java
+++ b/version/src/main/java/org/jboss/as/version/ProductConfig.java
@@ -15,8 +15,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.jar.Manifest;
 
 import org.jboss.modules.Module;
@@ -34,7 +36,7 @@ public class ProductConfig implements Serializable {
     private final String version;
     private final String consoleSlot;
     private final Stability defaultStability;
-    private final Stability minStability;
+    private final Set<Stability> stabilities;
     private boolean isProduct;
 
     public static ProductConfig fromFilesystemSlot(ModuleLoader loader, String home, Map<?, ?> providedProperties) {
@@ -51,6 +53,7 @@ public class ProductConfig implements Serializable {
         String consoleSlot = null;
         Stability defaultStability = Stability.COMMUNITY;
         Stability minStability = Stability.EXPERIMENTAL;
+        Stability maxStability = Stability.DEFAULT;
 
         InputStream manifestStream = null;
         try {
@@ -91,7 +94,7 @@ public class ProductConfig implements Serializable {
         version = productVersion;
         this.consoleSlot = consoleSlot;
         this.defaultStability = defaultStability;
-        this.minStability = minStability;
+        this.stabilities = EnumSet.range(maxStability, minStability);
     }
 
     private static String getProductConf(String home) {
@@ -129,7 +132,7 @@ public class ProductConfig implements Serializable {
         this.version = productVersion;
         this.consoleSlot = consoleSlot;
         this.defaultStability = Stability.DEFAULT;
-        this.minStability = Stability.DEFAULT;
+        this.stabilities = EnumSet.of(this.defaultStability);
     }
 
     public String getProductName() {
@@ -148,12 +151,20 @@ public class ProductConfig implements Serializable {
         return consoleSlot;
     }
 
+    /**
+     * Returns the presumed stability level of this product.
+     * @return a stability level
+     */
     public Stability getDefaultStability() {
         return this.defaultStability;
     }
 
-    public Stability getMinimumStability() {
-        return this.minStability;
+    /**
+     * Returns the set of permissible stability levels for this product.
+     * @return a set of stability levels
+     */
+    public Set<Stability> getStabilitySet() {
+        return this.stabilities;
     }
 
     public String getPrettyVersionString() {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6221

This pull request formalizes the concept of a quality level in the WildFly kernel based on the general strategy described in WFCORE-6221.
In general, a subsystem associate features within its management model with a specific Quality.  During management registration, only those features enabled by the quality level of the server will be registered.

See the test case here for an example of how I imagined this might work: https://github.com/pferraro/wildfly-core/tree/WFCORE-6221/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/quality

Please scrutinize.  Tell me what you like and do not like.