### PR TITLE
[WFCORE-6351] The publish-configuration command doesn't throw an error when the git location is invalid

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3750,4 +3750,7 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 502, value = "No child resource called %s could be found at address %s'.")
     IllegalArgumentException noChildResource(String name, String address);
+
+    @Message(id = 503, value = "Failed to publish configuration, because the remote name %s is not valid.")
+    ConfigurationPersistenceException failedToPublishConfigurationInvalidRemote(String name);
 }

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitConfigurationPersister.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitConfigurationPersister.java
@@ -154,6 +154,8 @@ public class GitConfigurationPersister extends XmlConfigurationPersister {
             } catch (GitAPIException ex) {
                 throw MGMT_OP_LOGGER.failedToPublishConfiguration(ex, name, ex.getMessage());
             }
+        } else {
+            throw MGMT_OP_LOGGER.failedToPublishConfigurationInvalidRemote(name);
         }
         return message.toString();
     }

--- a/server/src/test/java/org/jboss/as/controller/persistence/RemoteGitPersistenceResourceTestCase.java
+++ b/server/src/test/java/org/jboss/as/controller/persistence/RemoteGitPersistenceResourceTestCase.java
@@ -136,7 +136,15 @@ public class RemoteGitPersistenceResourceTestCase extends AbstractGitPersistence
             commits = listCommits(remoteRepository);
             Assert.assertEquals(1, commits.size());
             Assert.assertEquals("Repository initialized", commits.get(0));
+            //Publish to default remote
             persister.publish(null);
+            // Publish to an invalid remote location
+            try {
+                persister.publish("invalid_remote");
+                Assert.fail("Should have thrown an exception");
+            } catch (ConfigurationPersistenceException expected){
+                Assert.assertTrue(expected.getMessage().contains("WFLYCTL0503"));
+            }
             commits = listCommits(remoteRepository);
             Assert.assertEquals(5, commits.size());
             Assert.assertEquals("1st snapshot", commits.get(0));

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
@@ -307,12 +307,6 @@ public class GitRepositoryTestCase extends AbstractGitRepositoryTestCase {
             Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0455"));
         }
 
-        // :publish-configuration => push to origin
-        publish(null);
-        commits = listCommits(repository);
-        Assert.assertEquals(expectedNumberOfCommits, commits.size());
-        Assert.assertEquals("bar", commits.get(0));
-
         // :publish-configuration(location=empty) => push to empty)
         publish("empty");
         tags = listTags(emptyRemoteRepository);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6351