### PR TITLE
[WFCORE-6287] Replace deprecated systemProperties configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,21 +360,10 @@
                             <org.jboss.model.test.cache.root>${org.jboss.model.test.cache.root}</org.jboss.model.test.cache.root>
                             <org.jboss.model.test.classpath.cache>${org.jboss.model.test.classpath.cache}</org.jboss.model.test.classpath.cache>
                             <org.jboss.model.test.cache.strict>true</org.jboss.model.test.cache.strict>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <jboss.remoting.leakdebugging>false</jboss.remoting.leakdebugging>
+                            <test.level>${test.level}</test.level>
                         </systemPropertyVariables>
-                        <systemProperties>
-                            <property>
-                                <name>java.util.logging.manager</name>
-                                <value>org.jboss.logmanager.LogManager</value>
-                            </property>
-                            <property>
-                                <name>jboss.remoting.leakdebugging</name>
-                                <value>false</value>
-                            </property>
-                            <property>
-                                <name>test.level</name>
-                                <value>${test.level}</value>
-                            </property>
-                        </systemProperties>
                         <argLine>${surefire.system.args}</argLine>
                     </configuration>
 

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -518,20 +518,11 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemProperties>
-                                        <property>
-                                            <name>wildfly.bootable.jar</name>
-                                            <value>true</value>
-                                        </property>
-                                         <property>
-                                            <name>wildfly.bootable.jar.jar</name>
-                                            <value>${project.build.directory}/test-wildfly.jar</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.install.dir</name>
-                                            <value>${project.build.directory}/${server.output.dir.prefix}</value>
-                                        </property>
-                                    </systemProperties>
+                                    <systemPropertyVariables>
+                                        <wildfly.bootable.jar>true</wildfly.bootable.jar>
+                                        <wildfly.bootable.jar.jar>${project.build.directory}/test-wildfly.jar</wildfly.bootable.jar.jar>
+                                        <wildfly.bootable.jar.install.dir>${project.build.directory}/${server.output.dir.prefix}</wildfly.bootable.jar.install.dir>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                             <execution>
@@ -541,21 +532,10 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemProperties>
-                                        <property>
-                                            <name>wildfly.bootable.jar</name>
-                                            <value>true</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.jar</name>
-                                            <value>${project.build.directory}/test-wildfly-runtime.jar</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.install.dir</name>
-                                            <value>${project.build.directory}/${server.output.dir.prefix}-runtime</value>
-                                        </property>
-                                    </systemProperties>
                                     <systemPropertyVariables>
+                                        <wildfly.bootable.jar>true</wildfly.bootable.jar>
+                                        <wildfly.bootable.jar.jar>${project.build.directory}/test-wildfly-runtime.jar</wildfly.bootable.jar.jar>
+                                        <wildfly.bootable.jar.install.dir>${project.build.directory}/${server.output.dir.prefix}-runtime</wildfly.bootable.jar.install.dir>
                                         <jboss.args>${jboss.args} --cli-script=${ts.config.elytron.cli.no.embedded}</jboss.args>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -598,20 +598,11 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
-                                        <property>
-                                            <name>wildfly.bootable.jar</name>
-                                            <value>true</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.jar</name>
-                                            <value>${project.build.directory}/test-wildfly.jar</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.install.dir</name>
-                                            <value>${project.build.directory}/${server.output.dir.prefix}</value>
-                                        </property>
-                                    </systemProperties>
+                                    <systemPropertyVariables>
+                                        <wildfly.bootable.jar>true</wildfly.bootable.jar>
+                                        <wildfly.bootable.jar.jar>${project.build.directory}/test-wildfly.jar</wildfly.bootable.jar.jar>
+                                        <wildfly.bootable.jar.install.dir>${project.build.directory}/${server.output.dir.prefix}</wildfly.bootable.jar.install.dir>
+                                    </systemPropertyVariables>
                                     <excludes>
                                         <!-- No domain mode support -->
                                         <exclude>org.jboss.as.test.manualmode.management.cli.CLIEmbedHostControllerTestCase.java</exclude>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -473,20 +473,11 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <systemProperties>
-                                <property>
-                                    <name>wildfly.bootable.jar</name>
-                                    <value>true</value>
-                                </property>
-                                <property>
-                                    <name>wildfly.bootable.jar.jar</name>
-                                    <value>${project.build.directory}/test-wildfly.jar</value>
-                                </property>
-                                <property>
-                                    <name>wildfly.bootable.jar.install.dir</name>
-                                    <value>${project.build.directory}/${server.output.dir.prefix}</value>
-                                </property>
-                            </systemProperties>
+                            <systemPropertyVariables>
+                                <wildfly.bootable.jar>true</wildfly.bootable.jar>
+                                <wildfly.bootable.jar.jar>${project.build.directory}/test-wildfly.jar</wildfly.bootable.jar.jar>
+                                <wildfly.bootable.jar.install.dir>${project.build.directory}/${server.output.dir.prefix}</wildfly.bootable.jar.install.dir>
+                            </systemPropertyVariables>
                             <excludes>
                                 <exclude>org.jboss.as.test.integration.mgmt.access.LegacyConfigurationChangesHistoryTestCase</exclude>
                             </excludes>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -425,20 +425,11 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
-                                        <property>
-                                            <name>wildfly.bootable.jar</name>
-                                            <value>true</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.jar</name>
-                                            <value>${project.build.directory}/test-wildfly.jar</value>
-                                        </property>
-                                        <property>
-                                            <name>wildfly.bootable.jar.install.dir</name>
-                                            <value>${project.build.directory}/${server.output.dir.prefix}</value>
-                                        </property>
-                                    </systemProperties>
+                                    <systemPropertyVariables>
+                                        <wildfly.bootable.jar>true</wildfly.bootable.jar>
+                                        <wildfly.bootable.jar.jar>${project.build.directory}/test-wildfly.jar</wildfly.bootable.jar.jar>
+                                        <wildfly.bootable.jar.install.dir>${project.build.directory}/${server.output.dir.prefix}</wildfly.bootable.jar.install.dir>
+                                    </systemPropertyVariables>
                                     <excludes>
                                         <!-- Manipulates the discovery subsystem, which isn't installed, and tries
                                             to remove elytron capabilities that the installed config requires -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6287

Use the up-to-date configuration via `systemPropertyVariables` (https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html)
