### PR TITLE
[20.x][WFCORE-6302] CVE-2022-1259 Upgrade Undertow to 2.3.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.86.Final</version.io.netty>
         <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.5.Final</version.io.undertow>
+        <version.io.undertow>2.3.6.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
upstream #5507 

Jira issue: https://issues.redhat.com/browse/WFCORE-6302

