### PR TITLE
[WFCORE-6272] CVE-2022-4492 CVE-2023-1108 Upgrade Undertow to 2.3.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.4.Final</version.io.undertow>
+        <version.io.undertow>2.3.5.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.authentication.jakarta-authentication-api>3.0.0</version.jakarta.authentication.jakarta-authentication-api>


### PR DESCRIPTION
Also: update WildFly core tests to comply with [CVE-2022-4492](https://issues.redhat.com/browse/UNDERTOW-2212) fix.

Jira: https://issues.redhat.com/browse/WFCORE-6272


        Release Notes - Undertow - Version 2.3.5.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2252'>UNDERTOW-2252</a>] -         SslConduit.dataToUnwrap leaks on CI causing intermittent failures
</li>
</ul>
                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1875'>UNDERTOW-1875</a>] -         Matrix parameters with comma are not properly handled
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2207'>UNDERTOW-2207</a>] -         IOException thrown by UndertowOutputStream upon flush
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2212'>UNDERTOW-2212</a>] -         CVE-2022-4492 Server identity in https connection is not checked by the undertow client
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2239'>UNDERTOW-2239</a>] -         CVE-2023-1108 Infinite loop in `SslConduit` during close on JDK 11
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2250'>UNDERTOW-2250</a>] -         At CI script replace joschi/setup-jdk by the official actions/setup-java action
</li>
</ul>