### PR TITLE
[WFCORE-6384] When shuting down to perform an installation CLI is dis…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandLineMain.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandLineMain.java
@@ -21,7 +21,12 @@
 */
 package org.jboss.as.cli;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Locale;
@@ -29,19 +34,21 @@ import java.util.Properties;
 import java.util.logging.LogManager;
 
 import org.jboss.as.cli.impl.CliLauncher;
+import org.jboss.logging.Logger;
 import org.jboss.logmanager.Configurator;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.PropertyConfigurator;
-
 
 /**
 *
 * @author Alexey Loubyansky
 */
 public class CommandLineMain {
+    private static final Logger LOG = Logger.getLogger(CommandLineMain.class);
 
     public static void main(String[] args) throws Exception {
         configureLogManager(args);
+        createClientMarker();
         CliLauncher.main(args);
     }
 
@@ -150,5 +157,32 @@ public class CommandLineMain {
         properties.setProperty("formatter.PATTERN.pattern", "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n");
         properties.setProperty("formatter.PATTERN.properties", "pattern");
         return properties;
+    }
+
+    /**
+     * Creates a file marker under $JBOSS_HOME/bin directory. This is used by the shutdown operation to understand from where we have
+     * launched CLI instance when we are performing an update of a remote installation.
+     */
+    private static void createClientMarker() {
+        try {
+            final String jbossHome = System.getenv("JBOSS_HOME");
+            if (jbossHome != null) {
+                final Path cliMarkerPath = Paths.get(jbossHome).resolve("bin").resolve(Util.CLI_MARKER);
+                Files.deleteIfExists(cliMarkerPath);
+                Files.createFile(cliMarkerPath);
+
+                final File cliMarkerFile = cliMarkerPath.toFile();
+                cliMarkerFile.deleteOnExit();
+                final String data = String.valueOf(System.currentTimeMillis());
+                try (FileWriter writer = new FileWriter(cliMarkerFile, true)) {
+                    writer.write(data);
+                }
+                System.setProperty(Util.CLI_MARKER_VALUE, data);
+            }
+        } catch (SecurityException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.debug("Creation of cli marker failed and will be ignored.", e);
+        }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -108,6 +108,8 @@ public class Util {
     public static final String CHILDREN = "children";
     public static final String CHILD_TYPE = "child-type";
     public static final String CLEAR_TEXT = "clear-text";
+    public static final String CLI_MARKER = "cli-marker";
+    public static final String CLI_MARKER_VALUE = "cli-marker-value";
     public static final String COMBINED_DESCRIPTIONS = "combined-descriptions";
     public static final String COMPOSITE = "composite";
     public static final String CONCURRENT_GROUPS = "concurrent-groups";


### PR DESCRIPTION
…connected from DC

Jira issue: https://issues.redhat.com/browse/WFCORE-6384

Instead of comparing Paths to understand whether we are using a local CLI client instance when performing an installation, now we use a CLI client marker file. The content of this client marker file is returned by the `shutdown --perform-installation` management operation. If the content doesn't match, we are not using a local CLI instance. Otherwise, we use the most restrictive approach assuming assuming the CLI is local.