### PR TITLE
WFCORE-6347 Drop redundant getCapabity() method.

### DIFF
--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/RuntimeCapabilityProvider.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/RuntimeCapabilityProvider.java
@@ -14,16 +14,14 @@ import org.wildfly.service.descriptor.ServiceDescriptor;
  */
 public interface RuntimeCapabilityProvider<T> extends Supplier<RuntimeCapability<Void>>, ServiceDescriptor<T> {
 
-    RuntimeCapability<Void> getCapability();
-
     @Override
     default String getName() {
-        return this.getCapability().getName();
+        return this.get().getName();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     default Class<T> getType() {
-        return (Class<T>) this.getCapability().getCapabilityServiceValueType();
+        return (Class<T>) this.get().getCapabilityServiceValueType();
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6347

WFCORE-6347 fixup.