### PR TITLE
[WFCORE-6405] Make the org.wildfly.extension.elytron module private

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -23,6 +23,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.elytron">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <exports>
         <exclude path="org/wildfly/extension/elytron/ElytronExtension"/>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -92,6 +92,7 @@ import org.wildfly.extension.elytron.capabilities.CredentialSecurityFactory;
 import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
 import org.wildfly.extension.elytron.capabilities._private.SecurityEventListener;
 import org.wildfly.extension.elytron.expression.DeploymentExpressionResolverProcessor;
+import org.wildfly.security.SecurityFactory;
 import org.wildfly.security.Version;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.jaspi.ElytronAuthConfigFactory;
@@ -223,7 +224,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new JaasRealmDefinition());
 
         // Security Factories
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(CredentialSecurityFactory.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_CREDENTIAL_SECURITY_FACTORY, SECURITY_FACTORY_CREDENTIAL_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(SecurityFactory.class, CredentialSecurityFactory::from, ElytronDescriptionConstants.CUSTOM_CREDENTIAL_SECURITY_FACTORY, SECURITY_FACTORY_CREDENTIAL_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(KerberosSecurityFactoryDefinition.getKerberosSecurityFactoryDefinition());
 
         // Permission Mappers
@@ -246,7 +247,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getAggregatePrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getChainedPrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getConstantPrincipalTransformerDefinition());
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(PrincipalTransformer.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_PRINCIPAL_TRANSFORMER, PRINCIPAL_TRANSFORMER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(Function.class, PrincipalTransformer::from, ElytronDescriptionConstants.CUSTOM_PRINCIPAL_TRANSFORMER, PRINCIPAL_TRANSFORMER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getRegexPrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getRegexValidatingPrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getCasePrincipalTransformerDefinition());


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6405

The `org.wildfly.extension.elytron` module was originally public as there were some classes in the Elytron subsystem that custom components needed access to in order to implement them.

There are currently still two Elytron custom components that rely on needing to implement interfaces from the Elytron subsystem:

* `custom-principal-transformer` relies on a `org.wildfly.extension.elytron.capabilities.PrincipalTransformer` implementation
* `custom-credential-security-factory` relies on a `org.wildfly.extension.elytron.capabilities.CredentialSecurityFactory` implementation

This PR updates `custom-principal-transformer` and `custom-credential-security-factory` so they can be used without needing to implement classes from the Elytron subsystem. 

Note that this follows the same approach that was used to update `custom-security-event-listener` so that it no longer relied on implementing a class from the Elytron subsystem (see https://github.com/wildfly/wildfly-core/pull/3285).

With this change, we can mark the `org.wildfly.extension.module` as private.
