### PR TITLE
[WFCORE-6636] Upgrade log42-jboss-logmanager to 1.1.2.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.19.Final</version.org.jboss.logmanager.jboss-logmanager>
-        <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.1.1.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
+        <version.org.jboss.logmanager.log4j2-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j2-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.1.3.SP1</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.1.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.5.2.Final</version.org.jboss.msc.jboss-msc>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6636
