### PR TITLE
[WFCORE-6364][WFCORE-6363] WildFly Elytron component upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.1.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.2.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.2.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.1.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.0.2.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
         <version.xom.xom>1.3.7</version.xom.xom>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6363
https://issues.redhat.com/browse/WFCORE-6364


        Release Notes - WildFly Elytron - Version 2.2.0.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2354'>ELY-2354</a>] -         Failing tests on latest IBM Semeru Runtime Certified Edition 11.0.15.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2381'>ELY-2381</a>] -         LdapSecurityRealm can return duplicated values for filtered attributes
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2457'>ELY-2457</a>] -         Swallowed exception in KeyStoreCredentialStore.flush
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2475'>ELY-2475</a>] -         Use the primitive boolean expression in DelegatingAuthConfigFactory 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2496'>ELY-2496</a>] -         Add integrity to existing filesystem realms using Elytron Tool
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2530'>ELY-2530</a>] -         Elytron Tool encrypt command incorrectly overwrites CLI script
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2535'>ELY-2535</a>] -         EJB lookups between two deployments doesn&#39;t work
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2536'>ELY-2536</a>] -         Tool encrypt command creates invalid CLI script for bulk conversion
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2540'>ELY-2540</a>] -         Elytron Tool filesystem-realm-encrypt checks incorrect script location for overwrite
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2541'>ELY-2541</a>] -         Elytron Tool filesystem-realm-encrypt tests use incorrect credential store path
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2542'>ELY-2542</a>] -         Elytron Tool filesystem-realm-encrypt command creates CLI script even if upgrade fails
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2546'>ELY-2546</a>] -         Elytron Tool encrypt command appends CLI script if not overwritten
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2552'>ELY-2552</a>] -         Make it possible to access MechanismConfigurationSelector from AbstractMechanismAuthenticationFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2553'>ELY-2553</a>] -         Add JBOSS-DOMAIN-SERVER as a known SASL mechanism
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2556'>ELY-2556</a>] -         Release WildFly Elytron 2.2.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2551'>ELY-2551</a>] -         Upgrade jose4j to 0.9.3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1211'>ELY-1211</a>] -         FileAuditEndpoint doesn&#39;t allow for file encoding to be overridden
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2305'>ELY-2305</a>] -         Add the ability to ignore unavailable realms for a distributed-realm
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2554'>ELY-2554</a>] -         It is not possible to use custom SASL mechanisms with the authentication factory
</li>
</ul>


        Release Notes - WildFly Elytron EE - Version 3.0.2.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-30'>ELYEE-30</a>] -         Change bean class of produced beans
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-35'>ELYEE-35</a>] -         Incorporate changes from ELY-2475
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-33'>ELYEE-33</a>] -         Release Elytron EE 3.0.2.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-34'>ELYEE-34</a>] -         Upgrade WildFly Elytron to 2.2.0.Final
</li>
</ul>
                                                                                                                                                                
                                                                                                                                                            