### PR TITLE
WFCORE-6336 Remove deprecated OperationDefinition and SimpleOperationDefinition API

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
@@ -28,16 +28,12 @@ import static org.jboss.as.controller.registry.OperationEntry.Flag.immutableSetO
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -76,36 +72,6 @@ public abstract class OperationDefinition {
         }
         this.descriptionProvider = builder.descriptionProvider;
 
-    }
-
-    /** @deprecated use {@link #OperationDefinition(SimpleOperationDefinitionBuilder)}*/
-    @Deprecated
-    protected OperationDefinition(String name,
-                               OperationEntry.EntryType entryType,
-                               EnumSet<OperationEntry.Flag> flags,
-                               final ModelType replyType,
-                               final ModelType replyValueType,
-                               final boolean replyAllowNull,
-                               final DeprecationData deprecationData,
-                               AttributeDefinition[] replyParameters,
-                               AttributeDefinition[] parameters,
-                               AccessConstraintDefinition... accessConstraints
-    ) {
-        this.name = name;
-        this.entryType = entryType;
-        this.flags = immutableSetOf(flags);
-        this.parameters = parameters;
-        this.replyType = replyType;
-        this.replyValueType = replyValueType;
-        this.replyAllowNull = replyAllowNull;
-        this.deprecationData = deprecationData;
-        this.replyParameters = replyParameters;
-        if (accessConstraints == null) {
-            this.accessConstraints = Collections.<AccessConstraintDefinition>emptyList();
-        } else {
-            this.accessConstraints = Collections.unmodifiableList(Arrays.asList(accessConstraints));
-        }
-        this.descriptionProvider = null;
     }
 
     public String getName() {
@@ -161,40 +127,4 @@ public abstract class OperationDefinition {
         return replyParameters;
     }
 
-    /**
-     * Validates operation model against the definition and its parameters
-     *
-     * @param operation model node of type {@link ModelType#OBJECT}, representing an operation request
-     * @throws OperationFailedException if the value is not valid
-     *
-     * @deprecated Not used by the WildFly management kernel; will be removed in a future release
-     */
-    @Deprecated
-    public void validateOperation(final ModelNode operation) throws OperationFailedException {
-        if (operation.hasDefined(ModelDescriptionConstants.OPERATION_NAME) && deprecationData != null && deprecationData.isNotificationUseful()) {
-            ControllerLogger.DEPRECATED_LOGGER.operationDeprecated(getName(),
-                    PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).toCLIStyleString());
-        }
-        for (AttributeDefinition ad : this.parameters) {
-            ad.validateOperation(operation);
-        }
-    }
-
-    /**
-     * validates operation against the definition and sets model for the parameters passed.
-     *
-     * @param operationObject model node of type {@link ModelType#OBJECT}, typically representing an operation request
-     * @param model           model node in which the value should be stored
-     * @throws OperationFailedException if the value is not valid
-     *
-     * @deprecated Not used by the WildFly management kernel; will be removed in a future release
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    public final void validateAndSet(ModelNode operationObject, final ModelNode model) throws OperationFailedException {
-        validateOperation(operationObject);
-        for (AttributeDefinition ad : this.parameters) {
-            ad.validateAndSet(operationObject, model);
-        }
-    }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6336

There are no deprecated methods in SimpleOperationDefinition. Please correct me if I am wrong.