### PR TITLE
[WFCORE-5947] reenable test after Elytron 2.2.0.Final upgrade

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
@@ -89,7 +89,6 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -146,7 +145,6 @@ public abstract class AbstractKerberosMgmtSaslTestBase {
     @BeforeClass
     public static void beforeClass() {
         KerberosTestUtils.assumeKerberosAuthenticationSupported();
-        Assume.assumeFalse("WFCORE-5947 temporary skip test until IBM JDK fixes are incorporated in elytron upgrade", CoreUtils.IBM_JDK);
     }
 
     /**


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-5947

re-enable test after Elytron 2.2.0.Final upgrade completed in https://github.com/wildfly/wildfly-core/pull/5518

Both `KerberosHttpMgmtSaslTestCase` and `KerberosNativeMgmtSaslTestCase` pass in IBM JDK with Elytron 2.2.0.Final  
