### PR TITLE
[WFCORE-6293] Removing JDK 8 specific excludes from maven enforcer plugin configurations

### DIFF
--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -872,44 +872,4 @@
         </plugins>
     </build>
 
-    <profiles>
-
-        <profile>
-            <id>enforce</id>
-            <activation>
-                <property>
-                    <name>!skip-enforce</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>ban-transitive-deps</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
-                                        </banTransitiveDependencies>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>

--- a/core-feature-pack/ee-10-api/pom.xml
+++ b/core-feature-pack/ee-10-api/pom.xml
@@ -88,42 +88,4 @@
         </plugins>
     </build>
 
-    <profiles>
-
-        <profile>
-            <id>enforce</id>
-            <activation>
-                <property>
-                    <name>!skip-enforce</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>ban-transitive-deps</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
-                                        </banTransitiveDependencies>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/core-feature-pack/galleon-feature-pack/pom.xml
+++ b/core-feature-pack/galleon-feature-pack/pom.xml
@@ -242,9 +242,6 @@
                                     <rules>
                                         <banTransitiveDependencies>
                                             <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
                                                 <exclude>${project.groupId}:wildfly-core-feature-pack-common</exclude>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6293
