### PR TITLE
[WFCORE-6308] Removing unused Jetty ALPN provider - it was targeting JDK8 and below

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
@@ -20,7 +20,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.6" name="io.undertow.core">
+<module xmlns="urn:jboss:module:1.9" name="io.undertow.core">
+
     <resources>
         <artifact name="${io.undertow:undertow-core}"/>
     </resources>
@@ -36,11 +37,6 @@
         <module name="org.wildfly.openssl" optional="true"/>
         <module name="org.wildfly.security.elytron-web.undertow-server" services="import" />
         <module name="org.wildfly.common"/>
-        <system export="true">
-            <paths>
-                <!-- Needed for HTTP2 and SPDY support-->
-                <path name="org/eclipse/jetty/alpn"/>
-            </paths>
-        </system>
     </dependencies>
+
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6308