### PR TITLE
[WFCORE-6555] CVE-2023-3223 Upgrade Undertow to 2.3.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.99.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.5</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.8.Final</version.io.undertow>
+        <version.io.undertow>2.3.9.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.2</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira:
https://issues.redhat.com/browse/WFCORE-6555


        Release Notes - Undertow - Version 2.3.9.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2072'>UNDERTOW-2072</a>] -         DefaultByteBufferPool.getBuffer() may return null
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2271'>UNDERTOW-2271</a>] -         CVE-2023-3223 Large uploaded file does not persist to disk if the filename is omitted
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2296'>UNDERTOW-2296</a>] -         Wrong type in INCLUDE_MAPPING request attribute
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2305'>UNDERTOW-2305</a>] -         NPE from Http2ClearClientProvider#createSettingsFrame()
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2313'>UNDERTOW-2313</a>] -         NPE occurs in session invalidation if a session creation attempt hits UNDERTOW-1971
</li>
</ul>
                                                                                                            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2316'>UNDERTOW-2316</a>] -         Unify InMemorySessionManager getSession() method behavior with DistributableSessionManager
</li>
</ul>
                                                                                                                                                    