### PR TITLE
[WFCORE-6662] Remove deprecated usage of ServiceController.getValue() by capturing ModelControllerClientFactory ...

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Server.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Server.java
@@ -17,6 +17,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.ModelControllerClientFactory;
@@ -31,10 +34,14 @@ import org.jboss.as.server.SystemExiter;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
+import org.jboss.msc.Service;
 import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.value.Value;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
 import org.wildfly.core.jar.runtime._private.BootableJarLogger;
 
 /**
@@ -151,15 +158,17 @@ final class Server {
 
             configuration.setModuleLoader(moduleLoader);
 
-            Future<ServiceContainer> future = bootstrap.startup(configuration, Collections.<ServiceActivator>emptyList());
+            // As part of bootstrap install a service to capture the ProcessStateNotifier
+            AtomicReference<ProcessStateNotifier> notifierRef = new AtomicReference<>();
+            ServiceActivator notifierCapture = ctx -> captureNotifier(ctx, notifierRef);
+
+            Future<ServiceContainer> future = bootstrap.startup(configuration, Collections.singletonList(notifierCapture));
 
             serviceContainer = future.get();
 
             executorService = Executors.newCachedThreadPool();
 
-            @SuppressWarnings({"unchecked", "deprecation"})
-            final Value<ProcessStateNotifier> processStateNotifierValue = (Value<ProcessStateNotifier>) serviceContainer.getRequiredService(ControlledProcessStateService.SERVICE_NAME);
-            processStateNotifier = processStateNotifierValue.getValue();
+            processStateNotifier = notifierRef.get();
             processStateNotifier.addPropertyChangeListener(processStateListener);
             establishModelControllerClient(processStateNotifier.getCurrentState(), true);
 
@@ -221,6 +230,7 @@ final class Server {
         if (state != ControlledProcessState.State.STOPPING && state != ControlledProcessState.State.STOPPED && serviceContainer != null) {
             ModelControllerClientFactory clientFactory;
             try {
+                // TODO replace this in start() with the ServiceActivator approach we used to capture the ProcessStateNotifier
                 @SuppressWarnings("unchecked")
                 final ServiceController clientFactorySvc
                         = serviceContainer.getService(ServerService.JBOSS_SERVER_CLIENT_FACTORY);
@@ -263,5 +273,22 @@ final class Server {
                 return modelControllerClient;
             }
         }
+    }
+
+    private static void captureNotifier(ServiceActivatorContext ctx, AtomicReference<ProcessStateNotifier> notifierRef) {
+        ServiceBuilder<?> sb = ctx.getServiceTarget().addService();
+        final Supplier<ProcessStateNotifier> result = sb.requires(ControlledProcessStateService.INTERNAL_SERVICE_NAME);
+        sb.setInstance(new Service() {
+            @Override
+            public void start(StartContext context) {
+                notifierRef.set(result.get());
+                context.getController().setMode(ServiceController.Mode.REMOVE);
+            }
+
+            @Override
+            public void stop(StopContext context) {
+            }
+        });
+        sb.install();
     }
 }

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -40,6 +40,7 @@ import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.wildfly.core.embedded.logging.EmbeddedLogger;
@@ -208,6 +209,7 @@ public class EmbeddedStandaloneServerFactory {
         private ModelControllerClient modelControllerClient;
         private ExecutorService executorService;
         private ProcessStateNotifier processStateNotifier;
+        private final AtomicReference<ModelControllerClientFactory> clientFactorySvcCaptureRef;
 
         public StandaloneServerImpl(String[] cmdargs, Properties systemProps, Map<String, String> systemEnv, ModuleLoader moduleLoader, ClassLoader embeddedModuleCL) {
             this.cmdargs = cmdargs;
@@ -215,6 +217,7 @@ public class EmbeddedStandaloneServerFactory {
             this.systemEnv = systemEnv;
             this.moduleLoader = moduleLoader;
             this.embeddedModuleCL = embeddedModuleCL;
+            this.clientFactorySvcCaptureRef = new AtomicReference<>(null);
 
             processStateListener = new PropertyChangeListener() {
                 @Override
@@ -268,9 +271,10 @@ public class EmbeddedStandaloneServerFactory {
 
                     // As part of bootstrap install a service to capture the ProcessStateNotifier
                     AtomicReference<ProcessStateNotifier> notifierRef = new AtomicReference<>();
-                    ServiceActivator notifierCapture = ctx -> captureNotifier(ctx, notifierRef);
+                    ServiceActivator notifierCapture = ctx -> captureNotifier(ctx, notifierRef, ControlledProcessStateService.INTERNAL_SERVICE_NAME);
+                    ServiceActivator clientFactorySvcCapture = ctx -> captureNotifier(ctx, clientFactorySvcCaptureRef, ServerService.JBOSS_SERVER_CLIENT_FACTORY);
 
-                    Future<ServiceContainer> future = bootstrap.startup(configuration, Collections.singletonList(notifierCapture));
+                    Future<ServiceContainer> future = bootstrap.startup(configuration, List.of(notifierCapture, clientFactorySvcCapture));
 
                     serviceContainer = future.get();
 
@@ -296,9 +300,9 @@ public class EmbeddedStandaloneServerFactory {
             }
         }
 
-        private static void captureNotifier(ServiceActivatorContext ctx, AtomicReference<ProcessStateNotifier> notifierRef) {
+        private static<T> void captureNotifier(ServiceActivatorContext ctx, AtomicReference<T> notifierRef, ServiceName requiredService) {
             ServiceBuilder<?> sb = ctx.getServiceTarget().addService();
-            final Supplier<ProcessStateNotifier> result = sb.requires(ControlledProcessStateService.INTERNAL_SERVICE_NAME);
+            final Supplier<T> result = sb.requires(requiredService);
             sb.setInstance(new Service() {
                 @Override
                 public void start(StartContext context) {
@@ -378,24 +382,11 @@ public class EmbeddedStandaloneServerFactory {
         }
 
         private synchronized void establishModelControllerClient(ControlledProcessState.State state, boolean storeState) {
-            ModelControllerClient newClient = null;
-            if (state != ControlledProcessState.State.STOPPING && state != ControlledProcessState.State.STOPPED && serviceContainer != null) {
-                ModelControllerClientFactory clientFactory;
-                try {
-                    // TODO replace this in start() with the ServiceActivator approach we used to capture the ProcessStateNotifier
-                    @SuppressWarnings("unchecked")
-                    final ServiceController clientFactorySvc =
-                            serviceContainer.getService(ServerService.JBOSS_SERVER_CLIENT_FACTORY);
-                    clientFactory = (ModelControllerClientFactory) clientFactorySvc.getValue();
-                } catch (RuntimeException e) {
-                    // Either NPE because clientFactorySvc was not installed, or ISE from getValue because not UP
-                    clientFactory = null;
-                }
-                if (clientFactory != null) {
-                    newClient = clientFactory.createSuperUserClient(executorService, true);
-                }
+            modelControllerClient = null;
+            if (state != ControlledProcessState.State.STOPPING && state != ControlledProcessState.State.STOPPED
+                    && serviceContainer != null && clientFactorySvcCaptureRef.get() != null) {
+                modelControllerClient = clientFactorySvcCaptureRef.get().createSuperUserClient(executorService, true);
             }
-            modelControllerClient = newClient;
             if (storeState || currentProcessState == null) {
                 currentProcessState = state;
             }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerBootstrap.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerBootstrap.java
@@ -46,7 +46,7 @@ public class HostControllerBootstrap {
         final ControlledProcessState processState = new ControlledProcessState(true);
         shutdownHook.setControlledProcessState(processState);
         ServiceTarget target = serviceContainer.subTarget();
-        ProcessStateNotifier processStateNotifier = ControlledProcessStateService.addService(target, processState).getValue();
+        ProcessStateNotifier processStateNotifier = ControlledProcessStateService.addService(target, processState);
         RunningStateJmx.registerMBean(processStateNotifier, null, runningModeControl, false);
         final HostControllerService hcs = new HostControllerService(environment, runningModeControl, authCode, processState);
         target.addService(HostControllerService.HC_SERVICE_NAME, hcs).install();

--- a/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
@@ -98,7 +98,7 @@ final class BootstrapImpl implements Bootstrap {
         final ServiceTarget tracker = container.subTarget();
         final ControlledProcessState processState = new ControlledProcessState(true);
         shutdownHook.setControlledProcessState(processState);
-        ProcessStateNotifier processStateNotifier = ControlledProcessStateService.addService(tracker, processState).getValue();
+        ProcessStateNotifier processStateNotifier = ControlledProcessStateService.addService(tracker, processState);
         final SuspendController suspendController = new SuspendController();
         //Instantiating the suspendcontroller here to be able to get a reference to it in RunningStateJmx
         //Note that the SuspendController service will be started in the ServerService during the boot of the server.


### PR DESCRIPTION
...via ServiceActivator starting the Bootable JAR and Embedded server

This PR follows up on #5824, also built on top of that one.

Jira issue: https://issues.redhat.com/browse/WFCORE-6662

