### PR TITLE
WFCORE-6397/WFCORE-6398/WFCORE-6399 CapabilityServiceTarget/CapabilityServiceBuilder enhancements

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.msc.Service;
+import org.jboss.msc.service.LifecycleListener;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -37,19 +38,15 @@ import org.jboss.msc.service.ServiceName;
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public interface CapabilityServiceBuilder<T> extends ServiceBuilder<T> {
-    /**
-     * {@inheritDoc}
-     * @return this builder
-     */
+
     @Override
     CapabilityServiceBuilder<T> setInitialMode(ServiceController.Mode mode);
 
-    /**
-     * {@inheritDoc}
-     * @return this builder
-     */
     @Override
     CapabilityServiceBuilder<T> setInstance(Service service);
+
+    @Override
+    CapabilityServiceBuilder<T> addListener(LifecycleListener listener);
 
     /**
      * Provide value under given capability.

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
@@ -52,6 +52,15 @@ public interface CapabilityServiceBuilder<T> extends ServiceBuilder<T> {
     CapabilityServiceBuilder<T> setInstance(Service service);
 
     /**
+     * Provide value under given capability.
+     *
+     * @param capability capability provided value represents
+     * @param <V> consumed value type
+     * @return consumer providing value
+     */
+    <V> Consumer<V> provides(final RuntimeCapability<?> capability);
+
+    /**
      * Provide value under given capabilities.
      *
      * @param capabilities capabilities provided value represent

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
@@ -23,12 +23,13 @@ import org.jboss.msc.service.ServiceTarget;
 
 /**
  * The target of ServiceBuilder for capability installations.
- * CapabilityServiceBuilder to be installed on a target should be retrieved by calling one of the {@code addCapability} methods.
+ * CapabilityServiceBuilder to be installed on a target should be retrieved by calling {@link CapabilityServiceTarget#addService()}.
  * Notice that installation will only take place after {@link CapabilityServiceBuilder#install()} is invoked.
  * CapabilityServiceBuilder that are not installed are ignored.
  *
  * @author Tomaz Cerar (c) 2017 Red Hat Inc.
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ * @author Paul Ferraro
  */
 public interface CapabilityServiceTarget extends ServiceTarget {
 
@@ -38,7 +39,11 @@ public interface CapabilityServiceTarget extends ServiceTarget {
      * @param capability the capability to be installed
      * @return new capability builder instance
      * @throws IllegalArgumentException if capability does not provide a service
+     * @deprecated Use {@link #addService()} instead.
      */
+    @Deprecated
     CapabilityServiceBuilder<?> addCapability(final RuntimeCapability<?> capability) throws IllegalArgumentException;
 
+    @Override
+    CapabilityServiceBuilder<?> addService();
 }

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
@@ -19,6 +19,7 @@
 package org.jboss.as.controller;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.msc.service.LifecycleListener;
 import org.jboss.msc.service.ServiceTarget;
 
 /**
@@ -46,4 +47,10 @@ public interface CapabilityServiceTarget extends ServiceTarget {
 
     @Override
     CapabilityServiceBuilder<?> addService();
+
+    @Override
+    CapabilityServiceTarget addListener(LifecycleListener listener);
+
+    @Override
+    CapabilityServiceTarget removeListener(LifecycleListener listener);
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -488,8 +488,12 @@ public interface OperationContext extends ExpressionResolver {
      *
      * @return the service target
      * @throws UnsupportedOperationException if the calling step is not a runtime operation step
+     * @deprecated Use {@link #getCapabilityServiceTarget()} instead.
      */
-    ServiceTarget getServiceTarget() throws UnsupportedOperationException;
+    @Deprecated(forRemoval = true)
+    default ServiceTarget getServiceTarget() throws UnsupportedOperationException {
+        return this.getCapabilityServiceTarget();
+    }
 
     /**
      * Get the service target.  If the step is not a runtime operation handler step, an exception will be thrown.  The

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2713,6 +2713,12 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
         }
 
         @Override
+        public <V> Consumer<V> provides(final RuntimeCapability<?> capability) {
+            checkNotNullParam("capability", capability);
+            return super.provides(capability.isDynamicallyNamed() ? capability.getCapabilityServiceName(this.targetAddress) : capability.getCapabilityServiceName());
+        }
+
+        @Override
         public <V> Consumer<V> provides(final RuntimeCapability<?>... capabilities) {
             checkNotEmptyParam("capabilities", capabilities);
             return provides(capabilities, null);

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -116,7 +116,6 @@ import org.jboss.msc.service.DelegatingServiceBuilder;
 import org.jboss.msc.service.DelegatingServiceController;
 import org.jboss.msc.service.DelegatingServiceRegistry;
 import org.jboss.msc.service.DelegatingServiceTarget;
-import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -2169,7 +2168,7 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
         }
 
         @Override
-        public <T> CapabilityServiceBuilder<T> addService(final ServiceName name, final Service<T> service) throws IllegalArgumentException {
+        public <T> CapabilityServiceBuilder<T> addService(final ServiceName name, final org.jboss.msc.service.Service<T> service) throws IllegalArgumentException {
             final ServiceBuilder<T> realBuilder = new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService(name, service), name);
             // If done() has been called we are no longer associated with a management op and should just
             // return the builder from delegate

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2144,17 +2144,17 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
         }
 
         @Override
-        public ServiceBuilder<?> addService() {
+        public CapabilityServiceBuilder<?> addService() {
             final ServiceBuilder<?> realBuilder = new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService());
             // If done() has been called we are no longer associated with a management op and should just
             // return the builder from delegate
             synchronized (this) {
                 if (builderSupplier == null) {
-                    return realBuilder;
+                    return new CapabilityServiceBuilderImpl<>(realBuilder, targetAddress);
                 }
                 ContextServiceBuilder<?> csb = builderSupplier.getContextServiceBuilder(realBuilder);
                 builders.add(csb);
-                return csb;
+                return new CapabilityServiceBuilderImpl<>(csb, targetAddress);
             }
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -758,12 +758,7 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
     }
 
     @Override
-    public ServiceTarget getServiceTarget() throws UnsupportedOperationException {
-        return getCapabilityServiceTarget();
-    }
-
-    @Override
-    public CapabilityServiceTarget getCapabilityServiceTarget() throws UnsupportedOperationException {
+    public CapabilityServiceTarget getCapabilityServiceTarget() {
         return getServiceTarget(activeStep);
     }
 
@@ -776,7 +771,7 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
      *                           the {@link org.jboss.as.controller.OperationStepHandler} that is making the call.
      * @return the service target
      */
-    CapabilityServiceTarget getServiceTarget(final Step targetActiveStep) throws UnsupportedOperationException {
+    CapabilityServiceTarget getServiceTarget(final Step targetActiveStep) {
 
         readOnly = false;
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2183,6 +2183,18 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
             }
         }
 
+        @Override
+        public ContextServiceTarget addListener(LifecycleListener listener) {
+            super.addListener(listener);
+            return this;
+        }
+
+        @Override
+        public ContextServiceTarget removeListener(LifecycleListener listener) {
+            super.removeListener(listener);
+            return this;
+        }
+
         private static final class ProvidedValuesTrackingServiceBuilder extends DelegatingServiceBuilder {
             private final Set<ServiceName> providedValues = new HashSet<>();
 
@@ -2704,6 +2716,12 @@ final class OperationContextImpl extends AbstractOperationContext implements Aut
         @Override
         public CapabilityServiceBuilder<T> setInstance(org.jboss.msc.Service service) {
             super.setInstance(service);
+            return this;
+        }
+
+        @Override
+        public CapabilityServiceBuilder<T> addListener(LifecycleListener listener) {
+            super.addListener(listener);
             return this;
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -131,7 +131,7 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-final class OperationContextImpl extends AbstractOperationContext implements AutoCloseable {
+final class OperationContextImpl extends AbstractOperationContext {
 
     private static final Object NULL = new Object();
 

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -45,7 +45,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.common.Assert;
 import org.wildfly.security.auth.server.SecurityIdentity;
 
@@ -185,11 +184,6 @@ class ReadOnlyContext extends AbstractOperationContext {
     @Override
     public void removeService(ServiceController<?> controller) throws UnsupportedOperationException {
         throw readOnlyContext();
-    }
-
-    @Override
-    public ServiceTarget getServiceTarget() throws UnsupportedOperationException {
-        return primaryContext.getServiceTarget();
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
@@ -56,7 +56,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.msc.service.ServiceTarget;
 import org.junit.Test;
 import org.wildfly.security.auth.server.SecurityIdentity;
 
@@ -314,11 +313,6 @@ public class AuthorizedAddressTest {
 
         @Override
         public void removeService(ServiceController<?> controller) throws UnsupportedOperationException {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        public ServiceTarget getServiceTarget() throws UnsupportedOperationException {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 

--- a/discovery/src/main/java/org/wildfly/extension/discovery/StaticDiscoveryProviderAddHandler.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/StaticDiscoveryProviderAddHandler.java
@@ -28,14 +28,13 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.Service;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 import org.wildfly.discovery.AttributeValue;
 import org.wildfly.discovery.ServiceURL;
 import org.wildfly.discovery.impl.StaticDiscoveryProvider;
@@ -85,9 +84,8 @@ class StaticDiscoveryProviderAddHandler extends AbstractAddStepHandler {
             serviceURLs.add(serviceURL);
         }
 
-        ServiceName name = DiscoveryExtension.DISCOVERY_PROVIDER_CAPABILITY.getCapabilityServiceName(context.getCurrentAddress());
-        ServiceBuilder<?> builder = context.getCapabilityServiceTarget().addService(name);
-        Consumer<DiscoveryProvider> provider = builder.provides(name);
+        CapabilityServiceBuilder<?> builder = context.getCapabilityServiceTarget().addService();
+        Consumer<DiscoveryProvider> provider = builder.provides(DiscoveryExtension.DISCOVERY_PROVIDER_CAPABILITY);
         builder.setInstance(Service.newInstance(provider, new StaticDiscoveryProvider(serviceURLs)))
             .setInitialMode(ServiceController.Mode.ON_DEMAND)
             .install();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6397
Overload CapabilityServiceTarget.addService() to return CapabilityServiceBuilder<?>
Analog of ServiceTarget.addService(). Eliminates need to specify the RuntimeCapability twice when building the service for a capability.

https://issues.redhat.com/browse/WFCORE-6398
Add single argument CapabilityServiceBuilder.provides(...) method - avoiding unnecessary array allocation for most use cases.

https://issues.redhat.com/browse/WFCORE-6399
OperationContext.getServiceTarget() and getCapabilityServiceTarget() return the same object. Deprecate the former in favor of the latter.

~~Requires https://github.com/wildfly/wildfly-core/pull/5546~~ UPDATE: This was merged.  Rebased on main.