### PR TITLE
[WFCORE-6418] Upgrade Elytron Web to 4.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.2.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>3.0.1.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>4.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
         <version.xom.xom>1.3.7</version.xom.xom>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6418


        Release Notes - Elytron Web - Version 4.0.0.Final
                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-209'>ELYWEB-209</a>] -         Release Elytron Web 4.0.0.Final
</li>
</ul>
                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-208'>ELYWEB-208</a>] -         Upgrade Undertow to 2.3.7.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-210'>ELYWEB-210</a>] -         Upgrade Elytron to 2.2.1.Final
</li>
</ul>
                                                                                                                                                                
