### PR TITLE
[WFCORE-6501] Upgrade StAXMapper 1.5.0.Final

### DIFF
--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -300,8 +300,8 @@
       <artifactId>staxmapper</artifactId>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2.1 or later</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
           <distribution>repo</distribution>
         </license>
       </licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>2.0.1.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
-        <version.org.jboss.staxmapper>1.4.0.Final</version.org.jboss.staxmapper>
+        <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.8.10.Final</version.org.jboss.xnio>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFCORE-6501

Dev tag: https://github.com/jbossas/staxmapper/releases/tag/1.5.0.Final
Diff to previous integrated release: https://github.com/jbossas/staxmapper/compare/1.4.0.Final...1.5.0.Final
Staxmapper 1.5.0.Final is relicensed with the Apache Software License 2.0.
There are no API changes in that release compared to the previous 1.4.0.Final release.