### PR TITLE
[WFCORE-6339]: Define remote name as origin if none is defined.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
@@ -35,7 +35,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.eclipse.jgit.api.AddCommand;
@@ -135,10 +134,10 @@ public class GitRepository implements Closeable {
                 Files.copy(basePath, atticPath, StandardCopyOption.REPLACE_EXISTING);
                 clearExistingFiles(basePath, gitConfig.getRepository());
                 try (Git git = Git.init().setDirectory(baseDir).setInitialBranch(branch).call()) {
-                    String remoteName = UUID.randomUUID().toString();
+                    String remoteName = DEFAULT_REMOTE_NAME;
                     StoredConfig config = git.getRepository().getConfig();
-                    config.setString("remote", remoteName, "url", gitConfig.getRepository());
-                    config.setString("remote", remoteName, "fetch", "+" + R_HEADS + "*:" + R_REMOTES + remoteName + "/*");
+                    config.setString(ConfigConstants.CONFIG_REMOTE_SECTION, remoteName, ConfigConstants.CONFIG_KEY_URL, gitConfig.getRepository());
+                    config.setString(ConfigConstants.CONFIG_REMOTE_SECTION, remoteName, ConfigConstants.CONFIG_FETCH_SECTION, "+" + R_HEADS + "*:" + R_REMOTES + remoteName + "/*");
                     config.setBoolean(ConfigConstants.CONFIG_COMMIT_SECTION, null, ConfigConstants.CONFIG_KEY_GPGSIGN, gitConfig.isSign());
                     config.setBoolean(ConfigConstants.CONFIG_TAG_SECTION, null, ConfigConstants.CONFIG_KEY_GPGSIGN, gitConfig.isSign());
                     config.save();
@@ -300,7 +299,7 @@ public class GitRepository implements Closeable {
         }
         StoredConfig config = repository.getConfig();
         for (String remoteName : repository.getRemoteNames()) {
-            if (gitRepository.equals(config.getString("remote", remoteName, "url"))) {
+            if (gitRepository.equals(config.getString(ConfigConstants.CONFIG_REMOTE_SECTION, remoteName, ConfigConstants.CONFIG_KEY_URL))) {
                 return remoteName;
             }
         }

--- a/server/src/test/java/org/jboss/as/controller/persistence/RemoteGitPersistenceResourceTestCase.java
+++ b/server/src/test/java/org/jboss/as/controller/persistence/RemoteGitPersistenceResourceTestCase.java
@@ -81,15 +81,15 @@ public class RemoteGitPersistenceResourceTestCase extends AbstractGitPersistence
         Path standard = createFile(root, "standard.xml", "std");
         ConfigurationFile configurationFile = new ConfigurationFile(root.toFile(), "standard.xml", null, ConfigurationFile.InteractionPolicy.STANDARD, true, null);
         Assert.assertEquals(standard.toAbsolutePath().toString(), configurationFile.getBootFile().getAbsolutePath());
-        GitRepositoryConfiguration.Builder.getInstance()
-                .setBasePath(root)
-                .setRepository(remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString())
-                .build();
         try (GitRepository gitRepository = new GitRepository(GitRepositoryConfiguration.Builder.getInstance()
                 .setBasePath(root)
                 .setRepository(remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString())
                 .build())) {
             List<String> commits = listCommits(repository);
+            Assert.assertEquals(1, repository.getRemoteNames().size());
+            Assert.assertTrue(repository.getRemoteNames().contains("origin"));
+            StoredConfig config = repository.getConfig();
+            Assert.assertEquals(remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString(), config.getString(ConfigConstants.CONFIG_REMOTE_SECTION, "origin", ConfigConstants.CONFIG_KEY_URL));
             Assert.assertEquals(2, commits.size());
             Assert.assertEquals("Adding .gitignore", commits.get(0));
             Assert.assertEquals("Repository initialized", commits.get(1));


### PR DESCRIPTION
* When pulling from a remote repository the first time we set it to the 'origin' remote name.

Jira: https://issues.redhat.com/browse/WFCORE-6339
