### PR TITLE
[WFCORE-6342] The jmx-remoting dependeny on management needs to be mandatory.

### DIFF
--- a/core-feature-pack/galleon-common/src/main/resources/layers/standalone/jmx-remoting/layer-spec.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/layers/standalone/jmx-remoting/layer-spec.xml
@@ -3,7 +3,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jmx-remoting">
      <dependencies>
         <!-- requires jboss.remoting.endpoint.management service -->
-        <layer name="management" optional="true"/>
+        <layer name="management"/>
         <layer name="jmx"/> 
     </dependencies>
     <feature-group name="jmx-connector"/>


### PR DESCRIPTION

https://issues.redhat.com/browse/WFCORE-6342

This was previously made optional when we had multiple management layers to choose from but now we are back to one so needs to be mandatory.