### PR TITLE
[DO NOT MERGE] ** [WFCORE-6446] Testing if the syslog address was set.

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -110,7 +110,9 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
     @Test
     public void testLogOnSpecificLevel() throws Exception {
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
-        executeOperation(Operations.createWriteAttributeOperation(SYSLOG_HANDLER_ADDR, "level", "ERROR"));
+        // TODO (jrp) testing to see if this fails
+        System.out.println(executeOperation(Operations.createWriteAttributeOperation(SYSLOG_HANDLER_ADDR, "level", "ERROR")));
+        System.out.println(executeOperation(Operations.createReadResourceOperation(SYSLOG_HANDLER_ADDR, true)));
         queue.clear();
         makeLogs();
         testLog(queue, Level.FATAL);


### PR DESCRIPTION
This is a test to see if we can get more information from a test failure.