### PR TITLE
[WFCORE-4532] Enable security tests on JDK14+ since they no longer fail

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -308,10 +308,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
         }
     }
 
-    private static boolean isJDK14Plus() {
-        return "14".equals(System.getProperty("java.specification.version"));
-    }
-
     @BeforeClass
     public static void initTests() throws Exception {
         disabledAlgorithms = Security.getProperty("jdk.tls.disabledAlgorithms");
@@ -320,7 +316,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
             Security.setProperty("jdk.tls.disabledAlgorithms", "");
         }
 
-        if (isJDK14Plus()) return; // TODO: remove this line once WFCORE-4532 is fixed
         setUpKeyStores();
         AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Security.insertProviderAt(wildFlyElytronProvider, 1));
         csUtil = new CredentialStoreUtility("target/tlstest.keystore");
@@ -333,7 +328,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
         if (disabledAlgorithms != null) {
             Security.setProperty("jdk.tls.disabledAlgorithms", disabledAlgorithms);
         }
-        if (isJDK14Plus()) return; // TODO: remove this line once WFCORE-4532 is fixed
         deleteKeyStoreFiles();
         csUtil.cleanUp();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/OpenSslTlsTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/OpenSslTlsTestCase.java
@@ -104,7 +104,6 @@ public class OpenSslTlsTestCase {
     @Inject
     protected ManagementClient managementClient;
 
-    private static final String javaSpecVersion = System.getProperty("java.specification.version");
     private static final String PASSWORD = "Elytron";
 
     private static final String SERVER_KEY_STORE_NAME = "serverKS";
@@ -134,11 +133,6 @@ public class OpenSslTlsTestCase {
     private static final String TEST_JAR = "test.jar";
 
     @BeforeClass
-    public static void noJDK14Plus() {
-        Assume.assumeFalse("Avoiding JDK 14+ due to https://issues.jboss.org/browse/WFCORE-4532", getJavaSpecVersion() >= 14);
-    }
-
-    @BeforeClass
     public static void isOpenSSL111OrHigher() {
         Assume.assumeTrue("OpenSSL version in use does not support TLS 1.3", isOpenSslTls13Enabled());
     }
@@ -157,10 +151,6 @@ public class OpenSslTlsTestCase {
             return false;
         }
         return false;
-    }
-
-    private static int getJavaSpecVersion() {
-        return Integer.parseInt(javaSpecVersion);
     }
 
     static class ServerSetup extends TestRunnerConfigSetupTask {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-4532
