### PR TITLE
[WFCORE-6646]: Can't undefine "use-identity-roles" of /core-service=m…

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationUseIdentityRolesWriteAttributeHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationUseIdentityRolesWriteAttributeHandler.java
@@ -2,7 +2,6 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package org.jboss.as.domain.management.access;
 
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
@@ -29,13 +28,13 @@ class AccessAuthorizationUseIdentityRolesWriteAttributeHandler extends AbstractW
     @Override
     protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue,
             ModelNode oldValue, Resource model) throws OperationFailedException {
-        boolean useIdentityRoles = newValue.asBoolean();
-         if (useIdentityRoles == false) {
-             /*
+        boolean useIdentityRoles = newValue.isDefined() ? newValue.asBoolean() : AccessAuthorizationResourceDefinition.USE_IDENTITY_ROLES.getDefaultValue().asBoolean();
+        if (useIdentityRoles == false) {
+            /*
               * As we are no longer using identity roles we may need another role mapping strategy.
-              */
-             RbacSanityCheckOperation.addOperation(context);
-         }
+             */
+            RbacSanityCheckOperation.addOperation(context);
+        }
     }
 
     @Override

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
@@ -83,7 +83,7 @@ public class GenericCommandTestCase extends AbstractCliTestBase {
             assertTrue(readOutput2.contains("use-identity-roles=true"));
             assertTrue(readOutput2.contains("permission-combination-policy=rejecting"));
         } finally {
-            cli.sendLine("/core-service=management/access=authorization:write-attribute(name=use-identity-roles, value=false");
+            cli.sendLine("/core-service=management/access=authorization:undefine-attribute(name=use-identity-roles");
             cli.sendLine("/core-service=management/access=authorization:undefine-attribute(name=permission-combination-policy");
             cli.sendLine("command remove --command-name=authorization");
         }


### PR DESCRIPTION
…anagement/access=authorization.

* When the new value is undefined don't try to cast it to a booealn value.

Issue: https://issues.redhat.com/browse/WFCORE-6646