### PR TITLE
WFCORE-6369 Eliminate unnecessary collection copying in AbstractAddStepHandler constructors

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -82,7 +82,7 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
         return this.attributes;
     }
 
-    /** {@inheritDoc */
+    @Override
     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
         final Resource resource = createResource(context, operation);
         populateModel(context, operation, resource);
@@ -90,6 +90,7 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
         //verify model for alternatives & requires
         if (requiresRuntime(context)) {
             context.addStep(new OperationStepHandler() {
+                @Override
                 public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                     performRuntime(context, operation, resource);
 
@@ -210,9 +211,8 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      *                 not be {@code null}
      */
     protected void recordCapabilitiesAndRequirements(final OperationContext context, final ModelNode operation, Resource resource) throws OperationFailedException {
-        Set<RuntimeCapability> capabilitySet = context.getResourceRegistration().getCapabilities();
 
-        for (RuntimeCapability capability : capabilitySet) {
+        for (RuntimeCapability<?> capability : context.getResourceRegistration().getCapabilities()) {
             if (capability.isDynamicallyNamed()) {
                 context.registerCapability(capability.fromBaseCapability(context.getCurrentAddress()));
             } else {

--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD_INDEX;
@@ -44,28 +45,23 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
  */
 public class AbstractAddStepHandler implements OperationStepHandler, OperationDescriptor {
 
-    private static final Set<? extends AttributeDefinition> NULL_ATTRIBUTES = Collections.emptySet();
-    private static final AttributeDefinition[] NULL_ATTRIBUTE_ARRAY = new AttributeDefinition[0];
-
-    private static AttributeDefinition[] getAttributeDefinitionArray(Collection<? extends AttributeDefinition> attributes) {
-        return (attributes == null || attributes.isEmpty()) ? NULL_ATTRIBUTE_ARRAY : attributes.toArray(NULL_ATTRIBUTE_ARRAY);
-    }
-
     protected final Collection<? extends AttributeDefinition> attributes;
 
     /**
      * Constructs an add handler.
      */
     public AbstractAddStepHandler() { //default constructor to preserve backward compatibility
-        this.attributes = NULL_ATTRIBUTES;
+        this.attributes = List.of();
     }
 
     /**
      * Constructs an add handler
-     * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}.attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
      */
+    @SuppressWarnings("unchecked")
     public AbstractAddStepHandler(Collection<? extends AttributeDefinition> attributes) {
-        this(new Parameters().addAttribute(getAttributeDefinitionArray(attributes)));
+        // Create defensive copy, if collection was not already immutable
+        this.attributes = (attributes instanceof Set) ? Set.copyOf((Set<AttributeDefinition>) attributes) : List.copyOf(attributes);
     }
 
     /**
@@ -74,18 +70,11 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
      */
     public AbstractAddStepHandler(AttributeDefinition... attributes) {
-        this(new Parameters().addAttribute(attributes));
+        this(List.of(attributes));
     }
 
     public AbstractAddStepHandler(Parameters parameters) {
-
-        if (parameters.attributes == null) {
-            attributes = NULL_ATTRIBUTES;
-        } else if (parameters.attributes.size() == 1) {
-            attributes = Collections.singleton(parameters.attributes.iterator().next());
-        } else {
-            attributes = Collections.unmodifiableSet(parameters.attributes);
-        }
+        this.attributes = Collections.unmodifiableCollection(parameters.attributes);
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6369

Fix improper use of Set in AbstractAddStepHandler.Parameters, since AttributeDefinition is not hashable.