### PR TITLE
[WFCORE-6609] remove obsolete JMockit

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -287,12 +287,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
             <scope>test</scope>
@@ -387,24 +381,12 @@
                 </executions>
             </plugin>
 
-            <plugin><!-- to obtain jmockit jar path -->
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>getClasspathFilenames</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reuseForks>false</reuseForks>
-                    <argLine>-javaagent:${org.jmockit:jmockit:jar} ${surefire.jacoco.args} ${modular.jdk.args} -Dorg.wildfly.extension.elytron.restore-default-ssl-context=true -Dauthconfigprovider.factory=org.wildfly.security.auth.jaspi.ElytronAuthConfigFactory</argLine>
+                    <argLine>${surefire.jacoco.args} ${modular.jdk.args} -Dorg.wildfly.extension.elytron.restore-default-ssl-context=true -Dauthconfigprovider.factory=org.wildfly.security.auth.jaspi.ElytronAuthConfigFactory</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/DomainTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/DomainTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.wildfly.security.asn1.ASN1Encodable;
 import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.security.auth.principal.NamePrincipal;
@@ -51,13 +50,10 @@ import org.wildfly.security.x500.X500PrincipalBuilder;
 import org.wildfly.security.x500.cert.SubjectAlternativeNamesExtension;
 import org.wildfly.security.x500.cert.X509CertificateBuilder;
 
-import mockit.integration.junit4.JMockit;
-
 
 /**
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
-@RunWith(JMockit.class)
 public class DomainTestCase extends AbstractSubsystemTest {
 
     public DomainTestCase() {
@@ -81,7 +77,6 @@ public class DomainTestCase extends AbstractSubsystemTest {
     }
 
     private void init() throws Exception {
-        TestEnvironment.mockCallerModuleClassloader();
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("domain-test.xml").build();
         if (!services.isSuccessfulBoot()) {
             if (services.getBootError() != null) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SaslTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SaslTestCase.java
@@ -26,7 +26,6 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.msc.service.ServiceName;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.wildfly.security.auth.callback.ChannelBindingCallback;
 import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.auth.server.SaslAuthenticationFactory;
@@ -37,12 +36,10 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
-import mockit.integration.junit4.JMockit;
 
 /**
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
-@RunWith(JMockit.class)
 public class SaslTestCase extends AbstractSubsystemTest {
 
     public SaslTestCase() {
@@ -52,7 +49,6 @@ public class SaslTestCase extends AbstractSubsystemTest {
     private KernelServices services = null;
 
     private void init() throws Exception {
-        TestEnvironment.mockCallerModuleClassloader(); // to allow loading classes from testsuite
         services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource("sasl-test.xml").build();
         if (!services.isSuccessfulBoot()) {
             if (services.getBootError() != null) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -34,9 +34,6 @@ import org.wildfly.security.x500.cert.BasicConstraintsExtension;
 import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
 import org.wildfly.security.x500.cert.X509CertificateBuilder;
 
-import mockit.Mock;
-import mockit.MockUp;
-
 class TestEnvironment extends AdditionalInitialization {
 
     static final int LDAPS1_PORT = 11391;
@@ -192,18 +189,6 @@ class TestEnvironment extends AdditionalInitialization {
                 return FileVisitResult.CONTINUE;
             }
         });
-    }
-
-    // classloader obtaining mock to load classes from testsuite
-    private static class ClassLoadingAttributeDefinitionsMock extends MockUp<ClassLoadingAttributeDefinitions> {
-        @Mock
-        static ClassLoader resolveClassLoader(String module) {
-            return SaslTestCase.class.getClassLoader();
-        }
-    }
-
-    static void mockCallerModuleClassloader() {
-        new ClassLoadingAttributeDefinitionsMock();
     }
 
     static void activateService(KernelServices services, RuntimeCapability capability, String... dynamicNameElements) throws InterruptedException {

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,6 @@
         <version.org.jboss.xnio>3.8.12.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
-        <version.org.jmockit>1.39</version.org.jmockit>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>
         <version.org.mockito>3.10.0</version.org.mockito>
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>

--- a/testbom/pom.xml
+++ b/testbom/pom.xml
@@ -240,12 +240,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>${version.org.jmockit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-netty</artifactId>
                 <version>${version.org.mock-server.mockserver-netty}</version>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6609 remove obsolete JMockit 