### PR TITLE
[WFCORE-6519] Enabling logging tests because they no longer fail neither on JDK17 not on JDK21

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
@@ -35,9 +35,7 @@ import org.jboss.as.test.syslogserver.BlockedSyslogServerEventHandler;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
@@ -60,12 +58,6 @@ public class AuditLogBootingSyslogTest {
 
     private static final String DEFAULT_USER_KEY = "wildfly.sasl.local-user.default-user";
     private static final AuditLogToTLSElytronSyslogSetup SYSLOG_SETUP = new AuditLogToTLSElytronSyslogSetup();
-
-
-    @BeforeClass
-    public static void noJDK12Plus() {
-        Assume.assumeFalse("Avoiding JDK 12 due to https://bugs.openjdk.java.net/browse/JDK-8219658", "12".equals(System.getProperty("java.specification.version")));
-    }
 
 
     @Inject

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToTLSSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToTLSSyslogTestCase.java
@@ -17,8 +17,6 @@
  */
 package org.jboss.as.test.integration.auditlog;
 
-import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildFlyRunner;
 import org.junit.runner.RunWith;
@@ -32,10 +30,4 @@ import org.junit.runner.RunWith;
 //@RunAsClient
 @ServerSetup(AuditLogToTLSSyslogSetup.class)
 public class AuditLogToTLSSyslogTestCase extends AuditLogToSyslogTestCase {
-
-    @BeforeClass
-    public static void noJDK12Plus() {
-        Assume.assumeFalse("Avoiding JDK 12 due to https://bugs.openjdk.java.net/browse/JDK-8219658", "12".equals(System.getProperty("java.specification.version")));
-    }
-
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6519
