### PR TITLE
[WFCORE-6442] Make ModuleSpecification retains distinct ModuleDepende…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/FilterSpecification.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/FilterSpecification.java
@@ -23,6 +23,8 @@
 package org.jboss.as.server.deployment.module;
 
 import java.io.Serializable;
+import java.util.Objects;
+
 import org.jboss.modules.filter.PathFilter;
 
 /**
@@ -46,5 +48,18 @@ public final class FilterSpecification implements Serializable {
 
     public boolean isInclude() {
         return include;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FilterSpecification that = (FilterSpecification) o;
+        return include == that.include && pathFilter.equals(that.pathFilter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pathFilter, include);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleDependency.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleDependency.java
@@ -25,6 +25,7 @@ package org.jboss.as.server.deployment.module;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.jboss.modules.ModuleIdentifier;
@@ -176,5 +177,27 @@ public final class ModuleDependency implements Serializable {
 
     public boolean isImportServices() {
         return importServices;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModuleDependency that = (ModuleDependency) o;
+
+        // Note we don't include 'reason' in equals or hashcode as it does not drive distinct behavior
+        return export == that.export
+                && optional == that.optional
+                && importServices == that.importServices
+                && userSpecified == that.userSpecified
+                && Objects.equals(moduleLoader, that.moduleLoader)
+                && identifier.equals(that.identifier) && importFilters.equals(that.importFilters)
+                && exportFilters.equals(that.exportFilters);
+    }
+
+    @Override
+    public int hashCode() {
+        // Note we don't include 'reason' in equals or hashcode as it does not drive distinct behavior
+        return Objects.hash(moduleLoader, identifier, export, optional, importFilters, exportFilters, importServices, userSpecified);
     }
 }


### PR DESCRIPTION
…ncy instances that have the same id.

https://issues.redhat.com/browse/WFCORE-6442

Note that an alternate approach to solving this problem would be to introduce some sort of ModuleDependency.merge(ModuleDependency other) method, such that a ModuleSpecification would end up with just one entry per module id. That would require more consideration though, particularly in how filter rules should be combined. The approach here is conservative in that it basically goes back to the longstanding pre-WFCORE-6199 (i.e. WF 27 and earlier) behavior of potential having multiple dependencies entries for a given module, but still tries to avoid pointless duplication.
