### PR TITLE
[WFCORE-6495] Upgrade FasterXML Jackson to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>
         <version.com.google.guava>31.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
-        <version.com.fasterxml.jackson>2.14.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.5.0</version.commons-cli>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6495
