### PR TITLE
[WFCORE-6383] throwing boot errors if super.boot fails

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -591,6 +591,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
         return bootErrorCollector;
     }
 
+    protected final ModelNode getBootErrors() {
+        return bootErrorCollector.getErrors();
+    }
+
     protected OperationStepHandler createExtraValidationStepHandler() {
         return null;
     }

--- a/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
+++ b/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
@@ -74,7 +74,7 @@ public class BootErrorCollector {
         }
     }
 
-    private ModelNode getErrors() {
+    ModelNode getErrors() {
         synchronized (errors) {
             return errors.clone();
         }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTestCase.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.as.core.model.test.servergroup;
 
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
@@ -11,13 +12,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
-
-import javax.xml.stream.Location;
-import javax.xml.stream.XMLStreamException;
+import static org.junit.Assert.fail;
 
 import org.hamcrest.MatcherAssert;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
@@ -54,30 +53,10 @@ public class DomainServerGroupTestCase extends AbstractCoreModelTest {
                     .createContentRepositoryContent("12345678901234567890")
                     .createContentRepositoryContent("09876543210987654321")
                     .build();
-        } catch (XMLStreamException ex) {
-            String expectedMessage = ControllerLogger.ROOT_LOGGER.duplicateNamedElement("foo.war", new Location() {
-                public int getLineNumber() {
-                    return 1634;
-                }
-
-                public int getColumnNumber() {
-                    return 1;
-                }
-
-                public int getCharacterOffset() {
-                    return 1;
-                }
-
-                public String getPublicId() {
-                    return "";
-                }
-
-                public String getSystemId() {
-                    return "";
-                }
-            }).getMessage();
-            expectedMessage = expectedMessage.substring(expectedMessage.indexOf("WFLYCTL0073:"));
-            MatcherAssert.assertThat(ex.getMessage(), containsString(expectedMessage));
+            fail("Expected boot failed");
+        } catch (OperationFailedException ex) {
+            final String failureDescription = ex.getFailureDescription().asString();
+            MatcherAssert.assertThat(failureDescription, allOf(containsString("WFLYDC0063:"), containsString("foo.war")));
         }
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -67,7 +67,7 @@ public abstract class ModelTestModelControllerService extends AbstractController
     private volatile ManagementResourceRegistration rootRegistration;
     private volatile Throwable error;
     private volatile boolean bootSuccess;
-    private static final OperationFailedException unknownBootFailure = new OperationFailedException("Unknown failure while executing boot operations");
+    private static final String BOOT_ERROR_MESSAGE = "Failure while executing boot operations";
 
     /**
      * This is the constructor to use for 23.0.x core model tests.
@@ -297,7 +297,7 @@ public abstract class ModelTestModelControllerService extends AbstractController
             }
 
             if (!bootSuccess) {
-                error = unknownBootFailure;
+                error = new BootOperationFailedException(BOOT_ERROR_MESSAGE, super.getBootErrors());
             }
             return bootSuccess;
         } catch (Exception e) {
@@ -347,10 +347,10 @@ public abstract class ModelTestModelControllerService extends AbstractController
 
     public void waitForSetup() throws Exception {
         latch.await();
-        // Don't throw exception if a reason for the boot failure is not provided
-        if (error != null && !error.equals(unknownBootFailure)) {
-            if (error instanceof Exception)
+        if (error != null) {
+            if (error instanceof Exception) {
                 throw (Exception) error;
+            }
             throw new RuntimeException(error);
         }
     }
@@ -451,7 +451,13 @@ public abstract class ModelTestModelControllerService extends AbstractController
         }
     }
 
-    //These are here to overload the constuctor used for the different legacy controllers
+    private static class BootOperationFailedException extends OperationFailedException {
+        public BootOperationFailedException(final String msg, final ModelNode description) {
+            super(msg, description);
+        }
+    }
+
+    //These are here to overload the constructor used for the different legacy controllers
 
 
     @SuppressWarnings("InstantiationOfUtilityClass")

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -4,11 +4,14 @@
  */
 package org.jboss.as.remoting;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.jboss.as.controller.capability.RuntimeCapability.buildDynamicCapabilityName;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.remoting.Capabilities.IO_WORKER_CAPABILITY_NAME;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.EnumSet;
@@ -17,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
+import org.hamcrest.MatcherAssert;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
@@ -96,11 +100,15 @@ public class RemotingSubsystemTestCase extends AbstractRemotingSubsystemBaseTest
 
     @Test
     public void testHttpConnectorValidationStepFail() throws Exception {
-        KernelServices services = createKernelServicesBuilder(createAdditionalInitialization())
-                .setSubsystemXml(getSubsystemXml("remoting-with-duplicate-http-connector.xml"))
-                .build();
-
-        Assert.assertFalse(services.isSuccessfulBoot());
+        try {
+            KernelServices services = createKernelServicesBuilder(createAdditionalInitialization())
+                    .setSubsystemXml(getSubsystemXml("remoting-with-duplicate-http-connector.xml"))
+                    .build();
+            fail("Expected boot failed");
+        } catch (OperationFailedException ex) {
+            final String failureDescription = ex.getFailureDescription().asString();
+            MatcherAssert.assertThat(failureDescription, allOf(containsString("WFLYCTL0445:"), containsString("http")));
+        }
     }
 
     @Test


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6383

With this fix the `ModelTestControllerService.boot()` always throws new `BootOperationFailedException` if `super.boot` returns `false`.
Note that a few test-cases had to be changed according to it.
Regarding "BTW, I think the entire class can and should be package protected, but if there's some outside use I've missed, then never mind.", it is not possible as `BootErrorCollector` is also used outside the package.
Note 2: This will need a fix in WildFly code base in two PicketLink Subsystem tests. I will create a separate Jira for it.