### PR TITLE
[WFCORE-6500] Upgrade JBoss DMR 1.7.0.Final

### DIFF
--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -273,11 +273,6 @@
       <artifactId>jboss-dmr</artifactId>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2.1 only</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
-          <distribution>repo</distribution>
-        </license>
-        <license>
           <name>Apache License 2.0</name>
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
           <distribution>repo</distribution>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <version.org.jboss.byteman>4.0.21</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.3.0.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
+        <version.org.jboss.jboss-dmr>1.7.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.3.0.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>
         <version.org.jboss.logging.jboss-logging>3.5.3.Final</version.org.jboss.logging.jboss-logging>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFCORE-6500

Dev tag: https://github.com/jbossas/jboss-dmr/releases/tag/1.7.0.Final
Diff to previous integrated release: https://github.com/jbossas/jboss-dmr/compare/1.6.1.Final...1.7.0.Final
JBoss DMR 1.7.0.Final is relicensed with the Apache Software License 2.0.
There are no API changes in that release compared to the previous 1.6.1.Final release.

<details>
<summary>Release Notes - DMR - Version 1.7.0.Final</summary>
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/DMR-50'>DMR-50</a>] -         Relicense JBoss DMR with Apache License 2.0
</li>
<li>[<a href='https://issues.redhat.com/browse/DMR-51'>DMR-51</a>] -         Add GitHub action to test JBoss DMR 
</li>
<li>[<a href='https://issues.redhat.com/browse/DMR-52'>DMR-52</a>] -         Switch default branch to main
</li>
<li>[<a href='https://issues.redhat.com/browse/DMR-53'>DMR-53</a>] -         Improve community standards
</li>
</ul>
</details>
                                                      