### PR TITLE
WFCORE-6651 Update generic Extension implemention in wildfly-subsystem to only register parsers for schemas enabled by the current stability level.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/FeatureRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/FeatureRegistry.java
@@ -15,11 +15,7 @@ public interface FeatureRegistry extends FeatureFilter {
      * Returns the feature stability supported by this feature registry.
      * @return a stability level
      */
-    default Stability getStability() {
-        // TODO Default implementation is only here to prevent wildfly-full integration test failures
-        // Remove this once that is no longer the case
-        return Stability.DEFAULT;
-    }
+    Stability getStability();
 
     /**
      * Determines whether the specified feature is enabled by the configured stability level of the feature registry.

--- a/discovery/src/main/java/org/wildfly/extension/discovery/DiscoveryExtension.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/DiscoveryExtension.java
@@ -5,11 +5,9 @@
 
 package org.wildfly.extension.discovery;
 
-import org.jboss.as.controller.SubsystemModel;
 import org.wildfly.subsystem.SubsystemConfiguration;
 import org.wildfly.subsystem.SubsystemExtension;
 import org.wildfly.subsystem.SubsystemPersistence;
-import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
 
 /**
  * The extension class for the WildFly Discovery extension.
@@ -19,21 +17,6 @@ import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
 public class DiscoveryExtension extends SubsystemExtension<DiscoverySubsystemSchema> {
 
     public DiscoveryExtension() {
-        super(new SubsystemConfiguration() {
-            @Override
-            public String getName() {
-                return DiscoverySubsystemRegistrar.NAME;
-            }
-
-            @Override
-            public SubsystemModel getModel() {
-                return DiscoverySubsystemModel.CURRENT;
-            }
-
-            @Override
-            public SubsystemResourceDefinitionRegistrar getRegistrar() {
-                return new DiscoverySubsystemRegistrar();
-            }
-        }, SubsystemPersistence.of(DiscoverySubsystemSchema.CURRENT));
+        super(SubsystemConfiguration.of(DiscoverySubsystemRegistrar.NAME, DiscoverySubsystemModel.CURRENT, DiscoverySubsystemRegistrar::new), SubsystemPersistence.of(DiscoverySubsystemSchema.CURRENT));
     }
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/SubsystemConfiguration.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/SubsystemConfiguration.java
@@ -4,6 +4,8 @@
  */
 package org.wildfly.subsystem;
 
+import java.util.function.Supplier;
+
 import org.jboss.as.controller.SubsystemModel;
 import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
 
@@ -30,4 +32,30 @@ public interface SubsystemConfiguration {
      * @return the registrar of the subsystem.
      */
     SubsystemResourceDefinitionRegistrar getRegistrar();
+
+    /**
+     * Factory method creating a basic SubsystemConfiguration.
+     * @param subsystemName the subsystem name
+     * @param currentModel the current subsystem model version
+     * @param registrarFactory a supplier of the resource definition registrar for this subsystem
+     * @return a new subsystem configuration
+     */
+    static SubsystemConfiguration of(String name, SubsystemModel model, Supplier<SubsystemResourceDefinitionRegistrar> registrarFactory) {
+        return new SubsystemConfiguration() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public SubsystemModel getModel() {
+                return model;
+            }
+
+            @Override
+            public SubsystemResourceDefinitionRegistrar getRegistrar() {
+                return registrarFactory.get();
+            }
+        };
+    }
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/SubsystemExtension.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/SubsystemExtension.java
@@ -9,24 +9,24 @@ import java.util.Optional;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.SubsystemSchema;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.services.path.PathManager;
-import org.jboss.as.controller.xml.Schema;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
 
 /**
  * Generic extension implementation that registers a single subsystem.
  * @author Paul Ferraro
  */
-public class SubsystemExtension<S extends Schema> implements Extension {
+public class SubsystemExtension<S extends SubsystemSchema<S>> implements Extension {
 
     private final SubsystemConfiguration configuration;
-    private final SubsystemPersistence<S> persistenceConfiguration;
+    private final SubsystemPersistence<S> persistence;
 
-    public SubsystemExtension(SubsystemConfiguration configuration, SubsystemPersistence<S> persistenceConfiguration) {
+    public SubsystemExtension(SubsystemConfiguration configuration, SubsystemPersistence<S> persistence) {
         this.configuration = configuration;
-        this.persistenceConfiguration = persistenceConfiguration;
+        this.persistence = persistence;
     }
 
     @Override
@@ -45,13 +45,11 @@ public class SubsystemExtension<S extends Schema> implements Extension {
         };
         // Auto-register subsystem describe handler
         this.configuration.getRegistrar().register(registration, registrationContext).registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
-        registration.registerXMLElementWriter(this.persistenceConfiguration.getWriter());
+        registration.registerXMLElementWriter(this.persistence.getWriter());
     }
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        for (S schema : this.persistenceConfiguration.getSchemas()) {
-            context.setSubsystemXmlMapping(this.configuration.getName(), schema.getNamespace().getUri(), this.persistenceConfiguration.getReader(schema));
-        }
+        context.setSubsystemXmlMappings(this.configuration.getName(), this.persistence.getSchemas());
     }
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/SubsystemPersistence.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/SubsystemPersistence.java
@@ -15,7 +15,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescriptionWriter;
 import org.jboss.as.controller.PersistentSubsystemSchema;
 import org.jboss.as.controller.SubsystemSchema;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
-import org.jboss.as.controller.xml.Schema;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
@@ -25,7 +24,7 @@ import org.jboss.staxmapper.XMLElementWriter;
  * @author Paul Ferraro
  * @param <S> the schema type
  */
-public interface SubsystemPersistence<S extends Schema> {
+public interface SubsystemPersistence<S extends SubsystemSchema<S>> {
 
     /**
      * Returns the supported schemas of this subsystem.
@@ -79,7 +78,7 @@ public interface SubsystemPersistence<S extends Schema> {
      * @param writer an XML reader
      * @return a subsystem persistence configuration
      */
-    static <S extends Schema, R extends XMLElementReader<List<ModelNode>>> SubsystemPersistence<S> of(Set<S> schemas, Function<S, R> readerFactory, XMLElementWriter<SubsystemMarshallingContext> writer) {
+    static <S extends SubsystemSchema<S>, R extends XMLElementReader<List<ModelNode>>> SubsystemPersistence<S> of(Set<S> schemas, Function<S, R> readerFactory, XMLElementWriter<SubsystemMarshallingContext> writer) {
         return new DefaultSubsystemPersistence<>(schemas, readerFactory, writer);
     }
 
@@ -94,7 +93,7 @@ public interface SubsystemPersistence<S extends Schema> {
      * @param writer an XML reader
      * @return a subsystem persistence configuration
      */
-    static <S extends Schema, R extends XMLElementReader<List<ModelNode>>> SubsystemPersistence<S> of(Set<S> schemas, Function<S, R> readerFactory, S currentSchema, XMLElementReader<List<ModelNode>> currentReader, XMLElementWriter<SubsystemMarshallingContext> writer) {
+    static <S extends SubsystemSchema<S>, R extends XMLElementReader<List<ModelNode>>> SubsystemPersistence<S> of(Set<S> schemas, Function<S, R> readerFactory, S currentSchema, XMLElementReader<List<ModelNode>> currentReader, XMLElementWriter<SubsystemMarshallingContext> writer) {
         return new DefaultSubsystemPersistence<>(schemas, readerFactory, writer) {
             @Override
             public Set<S> getSchemas() {
@@ -113,7 +112,7 @@ public interface SubsystemPersistence<S extends Schema> {
         };
     }
 
-    class DefaultSubsystemPersistence<S extends Schema, R extends XMLElementReader<List<ModelNode>>> implements SubsystemPersistence<S> {
+    class DefaultSubsystemPersistence<S extends SubsystemSchema<S>, R extends XMLElementReader<List<ModelNode>>> implements SubsystemPersistence<S> {
         private final Set<S> schemas;
         private final Function<S, R> readerFactory;
         private final XMLElementWriter<SubsystemMarshallingContext> writer;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6651

Also, removes the default implementation of FeatureRegistry.getStability(), as this should no longer be needed for full-integration tests to pass.