### PR TITLE
[WFCORE-6448] Upgrade Eclipse Parsson from 1.1.3 to 1.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.bouncycastle>1.75</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.0</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.6.0.202305301015-r</version.org.eclipse.jgit>
-        <version.org.eclipse.parsson>1.1.3</version.org.eclipse.parsson>
+        <version.org.eclipse.parsson>1.1.4</version.org.eclipse.parsson>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.jboss.byteman>4.0.21</version.org.jboss.byteman>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6448

