### PR TITLE
Reducing the chance of flaky test failure

### DIFF
--- a/event-logger/src/test/java/org/wildfly/event/logger/AsyncEventLoggerTestCase.java
+++ b/event-logger/src/test/java/org/wildfly/event/logger/AsyncEventLoggerTestCase.java
@@ -112,7 +112,7 @@ public class AsyncEventLoggerTestCase extends AbstractEventLoggerTestCase {
             }
 
             for (int i = 0; i < logCount; i++) {
-                final String jsonString = writer.events.poll(TIMEOUT, TimeUnit.SECONDS);
+                final String jsonString = writer.events.poll(TIMEOUT+1L, TimeUnit.SECONDS);
                 Assert.assertNotNull("Expected value written, but was null", jsonString);
 
                 try (JsonReader reader = Json.createReader(new StringReader(jsonString))) {


### PR DESCRIPTION
**Description:**
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

**Failure:**
[INFO] Running org.wildfly.event.logger.AsyncEventLoggerTestCase
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.116 s <<< FAILURE! - in org.wildfly.event.logger.AsyncEventLoggerTestCase
[ERROR] testMultiLogger(org.wildfly.event.logger.AsyncEventLoggerTestCase)  Time elapsed: 5.114 s  <<< FAILURE!
java.lang.AssertionError: Expected value written, but was null
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertNotNull(Assert.java:713)
	at org.wildfly.event.logger.AsyncEventLoggerTestCase.testMultiLogger(AsyncEventLoggerTestCase.java:116)
	at org.wildfly.event.logger.AsyncEventLoggerTestCase.testMultiLogger(AsyncEventLoggerTestCase.java:62)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)

[INFO] Results:
[ERROR] Failures: 
[ERROR]   AsyncEventLoggerTestCase.testMultiLogger:62->testMultiLogger:116 Expected value written, but was null
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

**Solution:**
This test is fixed by increasing wait time a little bit more. 