### PR TITLE
WFCORE-6407 Deprecate non-default contructors from AbstractAddStepHandler and AbstractWriteAttributeHandler

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -6,6 +6,8 @@
 package org.jboss.as.controller;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
@@ -16,6 +18,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD_INDEX;
@@ -24,23 +27,32 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
  * Base class for {@link OperationStepHandler} implementations that add managed resource.
  *
  * @author John Bailey
+ * @author Paul Ferraro
  */
 public class AbstractAddStepHandler implements OperationStepHandler, OperationDescriptor {
 
+    private static final String AUTO_POPULATE_MODEL = "auto-populate-model";
+
+    /**
+     * This is only retained to support {@link #getAttributes()} and for those subclasses that reference this protected attribute directly.
+     */
+    @Deprecated(forRemoval = true) // This is referenceable by subclasses
     protected final Collection<? extends AttributeDefinition> attributes;
 
     /**
      * Constructs an add handler.
      */
-    public AbstractAddStepHandler() { //default constructor to preserve backward compatibility
+    public AbstractAddStepHandler() {
         this.attributes = List.of();
     }
 
     /**
      * Constructs an add handler
      * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use default constructor instead. Resource model auto-population logic relies on the {@link OperationDefinition#getParameters()} method of the operation definition with which this handler was registered.
      */
     @SuppressWarnings("unchecked")
+    @Deprecated(forRemoval = true)
     public AbstractAddStepHandler(Collection<? extends AttributeDefinition> attributes) {
         // Create defensive copy, if collection was not already immutable
         this.attributes = (attributes instanceof Set) ? Set.copyOf((Set<AttributeDefinition>) attributes) : List.copyOf(attributes);
@@ -50,16 +62,30 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      * Constructs an add handler
      *
      * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use default constructor instead. Resource model auto-population logic relies on the {@link OperationDefinition#getParameters()} method of the operation definition with which this handler was registered.
      */
+    @Deprecated(forRemoval = true)
     public AbstractAddStepHandler(AttributeDefinition... attributes) {
         this(List.of(attributes));
     }
 
+    /**
+     * Constructs an add handler
+     *
+     * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use default constructor instead. Resource model auto-population logic relies on the {@link OperationDefinition#getParameters()} method of the operation definition with which this handler was registered.
+     */
+    @Deprecated(forRemoval = true)
     public AbstractAddStepHandler(Parameters parameters) {
         this.attributes = parameters.attributes;
     }
 
+    /**
+     * Returns the attributes with which this handler was constructed.
+     * @deprecated Use the {@link OperationDefinition#getParameters()} method of the operation definition with which this handler was registered instead.
+     */
     @Override
+    @Deprecated(forRemoval = true)
     public Collection<? extends AttributeDefinition> getAttributes() {
         return this.attributes;
     }
@@ -138,6 +164,26 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      */
     protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws  OperationFailedException {
         populateModel(operation, resource);
+
+        // Detect operation header written by populateModel(ModelNode, ModelNode)
+        // If header exists, then subclass expects us to populate the model
+        if (operation.hasDefined(ModelDescriptionConstants.OPERATION_HEADERS, AUTO_POPULATE_MODEL)) {
+            ModelNode model = resource.getModel();
+            ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
+            Map<String, AttributeAccess> attributes = registration.getAttributes(PathAddress.EMPTY_ADDRESS);
+            for (AttributeDefinition parameter : registration.getOperationEntry(PathAddress.EMPTY_ADDRESS, ModelDescriptionConstants.ADD).getOperationDefinition().getParameters()) {
+                AttributeAccess attribute = attributes.get(parameter.getName());
+                if ((attribute != null) && !AttributeAccess.Flag.ALIAS.test(attribute)) {
+                    // Auto-populate add resource operation parameters that correspond to resource attributes, omitting aliases
+                    parameter.validateAndSet(operation, model);
+                } else {
+                    // Otherwise, just validate parameter
+                    parameter.validateOperation(operation);
+                }
+            }
+            // Remove header added via populateModel(ModelNode, ModelNode)
+            operation.get(ModelDescriptionConstants.OPERATION_HEADERS).remove(AUTO_POPULATE_MODEL);
+        }
     }
 
     /**
@@ -150,7 +196,9 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      * @param resource the resource that corresponds to the address of {@code operation}
      *
      * @throws OperationFailedException if {@code operation} is invalid or populating the model otherwise fails
+     * @deprecated Override {@link #populateModel(OperationContext, ModelNode, Resource)} if necessary
      */
+    @Deprecated(forRemoval = true)
     protected void populateModel(final ModelNode operation, final Resource resource) throws  OperationFailedException {
         populateModel(operation, resource.getModel());
     }
@@ -166,11 +214,14 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      * @param model persistent configuration model node that corresponds to the address of {@code operation}
      *
      * @throws OperationFailedException if {@code operation} is invalid or populating the model otherwise fails
+     * @deprecated Override {@link #populateModel(OperationContext, ModelNode, Resource)} if necessary
      */
+    @Deprecated(forRemoval = true)
     protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        for (AttributeDefinition attr : attributes) {
-            attr.validateAndSet(operation, model);
-        }
+        // Previously model auto-population happened here based on attributes provided via constructor
+        // If this method was invoked, we know that the subclass expects us to populate the model
+        // If so, indicate this via an operation header to be detected by our parent method
+        operation.get(ModelDescriptionConstants.OPERATION_HEADERS, AUTO_POPULATE_MODEL).set(true);
     }
 
     /**
@@ -194,7 +245,8 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
      */
     protected void recordCapabilitiesAndRequirements(final OperationContext context, final ModelNode operation, Resource resource) throws OperationFailedException {
 
-        for (RuntimeCapability<?> capability : context.getResourceRegistration().getCapabilities()) {
+        ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
+        for (RuntimeCapability<?> capability : registration.getCapabilities()) {
             if (capability.isDynamicallyNamed()) {
                 context.registerCapability(capability.fromBaseCapability(context.getCurrentAddress()));
             } else {
@@ -203,14 +255,18 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
         }
 
         ModelNode model = resource.getModel();
-        for (AttributeDefinition ad : attributes) {
-            if (model.hasDefined(ad.getName()) || ad.hasCapabilityRequirements()) {
-                ad.addCapabilityRequirements(context, resource, model.get(ad.getName()));
+        for (AttributeAccess attribute : registration.getAttributes(PathAddress.EMPTY_ADDRESS).values()) {
+            // Skip runtime attributes and aliases
+            if (AttributeAccess.Storage.RUNTIME.test(attribute) || AttributeAccess.Flag.ALIAS.test(attribute)) continue;
+
+            AttributeDefinition definition = attribute.getAttributeDefinition();
+            String attributeName = definition.getName();
+            if (model.hasDefined(attributeName) || definition.hasCapabilityRequirements()) {
+                definition.addCapabilityRequirements(context, resource, model.get(attributeName));
             }
         }
-        ImmutableManagementResourceRegistration mrr = context.getResourceRegistration();
-        assert mrr.getRequirements() != null;
-        for (CapabilityReferenceRecorder recorder : mrr.getRequirements()) {
+        assert registration.getRequirements() != null;
+        for (CapabilityReferenceRecorder recorder : registration.getRequirements()) {
             recorder.addCapabilityRequirements(context, resource, null);
         }
     }
@@ -343,6 +399,10 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
         }
     }
 
+    /**
+     * @deprecated Use default constructor instead.  Operation parameters are determined via the {@link OperationDefinition#getParameters()} of the {@code ModelDescriptionConstants#ADD} operation associated resource.
+     */
+    @Deprecated(forRemoval = true)
     public static class Parameters {
         // Set is not the ideal data structure, but since this is a protected field, we are stuck with it
         protected Set<AttributeDefinition> attributes = Set.of();

--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -29,7 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
  * @author John Bailey
  * @author Paul Ferraro
  */
-public class AbstractAddStepHandler implements OperationStepHandler, OperationDescriptor {
+public abstract class AbstractAddStepHandler implements OperationStepHandler, OperationDescriptor {
 
     private static final String AUTO_POPULATE_MODEL = "auto-populate-model";
 

--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -12,10 +12,8 @@ import org.jboss.dmr.ModelNode;
 
 import java.util.AbstractSet;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -324,24 +322,6 @@ public class AbstractAddStepHandler implements OperationStepHandler, OperationDe
         public OrderedResourceCreator(boolean indexedAdd, Set<String> orderedChildTypes) {
             this.indexedAdd = indexedAdd;
             this.orderedChildTypes = orderedChildTypes == null ? Collections.emptySet() : orderedChildTypes;
-        }
-
-        /**
-         * Constructor
-         *
-         * @param indexedAdd if ({@code true} this is the child of a parent with ordered children,
-         * and this child will be added at the {@code add-index} of the {@code add} operation in the
-         * parent's list of children of this type. If {@code false} this is a normal child, i.e. the
-         * insert will always happen at the end of the list as normal.
-         * @param orderedChildTypes if not {@code null} or empty, this indicates that this is a parent
-         * resource with ordered children, and the entries here are the type names of children which
-         * are ordered.
-         */
-        public OrderedResourceCreator(boolean indexedAdd, String... orderedChildTypes) {
-            this.indexedAdd = indexedAdd;
-            Set<String> set = new HashSet<>(orderedChildTypes.length);
-            set.addAll(Arrays.asList(orderedChildTypes));
-            this.orderedChildTypes = set;
         }
 
         @Override

--- a/controller/src/main/java/org/jboss/as/controller/AbstractBoottimeAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractBoottimeAddStepHandler.java
@@ -29,26 +29,20 @@ import org.jboss.dmr.ModelNode;
  */
 public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHandler {
 
-    /**
-     * {@inheritDoc}
-     */
     protected AbstractBoottimeAddStepHandler() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Deprecated(forRemoval = true)
     protected AbstractBoottimeAddStepHandler(Collection<? extends AttributeDefinition> attributes) {
         super(attributes);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Deprecated(forRemoval = true)
     protected AbstractBoottimeAddStepHandler(AttributeDefinition... attributes) {
         super(attributes);
     }
 
+    @Deprecated(forRemoval = true)
     public AbstractBoottimeAddStepHandler(Parameters parameters) {
         super(parameters);
     }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
@@ -35,7 +35,7 @@ import org.jboss.dmr.ModelNode;
  */
 public abstract class AbstractWriteAttributeHandler<T> implements OperationStepHandler {
 
-    private final ParametersValidator nameValidator = new ParametersValidator();
+    private static final ParametersValidator NAME_VALIDATOR = new ParametersValidator();
 
     private final Map<String, AttributeDefinition> attributeDefinitions;
 
@@ -60,7 +60,7 @@ public abstract class AbstractWriteAttributeHandler<T> implements OperationStepH
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
-        nameValidator.validate(operation);
+        NAME_VALIDATOR.validate(operation);
         final String attributeName = operation.require(NAME).asString();
         // Don't require VALUE. Let the validator decide if it's bothered by an undefined value
         ModelNode newValue = operation.hasDefined(VALUE) ? operation.get(VALUE) : new ModelNode();

--- a/controller/src/main/java/org/jboss/as/controller/ModelOnlyAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelOnlyAddStepHandler.java
@@ -41,23 +41,13 @@ public class ModelOnlyAddStepHandler extends AbstractAddStepHandler {
         return false;
     }
 
-    /**
-     * Throws {@link UnsupportedOperationException}.
-     *
-     * {@inheritDoc}
-     */
     @Override
     protected final void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-        throw new UnsupportedOperationException();
+        throw new IllegalStateException();
     }
 
-    /**
-     * Throws {@link UnsupportedOperationException}.
-     *
-     * {@inheritDoc}
-     */
     @Override
     protected final void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
-        throw new UnsupportedOperationException();
+        throw new IllegalStateException();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/ModelOnlyAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelOnlyAddStepHandler.java
@@ -18,15 +18,23 @@ import org.jboss.dmr.ModelNode;
  */
 public class ModelOnlyAddStepHandler extends AbstractAddStepHandler {
 
+    public static final OperationStepHandler INSTANCE = new ModelOnlyAddStepHandler();
+
+    protected ModelOnlyAddStepHandler() {
+    }
+
     /**
-     * Creates a new {@code ModelOnlyStepHandler} that stores the given attributes to the model.
-     *
-     * @param attributes the attributes
+     * @deprecated Use {@link #INSTANCE} instead.
      */
+    @Deprecated(forRemoval = true)
     public ModelOnlyAddStepHandler(AttributeDefinition... attributes) {
         super(attributes);
     }
 
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ModelOnlyAddStepHandler(Parameters parameters) {
         super(parameters);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ModelOnlyRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelOnlyRemoveStepHandler.java
@@ -19,24 +19,14 @@ public class ModelOnlyRemoveStepHandler extends AbstractRemoveStepHandler {
 
     public static final ModelOnlyRemoveStepHandler INSTANCE = new ModelOnlyRemoveStepHandler();
 
-    /**
-     * Throws {@link UnsupportedOperationException}.
-     *
-     * {@inheritDoc}
-     */
     @Override
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        throw new UnsupportedOperationException();
+        throw new IllegalStateException();
     }
 
-    /**
-     * Throws {@link UnsupportedOperationException}.
-     *
-     * {@inheritDoc}
-     */
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        throw new UnsupportedOperationException();
+        throw new IllegalStateException();
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/ModelOnlyWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelOnlyWriteAttributeHandler.java
@@ -16,10 +16,23 @@ import org.jboss.dmr.ModelNode;
  */
 public class ModelOnlyWriteAttributeHandler extends AbstractWriteAttributeHandler<Void> {
 
+    public static final OperationStepHandler INSTANCE = new ModelOnlyWriteAttributeHandler();
+
+    protected ModelOnlyWriteAttributeHandler() {
+    }
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ModelOnlyWriteAttributeHandler(AttributeDefinition... attributeDefinitions) {
         super(attributeDefinitions);
     }
 
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ModelOnlyWriteAttributeHandler(Collection<AttributeDefinition> attributeDefinitions) {
         super(attributeDefinitions);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ModelOnlyWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelOnlyWriteAttributeHandler.java
@@ -32,12 +32,12 @@ public class ModelOnlyWriteAttributeHandler extends AbstractWriteAttributeHandle
     @Override
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> handbackHolder) throws OperationFailedException {
         // should not be called as requiresRuntime returns false
-        throw new UnsupportedOperationException();
+        throw new IllegalStateException();
     }
 
     @Override
     protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Void handback) throws OperationFailedException {
         // should not be called as requiresRuntime returns false
-        throw new UnsupportedOperationException();
+        throw new IllegalStateException();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationDescriptor.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationDescriptor.java
@@ -10,7 +10,9 @@ import java.util.Collection;
 /**
  * Describes the parameters of operation..
  * @author Paul Ferraro
+ * @deprecated To be removed without replacement.
  */
+@Deprecated(forRemoval = true)
 public interface OperationDescriptor {
     Collection<? extends AttributeDefinition> getAttributes();
 }

--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredAddStepHandler.java
@@ -28,14 +28,31 @@ import org.jboss.dmr.ModelNode;
  */
 public class ReloadRequiredAddStepHandler extends AbstractAddStepHandler {
 
+    public static final OperationStepHandler INSTANCE = new ReloadRequiredAddStepHandler();
+
+    protected ReloadRequiredAddStepHandler() {
+    }
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ReloadRequiredAddStepHandler(AttributeDefinition... attributes) {
         super(attributes);
     }
 
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ReloadRequiredAddStepHandler(Collection<AttributeDefinition> attributes) {
         super(attributes);
     }
 
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ReloadRequiredAddStepHandler(Parameters parameters) {
         super(parameters);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredWriteAttributeHandler.java
@@ -18,10 +18,23 @@ import org.jboss.dmr.ModelType;
  */
 public class ReloadRequiredWriteAttributeHandler extends AbstractWriteAttributeHandler<Void> {
 
+    public static final OperationStepHandler INSTANCE = new ReloadRequiredWriteAttributeHandler();
+
+    protected ReloadRequiredWriteAttributeHandler() {
+    }
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ReloadRequiredWriteAttributeHandler(final AttributeDefinition... definitions) {
         super(definitions);
     }
 
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated(forRemoval = true)
     public ReloadRequiredWriteAttributeHandler(final Collection<AttributeDefinition> definitions) {
         super(definitions);
     }
@@ -34,12 +47,12 @@ public class ReloadRequiredWriteAttributeHandler extends AbstractWriteAttributeH
 //      In fact we just can't resolve the currentValue without any doubt. When in doubt reload, so we will return true in this case.
 //      For example if the currentValue is ${foo} and that for some reason foo has changed in between, then we should reload even if now ${foo} resolves
 //      as resolvedValue.
-        ModelNode resolvedTypedValue = convertToType(attributeName, resolvedValue);
+        ModelNode resolvedTypedValue = convertToType(context, attributeName, resolvedValue);
         return !resolvedTypedValue.equals(currentValue);
     }
 
-    private ModelNode convertToType(String attributeName, ModelNode resolvedValue) {
-        AttributeDefinition attributeDefinition = getAttributeDefinition(attributeName);
+    private static ModelNode convertToType(OperationContext context, String attributeName, ModelNode resolvedValue) {
+        AttributeDefinition attributeDefinition = context.getResourceRegistration().getAttributeAccess(PathAddress.EMPTY_ADDRESS, attributeName).getAttributeDefinition();
         ModelType type = attributeDefinition.getType();
         ModelNode converted = resolvedValue.clone();
         try {

--- a/controller/src/main/java/org/jboss/as/controller/RestartParentWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/RestartParentWriteAttributeHandler.java
@@ -6,6 +6,7 @@
 package org.jboss.as.controller;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.operations.common.Util;
@@ -23,11 +24,22 @@ import org.jboss.msc.service.ServiceName;
 public abstract class RestartParentWriteAttributeHandler extends AbstractWriteAttributeHandler<ModelNode> {
     private final String parentKeyName;
 
-    public RestartParentWriteAttributeHandler(String parentKeyName, AttributeDefinition... definitions) {
-        super(definitions);
+    public RestartParentWriteAttributeHandler(String parentKeyName) {
         this.parentKeyName = parentKeyName;
     }
 
+    /**
+     * @deprecated Use {@link #RestartParentWriteAttributeHandler(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public RestartParentWriteAttributeHandler(String parentKeyName, AttributeDefinition... definitions) {
+        this(parentKeyName, List.of(definitions));
+    }
+
+    /**
+     * @deprecated Use {@link #RestartParentWriteAttributeHandler(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public RestartParentWriteAttributeHandler(final String parentKeyName, final Collection<AttributeDefinition> definitions) {
         super(definitions);
         this.parentKeyName = parentKeyName;

--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -224,11 +225,15 @@ public class SimpleResourceDefinition implements ResourceDefinition {
      * @return an array of attribute definitions
      */
     protected AttributeDefinition[] getAddOperationParameters(ManagementResourceRegistration registration) {
-        return registration.getAttributes(PathAddress.EMPTY_ADDRESS).values().stream()
+        Stream<AttributeDefinition> attributes = registration.getAttributes(PathAddress.EMPTY_ADDRESS).values().stream()
                 .filter(AttributeAccess.Storage.CONFIGURATION) // Ignore runtime attributes
                 .map(AttributeAccess::getAttributeDefinition)
                 .filter(Predicate.not(AttributeDefinition::isResourceOnly)) // Ignore resource-only attributes
-                .toArray(AttributeDefinition[]::new);
+                ;
+        if (registration.isOrderedChildResource()) {
+            attributes = Stream.concat(Stream.of(DefaultResourceAddDescriptionProvider.INDEX), attributes);
+        }
+        return attributes.toArray(AttributeDefinition[]::new);
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceAddDescriptionProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceAddDescriptionProvider.java
@@ -32,8 +32,7 @@ import org.jboss.dmr.ModelType;
  */
 public class DefaultResourceAddDescriptionProvider implements DescriptionProvider {
 
-
-    private static AttributeDefinition INDEX = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ADD_INDEX, ModelType.INT, true).build();
+    public static final AttributeDefinition INDEX = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ADD_INDEX, ModelType.INT, true).build();
 
     private final ImmutableManagementResourceRegistration registration;
     final ResourceDescriptionResolver descriptionResolver;

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
@@ -20,7 +21,7 @@ import org.wildfly.common.Assert;
  *
  * @author Brian Stansberry
  */
-public final class AttributeAccess {
+public class AttributeAccess {
 
     /**
      * Indicates how an attributed is accessed.
@@ -73,7 +74,7 @@ public final class AttributeAccess {
     /**
      * Indicates whether an attribute is derived from the persistent configuration or is a purely runtime attribute.
      */
-    public enum Storage {
+    public enum Storage implements Predicate<AttributeAccess> {
         /**
          * An attribute whose value is stored in the persistent configuration.
          * The value may also be stored in runtime services.
@@ -96,10 +97,14 @@ public final class AttributeAccess {
             return label;
         }
 
+        @Override
+        public boolean test(AttributeAccess attribute) {
+            return attribute.getStorageType() == this;
+        }
     }
 
     /** Flags to indicate special characteristics of an attribute */
-    public enum Flag {
+    public enum Flag implements Predicate<AttributeAccess> {
         /** A modification to the attribute can be applied to the runtime without requiring a restart */
         RESTART_NONE,
         /** A modification to the attribute can only be applied to the runtime via a full jvm restart */
@@ -171,6 +176,11 @@ public final class AttributeAccess {
             }
 
             return result;
+        }
+
+        @Override
+        public boolean test(AttributeAccess attribute) {
+            return attribute.getFlags().contains(this);
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
@@ -22,7 +22,7 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
  *
  * @author Emanuel Muckenhuber
  */
-public final class OperationEntry {
+public class OperationEntry {
     public enum EntryType {
         PUBLIC, PRIVATE
     }

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -155,7 +155,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler())
                 .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
-                .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
+                .addReadWriteAttribute(ad, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
                 .addCapability(TEST_CAPABILITY3)
                 .build();
 
@@ -184,22 +184,22 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     private static final ResourceDefinition TEST_RESOURCE4 = ResourceBuilder.Factory.create(TEST_ADDRESS4.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(ad, other) {
-        @Override
-        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-            if(operation.hasDefined("fail")) {
-                throw new OperationFailedException("Let's rollback");
-            }
-        }
+            .setAddOperation(new AbstractAddStepHandler() {
+                @Override
+                protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+                    if (operation.hasDefined("fail")) {
+                        throw new OperationFailedException("Let's rollback");
+                    }
+                }
 
-        @Override
-        protected boolean requiresRuntime(OperationContext context) {
-            return true;
-        }
+                @Override
+                protected boolean requiresRuntime(OperationContext context) {
+                    return true;
+                }
             })
             .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
-            .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
-            .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
+            .addReadWriteAttribute(ad, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
+            .addReadWriteAttribute(other, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
             .addCapability(IO_POOL_RUNTIME_CAPABILITY)
             .addCapability(IO_WORKER_RUNTIME_CAPABILITY)
             .build();

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -136,10 +136,10 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     private static final ResourceDefinition TEST_RESOURCE1 = ResourceBuilder.Factory.create(TEST_ADDRESS1.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(ad, other))
-            .setRemoveOperation(new AbstractRemoveStepHandler() {})
-            .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
-            .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
+            .setAddOperation(new ModelOnlyAddStepHandler())
+            .setRemoveOperation(new ModelOnlyRemoveStepHandler())
+            .addReadWriteAttribute(ad, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
+            .addReadWriteAttribute(other, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
             .addOperation(SimpleOperationDefinitionBuilder.of("add-cap",
                             NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     (context, operation) -> {
@@ -153,7 +153,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     private static final ResourceDefinition SUB_RESOURCE = ResourceBuilder.Factory.create(TEST_ADDRESS3.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddOperation(new AbstractAddStepHandler())
+                .setAddOperation(new ModelOnlyAddStepHandler())
                 .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .addReadWriteAttribute(ad, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
                 .addCapability(TEST_CAPABILITY3)
@@ -162,10 +162,10 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     private static final ResourceDefinition TEST_RESOURCE2 = ResourceBuilder.Factory.create(TEST_ADDRESS2.getElement(0),
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setAddOperation(new AbstractAddStepHandler(ad, other))
+            .setAddOperation(new ModelOnlyAddStepHandler())
             .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
-            .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
-            .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
+            .addReadWriteAttribute(ad, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
+            .addReadWriteAttribute(other, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
             .addCapability(TEST_CAPABILITY2)
             .addOperation(SimpleOperationDefinitionBuilder.of("add-sub-resource",
                             NonResolvingResourceDescriptionResolver.INSTANCE).build(),

--- a/controller/src/test/java/org/jboss/as/controller/EnvVarAttributeOverrideModel.java
+++ b/controller/src/test/java/org/jboss/as/controller/EnvVarAttributeOverrideModel.java
@@ -18,8 +18,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.util.Arrays;
-
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
@@ -61,10 +59,10 @@ public abstract class EnvVarAttributeOverrideModel extends AbstractControllerTes
     private static ResourceDefinition createDummyProfileResourceDefinition() {
         return ResourceBuilder.Factory.create(CUSTOM_RESOURCE_ADDR.getElement(0),
                 NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddOperation(new AbstractAddStepHandler(Arrays.asList(MY_ATTR, MY_LIST_ATTR)))
+                .setAddOperation(new ModelOnlyAddStepHandler())
                 .setRemoveOperation(ReloadRequiredRemoveStepHandler.INSTANCE)
-                .addReadWriteAttribute(MY_ATTR, null, new ReloadRequiredWriteAttributeHandler(MY_ATTR))
-                .addReadWriteAttribute(MY_LIST_ATTR, null, new ReloadRequiredWriteAttributeHandler(MY_LIST_ATTR))
+                .addReadWriteAttribute(MY_ATTR, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
+                .addReadWriteAttribute(MY_LIST_ATTR, null, ReloadRequiredWriteAttributeHandler.INSTANCE)
                 .build();
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/RemoveNonExistingResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/RemoveNonExistingResourceTestCase.java
@@ -157,7 +157,7 @@ public class RemoveNonExistingResourceTestCase {
             SimpleResourceDefinition subsystemResource = new SimpleResourceDefinition(
                     PathElement.pathElement(SUBSYSTEM, module),
                     NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(),
+                    ModelOnlyAddStepHandler.INSTANCE,
                     ReloadRequiredRemoveStepHandler.INSTANCE
             ){
 
@@ -176,7 +176,7 @@ public class RemoveNonExistingResourceTestCase {
         public FakeSubmodelChild() {
             super(PathElement.pathElement(SUBMODEL_NAME),
                     NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(),
+                    ModelOnlyAddStepHandler.INSTANCE,
                     new RestartParentResourceRemoveHandler("attr") {
 
                         @Override

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
@@ -11,10 +11,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -371,8 +372,8 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
     private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
             super(new Parameters(PathElement.pathElement("root"), NonResolvingResourceDescriptionResolver.INSTANCE)
-                    .setAddHandler(new AbstractAddStepHandler())
-                    .setRemoveHandler(new AbstractRemoveStepHandler() {}));
+                    .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE));
         }
 
         @Override
@@ -420,7 +421,7 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
         @Override
         public void registerOperations(ManagementResourceRegistration registration) {
             super.registerOperations(registration);
-            super.registerAddOperation(registration, new AbstractAddStepHandler(attributes), OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
+            super.registerAddOperation(registration, ModelOnlyAddStepHandler.INSTANCE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
@@ -17,9 +17,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.PathAddress;
@@ -141,8 +141,8 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
         public ParentResourceDefinition() {
             super(PARENT_MAIN,
                     NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
-                    new ModelOnlyRemoveStepHandler());
+                    ModelOnlyAddStepHandler.INSTANCE,
+                    ModelOnlyRemoveStepHandler.INSTANCE);
         }
 
         @Override
@@ -160,8 +160,8 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
 
         public OrderedChildResourceDefinition() {
             super(new Parameters(CHILD, NonResolvingResourceDescriptionResolver.INSTANCE)
-                    .setAddHandler(new AbstractAddStepHandler(REQUEST_ATTRIBUTES))
-                    .setRemoveHandler(new ModelOnlyRemoveStepHandler())
+                    .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                     .setOrderedChild());
         }
 

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/CoreManagementRootResourceDefinition.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/CoreManagementRootResourceDefinition.java
@@ -11,8 +11,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 
@@ -26,7 +26,7 @@ class CoreManagementRootResourceDefinition extends PersistentResourceDefinition 
     CoreManagementRootResourceDefinition() {
         super(CoreManagementExtension.SUBSYSTEM_PATH,
                 CoreManagementExtension.getResourceDescriptionResolver(),
-                new AbstractAddStepHandler(),
+                ModelOnlyAddStepHandler.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
     }
 

--- a/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderAddHandler.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderAddHandler.java
@@ -26,10 +26,6 @@ import org.wildfly.discovery.spi.DiscoveryProvider;
  */
 class AggregateDiscoveryProviderAddHandler extends AbstractAddStepHandler {
 
-    AggregateDiscoveryProviderAddHandler() {
-        super(new Parameters().addAttribute(AggregateDiscoveryProviderDefinition.PROVIDER_NAMES));
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         CapabilityServiceBuilder<?> builder = context.getCapabilityServiceTarget().addService();

--- a/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderDefinition.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderDefinition.java
@@ -41,6 +41,6 @@ final class AggregateDiscoveryProviderDefinition extends SimpleResourceDefinitio
 
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(PROVIDER_NAMES, null, new ReloadRequiredWriteAttributeHandler(PROVIDER_NAMES));
+        resourceRegistration.registerReadWriteAttribute(PROVIDER_NAMES, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
     }
 }

--- a/discovery/src/main/java/org/wildfly/extension/discovery/DiscoverySubsystemDefinition.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/DiscoverySubsystemDefinition.java
@@ -33,7 +33,7 @@ final class DiscoverySubsystemDefinition extends SimpleResourceDefinition {
 
     DiscoverySubsystemDefinition() {
         super(new Parameters(PATH, DiscoveryExtension.SUBSYSTEM_RESOLVER)
-            .setAddHandler(new ModelOnlyAddStepHandler())
+            .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
             .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
         );
     }

--- a/discovery/src/main/java/org/wildfly/extension/discovery/StaticDiscoveryProviderAddHandler.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/StaticDiscoveryProviderAddHandler.java
@@ -29,10 +29,6 @@ import org.wildfly.discovery.spi.DiscoveryProvider;
  */
 class StaticDiscoveryProviderAddHandler extends AbstractAddStepHandler {
 
-    StaticDiscoveryProviderAddHandler() {
-        super(new Parameters().addAttribute(StaticDiscoveryProviderDefinition.SERVICES));
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         List<ModelNode> services = StaticDiscoveryProviderDefinition.SERVICES.resolveModelAttribute(context, resource.getModel()).asListOrEmpty();

--- a/discovery/src/main/java/org/wildfly/extension/discovery/StaticDiscoveryProviderDefinition.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/StaticDiscoveryProviderDefinition.java
@@ -73,6 +73,6 @@ final class StaticDiscoveryProviderDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(SERVICES, null, new ReloadRequiredWriteAttributeHandler(SERVICES));
+        resourceRegistration.registerReadWriteAttribute(SERVICES, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRoleAdd.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRoleAdd.java
@@ -31,7 +31,7 @@ class HostScopedRoleAdd extends ScopedRoleAddHandler {
     private final WritableAuthorizerConfiguration authorizerConfiguration;
 
     HostScopedRoleAdd(Map<String, HostEffectConstraint> constraintMap, WritableAuthorizerConfiguration authorizerConfiguration) {
-        super(authorizerConfiguration, HostScopedRolesResourceDefinition.BASE_ROLE, HostScopedRolesResourceDefinition.HOSTS);
+        super(authorizerConfiguration);
         this.constraintMap = constraintMap;
         this.authorizerConfiguration = authorizerConfiguration;
     }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRolesResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRolesResourceDefinition.java
@@ -18,13 +18,11 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
-import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.HostEffectConstraint;
 import org.jboss.as.controller.access.management.WritableAuthorizerConfiguration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -41,15 +39,9 @@ import org.jboss.dmr.ModelType;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-public class HostScopedRolesResourceDefinition extends SimpleResourceDefinition {
+public class HostScopedRolesResourceDefinition extends ScopedRoleResourceDefinition {
 
     public static final PathElement PATH_ELEMENT = PathElement.pathElement(HOST_SCOPED_ROLE);
-
-    public static final SimpleAttributeDefinition BASE_ROLE =
-            new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.BASE_ROLE, ModelType.STRING)
-            .setRestartAllServices()
-            .build();
-
 
     public static final ListAttributeDefinition HOSTS = SimpleListAttributeDefinition.Builder.of(ModelDescriptionConstants.HOSTS,
                 new SimpleAttributeDefinitionBuilder(HOST, ModelType.STRING)
@@ -64,12 +56,12 @@ public class HostScopedRolesResourceDefinition extends SimpleResourceDefinition 
             .setWrapXmlList(false)
             .build();
 
-    private final HostScopedRoleAdd addHandler;
-    private final HostScopedRoleRemove removeHandler;
-    private final HostScopedRoleWriteAttributeHandler writeAttributeHandler;
+    private final OperationStepHandler addHandler;
+    private final OperationStepHandler removeHandler;
+    private final OperationStepHandler writeAttributeHandler;
 
     public HostScopedRolesResourceDefinition(WritableAuthorizerConfiguration authorizerConfiguration) {
-        super(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control.host-scoped-role"));
+        super(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control.host-scoped-role"), authorizerConfiguration);
 
         Map<String, HostEffectConstraint> constraintMap = new HashMap<String, HostEffectConstraint>();
         this.addHandler = new HostScopedRoleAdd(constraintMap, authorizerConfiguration);
@@ -89,7 +81,6 @@ public class HostScopedRolesResourceDefinition extends SimpleResourceDefinition 
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
 
-        resourceRegistration.registerReadWriteAttribute(BASE_ROLE, null, new ReloadRequiredWriteAttributeHandler(BASE_ROLE));
         resourceRegistration.registerReadWriteAttribute(HOSTS, null, writeAttributeHandler);
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ScopedRoleAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ScopedRoleAddHandler.java
@@ -4,27 +4,18 @@
  */
 package org.jboss.as.domain.management.access;
 
-import org.jboss.as.controller.ParameterCorrector;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_SCOPED_ROLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP_SCOPED_ROLE;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.WritableAuthorizerConfiguration;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.logging.DomainManagementLogger;
@@ -44,52 +35,8 @@ abstract class ScopedRoleAddHandler extends AbstractAddStepHandler {
             AccessAuthorizationResourceDefinition.PATH_ELEMENT);
     private final WritableAuthorizerConfiguration authorizerConfiguration;
 
-    ScopedRoleAddHandler(final WritableAuthorizerConfiguration authorizerConfiguration, AttributeDefinition... attributes) {
-        super(enhanceAttributes(authorizerConfiguration, attributes));
+    ScopedRoleAddHandler(final WritableAuthorizerConfiguration authorizerConfiguration) {
         this.authorizerConfiguration = authorizerConfiguration;
-    }
-
-    private static Collection<? extends AttributeDefinition> enhanceAttributes(
-            final WritableAuthorizerConfiguration authorizerConfiguration, AttributeDefinition... attributes) {
-        List<AttributeDefinition> enhanced = new ArrayList<AttributeDefinition>(attributes.length);
-        for (AttributeDefinition current : attributes) {
-            if (current.getName().equals(ModelDescriptionConstants.BASE_ROLE)) {
-                assert current instanceof SimpleAttributeDefinition;
-                enhanced.add(new SimpleAttributeDefinitionBuilder((SimpleAttributeDefinition)current)
-                .setValidator(new ParameterValidator() {
-                    @Override
-                    public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
-                        Set<String> standardRoles = authorizerConfiguration.getStandardRoles();
-                        String specifiedRole = value.asString();
-                        for (String current : standardRoles) {
-                            if (specifiedRole.equalsIgnoreCase(current)) {
-                                return;
-                            }
-                        }
-
-                        throw DomainManagementLogger.ROOT_LOGGER.badBaseRole(specifiedRole);
-                    }
-                }).setCorrector(new ParameterCorrector() {
-                    @Override
-                    public ModelNode correct(ModelNode newValue, ModelNode currentValue) {
-                        Set<String> standardRoles = authorizerConfiguration.getStandardRoles();
-                        String specifiedRole = newValue.asString();
-
-                        for (String current : standardRoles) {
-                            if (specifiedRole.equalsIgnoreCase(current) && specifiedRole.equals(current) == false) {
-                                return new ModelNode(current);
-                            }
-                        }
-
-                        return newValue;
-                    }
-                }).build());
-            } else {
-                enhanced.add(current);
-            }
-        }
-
-        return enhanced;
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ScopedRoleResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ScopedRoleResourceDefinition.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.domain.management.access;
+
+import java.util.Set;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ParameterCorrector;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.access.management.WritableAuthorizerConfiguration;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.domain.management.logging.DomainManagementLogger;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Base {@link org.jboss.as.controller.ResourceDefinition} for scoped roles
+ */
+public abstract class ScopedRoleResourceDefinition extends SimpleResourceDefinition {
+
+    public static final SimpleAttributeDefinition BASE_ROLE =
+            new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.BASE_ROLE, ModelType.STRING)
+            .setRestartAllServices()
+            .build();
+
+    private final AttributeDefinition roleAttribute;
+
+    protected ScopedRoleResourceDefinition(PathElement path, ResourceDescriptionResolver resolver, WritableAuthorizerConfiguration authorizerConfiguration) {
+        super(path, resolver);
+        this.roleAttribute = new SimpleAttributeDefinitionBuilder(BASE_ROLE)
+                .setValidator(new ParameterValidator() {
+                    @Override
+                    public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+                        Set<String> standardRoles = authorizerConfiguration.getStandardRoles();
+                        String specifiedRole = value.asString();
+                        for (String current : standardRoles) {
+                            if (specifiedRole.equalsIgnoreCase(current)) {
+                                return;
+                            }
+                        }
+
+                        throw DomainManagementLogger.ROOT_LOGGER.badBaseRole(specifiedRole);
+                    }
+                }).setCorrector(new ParameterCorrector() {
+                    @Override
+                    public ModelNode correct(ModelNode newValue, ModelNode currentValue) {
+                        Set<String> standardRoles = authorizerConfiguration.getStandardRoles();
+                        String specifiedRole = newValue.asString();
+
+                        for (String current : standardRoles) {
+                            if (specifiedRole.equalsIgnoreCase(current) && specifiedRole.equals(current) == false) {
+                                return new ModelNode(current);
+                            }
+                        }
+
+                        return newValue;
+                    }
+                })
+                .build();
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registration) {
+        registration.registerReadWriteAttribute(this.roleAttribute, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleAdd.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleAdd.java
@@ -31,7 +31,7 @@ class ServerGroupScopedRoleAdd extends ScopedRoleAddHandler {
 
     ServerGroupScopedRoleAdd(Map<String, ServerGroupEffectConstraint> constraintMap,
                              WritableAuthorizerConfiguration authorizerConfiguration) {
-        super(authorizerConfiguration, ServerGroupScopedRoleResourceDefinition.BASE_ROLE, ServerGroupScopedRoleResourceDefinition.SERVER_GROUPS);
+        super(authorizerConfiguration);
         this.constraintMap = constraintMap;
         this.authorizerConfiguration = authorizerConfiguration;
     }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleResourceDefinition.java
@@ -18,13 +18,11 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
-import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ServerGroupEffectConstraint;
 import org.jboss.as.controller.access.management.WritableAuthorizerConfiguration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -41,15 +39,9 @@ import org.jboss.dmr.ModelType;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-public class ServerGroupScopedRoleResourceDefinition extends SimpleResourceDefinition {
+public class ServerGroupScopedRoleResourceDefinition extends ScopedRoleResourceDefinition {
 
     public static final PathElement PATH_ELEMENT = PathElement.pathElement(SERVER_GROUP_SCOPED_ROLE);
-
-    public static final SimpleAttributeDefinition BASE_ROLE =
-            new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.BASE_ROLE, ModelType.STRING)
-            .setRestartAllServices()
-            .build();
-
 
     public static final ListAttributeDefinition SERVER_GROUPS =
             SimpleListAttributeDefinition.Builder.of(ModelDescriptionConstants.SERVER_GROUPS,
@@ -66,12 +58,12 @@ public class ServerGroupScopedRoleResourceDefinition extends SimpleResourceDefin
             .setWrapXmlList(false)
             .build();
 
-    private final ServerGroupScopedRoleAdd addHandler;
-    private final ServerGroupScopedRoleRemove removeHandler;
-    private final ServerGroupScopedRoleWriteAttributeHandler writeAttributeHandler;
+    private final OperationStepHandler addHandler;
+    private final OperationStepHandler removeHandler;
+    private final OperationStepHandler writeAttributeHandler;
 
     public ServerGroupScopedRoleResourceDefinition(WritableAuthorizerConfiguration authorizerConfiguration) {
-        super(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control.server-group-scoped-role"));
+        super(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control.server-group-scoped-role"), authorizerConfiguration);
 
         Map<String, ServerGroupEffectConstraint> constraintMap = new HashMap<String, ServerGroupEffectConstraint>();
         this.addHandler = new ServerGroupScopedRoleAdd(constraintMap, authorizerConfiguration);
@@ -91,7 +83,6 @@ public class ServerGroupScopedRoleResourceDefinition extends SimpleResourceDefin
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
 
-        resourceRegistration.registerReadWriteAttribute(BASE_ROLE, null, new ReloadRequiredWriteAttributeHandler(BASE_ROLE));
         resourceRegistration.registerReadWriteAttribute(SERVER_GROUPS, null, writeAttributeHandler);
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/AccessControlXml.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/AccessControlXml.java
@@ -59,6 +59,7 @@ import org.jboss.as.domain.management.access.ApplicationClassificationTypeResour
 import org.jboss.as.domain.management.access.HostScopedRolesResourceDefinition;
 import org.jboss.as.domain.management.access.PrincipalResourceDefinition;
 import org.jboss.as.domain.management.access.RoleMappingResourceDefinition;
+import org.jboss.as.domain.management.access.ScopedRoleResourceDefinition;
 import org.jboss.as.domain.management.access.SensitivityClassificationTypeResourceDefinition;
 import org.jboss.as.domain.management.access.SensitivityResourceDefinition;
 import org.jboss.as.domain.management.access.ServerGroupScopedRoleResourceDefinition;
@@ -140,7 +141,7 @@ public class AccessControlXml {
             switch (element) {
                 case ROLE: {
                     parseScopedRole(reader, address, list, scopedRoleType, Element.SERVER_GROUP,
-                            ServerGroupScopedRoleResourceDefinition.BASE_ROLE, ServerGroupScopedRoleResourceDefinition.SERVER_GROUPS, true);
+                            ScopedRoleResourceDefinition.BASE_ROLE, ServerGroupScopedRoleResourceDefinition.SERVER_GROUPS, true);
                     break;
                 }
                 default: {
@@ -162,7 +163,7 @@ public class AccessControlXml {
             switch (element) {
                 case ROLE: {
                     parseScopedRole(reader, address, list, scopedRoleType, Element.HOST,
-                            HostScopedRolesResourceDefinition.BASE_ROLE, HostScopedRolesResourceDefinition.HOSTS, false);
+                            ScopedRoleResourceDefinition.BASE_ROLE, HostScopedRolesResourceDefinition.HOSTS, false);
                     break;
                 }
                 default: {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ManagementModel;
@@ -258,8 +257,8 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
         public SubsystemResourceDefinition() {
             super(SUBSYSTEM_ELEMENT,
                     NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
-                    new ModelOnlyRemoveStepHandler());
+                    ModelOnlyAddStepHandler.INSTANCE,
+                    ModelOnlyRemoveStepHandler.INSTANCE);
         }
 
 
@@ -305,8 +304,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
     class OrderedChildResourceDefinition extends AbstractChildResourceDefinition {
 
         OrderedChildResourceDefinition() {
-            super(ORDERED_CHILD,
-                    new AbstractAddStepHandler((REQUEST_ATTRIBUTES)));
+            super(ORDERED_CHILD, ModelOnlyAddStepHandler.INSTANCE);
         }
 
         @Override
@@ -319,8 +317,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
     class ExtraChildResourceDefinition extends AbstractChildResourceDefinition {
         public ExtraChildResourceDefinition() {
-            super(EXTRA_CHILD,
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES));
+            super(EXTRA_CHILD, ModelOnlyAddStepHandler.INSTANCE);
         }
     }
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
@@ -237,9 +237,8 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
 
     MockOperationContext getOperationContext(final PathAddress operationAddress) {
         final Resource root = createRootResource();
-        return new MockOperationContext(root, false, operationAddress, false);
+        return new MockOperationContext(root, operationAddress);
     }
-
 
     MockOperationContext getOperationContextWithIncludes(final PathAddress operationAddress) {
         final Resource root = createRootResource();
@@ -249,8 +248,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         Resource profileFour = Resource.Factory.create();
         profileFour.getModel().get(INCLUDES).add("profile-three");
         root.registerChild(PathElement.pathElement(PROFILE, "profile-four"), profileFour);
-        return new MockOperationContext(root, false, operationAddress, false);
-
+        return new MockOperationContext(root, operationAddress);
     }
 
     MockOperationContext getOperationContextForSubsystemIncludes(final PathAddress operationAddress, RootResourceInitializer initializer) {
@@ -265,17 +263,16 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         root.registerChild(PathElement.pathElement(PROFILE, "profile-five"), profileFive);
 
         initializer.addAdditionalResources(root);
-        return new MockOperationContext(root, false, operationAddress, false);
+        return new MockOperationContext(root, operationAddress);
     }
 
     private class MockOperationContext extends AbstractOperationTestCase.MockOperationContext {
         private boolean reloadRequired;
-        private boolean rollback;
+        private boolean rollback = false;
         private OperationStepHandler nextStep;
 
-        protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
-            super(root, booting, operationAddress);
-            this.rollback = rollback;
+        protected MockOperationContext(Resource root, PathAddress operationAddress) {
+            super(root, false, operationAddress, ProfileResourceDefinition.ATTRIBUTES);
             when(this.registration.getCapabilities()).thenReturn(Collections.singleton(ProfileResourceDefinition.PROFILE_CAPABILITY));
         }
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
@@ -23,7 +23,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
@@ -111,7 +110,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
 
     private void testAddServerGroupBadInfo(boolean primary, boolean rollback, boolean badProfile, boolean badSocketBindingGroup) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-three"));
-        final MockOperationContext operationContext = getOperationContext(rollback, pa);
+        final MockOperationContext operationContext = new MockOperationContext(pa, rollback);
 
         String profileName = badProfile ? "bad-profile" : "profile-two";
         String socketBindingGroupName = badSocketBindingGroup ? "bad-group" : "binding-two";
@@ -165,7 +164,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
 
     private void testRemoveServerGroup(boolean primary, boolean rollback) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-one"));
-        final MockOperationContext operationContext = getOperationContext(rollback, pa);
+        final MockOperationContext operationContext = new MockOperationContext(pa, rollback);
 
         final ModelNode operation = new ModelNode();
         operation.get(OP_ADDR).set(pa.toModelNode());
@@ -223,7 +222,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
 
     private void testUpdateServerGroupProfile(boolean primary, boolean rollback, boolean badProfile) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-one"));
-        final MockOperationContext operationContext = getOperationContext(rollback, pa);
+        final MockOperationContext operationContext = new MockOperationContext(pa, rollback);
 
         String profileName = badProfile ? "bad-profile" : "profile-two";
 
@@ -302,7 +301,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
     private void testUpdateServerGroupSocketBindingGroup(boolean primary, boolean rollback, boolean badSocketBindingGroup) throws Exception {
 
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-one"));
-        final MockOperationContext operationContext = getOperationContext(rollback, pa);
+        final MockOperationContext operationContext = new MockOperationContext(pa, rollback);
 
         String socketBindingGroupName = badSocketBindingGroup ? "bad-group" : "binding-two";
 
@@ -332,19 +331,14 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         }
     }
 
-    MockOperationContext getOperationContext(final boolean rollback, final PathAddress operationAddress) {
-        final Resource root = createRootResource();
-        return new MockOperationContext(root, false, operationAddress, rollback);
-    }
-
     private class MockOperationContext extends AbstractOperationTestCase.MockOperationContext {
         private boolean reloadRequired;
         private boolean rollback;
         private OperationStepHandler nextStep;
         private ModelNode nextStepOp;
 
-        protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
-            super(root, booting, operationAddress);
+        protected MockOperationContext(PathAddress operationAddress, final boolean rollback) {
+            super(createRootResource(), false, operationAddress, ServerGroupResourceDefinition.ADD_ATTRIBUTES);
             this.rollback = rollback;
             when(this.registration.getCapabilities()).thenReturn(Collections.singleton(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY));
         }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
@@ -250,7 +250,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
 
     MockOperationContext getOperationContext(final PathAddress operationAddress) {
         final Resource root = createRootResource();
-        return new MockOperationContext(root, false, operationAddress, false);
+        return new MockOperationContext(root, operationAddress);
     }
 
 
@@ -263,7 +263,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         socketBindingGroupFour.getModel().get(INCLUDES).add("binding-three");
         root.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "binding-four"), socketBindingGroupFour);
 
-        return new MockOperationContext(root, false, operationAddress, false);
+        return new MockOperationContext(root, operationAddress);
 
     }
 
@@ -279,17 +279,16 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         root.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "binding-five"), socketBindingGroupFive);
 
         initializer.addAdditionalResources(root);
-        return new MockOperationContext(root, false, operationAddress, false);
+        return new MockOperationContext(root, operationAddress);
     }
 
     private class MockOperationContext extends AbstractOperationTestCase.MockOperationContext {
         private boolean reloadRequired;
-        private boolean rollback;
+        private boolean rollback = false;
         private OperationStepHandler nextStep;
 
-        protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
-            super(root, booting, operationAddress);
-            this.rollback = rollback;
+        protected MockOperationContext(Resource root, PathAddress operationAddress) {
+            super(root, false, operationAddress, SocketBindingGroupResourceDefinition.INCLUDES);
             Set<RuntimeCapability> capabilities = new HashSet<>();
             capabilities.add(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
             capabilities.add(ProfileResourceDefinition.PROFILE_CAPABILITY);

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
@@ -109,7 +109,7 @@ class BufferPoolResourceDefinition extends PersistentResourceDefinition {
         super(new SimpleResourceDefinition.Parameters(IOExtension.BUFFER_POOL_PATH,
                 IOExtension.getResolver(Constants.BUFFER_POOL))
                 .setAddHandler(new BufferPoolAdd())
-                .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .addCapabilities(IO_POOL_RUNTIME_CAPABILITY,
                         IO_BYTE_BUFFER_POOL_RUNTIME_CAPABILITY)
                 .setDeprecatedSince(ModelVersion.create(4))

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -118,6 +118,7 @@ public interface CommonAttributes {
     SimpleAttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create("name", ModelType.STRING, true)
             .setAllowExpression(false)
             .setDeprecated(ModelVersion.create(1, 2, 0))
+            .setResourceOnly()
             .build();
 
     SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder("properties", true)

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -20,6 +20,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
 import org.jboss.as.controller.operations.validation.ObjectTypeValidator;
+import org.jboss.as.controller.registry.AttributeAccess.Flag;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.logging.capabilities.Capabilities;
 import org.jboss.as.logging.correctors.FileCorrector;
@@ -265,6 +266,7 @@ public interface CommonAttributes {
             .addAlternatives("filter-spec")
             .setDeprecated(ModelVersion.create(1, 2, 0))
             .setRequired(false)
+            .addFlag(Flag.ALIAS)
             .build();
 
     String ADD_HANDLER_OPERATION_NAME = "add-handler";

--- a/logging/src/test/java/org/jboss/as/logging/LogFilterTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LogFilterTestCase.java
@@ -11,6 +11,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
 
 import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.junit.Assert.assertEquals;
 
@@ -70,6 +72,7 @@ public class LogFilterTestCase extends AbstractOperationsTestCase {
         assertEquals("{\"replace\" => {\"replace-all\" => true,\"pattern\" => \"JBAS\",\"replacement\" => \"DUMMY\"}}",
                 Operations.readResult(result).asString());
         ModelNode readResourceOp = Operations.createReadResourceOperation(consoleAddress);
+        readResourceOp.get(ModelDescriptionConstants.INCLUDE_ALIASES).set(true);
         result = executeOperation(kernelServices, readResourceOp);
         assertThat(result, is(notNullValue()));
         assertThat(result.get(OUTCOME).asString(), is("success"));
@@ -77,7 +80,7 @@ public class LogFilterTestCase extends AbstractOperationsTestCase {
         ModelNode filterSpec = result.get(RESULT).get("filter-spec");
         assertThat(filterSpec.asString(), is("substituteAll(\"JBAS\",\"DUMMY\")"));
 
-        assertThat(result.get(RESULT).hasDefined("filter"), is(true));
+        assertThat(result.toJSONString(false), result.get(RESULT).hasDefined("filter"), is(true));
         assertThat(result.get(RESULT).get("filter").hasDefined("replace"), is(true));
         ModelNode replaceResult = result.get(RESULT).get("filter").get("replace");
         assertThat(replaceResult.hasDefined("pattern"), is(true));

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentAddHandler.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentAddHandler.java
@@ -5,13 +5,11 @@
 
 package org.jboss.as.management.client.content;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -19,24 +17,22 @@ import org.jboss.dmr.ModelNode;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class ManagedDMRContentAddHandler extends AbstractAddStepHandler {
+public class ManagedDMRContentAddHandler implements OperationStepHandler {
+
+    private final AttributeDefinition contentAttribute;
 
     public ManagedDMRContentAddHandler(final AttributeDefinition contentAttribute) {
-        super(contentAttribute);
-
+        this.contentAttribute = contentAttribute;
     }
-
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
-        PathElement pe = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement();
-
         ModelNode model = new ModelNode();
-        populateModel(operation, model);
+        this.contentAttribute.validateAndSet(operation, model);
 
         // Create and add the specialized resource type we use for a managed dmr content resource
-        ManagedDMRContentResource resource = new ManagedDMRContentResource(pe);
+        ManagedDMRContentResource resource = new ManagedDMRContentResource(context.getCurrentAddress().getLastElement());
         context.addResource(PathAddress.EMPTY_ADDRESS, resource);
         // IMPORTANT: Use writeModel, as this is what causes the content to be flushed to the content repo!
         resource.writeModel(model);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
@@ -35,12 +35,6 @@ import org.xnio.OptionMap;
  */
 public class ConnectorAdd extends AbstractAddStepHandler {
 
-    static final ConnectorAdd INSTANCE = new ConnectorAdd();
-
-    private ConnectorAdd() {
-        super(ConnectorResource.ATTRIBUTES);
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         final ModelNode fullModel = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
@@ -48,7 +42,7 @@ public class ConnectorAdd extends AbstractAddStepHandler {
         launchServices(context, fullModel);
     }
 
-    void launchServices(OperationContext context, ModelNode fullModel) throws OperationFailedException {
+    static void launchServices(OperationContext context, ModelNode fullModel) throws OperationFailedException {
         final String connectorName = context.getCurrentAddressValue();
         OptionMap optionMap = ConnectorUtils.getFullOptions(context, fullModel);
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorChildResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorChildResource.java
@@ -38,7 +38,7 @@ abstract class ConnectorChildResource extends SimpleResourceDefinition {
         super(parameters);
     }
     static void recreateParentService(OperationContext context, ModelNode parentModel) throws OperationFailedException {
-        ConnectorAdd.INSTANCE.launchServices(context, parentModel);
+        ConnectorAdd.launchServices(context, parentModel);
     }
 
     static ServiceName getParentServiceName(PathAddress parentAddress) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorRemove.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorRemove.java
@@ -7,6 +7,7 @@ package org.jboss.as.remoting;
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -17,17 +18,14 @@ import org.jboss.dmr.ModelNode;
  */
 public class ConnectorRemove extends AbstractRemoveStepHandler {
 
-    static final ConnectorRemove INSTANCE = new ConnectorRemove();
-
-    private ConnectorRemove() {
-    }
-
+    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
         final String name = context.getCurrentAddressValue();
         RemotingServices.removeConnectorServices(context, name);
     }
 
-    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {
-        // TODO:  RE-ADD SERVICES
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        ConnectorAdd.launchServices(context, model);
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -85,17 +84,15 @@ public class ConnectorResource extends SimpleResourceDefinition {
 
     ConnectorResource() {
         super(new Parameters(PATH, RemotingExtension.getResourceDescriptionResolver(CONNECTOR))
-                .setAddHandler(ConnectorAdd.INSTANCE)
-                .setRemoveHandler(ConnectorRemove.INSTANCE)
+                .setAddHandler(new ConnectorAdd())
+                .setRemoveHandler(new ConnectorRemove())
                 .setCapabilities(CONNECTOR_CAPABILITY));
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
         for (AttributeDefinition ad : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(ad, null, writeHandler);
+            resourceRegistration.registerReadWriteAttribute(ad, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
-
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
@@ -28,10 +28,6 @@ import org.jboss.remoting3.Endpoint;
  */
 class GenericOutboundConnectionAdd extends AbstractAddStepHandler {
 
-    GenericOutboundConnectionAdd() {
-        super(GenericOutboundConnectionResourceDefinition.ATTRIBUTES);
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource)
             throws OperationFailedException {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionResourceDefinition.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
@@ -53,9 +52,8 @@ class GenericOutboundConnectionResourceDefinition extends AbstractOutboundConnec
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
         for (AttributeDefinition attribute : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
+            resourceRegistration.registerReadWriteAttribute(attribute, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorAdd.java
@@ -30,13 +30,6 @@ import org.xnio.OptionMap;
  */
 public class HttpConnectorAdd extends AbstractAddStepHandler {
 
-    static final HttpConnectorAdd INSTANCE = new HttpConnectorAdd();
-
-    private HttpConnectorAdd() {
-        super(HttpConnectorResource.CONNECTOR_REF, HttpConnectorResource.AUTHENTICATION_PROVIDER, HttpConnectorResource.SECURITY_REALM,
-                HttpConnectorResource.SASL_AUTHENTICATION_FACTORY, ConnectorCommon.SASL_PROTOCOL, ConnectorCommon.SERVER_NAME);
-    }
-
     @Override
     protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         super.populateModel(context, operation, resource);
@@ -51,7 +44,7 @@ public class HttpConnectorAdd extends AbstractAddStepHandler {
         launchServices(context, connectorName, fullModel);
     }
 
-    void launchServices(OperationContext context, String connectorName, ModelNode model) throws OperationFailedException {
+    static void launchServices(OperationContext context, String connectorName, ModelNode model) throws OperationFailedException {
         OptionMap optionMap = ConnectorUtils.getFullOptions(context, model);
 
         final String connectorRef = HttpConnectorResource.CONNECTOR_REF.resolveModelAttribute(context, model).asString();

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorRemove.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorRemove.java
@@ -21,17 +21,17 @@ import org.jboss.dmr.ModelNode;
  */
 public class HttpConnectorRemove extends AbstractRemoveStepHandler {
 
-    static final HttpConnectorRemove INSTANCE = new HttpConnectorRemove();
-
+    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
         context.removeService(RemotingHttpUpgradeService.UPGRADE_SERVICE_NAME.append(name));
     }
 
+    @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
-        HttpConnectorAdd.INSTANCE.launchServices(context, name, model);
+        HttpConnectorAdd.launchServices(context, name, model);
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/HttpConnectorResource.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -71,17 +70,16 @@ public class HttpConnectorResource extends SimpleResourceDefinition {
 
     HttpConnectorResource() {
         super(new Parameters(PATH, RemotingExtension.getResourceDescriptionResolver(HTTP_CONNECTOR))
-                .setAddHandler(HttpConnectorAdd.INSTANCE)
-                .setRemoveHandler(HttpConnectorRemove.INSTANCE)
+                .setAddHandler(new HttpConnectorAdd())
+                .setRemoveHandler(new HttpConnectorRemove())
                 // expose a common connector capability (WFCORE-4875)
                 .setCapabilities(CONNECTOR_CAPABILITY, HTTP_CONNECTOR_CAPABILITY));
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
         for (AttributeDefinition attribute : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
+            resourceRegistration.registerReadWriteAttribute(attribute, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
@@ -26,10 +26,6 @@ import org.jboss.remoting3.Endpoint;
  */
 class LocalOutboundConnectionAdd extends AbstractAddStepHandler {
 
-    LocalOutboundConnectionAdd() {
-        super(LocalOutboundConnectionResourceDefinition.ATTRIBUTES);
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         installRuntimeService(context, resource.getModel());

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionResourceDefinition.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
@@ -57,9 +56,8 @@ class LocalOutboundConnectionResourceDefinition extends AbstractOutboundConnecti
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
         for (AttributeDefinition attribute : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
+            resourceRegistration.registerReadWriteAttribute(attribute, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
@@ -29,10 +29,6 @@ import org.xnio.OptionMap;
  */
 class RemoteOutboundConnectionAdd extends AbstractAddStepHandler {
 
-    RemoteOutboundConnectionAdd() {
-        super(RemoteOutboundConnectionResourceDefinition.ATTRIBUTES);
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         final ModelNode fullModel = Resource.Tools.readModel(resource);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
@@ -91,9 +90,8 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
         for (AttributeDefinition attribute : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
+            resourceRegistration.registerReadWriteAttribute(attribute, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
@@ -32,10 +32,6 @@ import org.xnio.XnioWorker;
  */
 class RemotingSubsystemAdd extends AbstractAddStepHandler {
 
-    RemotingSubsystemAdd() {
-        super(RemotingSubsystemRootResource.ATTRIBUTES);
-    }
-
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         // DomainServerCommunicationServices will already have created this service if the server group has {@link org.jboss.as.controller.descriptions.ModelDescriptionConstants#MANAGEMENT_SUBSYSTEM_ENDPOINT} enabled.

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
@@ -16,7 +16,6 @@ import java.util.stream.Stream;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
@@ -102,9 +101,8 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadWriteAttribute(WORKER, null, new WorkerAttributeWriteHandler());
 
-        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(OPTIONS);
         for (final AttributeDefinition attribute: OPTIONS) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
+            resourceRegistration.registerReadWriteAttribute(attribute, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
 
@@ -120,10 +118,6 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     }
 
     private static class WorkerAttributeWriteHandler extends ReloadRequiredWriteAttributeHandler {
-
-        WorkerAttributeWriteHandler() {
-            super(WORKER);
-        }
 
         @Override
         protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue,

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/validation/subsystem/ValidateSubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/validation/subsystem/ValidateSubsystemExtension.java
@@ -15,10 +15,10 @@ import java.util.List;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
@@ -77,7 +77,7 @@ public class ValidateSubsystemExtension implements Extension {
                 SimpleOperationDefinitionBuilder.of(ADD, NonResolvingResourceDescriptionResolver.INSTANCE)
                     .setParameters(addAttributes)
                     .build(),
-                new AbstractAddStepHandler(addAttributes));
+                ModelOnlyAddStepHandler.INSTANCE);
 
         //We always need to add a 'describe' operation
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
@@ -6,7 +6,7 @@
 package org.jboss.as.test.integration.domain.extension;
 
 
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -35,7 +35,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
             .build();
 
 
-    static SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder("security-domain", ModelType.STRING)
+    static final SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder("security-domain", ModelType.STRING)
             .setAllowExpression(true)
             .setRequired(false)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
@@ -53,7 +53,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
 
     public ConstrainedResource(PathElement pathElement) {
         super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN, AUTHENTICATION_INFLOW))
+                .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("datasources", "datasource"))));
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
@@ -13,10 +13,10 @@ import java.util.List;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.ModelVersion;
@@ -77,8 +77,8 @@ public class OrderedChildResourceExtension implements Extension {
         public SubsystemResourceDefinition() {
             super(SUBSYSTEM_PATH,
                     NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
-                    new ModelOnlyRemoveStepHandler());
+                    ModelOnlyAddStepHandler.INSTANCE,
+                    ModelOnlyRemoveStepHandler.INSTANCE);
         }
 
         @Override
@@ -102,8 +102,8 @@ public class OrderedChildResourceExtension implements Extension {
 
         public OrderedChildResourceDefinition() {
             super(new Parameters(CHILD, NonResolvingResourceDescriptionResolver.INSTANCE)
-                    .setAddHandler(new AbstractAddStepHandler())
-                    .setRemoveHandler(new ModelOnlyRemoveStepHandler())
+                    .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                     .setOrderedChild());
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SensitiveResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SensitiveResource.java
@@ -5,8 +5,7 @@
 
 package org.jboss.as.test.integration.domain.extension;
 
-
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -22,7 +21,7 @@ public class SensitiveResource extends SimpleResourceDefinition {
 
     public SensitiveResource(PathElement pathElement) {
         super(new  Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddHandler(new AbstractAddStepHandler())
+                .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,
                         new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("security", "security-domain"))));

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestAliasReadResourceDescriptionAddressExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestAliasReadResourceDescriptionAddressExtension.java
@@ -10,9 +10,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
@@ -60,8 +60,8 @@ public class TestAliasReadResourceDescriptionAddressExtension implements Extensi
         public AbstractResourceDefinition(PathElement pathElement) {
             super(pathElement,
                     NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(),
-                    new ModelOnlyRemoveStepHandler());
+                    ModelOnlyAddStepHandler.INSTANCE,
+                    ModelOnlyRemoveStepHandler.INSTANCE);
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtensionCommon.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtensionCommon.java
@@ -5,9 +5,9 @@
 
 package org.jboss.as.test.integration.domain.extension;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
@@ -29,11 +29,11 @@ public abstract class VersionedExtensionCommon implements Extension {
     public static final String IGNORED_SUBSYSTEM_NAME = "ignored-test-subsystem";
 
 
-    static AttributeDefinition TEST_ATTRIBUTE = SimpleAttributeDefinitionBuilder.create("test-attribute", ModelType.STRING, true).build();
+    static final AttributeDefinition TEST_ATTRIBUTE = SimpleAttributeDefinitionBuilder.create("test-attribute", ModelType.STRING, true).build();
 
     protected static ResourceDefinition createResourceDefinition(final PathElement element) {
         return new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(element, NonResolvingResourceDescriptionResolver.INSTANCE)
-        .setAddHandler(new AbstractAddStepHandler())
+        .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
         .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
     }
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
@@ -75,8 +75,6 @@ public class ConstrainedResource extends SimpleResourceDefinition {
                                 throw new OperationFailedException("Jndi name shouldn't include '//' or end with '/'");
                             }
                         }
-                    } else {
-                        throw new OperationFailedException("Jndi name is required");
                     }
                 }
             })

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
@@ -4,10 +4,9 @@
  */
 package org.jboss.as.test.integration.mgmt.access.extension;
 
-
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -40,7 +39,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
             .addAccessConstraint(DS_SECURITY_DEF)
             .build();
 
-    static SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder("security-domain", ModelType.STRING)
+    static final SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder("security-domain", ModelType.STRING)
             .setAllowExpression(true)
             .setAttributeGroup("security")
             .setRequired(false)
@@ -57,11 +56,11 @@ public class ConstrainedResource extends SimpleResourceDefinition {
             .build();
 
 
-    static SimpleAttributeDefinition NEW_CONNECTION_SQL = new SimpleAttributeDefinitionBuilder("new-connection-sql", ModelType.STRING, true)
+    static final SimpleAttributeDefinition NEW_CONNECTION_SQL = new SimpleAttributeDefinitionBuilder("new-connection-sql", ModelType.STRING, true)
             .setAllowExpression(true)
             .build();
 
-    static SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder("jndi-name", ModelType.STRING, true)
+    static final SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder("jndi-name", ModelType.STRING, true)
             .setAllowExpression(true)
             .setAttributeGroup("naming")
             .setValidator(new ParameterValidator() {
@@ -85,7 +84,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
 
     public ConstrainedResource(PathElement pathElement) {
         super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN, AUTHENTICATION_INFLOW))
+                .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
                 .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "datasource"))));
     }

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
@@ -5,8 +5,7 @@
 
 package org.jboss.as.test.integration.mgmt.access.extension;
 
-
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -22,7 +21,7 @@ public class SensitiveResource extends SimpleResourceDefinition {
 
     public SensitiveResource(PathElement pathElement) {
         super(new Parameters(pathElement, NonResolvingResourceDescriptionResolver.INSTANCE)
-                .setAddHandler(new AbstractAddStepHandler())
+                .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
                 .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,
                         new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "security-domain"))));

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -12,10 +12,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import java.util.Set;
 import java.util.logging.Logger;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.ModelVersion;
@@ -92,7 +92,7 @@ public class BlockerExtension implements Extension {
         private final boolean forHost;
         private BlockerSubsystemResourceDefinition(boolean forHost) {
             super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(),
+                    ModelOnlyAddStepHandler.INSTANCE,
                     ModelOnlyRemoveStepHandler.INSTANCE);
             this.forHost = forHost;
         }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
@@ -14,10 +14,10 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -92,7 +92,7 @@ public class ErrorExtension implements Extension {
         private final boolean forHost;
         private BlockerSubsystemResourceDefinition(boolean forHost) {
             super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(), ErrorRemovingBlockingSubsystemStepHandler.REMOVE_SUBSYSTEM_INSTANCE);
+                    ModelOnlyAddStepHandler.INSTANCE, ErrorRemovingBlockingSubsystemStepHandler.REMOVE_SUBSYSTEM_INSTANCE);
             this.forHost = forHost;
         }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
@@ -14,10 +14,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.logging.Logger;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
@@ -81,7 +81,7 @@ public class LogStreamExtension implements Extension {
         private final OperationStepHandler handler;
         private LogStreamSubsystemResourceDefinition() {
             super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), NonResolvingResourceDescriptionResolver.INSTANCE,
-                    new AbstractAddStepHandler(),
+                    ModelOnlyAddStepHandler.INSTANCE,
                     ModelOnlyRemoveStepHandler.INSTANCE);
             this.handler = new LogStreamHandler();
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6407

Essentially, this change avoids the need for subsystems to specify AttributeDefinition instances to their add resource and write-attribute operation handlers.
See jira for full rationale.
This change will require minor unit test updates to wildfly, so expect failures in full integration test runs until those fixes are available and merged.
Given that this proposed change affects every add/write-attribute operation, I wanted to make this available for review/feedback as soon as possible.

This should simplify the creation and registration of add and write-attribute operation handlers as well as further reduce our memory footprint, since many operation handler implementations can now be consolidated both within and across subsystems.

~~Requires https://github.com/wildfly/wildfly-core/pull/5644~~ Merged.