### PR TITLE
[WFCORE-6444] Upgrade BouncyCastle to 1.76.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.10.0</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
-        <version.org.bouncycastle>1.75</version.org.bouncycastle>
+        <version.org.bouncycastle>1.76</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.0</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.6.0.202305301015-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.3</version.org.eclipse.parsson>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6444

Upstream: #5596 
