### PR TITLE
[WFCORE-6415] Upgrade Bouncy Castle from 1.73 to 1.74

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.10.0</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
-        <version.org.bouncycastle>1.73</version.org.bouncycastle>
+        <version.org.bouncycastle>1.74</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.0</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.6.0.202305301015-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.2</version.org.eclipse.parsson>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6415

Diff: https://github.com/bcgit/bc-java/compare/r1rv73...r1rv74