### PR TITLE
[WFCORE-6557] CVE-2023-44487 Upgrade Netty to 4.1.100.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.commons-io>2.10.0</version.commons-io>
-        <version.io.netty>4.1.99.Final</version.io.netty>
+        <version.io.netty>4.1.100.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.5</version.io.smallrye.jandex>
         <version.io.undertow>2.3.8.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.2</version.jakarta.json.jakarta-json-api>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6557

This is a test-only dependency