### PR TITLE
[WFCORE-6384] Do not initialize the logger before the log manager is …

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandLineMain.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandLineMain.java
@@ -44,7 +44,6 @@ import org.jboss.logmanager.PropertyConfigurator;
 * @author Alexey Loubyansky
 */
 public class CommandLineMain {
-    private static final Logger LOG = Logger.getLogger(CommandLineMain.class);
 
     public static void main(String[] args) throws Exception {
         configureLogManager(args);
@@ -182,7 +181,7 @@ public class CommandLineMain {
         } catch (SecurityException e) {
             throw e;
         } catch (Exception e) {
-            LOG.debug("Creation of cli marker failed and will be ignored.", e);
+            Logger.getLogger(CommandLineMain.class).debug("Creation of cli marker failed and will be ignored.", e);
         }
     }
 }


### PR DESCRIPTION
…configured.

https://issues.redhat.com/browse/WFCORE-6384

Follows up on #5537 
