### PR TITLE
[WFCORE-6468] Upgrade Undertow to 2.3.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.86.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.2</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.7.Final</version.io.undertow>
+        <version.io.undertow>2.3.8.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.2</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6468


        Release Notes - Undertow - Version 2.3.8.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2228'>UNDERTOW-2228</a>] -         [GSS](7.4.z) Undertow write-timeout can cause a truncate response for request coming through keep-alive connection
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2275'>UNDERTOW-2275</a>] -         Undertow read-timeout can close connection unexpectedly before returning response for POST request larger than the default buffer size
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2281'>UNDERTOW-2281</a>] -         Undertow HTTP2 breaks protocol specification when client misbehaves
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2285'>UNDERTOW-2285</a>] -         Query parameters get lost in the included JSP page 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2293'>UNDERTOW-2293</a>] -         Server responds with chunked transfer even for short data from deployment
</li>
</ul>
                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2282'>UNDERTOW-2282</a>] -         Upgrade spotbugs to 4.7.3.4
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2292'>UNDERTOW-2292</a>] -         Make HttpRequestConduit.processWrite thread safe with concurrent flush calls
</li>
</ul>
                                                                                                                                                        