### PR TITLE
[WFCORE-6475] Upgrade WildFly Elytron to 2.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.2.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.2.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6475


        Release Notes - WildFly Elytron - Version 2.2.2.Final
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2550'>ELY-2550</a>] -         Add option to skip certificate verification with the realm when using SASL EXTERNAL
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2587'>ELY-2587</a>] -         Release WildFly Elytron 2.2.2.Final
</li>
</ul>
                                                                                                                                                                                                                                            
