### PR TITLE
[WFCORE-6403] Upgrade WildFly Elytron to 2.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.2.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.2.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>3.0.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6403


        Release Notes - WildFly Elytron - Version 2.2.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2564'>ELY-2564</a>] -         Add the ability to disable OIDC access token &quot;typ&quot; claim validation via a system property
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2565'>ELY-2565</a>] -         Update actions/checkout in Elytron website workflow to v3
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2391'>ELY-2391</a>] -         Add a test case to BasicAuthenticationMechanismTest that attempts to use the wrong password for the user
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2558'>ELY-2558</a>] -         Update assertions in OpenSSHKeyParserTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2559'>ELY-2559</a>] -         Update CredentialStoreSaslAuthenticationTest 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2567'>ELY-2567</a>] -          Automatically retrieve roles from an OIDC access token&#39;s &quot;roles&quot; claim if present
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2569'>ELY-2569</a>] -         Release WildFly Elytron 2.2.1.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2555'>ELY-2555</a>] -         Upgrade net.minidev:json-smart to 2.4.9
</li>
</ul>
