### PR TITLE
WFCORE-6400 Update DeploymentPhaseContext to return a ServiceTarget capable of resolving capability requirements.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceBuilder.java
@@ -19,25 +19,22 @@
 package org.jboss.as.controller;
 
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.msc.Service;
 import org.jboss.msc.service.LifecycleListener;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
  * A builder for an individual service in a {@code CapabilityServiceTarget}.
- * Create an instance via the {@link CapabilityServiceTarget#addCapability(RuntimeCapability)}.
- * Builder also adds support to define capability requirement via {@link #requiresCapability(String, Class, String...)}.
+ * Create an instance via the {@link CapabilityServiceTarget#addService()} method.
  *
  * @param <T> the service type
  * @author Tomaz Cerar (c) 2017 Red Hat Inc.
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-public interface CapabilityServiceBuilder<T> extends ServiceBuilder<T> {
+public interface CapabilityServiceBuilder<T> extends RequirementServiceBuilder<T> {
 
     @Override
     CapabilityServiceBuilder<T> setInitialMode(ServiceController.Mode mode);
@@ -86,15 +83,4 @@ public interface CapabilityServiceBuilder<T> extends ServiceBuilder<T> {
      * @return consumer providing value
      */
     <V> Consumer<V> provides(final RuntimeCapability<?>[] capabilities, final ServiceName[] aliases);
-
-    /**
-     * Capability requirement.
-     *
-     * @param capabilityName name of capability requirement
-     * @param dependencyType the class of the value of the dependency
-     * @param <V>            the type of the value of the dependency
-     * @param referenceNames dynamic part(s) of capability name, only useful when using dynamic named capabilities
-     * @return readonly dependency reference
-     */
-    <V> Supplier<V> requiresCapability(String capabilityName, Class<V> dependencyType, String... referenceNames);
 }

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
@@ -20,6 +20,7 @@ package org.jboss.as.controller;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.msc.service.LifecycleListener;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * The target of ServiceBuilder for capability installations.
@@ -46,6 +47,10 @@ public interface CapabilityServiceTarget extends RequirementServiceTarget {
 
     @Override
     CapabilityServiceBuilder<?> addService();
+
+    @Deprecated
+    @Override
+    CapabilityServiceBuilder<?> addService(ServiceName name);
 
     @Override
     CapabilityServiceTarget addListener(LifecycleListener listener);

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityServiceTarget.java
@@ -20,7 +20,6 @@ package org.jboss.as.controller;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.msc.service.LifecycleListener;
-import org.jboss.msc.service.ServiceTarget;
 
 /**
  * The target of ServiceBuilder for capability installations.
@@ -32,10 +31,10 @@ import org.jboss.msc.service.ServiceTarget;
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  * @author Paul Ferraro
  */
-public interface CapabilityServiceTarget extends ServiceTarget {
+public interface CapabilityServiceTarget extends RequirementServiceTarget {
 
     /**
-     * Gets a builder which can be used to add a capability service into this capability target.
+     * Returns a builder for installing a service that provides a capability.
      *
      * @param capability the capability to be installed
      * @return new capability builder instance
@@ -53,4 +52,7 @@ public interface CapabilityServiceTarget extends ServiceTarget {
 
     @Override
     CapabilityServiceTarget removeListener(LifecycleListener listener);
+
+    @Override
+    CapabilityServiceTarget subTarget();
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2139,44 +2139,27 @@ final class OperationContextImpl extends AbstractOperationContext {
 
         @Override
         public CapabilityServiceBuilder<?> addService() {
-            final ServiceBuilder<?> realBuilder = new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService());
-            // If done() has been called we are no longer associated with a management op and should just
-            // return the builder from delegate
-            synchronized (this) {
-                if (builderSupplier == null) {
-                    return new CapabilityServiceBuilderImpl<>(realBuilder, targetAddress);
-                }
-                ContextServiceBuilder<?> csb = builderSupplier.getContextServiceBuilder(realBuilder);
-                builders.add(csb);
-                return new CapabilityServiceBuilderImpl<>(csb, targetAddress);
-            }
+            return this.wrap(new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService()));
         }
 
         @Override
-        public ServiceBuilder<?> addService(final ServiceName name) {
-            final ServiceBuilder<?> realBuilder = new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService(name), name);
-            // If done() has been called we are no longer associated with a management op and should just
-            // return the builder from delegate
-            synchronized (this) {
-                if (builderSupplier == null) {
-                    return realBuilder;
-                }
-                ContextServiceBuilder<?> csb = builderSupplier.getContextServiceBuilder(realBuilder);
-                builders.add(csb);
-                return csb;
-            }
+        public CapabilityServiceBuilder<?> addService(final ServiceName name) {
+            return this.wrap(new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService(name), name));
         }
 
         @Override
         public <T> CapabilityServiceBuilder<T> addService(final ServiceName name, final org.jboss.msc.service.Service<T> service) throws IllegalArgumentException {
-            final ServiceBuilder<T> realBuilder = new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService(name, service), name);
+            return this.wrap(new ProvidedValuesTrackingServiceBuilder(super.getDelegate().addService(name, service), name));
+        }
+
+        private <T> CapabilityServiceBuilder<T> wrap(ServiceBuilder<T> builder) {
             // If done() has been called we are no longer associated with a management op and should just
             // return the builder from delegate
             synchronized (this) {
                 if (builderSupplier == null) {
-                    return new CapabilityServiceBuilderImpl<>(realBuilder, targetAddress);
+                    return new CapabilityServiceBuilderImpl<>(builder, targetAddress);
                 }
-                ContextServiceBuilder<T> csb = builderSupplier.getContextServiceBuilder(realBuilder);
+                ContextServiceBuilder<T> csb = builderSupplier.getContextServiceBuilder(builder);
                 builders.add(csb);
                 return new CapabilityServiceBuilderImpl<>(csb, targetAddress);
             }
@@ -2228,9 +2211,9 @@ final class OperationContextImpl extends AbstractOperationContext {
         @SuppressWarnings("unchecked")
         public CapabilityServiceBuilder<?> addCapability(final RuntimeCapability<?> capability) throws IllegalArgumentException {
             if (capability.isDynamicallyNamed()) {
-                return new CapabilityServiceBuilderImpl(addService(capability.getCapabilityServiceName(targetAddress)), targetAddress);
+                return this.addService(capability.getCapabilityServiceName(targetAddress));
             } else {
-                return new CapabilityServiceBuilderImpl(addService(capability.getCapabilityServiceName()), targetAddress);
+                return this.addService(capability.getCapabilityServiceName());
             }
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2194,6 +2194,11 @@ final class OperationContextImpl extends AbstractOperationContext {
             return this;
         }
 
+        @Override
+        public CapabilityServiceTarget subTarget() {
+            return new ContextServiceTarget(super.subTarget(), this.builderSupplier, this.targetAddress);
+        }
+
         private static final class ProvidedValuesTrackingServiceBuilder extends DelegatingServiceBuilder {
             private final Set<ServiceName> providedValues = new HashSet<>();
 

--- a/controller/src/main/java/org/jboss/as/controller/RequirementServiceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/RequirementServiceBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.function.Supplier;
+
+import org.jboss.msc.Service;
+import org.jboss.msc.service.LifecycleListener;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+
+/**
+ * A {@link org.jboss.msc.service.ServiceBuilder} that supports capability requirements.
+ * @param <T> an ignored service value type
+ * @author Paul Ferraro
+ */
+public interface RequirementServiceBuilder<T> extends ServiceBuilder<T> {
+
+    @Override
+    RequirementServiceBuilder<T> setInitialMode(ServiceController.Mode mode);
+
+    @Override
+    RequirementServiceBuilder<T> setInstance(Service service);
+
+    @Override
+    RequirementServiceBuilder<T> addListener(LifecycleListener listener);
+
+    /**
+     * Registers a requirement on the specified capability.
+     * @param capabilityName name of capability requirement
+     * @param dependencyType the class of the value of the dependency
+     * @param referenceNames dynamic part(s) of capability name, only useful when using dynamic named capabilities
+     * @param <V> the type of the value of the dependency
+     * @return a reference to the required dependency
+     */
+    <V> Supplier<V> requiresCapability(String capabilityName, Class<V> dependencyType, String... referenceNames);
+}

--- a/controller/src/main/java/org/jboss/as/controller/RequirementServiceTarget.java
+++ b/controller/src/main/java/org/jboss/as/controller/RequirementServiceTarget.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import org.jboss.msc.service.LifecycleListener;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * {@link org.jboss.msc.service.ServiceTarget} whose builders support capability requirements.
+ * @author Paul Ferraro
+ */
+public interface RequirementServiceTarget extends ServiceTarget {
+
+    @Override
+    RequirementServiceBuilder<?> addService();
+
+    @Override
+    RequirementServiceTarget addListener(LifecycleListener listener);
+
+    @Override
+    RequirementServiceTarget removeListener(LifecycleListener listener);
+
+    @Override
+    RequirementServiceTarget subTarget();
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentPhaseContext.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentPhaseContext.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.server.deployment;
 
+import org.jboss.as.controller.RequirementServiceTarget;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
@@ -51,8 +52,22 @@ public interface DeploymentPhaseContext extends Attachable {
      * the {@link #getPhaseServiceName()} method.
      *
      * @return the service target
+     * @deprecated Use {@link #getRequirementServiceTarget()} instead.
      */
-    ServiceTarget getServiceTarget();
+    @Deprecated(forRemoval = true)
+    default ServiceTarget getServiceTarget() {
+        return this.getRequirementServiceTarget();
+    }
+
+    /**
+     * Returns the target into which this phase should install services.
+     * <b>Please note</b> that services added via this context do <b>not</b> have any implicit dependencies by default;
+     * any root-level deployment services that you add should depend on the service name of the current phase,
+     * acquired via the {@link #getPhaseServiceName()} method.
+     *
+     * @return the service target
+     */
+    RequirementServiceTarget getRequirementServiceTarget();
 
     /**
      * Get the service registry for the container, which may be used to look up services.

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentPhaseContextImpl.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentPhaseContextImpl.java
@@ -24,23 +24,23 @@ package org.jboss.as.server.deployment;
 
 import java.util.List;
 
+import org.jboss.as.controller.RequirementServiceTarget;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.msc.service.ServiceTarget;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 final class DeploymentPhaseContextImpl extends SimpleAttachable implements DeploymentPhaseContext {
-    private final ServiceTarget serviceTarget;
+    private final RequirementServiceTarget serviceTarget;
     private final ServiceRegistry serviceRegistry;
     private final List<DeploymentUnitPhaseDependency> dependencies;
     private final DeploymentUnit deploymentUnitContext;
     private final Phase phase;
 
-    DeploymentPhaseContextImpl(final ServiceTarget serviceTarget, final ServiceRegistry serviceRegistry, final List<DeploymentUnitPhaseDependency> dependencies, final DeploymentUnit deploymentUnitContext, final Phase phase) {
+    DeploymentPhaseContextImpl(final RequirementServiceTarget serviceTarget, final ServiceRegistry serviceRegistry, final List<DeploymentUnitPhaseDependency> dependencies, final DeploymentUnit deploymentUnitContext, final Phase phase) {
         this.serviceTarget = serviceTarget;
         this.serviceRegistry = serviceRegistry;
         this.dependencies = dependencies;
@@ -48,22 +48,27 @@ final class DeploymentPhaseContextImpl extends SimpleAttachable implements Deplo
         this.phase = phase;
     }
 
+    @Override
     public ServiceName getPhaseServiceName() {
         return deploymentUnitContext.getServiceName().append(phase.name());
     }
 
-    public ServiceTarget getServiceTarget() {
+    @Override
+    public RequirementServiceTarget getRequirementServiceTarget() {
         return serviceTarget;
     }
 
+    @Override
     public ServiceRegistry getServiceRegistry() {
         return serviceRegistry;
     }
 
+    @Override
     public DeploymentUnit getDeploymentUnit() {
         return deploymentUnitContext;
     }
 
+    @Override
     public Phase getPhase() {
         return phase;
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseService.java
@@ -29,13 +29,19 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
+import org.jboss.as.controller.RequirementServiceBuilder;
+import org.jboss.as.controller.RequirementServiceTarget;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.LifecycleEvent;
 import org.jboss.msc.service.LifecycleListener;
+import org.jboss.msc.service.DelegatingServiceBuilder;
 import org.jboss.msc.service.DelegatingServiceRegistry;
+import org.jboss.msc.service.DelegatingServiceTarget;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceContainer;
@@ -119,7 +125,7 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
         final List<RegisteredDeploymentUnitProcessor> list = chains.getChain(phase);
         final ListIterator<RegisteredDeploymentUnitProcessor> iterator = list.listIterator();
         final ServiceContainer container = context.getController().getServiceContainer();
-        final ServiceTarget serviceTarget = context.getChildTarget().subTarget();
+        final RequirementServiceTarget serviceTarget = new DeploymentUnitServiceTarget(context.getChildTarget().subTarget(), deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT));
         final DeploymentUnit parent = deploymentUnit.getParent();
 
         final List<DeploymentUnitPhaseDependency> dependencies = new LinkedList<>();
@@ -276,5 +282,68 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
             }
         }
         return !shouldNotRun.contains(deployer.getSubsystemName());
+    }
+
+    static class DeploymentUnitServiceTarget extends DelegatingServiceTarget implements RequirementServiceTarget {
+        private final CapabilityServiceSupport support;
+
+        DeploymentUnitServiceTarget(ServiceTarget target, CapabilityServiceSupport support) {
+            super(target);
+            this.support = support;
+        }
+
+        @Override
+        public RequirementServiceTarget addListener(LifecycleListener listener) {
+            super.addListener(listener);
+            return this;
+        }
+
+        @Override
+        public RequirementServiceTarget removeListener(LifecycleListener listener) {
+            super.removeListener(listener);
+            return this;
+        }
+
+        @Override
+        public RequirementServiceTarget subTarget() {
+            return new DeploymentUnitServiceTarget(super.subTarget(), this.support);
+        }
+
+        @Override
+        public RequirementServiceBuilder<?> addService() {
+            return new DeploymentUnitServiceBuilder<>(super.addService(), this.support);
+        }
+    }
+
+    static class DeploymentUnitServiceBuilder<T> extends DelegatingServiceBuilder<T> implements RequirementServiceBuilder<T> {
+        private final CapabilityServiceSupport support;
+
+        DeploymentUnitServiceBuilder(ServiceBuilder<T> builder, CapabilityServiceSupport support) {
+            super(builder);
+            this.support = support;
+        }
+
+        @Override
+        public RequirementServiceBuilder<T> setInitialMode(Mode mode) {
+            super.setInitialMode(mode);
+            return this;
+        }
+
+        @Override
+        public RequirementServiceBuilder<T> setInstance(org.jboss.msc.Service service) {
+            super.setInstance(service);
+            return this;
+        }
+
+        @Override
+        public RequirementServiceBuilder<T> addListener(LifecycleListener listener) {
+            super.addListener(listener);
+            return this;
+        }
+
+        @Override
+        public <V> Supplier<V> requiresCapability(String capabilityName, Class<V> dependencyType, String... referenceNames) {
+            return super.requires(this.support.getCapabilityServiceName(capabilityName, referenceNames));
+        }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6400

N.B. The interfaces extracted from CapabilityServiceTarget/CapabilityServiceBuilder intentionally override only non-deprecated MSC ServiceTarget/ServiceBuilder methods.

Technically, the proposed modification to the DeploymentPhaseContext.getServiceTarget() return type, while source-compatible, is not binary-compatibile.
I assumed this would be an acceptable change, since the org.wildfly.core:wildfly-server module is private, and this would only affect external subsystems that perform service installation from a custom DeploymentUnitProcessor.