### PR TITLE
WFCORE-6625: remove org.glassfish:jakarta.json license info

### DIFF
--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -7,21 +7,6 @@
 <licenseSummary>
   <dependencies>
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>jakarta.json</artifactId>
-      <licenses>
-        <license>
-          <name>Eclipse Public License 2.0</name>
-        </license>
-        <license>
-          <name>GNU General Public License v2.0 only, with Classpath exception</name>
-        </license>
-        <license>
-          <name>Eclipse Distribution License, Version 1.0</name>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
       <licenses>


### PR DESCRIPTION
Issue: [WFCORE-6625](https://issues.redhat.com/browse/WFCORE-6625)

The EDL was originally added with PR #4103 but I couldn't find a reason why.