### PR TITLE
WFCORE-6354 Remove obsolete org.jboss.msc dependency from org.jboss.as.network

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
@@ -34,7 +34,6 @@
     <dependencies>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.common"/>
-        <module name="org.jboss.msc"/>
         <module name="org.jboss.logging" />
     </dependencies>
 </module>

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -83,10 +83,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.msc</groupId>
-            <artifactId>jboss-msc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6354