### PR TITLE
[WFCORE-6309] The license for StaxMapper should be LGPL 2.1 or Later.

### DIFF
--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -295,7 +295,7 @@
       <artifactId>staxmapper</artifactId>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2.1 only</name>
+          <name>GNU Lesser General Public License v2.1 or later</name>
           <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
           <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6309