### PR TITLE
[WFCORE-6456] Add checks to LayersTest to confirm expected unused or …

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -30,6 +30,7 @@
         <module name="jdk.security.auth"/>
 
         <module name="io.undertow.core" />
+        <module name="io.smallrye.jandex"/>
         <module name="org.eclipse.jgit" optional="true"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.deployment-repository"/>
@@ -52,7 +53,6 @@
         <module name="org.jboss.common-beans" services="export" optional="true"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.invocation"/>
-        <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.marshalling"/>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -38,11 +38,7 @@ public class LayersTestCase {
         // Not currently used internally
         "org.wildfly.event.logger",
         // wildfly-elytron-http-stateful-basic
-        "org.wildfly.security.http.sfbasic",
-        // wildfly-elytron-tool
-        "org.apache.commons.cli",
-        "org.apache.commons.lang3",
-        "org.wildfly.security.elytron-tool",
+        "org.wildfly.security.http.sfbasic"
     };
     // Packages that are not referenced from the module graph but needed.
     // This is the expected set of un-referenced modules found when scanning
@@ -70,6 +66,10 @@ public class LayersTestCase {
         "wildflyee.api",
         // bootable jar runtime
         "org.wildfly.bootable-jar",
+        // wildfly-elytron-tool
+        "org.apache.commons.cli",
+        "org.apache.commons.lang3",
+        "org.wildfly.security.elytron-tool",
     };
 
     /**

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -20,8 +20,8 @@ import org.junit.Test;
  * @author jdenise@redhat.com
  */
 public class LayersTestCase {
-
-    // Packages that are provisioned but not used (not injected nor referenced).
+    // Packages that are provisioned by the test-standalone-reference installation
+    // but not used in the test-all-layers installation.
     // This is the expected set of not provisioned modules when all layers are provisioned.
     private static final String[] NOT_USED = {
         // deprecated and unused
@@ -43,12 +43,10 @@ public class LayersTestCase {
         "org.apache.commons.cli",
         "org.apache.commons.lang3",
         "org.wildfly.security.elytron-tool",
-        //internal json 1 API
-        "internal.javax.json.api.ee8"
     };
     // Packages that are not referenced from the module graph but needed.
     // This is the expected set of un-referenced modules found when scanning
-    // the default configuration.
+    // the test-standalone-reference configuration.
     private static final String[] NOT_REFERENCED = {
         //  injected by server in UndertowHttpManagementService
         "org.jboss.as.domain-http-error-context",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/layers/Result.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/layers/Result.java
@@ -60,13 +60,16 @@ public class Result {
     private final Map<String, Set<String>> unresolvedOptional;
     private final Set<String> modules;
     private final Set<String> notReferenced;
+    private final Set<String> aliases;
     private final List<ExtensionResult> extensions;
 
-    Result(long size, Set<String> modules, Map<String, Set<String>> unresolvedOptional, Set<String> notReferenced, List<ExtensionResult> extensions) {
+    Result(long size, Set<String> modules, Map<String, Set<String>> unresolvedOptional, Set<String> notReferenced,
+           Set<String> aliases, List<ExtensionResult> extensions) {
         this.size = size;
         this.modules = modules;
         this.unresolvedOptional = unresolvedOptional;
         this.notReferenced = notReferenced;
+        this.aliases = aliases;
         this.extensions = extensions;
     }
 
@@ -96,6 +99,13 @@ public class Result {
      */
     public Set<String> getNotReferenced() {
         return notReferenced;
+    }
+
+    /**
+     * @return the aliases
+     */
+    public Set<String> getAliases() {
+        return aliases;
     }
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/layers/Scanner.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/layers/Scanner.java
@@ -51,72 +51,72 @@ public class Scanner {
         Map<String, Set<String>> modulesReference = new HashMap<>();
         Set<String> modules = new HashSet<>();
         Files.walkFileTree(modulePath, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                    throws IOException {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                            throws IOException {
 
-                if (file.getFileName().toString().equals("module.xml")) {
-                    try {
-                        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
-                                .newInstance();
-                        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                        Document document = documentBuilder.parse(file.toFile());
-                        Element elemAlias = (Element) document.getElementsByTagName("module-alias").item(0);
-                        if (elemAlias != null) {
-                            String moduleName = elemAlias.getAttribute("name");
-                            String target = elemAlias.getAttribute("target-name");
-                            Set<String> referencing = modulesReference.get(target);
-                            if (referencing == null) {
-                                referencing = new HashSet<>();
-                                modulesReference.put(target, referencing);
-                            }
-                            referencing.add(moduleName);
-                            return FileVisitResult.CONTINUE;
-                        }
-                        Element elem = (Element) document.getElementsByTagName("module").item(0);
-                        if (elem == null) {
-                            return FileVisitResult.CONTINUE;
-                        }
-                        String moduleName = elem.getAttribute("name");
-                        modules.add(moduleName);
-                        Node n = document.getElementsByTagName("dependencies").item(0);
-                        Set<String> optionals = new TreeSet<>();
-                        if (n != null) {
-                            NodeList deps = n.getChildNodes();
-                            for (int i = 0; i < deps.getLength(); i++) {
-                                if (deps.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                                    Element element = (Element) deps.item(i);
-                                    if (element.getNodeName().equals("module")) {
-                                        String mod = element.getAttribute("name");
-                                        if (element.hasAttribute("optional")) {
-                                            if (element.getAttribute("optional").equals("true")) {
-                                                optionals.add(mod);
+                        if (file.getFileName().toString().equals("module.xml")) {
+                            try {
+                                DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                                        .newInstance();
+                                DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+                                Document document = documentBuilder.parse(file.toFile());
+                                Element elemAlias = (Element) document.getElementsByTagName("module-alias").item(0);
+                                if (elemAlias != null) {
+                                    String moduleName = elemAlias.getAttribute("name");
+                                    String target = elemAlias.getAttribute("target-name");
+                                    Set<String> referencing = modulesReference.get(target);
+                                    if (referencing == null) {
+                                        referencing = new HashSet<>();
+                                        modulesReference.put(target, referencing);
+                                    }
+                                    referencing.add(moduleName);
+                                    return FileVisitResult.CONTINUE;
+                                }
+                                Element elem = (Element) document.getElementsByTagName("module").item(0);
+                                if (elem == null) {
+                                    return FileVisitResult.CONTINUE;
+                                }
+                                String moduleName = elem.getAttribute("name");
+                                modules.add(moduleName);
+                                Node n = document.getElementsByTagName("dependencies").item(0);
+                                Set<String> optionals = new TreeSet<>();
+                                if (n != null) {
+                                    NodeList deps = n.getChildNodes();
+                                    for (int i = 0; i < deps.getLength(); i++) {
+                                        if (deps.item(i).getNodeType() == Node.ELEMENT_NODE) {
+                                            Element element = (Element) deps.item(i);
+                                            if (element.getNodeName().equals("module")) {
+                                                String mod = element.getAttribute("name");
+                                                if (element.hasAttribute("optional")) {
+                                                    if (element.getAttribute("optional").equals("true")) {
+                                                        optionals.add(mod);
+                                                    }
+                                                }
+                                                Set<String> referencing = modulesReference.get(mod);
+                                                if (referencing == null) {
+                                                    referencing = new HashSet<>();
+                                                    modulesReference.put(mod, referencing);
+                                                }
+                                                referencing.add(moduleName);
                                             }
                                         }
-                                        Set<String> referencing = modulesReference.get(mod);
-                                        if (referencing == null) {
-                                            referencing = new HashSet<>();
-                                            modulesReference.put(mod, referencing);
-                                        }
-                                        referencing.add(moduleName);
                                     }
                                 }
+                                optionalDependencies.put(moduleName, optionals);
+                            } catch (Exception ex) {
+                                throw new IOException(ex);
                             }
                         }
-                        optionalDependencies.put(moduleName, optionals);
-                    } catch (Exception ex) {
-                        throw new IOException(ex);
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult postVisitDirectory(Path dir, IOException e)
+                            throws IOException {
+                        return FileVisitResult.CONTINUE;
                     }
                 }
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException e)
-                    throws IOException {
-                return FileVisitResult.CONTINUE;
-            }
-        }
         );
         Map<String, Set<String>> missing = new TreeMap<>();
         // Retrieve all optional dependencies that have not been provisioned.
@@ -137,8 +137,7 @@ public class Scanner {
         // eg: modA is unreferenced but references modB. modB must be marked as unreferenced too
         // because its referent is not referenced.
         Set<String> allNotReferenced = new TreeSet<>();
-        Set<String> mods = new HashSet<>();
-        mods.addAll(modules);
+        Set<String> mods = new HashSet<>(modules);
         // remove all the extension modules
         Set<String> extensions = retrieveExtensionModules(configFile);
         mods.removeAll(extensions);
@@ -150,6 +149,17 @@ public class Scanner {
                 if (referencers == null || referencers.isEmpty()) {
                     notReferenced.add(m);
                     allNotReferenced.add(m);
+                } else if (referencers.size() == 1) {
+                    // See if the only remaining referencer to 'm' is itself
+                    // only retained by a circular reference from 'm'
+                    String referencer = referencers.iterator().next();
+                    Set<String> reverse = modulesReference.get(referencer);
+                    if (reverse != null && reverse.size() == 1 && reverse.contains(m)) {
+                        notReferenced.add(m);
+                        allNotReferenced.add(m);
+                        notReferenced.add(referencer);
+                        allNotReferenced.add(referencer);
+                    }
                 }
             }
             // No more unreferenced, break.
@@ -162,12 +172,10 @@ public class Scanner {
             // and in turn will be marked as un-referenced.
             for (Map.Entry<String, Set<String>> entry : modulesReference.entrySet()) {
                 for (String orphan : notReferenced) {
-                    if (entry.getValue().contains(orphan)) {
-                        entry.getValue().remove(orphan);
-                    }
+                    entry.getValue().remove(orphan);
                 }
             }
-            // the un-referenced modules are removed before iterating ungain all modules.
+            // the un-referenced modules are removed before iterating again all modules.
             mods.removeAll(notReferenced);
         }
         // Compute all modules (size and names) reachable from each extension
@@ -218,7 +226,7 @@ public class Scanner {
     }
 
     private static void getDependencies(Path modulePath, String module, Set<String> dependencies,
-            Set<String> seen, List<Long> size) throws Exception {
+                                        Set<String> seen, List<Long> size) throws Exception {
         if (seen.contains(module)) {
             return;
         }


### PR DESCRIPTION
…unreferenced modules are indeed unused/unreferenced

Also reorganize the reporting logic and add a few asserts confirming the expected installations are there.

https://issues.redhat.com/browse/WFCORE-6456
https://issues.redhat.com/browse/WFCORE-6459
https://issues.redhat.com/browse/WFCORE-6465

Also, split the 'unused' testing from the 'unreferenced' as they are orthogonal.

https://issues.redhat.com/browse/WFCORE-6481

Also improves testing of alias modules:

https://issues.redhat.com/browse/WFCORE-6498
