### PR TITLE
[WFCORE-6502] Fix variable configuration on common.conf.bat are ignored

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -3,7 +3,6 @@ call %*
 goto :eof
 
 :commonConf
-setlocal
 if "x%COMMON_CONF%" == "x" (
    set "COMMON_CONF=%DIRNAME%common.conf.bat"
 ) else (
@@ -14,7 +13,6 @@ if "x%COMMON_CONF%" == "x" (
 if exist "%COMMON_CONF%" (
    call "%COMMON_CONF%" %*
 )
-endlocal
 goto :eof
 
 :setPackageAvailable


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6502

Remove the usage of setLocal/endLocal on common.bat that makes any variable configuration on common.conf.bat are ignored since the environment is restored to the original one after loading common.conf.bat.
