### PR TITLE
[WFCORE-6661] More accurate, resettable start time calculation

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Server.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Server.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.ProcessStateNotifier;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.DelegatingModelControllerClient;
 import org.jboss.as.server.Bootstrap;
+import org.jboss.as.server.ElapsedTime;
 import org.jboss.as.server.Main;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerService;
@@ -147,7 +148,8 @@ final class Server {
             });
 
             // Determine the ServerEnvironment
-            ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv, ServerEnvironment.LaunchType.STANDALONE, startTime).getServerEnvironment();
+            ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv,
+                    ServerEnvironment.LaunchType.STANDALONE, ElapsedTime.startingFromJvmStart()).getServerEnvironment();
             if (serverEnvironment == null) {
                 // Nothing to do
                 return;

--- a/embedded/src/main/java/org/wildfly/core/embedded/ChainedContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/ChainedContext.java
@@ -11,6 +11,8 @@ import java.util.List;
 import org.wildfly.core.embedded.logging.EmbeddedLogger;
 
 /**
+ * A {@link Context} that wraps other contexts and invokes them in the order they are {@link #add(Context) added}.
+ *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 class ChainedContext implements Context {

--- a/embedded/src/main/java/org/wildfly/core/embedded/Configuration.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/Configuration.java
@@ -19,7 +19,7 @@ import org.jboss.modules.ModuleLoader;
 import org.wildfly.core.embedded.logging.EmbeddedLogger;
 
 /**
- * Represents a configuration for the embedded server.
+ * Represents a configuration for creating an {@link EmbeddedManagedProcess}.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */

--- a/embedded/src/main/java/org/wildfly/core/embedded/Context.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/Context.java
@@ -6,7 +6,7 @@
 package org.wildfly.core.embedded;
 
 /**
- * A context used to activate and restore the environment for embedded containers.
+ * A context used to activate and restore the environment for an {@link EmbeddedManagedProcess}.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.ModelControllerClientFactory;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.DelegatingModelControllerClient;
+import org.jboss.as.server.ElapsedTime;
 import org.jboss.as.host.controller.DomainModelControllerService;
 import org.jboss.as.host.controller.HostControllerEnvironment;
 import org.jboss.as.host.controller.Main;
@@ -234,12 +235,12 @@ public class EmbeddedHostControllerFactory {
 
         @Override
         public void start() throws EmbeddedProcessStartException {
+            ElapsedTime elapsedTime = ElapsedTime.startingFromNow();
             ClassLoader tccl = SecurityActions.getTccl();
             try {
                 SecurityActions.setTccl(embeddedModuleCL);
                 EmbeddedHostControllerBootstrap hostControllerBootstrap = null;
                 try {
-                    final long startTime = System.currentTimeMillis();
                     // Take control of server use of System.exit
                     SystemExiter.initialize(new SystemExiter.Exiter() {
                         @Override
@@ -249,7 +250,7 @@ public class EmbeddedHostControllerFactory {
                     });
 
                     // Determine the HostControllerEnvironment
-                    HostControllerEnvironment environment = createHostControllerEnvironment(jbossHomeDir, cmdargs, startTime);
+                    HostControllerEnvironment environment = createHostControllerEnvironment(jbossHomeDir, cmdargs, elapsedTime);
 
                     FutureServiceContainer futureContainer = new FutureServiceContainer();
                     final byte[] authBytes = new byte[16];
@@ -400,7 +401,8 @@ public class EmbeddedHostControllerFactory {
             SystemExiter.initialize(SystemExiter.Exiter.DEFAULT);
         }
 
-        private static HostControllerEnvironment createHostControllerEnvironment(File jbossHome, String[] cmdargs, long startTime) {
+        private static HostControllerEnvironment createHostControllerEnvironment(File jbossHome, String[] cmdargs,
+                                                                                 ElapsedTime elapsedTime) {
             SecurityActions.setPropertyPrivileged(HostControllerEnvironment.HOME_DIR, jbossHome.getAbsolutePath());
 
             List<String> cmds = new ArrayList<String>(Arrays.asList(cmdargs));
@@ -427,7 +429,7 @@ public class EmbeddedHostControllerFactory {
                 if (value != null)
                     cmds.add("-D" + prop + "=" + value);
             }
-            return Main.determineEnvironment(cmds.toArray(new String[cmds.size()]), startTime, ProcessType.EMBEDDED_HOST_CONTROLLER).getHostControllerEnvironment();
+            return Main.determineEnvironment(cmds.toArray(new String[cmds.size()]), elapsedTime, ProcessType.EMBEDDED_HOST_CONTROLLER).getHostControllerEnvironment();
         }
 
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
@@ -140,7 +140,14 @@ public class EmbeddedProcessFactory {
 
         setupVfsModule(moduleLoader);
 
-        // Load the Embedded Server Module
+        // Load the org.wildfly.embedded module using the ModuleLoader from the Configuration
+        //
+        // Note that, depending on the Configuration, the classes in this module may be of a different
+        // version from those with the same name included in the archive that provides this
+        // EmbeddedProcessFactory class. The module must provide a factory class whose name matches SERVER_FACTORY
+        // that provides a 'create' method with the same parameter types as the one provided by the same class
+        // in this class's artifact, and that returns an object that provides methods with the same signatures
+        // as those in the EmbeddedManagedProcess interface included in this class's artifact.
         final Module embeddedModule;
         try {
             embeddedModule = moduleLoader.loadModule(MODULE_ID_EMBEDDED);
@@ -148,7 +155,7 @@ public class EmbeddedProcessFactory {
             throw EmbeddedLogger.ROOT_LOGGER.moduleLoaderError(mle, MODULE_ID_EMBEDDED, moduleLoader);
         }
 
-        // Load the Embedded Server Factory via the modular environment
+        // Load the EmbeddedStandaloneServerFactory via the modular environment.
         final ModuleClassLoader embeddedModuleCL = embeddedModule.getClassLoader();
         final Class<?> embeddedServerFactoryClass;
         final Class<?> standaloneServerClass;
@@ -238,7 +245,14 @@ public class EmbeddedProcessFactory {
 
         setupVfsModule(moduleLoader);
 
-        // Load the Embedded Server Module
+        // Load the org.wildfly.embedded module using the ModuleLoader from the Configuration
+        //
+        // Note that, depending on the Configuration, the classes in this module may be of a different
+        // version from those with the same name included in the archive that provides this
+        // EmbeddedProcessFactory class. The module must provide a factory class whose name matches HOST_FACTORY
+        // that provides a 'create' method with the same parameter types as the one provided by the same class
+        // in this class's artifact, and that returns an object that provides methods with the same signatures
+        // as those in the EmbeddedManagedProcess interface included in this class's artifact.
         final Module embeddedModule;
         try {
             embeddedModule = moduleLoader.loadModule(MODULE_ID_EMBEDDED);
@@ -246,7 +260,7 @@ public class EmbeddedProcessFactory {
             throw EmbeddedLogger.ROOT_LOGGER.moduleLoaderError(mle, MODULE_ID_EMBEDDED, moduleLoader);
         }
 
-        // Load the Embedded Server Factory via the modular environment
+        // Load the EmbeddedHostControllerFactory via the modular environment
         final ModuleClassLoader embeddedModuleCL = embeddedModule.getClassLoader();
         final Class<?> embeddedHostControllerFactoryClass;
         final Class<?> hostControllerClass;

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.ModelControllerClientFactory;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.DelegatingModelControllerClient;
 import org.jboss.as.server.Bootstrap;
+import org.jboss.as.server.ElapsedTime;
 import org.jboss.as.server.Main;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerService;
@@ -239,6 +240,7 @@ public class EmbeddedStandaloneServerFactory {
 
         @Override
         public void start() throws EmbeddedProcessStartException {
+            ElapsedTime elapsedTime = ElapsedTime.startingFromNow();
             ClassLoader tccl = SecurityActions.getTccl();
             try {
                 SecurityActions.setTccl(embeddedModuleCL);
@@ -255,7 +257,8 @@ public class EmbeddedStandaloneServerFactory {
                     });
 
                     // Determine the ServerEnvironment
-                    ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv, ServerEnvironment.LaunchType.EMBEDDED, startTime).getServerEnvironment();
+                    ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv,
+                            ServerEnvironment.LaunchType.EMBEDDED, elapsedTime).getServerEnvironment();
                     if (serverEnvironment == null) {
                         // Nothing to do
                         return;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -6,6 +6,7 @@
 package org.jboss.as.host.controller;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.server.ElapsedTime.startingFromNow;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
+import org.jboss.as.server.ElapsedTime;
 import org.jboss.as.controller.operations.common.ProcessEnvironment;
 import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.host.controller.jvm.JvmType;
@@ -246,7 +248,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
     private final HostRunningModeControl runningModeControl;
     private final boolean securityManagerEnabled;
     private final UUID hostControllerUUID;
-    private final long startTime;
+    private final ElapsedTime elapsedTime;
     private final ProcessType processType;
 
     /** Only for test cases */
@@ -256,14 +258,14 @@ public class HostControllerEnvironment extends ProcessEnvironment {
                                      String initialHostConfig, RunningMode initialRunningMode, boolean backupDomainFiles, boolean useCachedDc, ProductConfig productConfig) {
         this(hostSystemProperties, isRestart, modulePath, processControllerAddress, processControllerPort, hostControllerAddress, hostControllerPort, defaultJVM,
                 domainConfig, initialDomainConfig, hostConfig, initialHostConfig, initialRunningMode, backupDomainFiles, useCachedDc, productConfig, false,
-                System.currentTimeMillis(), ProcessType.HOST_CONTROLLER, ConfigurationFile.InteractionPolicy.STANDARD, ConfigurationFile.InteractionPolicy.STANDARD);
+                startingFromNow(), ProcessType.HOST_CONTROLLER, ConfigurationFile.InteractionPolicy.STANDARD, ConfigurationFile.InteractionPolicy.STANDARD);
     }
 
     public HostControllerEnvironment(Map<String, String> hostSystemProperties, boolean isRestart, String modulePath,
                                      InetAddress processControllerAddress, Integer processControllerPort, InetAddress hostControllerAddress,
                                      Integer hostControllerPort, String defaultJVM, String domainConfig, String initialDomainConfig, String hostConfig,
                                      String initialHostConfig, RunningMode initialRunningMode, boolean backupDomainFiles, boolean useCachedDc,
-                                     ProductConfig productConfig, boolean securityManagerEnabled, long startTime, ProcessType processType,
+                                     ProductConfig productConfig, boolean securityManagerEnabled, ElapsedTime elapsedTime, ProcessType processType,
                                      ConfigurationFile.InteractionPolicy hostConfigInteractionPolicy, ConfigurationFile.InteractionPolicy domainConfigInteractionPolicy) {
 
         this.hostSystemProperties = new HashMap<>(Assert.checkNotNullParam("hostSystemProperties", hostSystemProperties));
@@ -278,7 +280,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         this.hostControllerPort = hostControllerPort;
         this.isRestart = isRestart;
         this.modulePath = modulePath;
-        this.startTime = startTime;
+        this.elapsedTime = elapsedTime;
         this.initialRunningMode = initialRunningMode;
         this.runningModeControl = new HostRunningModeControl(initialRunningMode, RestartMode.SERVERS);
         this.domainConfigInteractionPolicy = domainConfigInteractionPolicy;
@@ -782,7 +784,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
      * @return the time, in ms since the epoch
      */
     public long getStartTime() {
-        return startTime;
+        return elapsedTime.getStartTime();
     }
 
     @Override
@@ -866,6 +868,15 @@ public class HostControllerEnvironment extends ProcessEnvironment {
 
     boolean isSecurityManagerEnabled() {
         return securityManagerEnabled;
+    }
+
+    /**
+     * Gets this Host Controller's {@link ElapsedTime} tracker.
+     *
+     * @return the elapsed time tracker. Will not be {@code null}.
+     */
+    ElapsedTime getElapsedTime() {
+        return elapsedTime;
     }
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.host.controller;
 
+import static org.jboss.as.server.ElapsedTime.startingFromJvmStart;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +26,7 @@ import java.util.Properties;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.interfaces.InetAddressUtil;
+import org.jboss.as.server.ElapsedTime;
 import org.jboss.as.controller.operations.common.ProcessEnvironment;
 import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
@@ -124,9 +127,8 @@ public final class Main {
 
     private HostControllerBootstrap boot(String[] args, final String authCode) {
         try {
-            // TODO make this settable via an embedding process
-            final long startTime = Module.getStartTime();
-            final HostControllerEnvironmentWrapper hostControllerEnvironmentWrapper = determineEnvironment(args, startTime);
+            final HostControllerEnvironmentWrapper hostControllerEnvironmentWrapper =
+                    determineEnvironment(args, startingFromJvmStart(), ProcessType.HOST_CONTROLLER);
             if (hostControllerEnvironmentWrapper.getHostControllerEnvironment() == null) {
                 usage(hostControllerEnvironmentWrapper.getProductConfig()); // In case there was an error determining the environment print the usage
                 if (hostControllerEnvironmentWrapper.getHostControllerEnvironmentStatus() == HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR) {
@@ -188,11 +190,9 @@ public final class Main {
         CommandLineArgumentUsageImpl.printUsage(productConfig, STDOUT);
     }
 
-    public static HostControllerEnvironmentWrapper determineEnvironment(String[] args, long startTime) {
-        return determineEnvironment(args, startTime, ProcessType.HOST_CONTROLLER);
-    }
-
-    public static HostControllerEnvironmentWrapper determineEnvironment(String[] args, long startTime, ProcessType processType) {
+    public static HostControllerEnvironmentWrapper determineEnvironment(String[] args,
+                                                                        ElapsedTime elapsedTime,
+                                                                        ProcessType processType) {
         Integer pmPort = null;
         InetAddress pmAddress = null;
         final PCSocketConfig pcSocketConfig = new PCSocketConfig();
@@ -479,7 +479,7 @@ public final class Main {
         return new HostControllerEnvironmentWrapper(new HostControllerEnvironment(hostSystemProperties, isRestart, modulePath,
                 pmAddress, pmPort, pcSocketConfig.getBindAddress(), pcSocketConfig.getBindPort(), defaultJVM, domainConfig,
                 initialDomainConfig, hostConfig, initialHostConfig, initialRunningMode, backupDomainFiles, cachedDc,
-                productConfig, securityManagerEnabled, startTime, processType, hostConfigInteractionPolicy, domainConfigInteractionPolicy));
+                productConfig, securityManagerEnabled, elapsedTime, processType, hostConfigInteractionPolicy, domainConfigInteractionPolicy));
     }
 
     private static boolean isJavaSecurityManagerConfigured(final Map<String, String> props) {

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -58,26 +58,29 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
     private final SuspendController suspendController;
     private final boolean standalone;
     private final boolean selfContained;
+    private final ElapsedTime elapsedTime;
     private volatile FutureServiceContainer futureContainer;
-    private volatile long startTime;
+    private volatile boolean everStopped;
 
     ApplicationServerService(final List<ServiceActivator> extraServices, final Bootstrap.Configuration configuration,
-                             final ControlledProcessState processState, final SuspendController suspendController) {
+                             final ControlledProcessState processState, final SuspendController suspendController,
+                             final ElapsedTime elapsedTime) {
         this.extraServices = extraServices;
         this.configuration = configuration;
         runningModeControl = configuration.getRunningModeControl();
-        startTime = configuration.getStartTime();
         standalone = configuration.getServerEnvironment().isStandalone();
         selfContained = configuration.getServerEnvironment().isSelfContained();
         this.processState = processState;
         this.suspendController = suspendController;
+        this.elapsedTime = elapsedTime;
     }
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
 
-        //Moved to AbstractControllerService.start()
-        //processState.setStarting();
+        // If this is a reload, track start time independently of the overall process elapsed time
+        ElapsedTime startupTime = everStopped ? elapsedTime.checkpoint() : elapsedTime;
+
         final Bootstrap.Configuration configuration = this.configuration;
         final ServerEnvironment serverEnvironment = configuration.getServerEnvironment();
         final ProductConfig config = serverEnvironment.getProductConfig();
@@ -128,15 +131,9 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         final ServiceContainer container = myController.getServiceContainer();
         futureContainer = new FutureServiceContainer();
 
-        long startTime = this.startTime;
-        if (startTime == -1) {
-            startTime = System.currentTimeMillis();
-        } else {
-            this.startTime = -1;
-        }
         CurrentServiceContainer.setServiceContainer(context.getController().getServiceContainer());
 
-        final BootstrapListener bootstrapListener = new BootstrapListener(container, startTime, serviceTarget, futureContainer, prettyVersion, serverEnvironment.getServerTempDir());
+        final BootstrapListener bootstrapListener = new BootstrapListener(container, startupTime, serviceTarget, futureContainer, prettyVersion, serverEnvironment.getServerTempDir());
         bootstrapListener.getStabilityMonitor().addController(myController);
         // Install either a local or remote content repository
         if(standalone) {
@@ -207,6 +204,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         String prettyVersion = configuration.getServerEnvironment().getProductConfig().getPrettyVersionString();
         ServerLogger.AS_ROOT_LOGGER.serverStopped(prettyVersion, (int) (context.getElapsedTime() / 1000000L));
         BootstrapListener.deleteStartupMarker(configuration.getServerEnvironment().getServerTempDir());
+        everStopped = true;
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -81,7 +81,6 @@ public interface Bootstrap {
 
         private ModuleLoader moduleLoader = Module.getBootModuleLoader();
         private ConfigurationPersisterFactory configurationPersisterFactory;
-        private long startTime;
 
 
         public Configuration(final ServerEnvironment serverEnvironment) {
@@ -99,7 +98,6 @@ public interface Bootstrap {
                     .withSecurityIdentitySupplier(this.securityIdentitySupplier)
                     .build();
             this.capabilityRegistry = new CapabilityRegistry(true);
-            this.startTime = serverEnvironment.getStartTime();
         }
 
         /**
@@ -233,9 +231,12 @@ public interface Bootstrap {
          * Get the server start time to report in the logs.
          *
          * @return the server start time
+         *
+         * @deprecated Use {@link #getServerEnvironment()}.{@link ServerEnvironment#getStartTime() getStartTime()}
          */
+        @Deprecated(forRemoval = true)
         public long getStartTime() {
-            return startTime;
+            return serverEnvironment.getStartTime();
         }
     }
 

--- a/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
@@ -106,7 +106,8 @@ final class BootstrapImpl implements Bootstrap {
                 processStateNotifier, suspendController,
                 configuration.getRunningModeControl(),
                 configuration.getServerEnvironment().getLaunchType() != ServerEnvironment.LaunchType.APPCLIENT);
-        final Service<?> applicationServerService = new ApplicationServerService(extraServices, configuration, processState, suspendController);
+        final Service<?> applicationServerService = new ApplicationServerService(extraServices, configuration, processState,
+                suspendController, configuration.getServerEnvironment().getElapsedTime());
         tracker.addService(Services.JBOSS_AS, applicationServerService)
             .install();
         final ServiceController<?> rootService = container.getRequiredService(Services.JBOSS_AS);

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -32,16 +32,16 @@ public final class BootstrapListener {
     private final StabilityMonitor monitor = new StabilityMonitor();
     private final ServiceContainer serviceContainer;
     private final ServiceTarget serviceTarget;
-    private final long startTime;
+    private final ElapsedTime elapsedTime;
     private final String prettyVersion;
     private final FutureServiceContainer futureContainer;
     private final File tempDir;
     private  String startedCleanMessage;
     private  String startedWitErrorsMessage;
 
-    public BootstrapListener(final ServiceContainer serviceContainer, final long startTime, final ServiceTarget serviceTarget, final FutureServiceContainer futureContainer, final String prettyVersion, final File tempDir) {
+    public BootstrapListener(final ServiceContainer serviceContainer, final ElapsedTime elapsedTime, final ServiceTarget serviceTarget, final FutureServiceContainer futureContainer, final String prettyVersion, final File tempDir) {
         this.serviceContainer = serviceContainer;
-        this.startTime = startTime;
+        this.elapsedTime = elapsedTime;
         this.serviceTarget = serviceTarget;
         this.prettyVersion = prettyVersion;
         this.futureContainer = futureContainer;
@@ -66,7 +66,7 @@ public final class BootstrapListener {
             Thread.currentThread().interrupt();
         } finally {
             serviceTarget.removeMonitor(monitor);
-            final long bootstrapTime = System.currentTimeMillis() - startTime;
+            final long bootstrapTime = elapsedTime.getElapsedTime();
             done(bootstrapTime, statistics, messages);
             monitor.clear();
         }
@@ -108,10 +108,10 @@ public final class BootstrapListener {
         }
         if (failed == 0 && problem == 0) {
             startedCleanMessage = ServerLogger.AS_ROOT_LOGGER.startedCleanMessage(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, onDemand + passive + lazy, appendMessage);
-            createStartupMarker("success", startTime);
+            createStartupMarker("success", elapsedTime.getStartTime());
         } else {
             startedWitErrorsMessage = ServerLogger.AS_ROOT_LOGGER.startedWitErrorsMessage(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, failed + problem, onDemand + passive + lazy, appendMessage);
-            createStartupMarker("error", startTime);
+            createStartupMarker("error", elapsedTime.getStartTime());
         }
     }
 

--- a/server/src/main/java/org/jboss/as/server/ElapsedTime.java
+++ b/server/src/main/java/org/jboss/as/server/ElapsedTime.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.server;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Tracks elapsed time since either JVM start or a moment of initialization. The start point
+ * for the calculation can be 'reset', allowing the calculation provided by an instance to
+ * account for a conceptual 'restart'.
+ */
+public final class ElapsedTime {
+
+    /**
+     * Creates a tracker that tracks elapsed time since JVM start.
+     * @return the tracker. Will not return {@code null}.
+     */
+    public static ElapsedTime startingFromJvmStart() {
+        return new ElapsedTime(null);
+    }
+
+    /**
+     * Creates a tracker that tracks elapsed time since the invocation of this method.
+     * @return the tracker. Will not return {@code null}.
+     */
+    public static ElapsedTime startingFromNow() {
+        return new ElapsedTime(System.currentTimeMillis());
+    }
+
+    private volatile Long startTime;
+
+    // Guarded by this
+    private final Map<ElapsedTime, Object > checkpoints = new WeakHashMap<>();
+
+    private ElapsedTime(Long startTime) {
+        this.startTime = startTime;
+    }
+
+    /**
+     * Gets the tracker's start point.
+     *
+     * @return the start point for this tracker, in milliseconds since the epoch.
+     */
+    public long getStartTime() {
+        return startTime != null ? startTime : ManagementFactory.getRuntimeMXBean().getStartTime();
+    }
+
+    /**
+     * Get the elapsed time in milliseconds since this tracker's start point.
+     *
+     * @return the elapsed time
+     */
+    public long getElapsedTime() {
+        return startTime == null ? ManagementFactory.getRuntimeMXBean().getUptime() : System.currentTimeMillis() - startTime;
+    }
+
+    /**
+     * Reset this tracker to begin tracking from the {@link RuntimeMXBean#getStartTime() JVM start time}.
+     * Any ElapsedTime objects that were returned from this object's {@link #checkpoint()} method will also be reset.
+     * Meant for cases where the 'origin' moment may have changed and this tracker should be updated accordingly --
+     * for example, in a 'restored' JVM that supports some form of checkpoint and restore behavior.
+     */
+    public synchronized void reset() {
+        startTime = null;
+        for (ElapsedTime checkpoint : checkpoints.keySet()) {
+            checkpoint.reset();
+        }
+    }
+
+    /**
+     * Create an ElapsedTime that tracks elapsed time from the current time, but
+     * whose starting point will automatically be {@link #reset() reset} if this object is reset.
+     */
+    public synchronized ElapsedTime checkpoint() {
+        ElapsedTime checkpoint = ElapsedTime.startingFromNow();
+        checkpoints.put(checkpoint, null);
+        return checkpoint;
+    }
+
+
+}

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -79,7 +79,7 @@ public final class Main {
             Module.registerURLStreamHandlerFactoryModule(Module.getBootModuleLoader().loadModule("org.jboss.vfs"));
             ServerEnvironmentWrapper serverEnvironmentWrapper = determineEnvironment(args, WildFlySecurityManager.getSystemPropertiesPrivileged(),
                     WildFlySecurityManager.getSystemEnvironmentPrivileged(), ServerEnvironment.LaunchType.STANDALONE,
-                    Module.getStartTime());
+                    ElapsedTime.startingFromJvmStart());
             if (serverEnvironmentWrapper.getServerEnvironment() == null) {
                 if (serverEnvironmentWrapper.getServerEnvironmentStatus() == ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR) {
                     abort(null);
@@ -113,11 +113,11 @@ public final class Main {
      * @param systemProperties system properties
      * @param systemEnvironment environment variables
      * @param launchType how the process was launched
-     * @param startTime time in ms since the epoch when the process was considered to be started
+     * @param elapsedTime tracker for elapsed time since the process was considered to be started
      * @return the ServerEnvironment object
      */
     public static ServerEnvironmentWrapper determineEnvironment(String[] args, Properties systemProperties, Map<String, String> systemEnvironment,
-                                                         ServerEnvironment.LaunchType launchType, long startTime) {
+                                                         ServerEnvironment.LaunchType launchType, ElapsedTime elapsedTime) {
         final int argsLength = args.length;
         String serverConfig = null;
         String gitRepository = null;
@@ -412,7 +412,7 @@ public final class Main {
         // Re-create using updated properties
         productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), systemProperties);
         return new ServerEnvironmentWrapper(new ServerEnvironment(hostControllerName, systemProperties, systemEnvironment,
-                serverConfig, configInteractionPolicy, launchType, runningMode, productConfig, startTime, startSuspended,
+                serverConfig, configInteractionPolicy, launchType, runningMode, productConfig, elapsedTime, startSuspended,
                 startGracefully, gitRepository, gitBranch, gitAuthConfiguration, supplementalConfiguration));
     }
 

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -299,22 +299,35 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
     private final ProductConfig productConfig;
     private final RunningModeControl runningModeControl;
     private final UUID serverUUID;
-    private final long startTime;
+    private final ElapsedTime elapsedTime;
     private final boolean startSuspended;
     private final boolean startGracefully;
     private final GitRepository repository;
     private volatile Stability stability;
 
+    /** Only for test cases */
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
             final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
             final RunningMode initialRunningMode, ProductConfig productConfig, boolean startSuspended) {
         this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
-                System.currentTimeMillis(), startSuspended, false, null, null, null, null);
+                ElapsedTime.startingFromNow(), startSuspended, false, null, null, null, null);
+    }
+
+    /** @deprecated use the variant that takes an {@link ElapsedTime elapsedTime} parameter instead of {@code long startTime}*/
+    @Deprecated(forRemoval = true)
+    public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
+                             final ConfigurationFile.InteractionPolicy configurationInteractionPolicy, final LaunchType launchType,
+                             final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended,
+                             final boolean startGracefully, final String gitRepository, final String gitBranch, final String gitAuthConfiguration,
+                             final String supplementalConfiguration) {
+        this(hostControllerName, props, env, serverConfig, configurationInteractionPolicy, launchType, initialRunningMode,
+                productConfig, ElapsedTime.startingFromJvmStart(), startSuspended, startGracefully,
+                gitRepository, gitBranch, gitAuthConfiguration, supplementalConfiguration);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
             final ConfigurationFile.InteractionPolicy configurationInteractionPolicy, final LaunchType launchType,
-            final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended,
+            final RunningMode initialRunningMode, ProductConfig productConfig, ElapsedTime elapsedTime, boolean startSuspended,
             final boolean startGracefully, final String gitRepository, final String gitBranch, final String gitAuthConfiguration,
             final String supplementalConfiguration) {
         assert props != null;
@@ -330,7 +343,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
 
         this.initialRunningMode = initialRunningMode == null ? RunningMode.NORMAL : initialRunningMode;
         this.runningModeControl = new RunningModeControl(this.initialRunningMode);
-        this.startTime = startTime;
+        this.elapsedTime = elapsedTime;
 
         this.hostControllerName = hostControllerName;
         if (standalone && hostControllerName != null) {
@@ -1088,7 +1101,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
      * @return the time, in ms since the epoch
      */
     public long getStartTime() {
-        return startTime;
+        return elapsedTime.getStartTime();
     }
 
     public boolean useGit() {
@@ -1287,5 +1300,14 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             default:      return alias;
         }
         return "standalone-" + alias + ".xml";
+    }
+
+    /**
+     * Gets this server's {@link ElapsedTime} tracker.
+     *
+     * @return the elapsed time tracker. Will not be {@code null}.
+     */
+    ElapsedTime getElapsedTime() {
+        return elapsedTime;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerStartTask.java
+++ b/server/src/main/java/org/jboss/as/server/ServerStartTask.java
@@ -114,7 +114,7 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         // Create server environment on the server, so that the system properties are getting initialized on the right side
         final ServerEnvironment providedEnvironment = new ServerEnvironment(hostControllerName, properties,
                 WildFlySecurityManager.getSystemEnvironmentPrivileged(), null, null, ServerEnvironment.LaunchType.DOMAIN,
-                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend, gracefulStartup, null, null, null, null);
+                RunningMode.NORMAL, productConfig, ElapsedTime.startingFromJvmStart(), suspend, gracefulStartup, null, null, null, null);
         DomainServerCommunicationServices.updateOperationID(initialOperationID);
 
         // TODO perhaps have ConfigurationPersisterFactory as a Service


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6661

This encapsulates the existing and possible future (WFCORE-6657) behavior around calculating and resetting 'start time' in a class, instead of passing around primitive 'startTime' longs and doing math. It uses RuntimeMXBean for the original 'start time' of a non-embedded process, instead of using Module.getStartTime(), which is a time when JBoss Modules started, not when the JVM did.
