### PR TITLE
[WFCORE-6590] Upgrade commons-lang3 from 3.12.0 to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <version.commons-cli>1.5.0</version.commons-cli>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-daemon>1.3.4</version.commons-daemon>
-        <version.commons-lang3>3.12.0</version.commons-lang3>
+        <version.commons-lang3>3.13.0</version.commons-lang3>
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.100.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.5</version.io.smallrye.jandex>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6590

