### PR TITLE
[WFCORE-6618] Upgrade BouncyCastle from 1.76 to 1.77

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.11.0</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
-        <version.org.bouncycastle>1.76</version.org.bouncycastle>
+        <version.org.bouncycastle>1.77</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.7.0.202309050840-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6618
