### PR TITLE
[WFCORE-6667] Upgrade WildFly Elytron to 2.2.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.2.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.2.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6667

    Release Notes - WildFly Elytron - Version 2.2.3.Final

Task

*    [ELY-2570](https://issues.redhat.com/browse/ELY-2570) - Add newly added constants for bearer-only support to org.wildfly.security.http.oidc.Oidc
* [ELY-2583](https://issues.redhat.com/browse/ELY-2583) - Make requestURI and Source-Address available from RealmSuccessfulAuthenticationEvent and RealmFailedAuthenticationEvent

Release

*    [ELY-2712](https://issues.redhat.com/browse/ELY-2712) - Release WildFly Elytron 2.2.3.Final