### PR TITLE
[WFCORE-6454] Use TCP/IP process communication for surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,10 @@
         </surefire.system.args>
         <test.level>INFO</test.level>
 
+        <!-- This overrides default surefire plugin version specified in parent pom - reason is to enable TCP/IP communication,
+             see https://maven.apache.org/surefire/maven-surefire-plugin/examples/process-communication.html -->
+	<version.surefire.plugin>3.1.2</version.surefire.plugin>
+
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
         <version.org.jboss.galleon>5.0.9.Final</version.org.jboss.galleon>
@@ -356,6 +360,7 @@
                         </dependency>
                     </dependencies>
                     <configuration>
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <enableAssertions>true</enableAssertions>
                         <systemPropertyVariables>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -323,6 +323,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <failIfNoTests>false</failIfNoTests>
+			<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                         <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
                         <systemPropertyVariables>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6454

This change utilizes new TCP/IP communication for surefire execution [1].

By default, the communication writes to STDOUT which may lead to similar messages in the execution output if something else also writes there at wrong time:

```
[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1.
See FAQ web page and the dump file ... .dumpstream.
```

This change should mittigate such warnings and also should reduce number of open files during execution which may lead to crash on some systems with `nofile` limit set quite low.

Truth is that this issue hasn't been seen in this upstream WildFly Core project, still I believe this change should be beneficial avoiding eventual issue in the future.

[1] https://maven.apache.org/surefire/maven-surefire-plugin/examples/process-communication.html
