### PR TITLE
[WFCORE-6435] Make WildFly 29 available in ModelTestControllerVersion

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -62,6 +62,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
 
         //we only test EAP 7.4 and newer
         data.add(new TransformersTestParameter(ModelVersion.create(16, 0, 0), ModelTestControllerVersion.EAP_7_4_0));
+        data.add(new TransformersTestParameter(ModelVersion.create(19, 0, 0), ModelTestControllerVersion.EAP_8_0_0));
         return data;
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -37,6 +37,11 @@ public enum ModelTestControllerVersion {
     //EAP releases
     EAP_7_4_0("7.4.0.GA-redhat-00005", true, "23.0.0", "15.0.2.Final-redhat-00001", "7.4.0"),
 
+    // We use 8.0.0 version which is based on WF29. Once we get 8.0.0.GA out, we will replace this by:
+    // EAP_8_0_0("8.0.0.GA-redhat-?????", true, "29.0.0", "21.1.0.Final-redhat-?????", "8.0.0"),
+    // See https://issues.redhat.com/browse/WFCORE-6453
+    EAP_8_0_0("29.0.0.Final", false, "29.0.0", "21.1.0.Final", "8.0.0"),
+
     // https://issues.redhat.com/browse/WFCORE-5753
     // Once EAP XP 4 is out, we need to replace the following live with
     // EAP_XP_4("4.0.0.GA-redhat-0000x", true, "24.0.0", "18.0.0.Final-redhat-0000x", "xp4")

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.2.1.Final</version.org.wildfly.discovery>
         <version.org.wildfly.installation-manager.installation-manager-api>1.0.1.Final</version.org.wildfly.installation-manager.installation-manager-api>
-        <version.org.wildfly.legacy.test>7.0.0.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>8.0.1.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.2.5.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6435

Adds EAP_8_0_0_TEMP as a temporal Model Controller version for testing and upgrades wildfly.legacy.test to 8.0.0.Final