### PR TITLE
WFCORE-6505 Avoid creating duplicate thread groups on server reload

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/gui/JConsoleCLIPlugin.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/JConsoleCLIPlugin.java
@@ -187,10 +187,9 @@ public class JConsoleCLIPlugin extends JConsolePlugin {
     }
 
     private ExecutorService createExecutor() {
-        final ThreadGroup group = new ThreadGroup("management-client-thread");
         final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
             public JBossThreadFactory run() {
-                return new JBossThreadFactory(group, Boolean.FALSE, null, "%G " + executorCount.incrementAndGet() + "-%t", null, null);
+                return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, "%G " + executorCount.incrementAndGet() + "-%t", null, null);
             }
         });
         return EnhancedQueueExecutor.DISABLE_HINT ?
@@ -245,5 +244,10 @@ public class JConsoleCLIPlugin extends JConsolePlugin {
                 return;
             }
         }
+    }
+
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("management-client-thread");
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/AbstractModelControllerOperationHandlerFactoryService.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/AbstractModelControllerOperationHandlerFactoryService.java
@@ -88,7 +88,7 @@ public abstract class AbstractModelControllerOperationHandlerFactoryService impl
 
         final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
             public JBossThreadFactory run() {
-                return new JBossThreadFactory(new ThreadGroup("management-handler-thread"), Boolean.FALSE, null, "%G - %t", null, null);
+                return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, "%G - %t", null, null);
             }
         });
         if (EnhancedQueueExecutor.DISABLE_HINT) {
@@ -159,6 +159,11 @@ public abstract class AbstractModelControllerOperationHandlerFactoryService impl
 
     protected final ExecutorService getClientRequestExecutor() {
         return clientRequestExecutor;
+    }
+
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("management-handler-thread");
     }
 
 }

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
@@ -233,7 +233,7 @@ class DeploymentScannerAdd implements OperationStepHandler {
     static ScheduledExecutorService createScannerExecutorService() {
         final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<ThreadFactory>() {
             public ThreadFactory run() {
-                return new JBossThreadFactory(new ThreadGroup("DeploymentScanner-threads"), Boolean.FALSE, null, "%G - %t", null, null);
+                return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, "%G - %t", null, null);
             }
         });
         return Executors.newScheduledThreadPool(2, threadFactory);
@@ -302,5 +302,10 @@ class DeploymentScannerAdd implements OperationStepHandler {
         public Set<String> getUnrelatedDeployments(ModelNode owner) {
             return Collections.emptySet();
         }
+    }
+
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("DeploymentScanner-threads");
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -540,7 +540,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
         prepareStepHandler.setExecutorService(executorService);
         ThreadFactory pingerThreadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
             public JBossThreadFactory run() {
-                return new JBossThreadFactory(new ThreadGroup("proxy-pinger-threads"), Boolean.TRUE, null, "%G - %t", null, null);
+                return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.TRUE, null, "%G - %t", null, null);
             }
         });
         pingScheduler = Executors.newScheduledThreadPool(PINGER_POOL_SIZE, pingerThreadFactory);
@@ -1799,4 +1799,10 @@ public class DomainModelControllerService extends AbstractControllerService impl
             }
         }
     }
+
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("proxy-pinger-threads");
+    }
+
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -84,10 +84,10 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
     public static final ServiceName HC_EXECUTOR_SERVICE_NAME = HC_SERVICE_NAME.append("executor");
     public static final ServiceName HC_SCHEDULED_EXECUTOR_SERVICE_NAME = HC_SERVICE_NAME.append("scheduled", "executor");
 
-    private final ThreadGroup threadGroup = new ThreadGroup("Host Controller Service Threads");
+    private static final ThreadGroup THREAD_GROUP = new ThreadGroup("Host Controller Service Threads");
     private final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
         public JBossThreadFactory run() {
-            return new JBossThreadFactory(threadGroup, Boolean.FALSE, null, "%G - %t", null, null);
+            return new JBossThreadFactory(THREAD_GROUP, Boolean.FALSE, null, "%G - %t", null, null);
         }
     });
     private final HostControllerEnvironment environment;
@@ -215,7 +215,7 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
         ConsoleAvailabilityService.addService(serviceTarget, bootstrapListener::logAdminConsole);
 
         DomainModelControllerService.addService(serviceTarget, environment, runningModeControl, processState,
-                bootstrapListener, hostPathManagerService, capabilityRegistry, threadGroup);
+                bootstrapListener, hostPathManagerService, capabilityRegistry, THREAD_GROUP);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ProcessControllerConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ProcessControllerConnectionService.java
@@ -83,7 +83,7 @@ class ProcessControllerConnectionService implements Service<ProcessControllerCon
         try {
             final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
                 public JBossThreadFactory run() {
-                    return new JBossThreadFactory(new ThreadGroup("ProcessControllerConnection-thread"), Boolean.FALSE, null, "%G - %t", null, null);
+                    return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, "%G - %t", null, null);
                 }
             });
             final ExecutorService executorService;
@@ -216,4 +216,8 @@ class ProcessControllerConnectionService implements Service<ProcessControllerCon
         return client;
     }
 
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("ProcessControllerConnection-thread");
+    }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/ServerToHostOperationHandlerFactoryService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/ServerToHostOperationHandlerFactoryService.java
@@ -68,7 +68,7 @@ public class ServerToHostOperationHandlerFactoryService implements ManagementCha
 
     private final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
         public JBossThreadFactory run() {
-            return new JBossThreadFactory(new ThreadGroup("server-registration-threads"), Boolean.FALSE, null, "%G - %t", null, null);
+            return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, "%G - %t", null, null);
         }
     });
     private volatile ExecutorService registrations;
@@ -123,4 +123,8 @@ public class ServerToHostOperationHandlerFactoryService implements ManagementCha
         return channelHandler;
     }
 
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("server-registration-threads");
+    }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -232,11 +232,10 @@ public final class ServerService extends AbstractControllerService {
                                   final SuspendController suspendController) {
 
         // Install Executor services
-        final ThreadGroup threadGroup = new ThreadGroup("ServerService ThreadGroup");
         final String namePattern = "ServerService Thread Pool -- %t";
         final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<ThreadFactory>() {
             public ThreadFactory run() {
-                return new JBossThreadFactory(threadGroup, Boolean.FALSE, null, namePattern, null, null);
+                return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, namePattern, null, null);
             }
         });
 
@@ -276,7 +275,7 @@ public final class ServerService extends AbstractControllerService {
 
         serviceBuilder.install();
 
-        ExternalManagementRequestExecutor.install(serviceTarget, threadGroup, EXECUTOR_CAPABILITY.getCapabilityServiceName());
+        ExternalManagementRequestExecutor.install(serviceTarget, ThreadGroupHolder.THREAD_GROUP, EXECUTOR_CAPABILITY.getCapabilityServiceName());
     }
 
     public synchronized void start(final StartContext context) throws StartException {
@@ -693,5 +692,10 @@ public final class ServerService extends AbstractControllerService {
         public synchronized ScheduledExecutorService getValue() throws IllegalStateException {
             return scheduledExecutorService;
         }
+    }
+
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("ServerService ThreadGroup");
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentMountProvider.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentMountProvider.java
@@ -120,7 +120,7 @@ public interface DeploymentMountProvider {
                 try {
                     final JBossThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
                         public JBossThreadFactory run() {
-                            return new JBossThreadFactory(new ThreadGroup("ServerDeploymentRepository-temp-threads"), true, null, "%G - %t", null, null);
+                            return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, true, null, "%G - %t", null, null);
                         }
                     });
                     scheduledExecutorService =  Executors.newScheduledThreadPool(2, threadFactory);
@@ -166,6 +166,11 @@ public interface DeploymentMountProvider {
                 }
             }
 
+        }
+
+        // Wrapper class to delay thread group creation until when it's needed.
+        private static class ThreadGroupHolder {
+            private static final ThreadGroup THREAD_GROUP = new ThreadGroup("ServerDeploymentRepository-temp-threads");
         }
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/TempFileProviderService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/TempFileProviderService.java
@@ -52,7 +52,7 @@ public class TempFileProviderService implements Service<TempFileProvider> {
        try {
            final JBossThreadFactory threadFactory = doPrivileged(new PrivilegedAction<JBossThreadFactory>() {
                public JBossThreadFactory run() {
-                   return new JBossThreadFactory(new ThreadGroup("TempFileProviderService-temp-threads"), Boolean.TRUE, null, "%G - %t", null, null);
+                   return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.TRUE, null, "%G - %t", null, null);
                }
            });
            ScheduledThreadPoolExecutor ex = new ScheduledThreadPoolExecutor(0, threadFactory);
@@ -86,5 +86,10 @@ public class TempFileProviderService implements Service<TempFileProvider> {
 
     public static TempFileProvider provider() {
         return PROVIDER;
+    }
+
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("TempFileProviderService-temp-threads");
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainControllerClientConfig.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainControllerClientConfig.java
@@ -54,10 +54,9 @@ public class DomainControllerClientConfig implements Closeable {
 
     private static final AtomicInteger executorCount = new AtomicInteger();
     static ExecutorService createDefaultExecutor() {
-        final ThreadGroup group = new ThreadGroup("domain-mgmt-client-thread");
         final ThreadFactory threadFactory = doPrivileged(new PrivilegedAction<ThreadFactory>() {
             public ThreadFactory run() {
-                return new JBossThreadFactory(group, Boolean.FALSE, null, "%G " + executorCount.incrementAndGet() + "-%t", null, null);
+                return new JBossThreadFactory(ThreadGroupHolder.THREAD_GROUP, Boolean.FALSE, null, "%G " + executorCount.incrementAndGet() + "-%t", null, null);
             }
         });
         return new ThreadPoolExecutor(4, 4, 30L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(256), threadFactory);
@@ -115,4 +114,8 @@ public class DomainControllerClientConfig implements Closeable {
         return new DomainControllerClientConfig(endpoint, executorService, destroyExecutor);
     }
 
+    // Wrapper class to delay thread group creation until when it's needed.
+    private static class ThreadGroupHolder {
+        private static final ThreadGroup THREAD_GROUP = new ThreadGroup("domain-mgmt-client-thread");
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6505

This is wildfly-core part of eliminating duplicate thread groups creation.

I tried to remove the thread groups and instead inject the group name string straight into the name pattern, where it was used by ("%G - ...").