### PR TITLE
[WFCORE-6373] Upgrade WildFly Elytron EE to 3.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.2.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.1.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.0.2.Final</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
         <version.xom.xom>1.3.7</version.xom.xom>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6373


        Release Notes - WildFly Elytron EE - Version 3.0.3.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-36'>ELYEE-36</a>] -         ElytronCallerDetailsResolver.getPrincipalsByType does not include subtypes
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYEE-38'>ELYEE-38</a>] -         Release WildFly Elytron EE 3.0.3.Final
</li>
</ul>
                                                                                                                                                                                                                                                            
