### PR TITLE
[WFCORE-6279] Replace Deployment Processors Javax dependencies with J…

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/EESecurityDependencyProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/EESecurityDependencyProcessor.java
@@ -23,19 +23,18 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 /**
- * A simple {@link DeploymentUnitProcessor} that adds the 'javax.security.auth.message.api' and 'javax.security.jacc.api'
+ * A simple {@link DeploymentUnitProcessor} that adds the 'jakarta.security.auth.message.api' and 'jakarta.security.jacc.api'
  * modules to the deployment.
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
 class EESecurityDependencyProcessor implements DeploymentUnitProcessor {
 
-    public static final ModuleIdentifier AUTH_MESSAGE_API = ModuleIdentifier.create("javax.security.auth.message.api");
-    public static final ModuleIdentifier JACC_API = ModuleIdentifier.create("javax.security.jacc.api");
+    public static final String AUTH_MESSAGE_API = "jakarta.security.auth.message.api";
+    public static final String JACC_API = "jakarta.security.jacc.api";
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) {

--- a/server/src/main/java/org/jboss/as/server/deployment/module/DriverDependenciesProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/DriverDependenciesProcessor.java
@@ -30,7 +30,6 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.vfs.VirtualFile;
 
@@ -39,7 +38,7 @@ import org.jboss.vfs.VirtualFile;
  */
 public class DriverDependenciesProcessor implements DeploymentUnitProcessor {
     private static final String SERVICE_FILE_NAME = "META-INF/services/java.sql.Driver";
-    private static final ModuleIdentifier JTA = ModuleIdentifier.create("javax.transaction.api");
+    private static final String JTA = "jakarta.transaction.api";
 
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {


### PR DESCRIPTION
…akarta modules

Jira issue: https://issues.redhat.com/browse/WFCORE-6279

An alternative PR for https://github.com/wildfly/wildfly-core/pull/5434 where we are only replacing the javax module identifier with jakarta variants without warning or taking into account alias for exclusions or user dependencies