### PR TITLE
[WFCORE-6320] Remove deprecated ModelController methods

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelController.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelController.java
@@ -23,14 +23,11 @@
 package org.jboss.as.controller;
 
 import java.security.Permission;
-import java.util.concurrent.Executor;
 
-import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
-import org.jboss.as.controller.registry.NotificationHandlerRegistration;
 import org.jboss.as.controller.security.ControllerPermission;
 import org.jboss.dmr.ModelNode;
 
@@ -74,40 +71,6 @@ public interface ModelController {
      * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     OperationResponse execute(Operation operation, OperationMessageHandler handler, OperationTransactionControl control);
-
-    /**
-     * Create an in-VM client whose operations are executed as if they were invoked by a user in the
-     * RBAC {@code SuperUser} role, regardless of any security identity that is or isn't associated
-     * with the calling thread when the client is invoked. <strong>This client generally should not
-     * be used to handle requests from external callers, and if it is used great care should be
-     * taken to ensure such use is not suborning the intended access control scheme.</strong>
-     * <p>
-     * In a VM with a {@link java.lang.SecurityManager SecurityManager} installed, invocations
-     * against the returned client can only occur from a calling context with the
-     * {@link org.jboss.as.controller.security.ControllerPermission#PERFORM_IN_VM_CALL PERFORM_IN_VM_CALL}
-     * permission. Without this permission a {@link SecurityException} will be thrown.
-     *
-     * @param executor the executor to use for asynchronous operation execution. Cannot be {@code null}
-     * @return the client. Will not return {@code null}
-     *
-     * @throws SecurityException if the caller does not have the
-     *            {@link org.jboss.as.controller.security.ControllerPermission#CAN_ACCESS_MODEL_CONTROLLER CAN_ACCESS_MODEL_CONTROLLER}
-     *            permission
-     *
-     * @deprecated Use {@link ModelControllerClientFactory}. Will be removed in the next major or minor release.
-     */
-    @Deprecated
-    ModelControllerClient createClient(Executor executor);
-
-    /**
-     * Returns the {@code NotificationHandlerRegistration} that registers notification handlers for this model controller.
-     *
-     * @return the notification handler registration
-     *
-     * @deprecated Use {@link org.jboss.as.controller.notification.NotificationHandlerRegistry}. Will be removed in the next major or minor release.
-     */
-    @Deprecated
-    NotificationHandlerRegistration getNotificationRegistry();
 
     /**
      * A callback interface for the operation's completion status.  Implemented in order to control whether a complete

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -738,11 +738,6 @@ class ModelControllerImpl implements ModelController {
         return modelControllerResource;
     }
 
-    @Override
-    public ModelControllerClient createClient(final Executor executor) {
-        return getClientFactory().createSuperUserClient(executor, false);
-    }
-
     ModelControllerClient createBootClient(final Executor executor) {
         return getClientFactory().createBootClient(executor);
     }
@@ -918,8 +913,8 @@ class ModelControllerImpl implements ModelController {
         return serviceTarget;
     }
 
-    @Override
-    public NotificationHandlerRegistration getNotificationRegistry() {
+
+    NotificationHandlerRegistration getNotificationRegistry() {
         return notificationSupport.getNotificationRegistry();
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
@@ -208,7 +208,7 @@ public class MetricsRegistrationTestCase {
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
 
-        client = controller.createClient(executor);
+        client = svc.getModelControllerClientFactory().createClient(executor);
 
         return svc.managementControllerResource;
     }

--- a/controller/src/test/java/org/jboss/as/controller/MetricsUndefinedValueUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/MetricsUndefinedValueUnitTestCase.java
@@ -214,7 +214,7 @@ public class MetricsUndefinedValueUnitTestCase {
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
 
-        client = controller.createClient(executor);
+        client = svc.getModelControllerClientFactory().createClient(executor);
 
         return svc.managementControllerResource;
     }

--- a/controller/src/test/java/org/jboss/as/controller/MockModelController.java
+++ b/controller/src/test/java/org/jboss/as/controller/MockModelController.java
@@ -22,13 +22,9 @@
 
 package org.jboss.as.controller;
 
-import java.util.concurrent.Executor;
-
-import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
-import org.jboss.as.controller.registry.NotificationHandlerRegistration;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -42,15 +38,5 @@ public abstract class MockModelController implements ModelController {
     public OperationResponse execute(Operation operation, OperationMessageHandler handler, OperationTransactionControl control) {
         ModelNode simpleResponse = execute(operation.getOperation(), handler, control, operation);
         return OperationResponse.Factory.createSimple(simpleResponse);
-    }
-
-    @Override
-    public ModelControllerClient createClient(Executor executor) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public NotificationHandlerRegistration getNotificationRegistry() {
-        throw new UnsupportedOperationException();
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerClientTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerClientTestCase.java
@@ -49,7 +49,6 @@ import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.impl.ExistingChannelModelControllerClient;
 import org.jboss.as.controller.client.impl.InputStreamEntry;
-import org.jboss.as.controller.registry.NotificationHandlerRegistration;
 import org.jboss.as.controller.remote.ModelControllerClientOperationHandler;
 import org.jboss.as.controller.remote.ResponseAttachmentInputStreamSupport;
 import org.jboss.as.controller.support.RemoteChannelPairSetup;
@@ -371,15 +370,9 @@ public class ModelControllerClientTestCase {
 
     private abstract static class MockModelController extends org.jboss.as.controller.MockModelController {
         protected volatile ModelNode operation;
-        private final NotificationHandlerRegistration notificationRegistry = NotificationHandlerRegistration.Factory.create();
 
         ModelNode getOperation() {
             return operation;
-        }
-
-        @Override
-        public NotificationHandlerRegistration getNotificationRegistry() {
-            return notificationRegistry;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -133,7 +133,7 @@ public class ModelControllerImplUnitTestCase {
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
         notificationHandler = new ServiceNotificationHandler();
-        controller.getNotificationRegistry().registerNotificationHandler(PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT).append(SERVICE, MANAGEMENT_OPERATIONS), notificationHandler, notificationHandler);
+        svc.getNotificationHandlerRegistry().registerNotificationHandler(PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT).append(SERVICE, MANAGEMENT_OPERATIONS), notificationHandler, notificationHandler);
         assertEquals(ControlledProcessState.State.RUNNING, svc.getCurrentProcessState());
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
@@ -108,7 +108,7 @@ public class OperationCancellationUnitTestCase {
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
 
-        client = controller.createClient(executor);
+        client = svc.getModelControllerClientFactory().createClient(executor);
 
         managementControllerResource = svc.managementControllerResource;
     }

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -88,7 +88,7 @@ public class OperationTimeoutUnitTestCase {
         controllerService.awaitStartup(30, TimeUnit.SECONDS);
         ModelController controller = controllerService.getValue();
 
-        client = controller.createClient(executor);
+        client = controllerService.getModelControllerClientFactory().createClient(executor);
 
         System.setProperty(BlockingTimeout.SYSTEM_PROPERTY, "1");
     }

--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorize
 import org.jboss.as.controller.access.management.ManagementSecurityIdentitySupplier;
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.notification.NotificationHandlerRegistry;
 import org.jboss.as.controller.persistence.ConfigurationExtension;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
@@ -122,6 +123,15 @@ public abstract class TestModelControllerService extends AbstractControllerServi
 
     public CapabilityRegistry getCapabilityRegistry() {
         return capabilityRegistry;
+    }
+
+    public NotificationHandlerRegistry getNotificationHandlerRegistry() {
+        return getNotificationSupport().getNotificationRegistry();
+    }
+
+    @Override
+    public ModelControllerClientFactory getModelControllerClientFactory() {
+        return super.getModelControllerClientFactory();
     }
 
     static OperationDefinition getOD(String name) {

--- a/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
@@ -165,19 +165,19 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
     public void test_RESOURCE_ADDED_NOTIFICATION() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_ADDED_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         executeForResult(createOperation(ADD, resourceAddress));
         assertEquals("the notification handler did not receive the " + RESOURCE_ADDED_NOTIFICATION, 1, handler.getNotifications().size());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
     public void test_RESOURCE_ADDED_NOTIFICATION_isNotSentWhenAddOperationFails() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_ADDED_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         ModelNode addOperation = createOperation(ADD, resourceAddress);
         addOperation.get(FAIL_ADD_OPERATION.getName()).set(true);
@@ -185,7 +185,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         assertTrue("the notification handler unexpectedly receives the " + RESOURCE_ADDED_NOTIFICATION, handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -194,12 +194,12 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_REMOVED_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         executeForResult(createOperation(REMOVE, resourceAddress));
         assertEquals("the notification handler did not receive the " + RESOURCE_REMOVED_NOTIFICATION, 1, handler.getNotifications().size());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -210,12 +210,12 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_REMOVED_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         executeForFailure(createOperation(REMOVE, resourceAddress));
         assertTrue("the notification handler unexpectedly receives the " + RESOURCE_REMOVED_NOTIFICATION, handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -230,7 +230,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         long newValue = System.currentTimeMillis();
         ModelNode writeAttribute = createOperation(WRITE_ATTRIBUTE_OPERATION, resourceAddress);
@@ -245,7 +245,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
         assertFalse(notification.getData().require(OLD_VALUE).isDefined());
         assertEquals(newValue, notification.getData().require(NEW_VALUE).asLong());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -255,7 +255,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         String incorrectValue = UUID.randomUUID().toString();
         ModelNode writeAttribute = createOperation(WRITE_ATTRIBUTE_OPERATION, resourceAddress);
@@ -264,7 +264,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
         executeForFailure(writeAttribute);
         assertTrue("the notification handler unexpectedly receives the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -276,7 +276,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         ModelNode writeAttribute = createOperation(WRITE_ATTRIBUTE_OPERATION, resourceAddress);
         writeAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
@@ -284,7 +284,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
         executeForResult(writeAttribute);
         assertEquals("the notification handler unexpectedly receives the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, 0, handler.getNotifications().size());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -296,7 +296,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         ModelNode undefineAttribute = createOperation(UNDEFINE_ATTRIBUTE_OPERATION, resourceAddress);
         undefineAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
@@ -308,7 +308,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
         assertEquals(initialValue, notification.getData().require(OLD_VALUE).asLong());
         assertFalse(notification.getData().require(NEW_VALUE).isDefined());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -319,7 +319,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
         ModelNode undefineAttribute = createOperation(UNDEFINE_ATTRIBUTE_OPERATION, resourceAddress);
         undefineAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
@@ -327,7 +327,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         assertTrue("the notification handler unexpectedly receives the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -338,7 +338,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
 
         long newValue = System.currentTimeMillis();
@@ -354,7 +354,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
         assertEquals(MY_RUNTIME_ATTRIBUTE.getDefaultValue().asLong(), notification.getData().require(OLD_VALUE).asLong());
         assertEquals(newValue, notification.getData().require(NEW_VALUE).asLong());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     @Test
@@ -366,7 +366,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
-        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
 
 
         long newValue = System.currentTimeMillis();
@@ -381,7 +381,7 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
         assertEquals(initialValue, notification.getData().require(OLD_VALUE).asLong());
         assertEquals(newValue, notification.getData().require(NEW_VALUE).asLong());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
     }
 
     private static class TestNotificationHandler implements NotificationFilter {

--- a/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
@@ -88,7 +88,7 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
     @Test
     public void testCompositeOperationThatEmitsNotifications() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         ModelNode operation = new ModelNode();
         operation.get(OP).set("composite");
@@ -108,13 +108,13 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
         assertEquals("param1", handler.getNotifications().get(0).getMessage());
         assertEquals("param2", handler.getNotifications().get(1).getMessage());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
     public void testCompositeOperationWithFirstOperationFailing() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         ModelNode operation = new ModelNode();
         operation.get(OP).set("composite");
@@ -131,13 +131,13 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
 
         assertTrue("the notification were emitted", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
     public void testCompositeOperationWithSecondOperationFailing() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         ModelNode operation = new ModelNode();
         operation.get(OP).set("composite");
@@ -154,7 +154,7 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
 
         assertTrue("the notification were emitted", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
 }

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
@@ -120,7 +120,7 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
 
         // register the handler...
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
         executeForResult(createOperation(MY_OPERATION));
 
         assertEquals("the notification handler did not receive the notifications", 2, handler.getNotifications().size());
@@ -128,14 +128,14 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
         assertEquals(MESSAGE1, handler.getNotifications().get(0).getMessage());
         assertEquals(MESSAGE2, handler.getNotifications().get(1).getMessage());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
 
     @Test
     public void testSendNotificationForFailingOperationInFirstStep() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         ModelNode operation = createOperation(MY_OPERATION);
         operation.get(FAIL_FIRST_STEP.getName()).set(true);
@@ -149,14 +149,14 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
 
         assertTrue("the notification handler did not receive any notifications", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
 
     @Test
     public void testSendNotificationForFailingOperationInSecondStep() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         ModelNode operation = createOperation(MY_OPERATION);
         operation.get(FAIL_SECOND_STEP.getName()).set(true);
@@ -169,13 +169,13 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
 
         assertTrue("the notification handler did not receive any notifications", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
     public void testSendNotificationForRollingBackOperation() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         ModelNode operation = createOperation(MY_OPERATION);
         operation.get(ROLLBACK.getName()).set(true);
@@ -188,6 +188,6 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
 
         assertTrue("the notification handler did not receive any notifications", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
@@ -74,7 +74,7 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
     @Test
     public void testSendNotification() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
 
                     @Override
                     public boolean isNotificationEnabled(Notification notification) {
@@ -86,13 +86,13 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
         executeForResult(createOperation(MY_OPERATION));
         assertEquals("the notification handler did not receive the notification", 1, handler.getNotifications().size());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
     public void testSendNotificationWithFilter() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
 
             @Override
             public boolean isNotificationEnabled(Notification notification) {
@@ -103,7 +103,7 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
         executeForResult(createOperation(MY_OPERATION));
         assertTrue("the notification handler must not receive the filtered out notification", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
@@ -119,19 +119,19 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
             }
         };
 
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
 
         // having a failing notification handler has no incidence on the operation that triggered the notification emission
         executeForResult(createOperation(MY_OPERATION));
         assertTrue("the notification handler did receive the notification", gotNotification.get());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
     public void testSendNotificationWithFailingFilter() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
             @Override
             public boolean isNotificationEnabled(Notification notification) {
                 throw new IllegalStateException("somehow, the filter throws an exception");
@@ -142,16 +142,16 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
         // but the handler will not be notified
         assertTrue("the notification handler did receive the notification", handler.getNotifications().isEmpty());
 
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
     }
 
     @Test
     public void testSendNotificationAfterUnregisteringHandler() throws Exception {
         ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
         // register the handler...
-        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
         // ... and unregister it
-        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        getNotificationHandlerRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
         executeForResult(createOperation(MY_OPERATION));
         assertTrue("the unregistered notification handler did not receive the notification", handler.getNotifications().isEmpty());
     }

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -51,6 +51,7 @@ import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.TestModelControllerService;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.notification.NotificationHandlerRegistry;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
@@ -80,6 +81,7 @@ public abstract class AbstractControllerTestBase {
     protected ModelController controller;
     protected volatile ProcessType processType;
     protected CapabilityRegistry capabilityRegistry;
+    private NotificationHandlerRegistry notificationHandlerRegistry;
 
     protected AbstractControllerTestBase(ProcessType processType) {
         this.processType = processType;
@@ -169,6 +171,7 @@ public abstract class AbstractControllerTestBase {
         svc.awaitStartup(30, TimeUnit.SECONDS);
         controller = svc.getValue();
         capabilityRegistry = svc.getCapabilityRegistry();
+        notificationHandlerRegistry = svc.getNotificationHandlerRegistry();
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
     }
@@ -193,6 +196,10 @@ public abstract class AbstractControllerTestBase {
 
     protected void addBootOperations(List<ModelNode> bootOperations) {
 
+    }
+
+    protected NotificationHandlerRegistry getNotificationHandlerRegistry() {
+        return notificationHandlerRegistry;
     }
 
     public class ModelControllerService extends TestModelControllerService {

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -80,6 +80,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
+import org.jboss.as.controller.ModelControllerClientFactory;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -147,10 +148,10 @@ public abstract class AbstractProxyControllerTest {
         operation.get(OP).set("setup");
         operation.get(OP_ADDR).setEmptyList();
 
-        mainControllerClient = mainService.getValue().createClient(executor);
+        mainControllerClient = mainService.getModelControllerClientFactory().createSuperUserClient(executor);
         mainControllerClient.execute(operation);
 
-        proxiedControllerClient = proxyService.getValue().createClient(executor);
+        proxiedControllerClient = proxyService.getModelControllerClientFactory().createSuperUserClient(executor);
         proxiedControllerClient.execute(operation);
     }
 
@@ -664,6 +665,8 @@ public abstract class AbstractProxyControllerTest {
     }
 
     public class ProxyModelControllerService extends TestModelControllerService {
+
+        private volatile ModelControllerClientFactory clientFactory;
 
         ProxyModelControllerService(final ControlledProcessState processState) {
             super(ProcessType.EMBEDDED_SERVER, new NullConfigurationPersister(), processState,

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestKernelServicesImpl.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestKernelServicesImpl.java
@@ -207,7 +207,7 @@ public abstract class ModelTestKernelServicesImpl<T extends ModelTestKernelServi
         } else {
             ExecutorService executor = Executors.newCachedThreadPool();
             try {
-                ModelControllerClient client = controller.createClient(executor);
+                ModelControllerClient client = controllerService.getModelControllerClientFactory().createClient(executor);
                 OperationBuilder builder = OperationBuilder.create(operation);
                 for (InputStream in : inputStreams) {
                     builder.addInputStream(in);

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
+import org.jboss.as.controller.ModelControllerClientFactory;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -226,6 +227,11 @@ public abstract class ModelTestModelControllerService extends AbstractController
 
     TransformerRegistry getTransformersRegistry() {
         return transformerRegistry;
+    }
+
+    @Override
+    protected ModelControllerClientFactory getModelControllerClientFactory() {
+        return super.getModelControllerClientFactory();
     }
 
     @Override

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
@@ -97,7 +97,7 @@ public class PlatformMBeanResourceUnitTestCase {
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
 
-        client = controller.createClient(Executors.newSingleThreadExecutor());
+        client = svc.getModelControllerClientFactory().createClient(Executors.newSingleThreadExecutor());
     }
 
     @AfterClass

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ModelControllerClientFactory;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceBuilder;
@@ -89,5 +90,10 @@ public class PlatformMBeanTestModelControllerService extends AbstractControllerS
     protected void bootThreadDone() {
         super.bootThreadDone();
         latch.countDown();
+    }
+
+    @Override
+    protected ModelControllerClientFactory getModelControllerClientFactory() {
+        return super.getModelControllerClientFactory();
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6320

The bulk of the change is cleaning up test use of the deprecated methods.