### PR TITLE
[WFCORE-6433] ServerGroupResourceDefinition registered DomainServerLifecycleHandlers in the wrong place

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
@@ -148,11 +148,11 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
         resourceRegistration.registerOperationHandler(DeploymentAttributes.SERVER_GROUP_REPLACE_DEPLOYMENT_DEFINITION,  new ServerGroupDeploymentReplaceHandler(fileRepository, contentRepository));
+        DomainServerLifecycleHandlers.registerServerGroupHandlers(resourceRegistration);
     }
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-        DomainServerLifecycleHandlers.registerServerGroupHandlers(resourceRegistration);
         resourceRegistration.registerSubModel(JvmResourceDefinition.GLOBAL);
         resourceRegistration.registerSubModel(DomainDeploymentResourceDefinition.createForServerGroup(fileRepository, contentRepository));
         resourceRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(Location.SERVER_GROUP));


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6433