### PR TITLE
[WFCORE-6395] Workaround for WFCORE-6395

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -189,6 +189,11 @@ abstract class AbstractOperationContext implements OperationContext, AutoCloseab
      */
     private final Set<PathAddress> modifiedResourcesForModelValidation;
 
+    /**
+     * Flags this Operation Context as a context that will be used as a delegate on another Operation Context
+     */
+    private volatile boolean delegatedContext;
+
 
     enum ContextFlag {
         ROLLBACK_ON_FAIL, ALLOW_RESOURCE_SERVICE_RESTART,
@@ -460,6 +465,14 @@ abstract class AbstractOperationContext implements OperationContext, AutoCloseab
         if (modifiedResourcesForModelValidation != null) {
             modifiedResourcesForModelValidation.clear();
         }
+    }
+
+    void setDelegatedContext(boolean delegated) {
+        this.delegatedContext = delegated;
+    }
+
+    boolean isDelegatedContext() {
+        return this.delegatedContext;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -250,22 +250,24 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
 
     @Override
     public void close() {
-        this.originalModel = this.managementModel = null;
-        this.lockStep = this.containerMonitorStep = null;
-        this.contextAttachments.close();
-        synchronized (this.realRemovingControllers) {
-            this.realRemovingControllers.clear();
-            this.removalSteps.clear();
-        }
-        this.addedRequirements.clear();
-        this.removedCapabilities.clear();
-        this.affectsModel.clear();
-        this.authorizations.clear();
-        this.serviceTargets.clear();
-        this.serviceRegistries.clear();
+        if (!isDelegatedContext()) {
+            this.originalModel = this.managementModel = null;
+            this.lockStep = this.containerMonitorStep = null;
+            this.contextAttachments.close();
+            synchronized (this.realRemovingControllers) {
+                this.realRemovingControllers.clear();
+                this.removalSteps.clear();
+            }
+            this.addedRequirements.clear();
+            this.removedCapabilities.clear();
+            this.affectsModel.clear();
+            this.authorizations.clear();
+            this.serviceTargets.clear();
+            this.serviceRegistries.clear();
 
-        // DON'T close 'attachments' -- that object is owned by ModelControllerImpl
-        super.close();
+            // DON'T close 'attachments' -- that object is owned by ModelControllerImpl
+            super.close();
+        }
     }
 
     public InputStream getAttachmentStream(final int index) {

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -73,6 +73,7 @@ class ReadOnlyContext extends AbstractOperationContext {
                 booting, controller.getAuditLogger(), controller.getNotificationSupport(),
                 controller, true, null, null, securityIdentitySupplier);
         this.primaryContext = primaryContext;
+        this.primaryContext.setDelegatedContext(true);
         this.controller = controller;
         this.operationId = operationId;
         this.managementModel = managementModel;


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6395

This is just a workaround until find a better fix for this. I haven't found yet a better way to do this, as soon as we have a ReadOnlyContext and its delegated is closed in a different thread, we could face this issue.

We have hit it when the managed servers are being registered, so we could even be more fine and only avoid the main OperationContext clean up only for those cases, but I'm not sure if there could be other cases for other management operations.
