### PR TITLE
[WFCORE-6338]: A resource name can't match an attribute name of this resource.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtension.java
@@ -231,7 +231,7 @@ public class YamlConfigurationExtension implements ConfigurationExtension {
                                 if (!postExtensionOps.isEmpty()) {
                                     ParsedBootOp op = postExtensionOps.get(postExtensionOps.size() - 1);
                                     if (! address.equals(op.getAddress())) { // else already processed
-                                        Map<String, Object> map = new HashMap<>(yaml);
+                                        Map<String, Object> map = value instanceof Map ? new HashMap<>((Map)value) : new HashMap<>(yaml);
                                         //need to process attributes for adding
                                         processAttributes(address, rootRegistration, operationEntry, map, postExtensionOps);
                                         processResource(address, map, rootRegistration, resourceRegistration, xmlOperations, postExtensionOps, false);

--- a/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
@@ -157,7 +157,7 @@ public class YamlConfigurationExtensionTest {
         ConfigurationExtension instance = ConfigurationExtensionFactory.createConfigurationExtension(Paths.get(this.getClass().getResource("simple.yml").toURI()));
         instance.processOperations(rootRegistration, postExtensionOps);
         assertFalse(postExtensionOps.isEmpty());
-        assertEquals(4, postExtensionOps.size());
+        assertEquals(5, postExtensionOps.size());
         assertEquals(ADD, postExtensionOps.get(0).operationName);
         assertEquals(PathAddress.pathAddress("basic", "test"), postExtensionOps.get(0).address);
         assertFalse(postExtensionOps.get(0).operation.hasDefined("value"));
@@ -173,6 +173,10 @@ public class YamlConfigurationExtensionTest {
         assertEquals(PathAddress.pathAddress("system-property", "ccc"), postExtensionOps.get(3).address);
         assertTrue(postExtensionOps.get(3).operation.hasDefined("value"));
         assertEquals("test", postExtensionOps.get(3).operation.get("value").asString());
+        assertEquals(ADD, postExtensionOps.get(4).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "value"), postExtensionOps.get(4).address);
+        assertTrue(postExtensionOps.get(4).operation.hasDefined("value"));
+        assertEquals("test", postExtensionOps.get(4).operation.get("value").asString());
     }
 
     /**
@@ -230,7 +234,7 @@ public class YamlConfigurationExtensionTest {
         ConfigurationExtension instance = ConfigurationExtensionFactory.createConfigurationExtension(Paths.get(this.getClass().getResource("simple.yml").toURI()));
         instance.processOperations(rootRegistration, postExtensionOps);
         assertFalse(postExtensionOps.isEmpty());
-        assertEquals(6, postExtensionOps.size());
+        assertEquals(7, postExtensionOps.size());
         assertEquals(ADD, postExtensionOps.get(0).operationName);
         assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(0).address);
         assertFalse(postExtensionOps.get(0).operation.hasDefined("value"));
@@ -252,6 +256,10 @@ public class YamlConfigurationExtensionTest {
         assertEquals(PathAddress.pathAddress("system-property", "ccc"), postExtensionOps.get(5).address);
         assertTrue(postExtensionOps.get(5).operation.hasDefined("value"));
         assertEquals("test", postExtensionOps.get(5).operation.get("value").asString());
+        assertEquals(ADD, postExtensionOps.get(6).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "value"), postExtensionOps.get(6).address);
+        assertTrue(postExtensionOps.get(6).operation.hasDefined("value"));
+        assertEquals("test", postExtensionOps.get(6).operation.get("value").asString());
     }
 
     /**

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/yaml/simple.yml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/yaml/simple.yml
@@ -10,6 +10,8 @@ wildfly-configuration:
     system-property:
       ccc:
         value: test
+      value:
+        value: test
     basic:
       test:
 #User defined elements, must be ignored.


### PR DESCRIPTION
* Fixing the case when the resource name matches a resource attribute name.

Jira: https://issues.redhat.com/browse/WFCORE-6338