### PR TITLE
Fix for WFCORE-6656, CLI, shaded jar can't start embedded when logging json formater configured

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -729,19 +729,11 @@
             </exclusions>
         </dependency>
 
+        <!-- Dependency needed by the CLI fat jar (client classifier) to support JBoss Log Manager JSON Formatter 
+             that still depends on EE8 javax.json API -->
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -113,6 +113,26 @@
             <artifactId>wildfly-cli</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-network</artifactId>
         </dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6656
