### PR TITLE
[WFCORE-6388] Upgrade Undertow to 2.3.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.86.Final</version.io.netty>
         <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.6.Final</version.io.undertow>
+        <version.io.undertow>2.3.7.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6388


        Release Notes - Undertow - Version 2.3.7.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1996'>UNDERTOW-1996</a>] -         RequestLimit active-request leak caused by reading data through InputStream in user-defined thread pool when using async servlet
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2216'>UNDERTOW-2216</a>] -         directory listing paths should be relative
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2241'>UNDERTOW-2241</a>] -         Undertow write-timeout can cause missing the last zero-length chunk in long polling
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2243'>UNDERTOW-2243</a>] -         Eager flush/close on content length response prevents POST from finishing
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2255'>UNDERTOW-2255</a>] -         503 response in ProxyHandler when backend supports HTTP/2
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2270'>UNDERTOW-2270</a>] -          io.undertow.servlet.spec.HttpServletRequestImpl NPE thrown
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2276'>UNDERTOW-2276</a>] -         HeaderMap.contains NPE on empty HeaderValues
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2277'>UNDERTOW-2277</a>] -         ServletOutputStream/ServletPrinter allows mismatch between content-length header and length of message
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1896'>UNDERTOW-1896</a>] -         NetworkUtils - improve  IPv6 address parsing
</li>
</ul>
                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2247'>UNDERTOW-2247</a>] -         Add support to recursive writes at HttpResponseConduit
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2248'>UNDERTOW-2248</a>] -         WriteTimeoutStreamSinkConduit should clear the expireTime on timeout
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2267'>UNDERTOW-2267</a>] -         Fix change in behaviour of Servlet.init() method when loadOnStartup is required
</li>
</ul>
                                                                                                                                                            