### PR TITLE
[WFCORE-6506] Initial Java releases contain neither minor nor micro part in the version string - adjusting tests

### DIFF
--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -121,7 +121,7 @@ public class ManagedServerBootCmdFactoryTestCase {
     private static int getJavaVersion() throws NumberFormatException {
         final String versionString = System.getProperty("java.version");
         int indexOfDot = versionString.indexOf('.');
-        return Integer.valueOf(versionString.substring(0, indexOfDot)).intValue();
+        return Integer.valueOf(indexOfDot > 0 ? versionString.substring(0, indexOfDot) : versionString).intValue();
     }
 
     /**

--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -293,7 +293,7 @@ public class CommandBuilderTest {
     private static int getJavaVersion() throws NumberFormatException {
         final String versionString = System.getProperty("java.version");
         int indexOfDot = versionString.indexOf('.');
-        return Integer.valueOf(versionString.substring(0, indexOfDot)).intValue();
+        return Integer.valueOf(indexOfDot > 0 ? versionString.substring(0, indexOfDot) : versionString).intValue();
     }
 
     private void testModularJvmArguments(final Collection<String> command, final int expectedCount) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6506