### PR TITLE
[WFCORE-6302] CVE-2022-1259 Upgrade Undertow to 2.3.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.86.Final</version.io.netty>
         <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.5.Final</version.io.undertow>
+        <version.io.undertow>2.3.6.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6302


        Release Notes - Undertow - Version 2.3.6.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1938'>UNDERTOW-1938</a>] -         MaxRequestSizeTestCase.testMaxRequestHeaderSize fails with 500 on Windows
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2259'>UNDERTOW-2259</a>] -         LoadBalancerConnectionPoolingTestCase fails when system is slow
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2056'>UNDERTOW-2056</a>] -         CVE-2022-1259 Replace AbstractFramedStreamSinkChannel.awaitWritable by a timeout task
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2075'>UNDERTOW-2075</a>] -         AbstractFramedChannel should not delegate a new task to IO thread if current thread is IO
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2077'>UNDERTOW-2077</a>] -         ReferenceCountedPooled view close() is not truly idempotent
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2137'>UNDERTOW-2137</a>] -         Freed method can still create issues when queued max buffers are consumed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2245'>UNDERTOW-2245</a>] -         javax.servlet.*.mapping request attributes are not available in servlets forwarded with RequestDispatcher
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2246'>UNDERTOW-2246</a>] -         DirectByteBufferDeallocator does not support android
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2251'>UNDERTOW-2251</a>] -         Protocol error with HTTP/2 and Expect: 100-continue persists
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2258'>UNDERTOW-2258</a>] -         Http2ClientConnection does not handle continue responses properly
</li>
</ul>
                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2076'>UNDERTOW-2076</a>] -         Short circuit AbstractFramedChannel resume/suspendReceives operation
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2260'>UNDERTOW-2260</a>] -         Remove Jetty ALPN provider that was targeting JDK8 and below
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2263'>UNDERTOW-2263</a>] -         Enhance and detail further the spotbugs exclude files
</li>
</ul>
                                                                                                                                                            