### PR TITLE
[WFCORE-6313] fixed the package name of NativeManagementRemoveHandler…

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
@@ -33,7 +33,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.host.controller.HostModelUtil;
 import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
 import org.jboss.as.host.controller.operations.NativeManagementAddHandler;
-import org.jboss.as.server.operations.NativeManagementRemoveHandler; // TODO Wrong package. See WFCORE-6313
+import org.jboss.as.host.controller.operations.NativeManagementRemoveHandler;
 import org.jboss.dmr.ModelType;
 
 /**


### PR DESCRIPTION
… used in NativeManagementResourceDefinition

Except of RBAC checking, the code is the same as the prevous one. According to local tests, both WildFly Core and WildFly test-suites pass successfully.

Issue: https://issues.redhat.com/browse/WFCORE-6313


