### PR TITLE
[WFCORE-6644] Upgrade log4j2 from 2.19.0 to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         -->
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
-        <version.org.apache.logging.log4j>2.19.0</version.org.apache.logging.log4j>
+        <version.org.apache.logging.log4j>2.22.0</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.11.0</version.org.apache.sshd>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Log4j2LoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Log4j2LoggingProfilesTestCase.java
@@ -39,6 +39,8 @@ public class Log4j2LoggingProfilesTestCase extends AbstractLoggingProfilesTestCa
                 new RuntimePermission("getenv.*"),
                 // Required for the SystemPropertiesPropertySource System.getProperties().
                 new PropertyPermission("*", "read,write"),
+                // The the org.apache.logging.log4j.util.ProviderUtil requires this for the Class.getDeclaredConstructor()
+                new RuntimePermission("accessDeclaredMembers"),
         };
         addPermissions(deployment, permissions);
     }


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6644
