### PR TITLE
[WFCORE-5917] Use variable expansion replacement instead of pattern r…

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -212,8 +212,9 @@ fi
 # clean server opts
 for var in $SERVER_OPTS
 do
-   if [ "${var//"-Djboss.server.base.dir"/}" != "${var}" ]; then
-     SERVER_OPTS="${SERVER_OPTS//$var/}"
+   v=`echo "${var}" | sed 's/-Djboss.server.base.dir//g'`
+   if [ "${v}" != "${var}" ]; then
+     SERVER_OPTS=`echo "${SERVER_OPTS}" | sed "s|${var}||g"`
    fi
 done
 

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -212,8 +212,8 @@ fi
 # clean server opts
 for var in $SERVER_OPTS
 do
-   if [ "${var#"-Djboss.server.base.dir"}" != "$var" ]; then
-      SERVER_OPTS=${SERVER_OPTS#"$var"}
+   if [ "${var//"-Djboss.server.base.dir"/}" != "${var}" ]; then
+     SERVER_OPTS="${SERVER_OPTS//$var/}"
    fi
 done
 

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptProcess.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptProcess.java
@@ -235,6 +235,12 @@ public class ScriptProcess extends Process implements AutoCloseable {
     }
 
     @Override
+    public ProcessHandle toHandle() {
+        checkStatus();
+        return delegate.toHandle();
+    }
+
+    @Override
     public String toString() {
         return getCommandString(Collections.emptyList());
     }


### PR DESCRIPTION
…emoving to avoid duplicate jboss.server.base.dir options

Jira issue: https://issues.redhat.com/browse/WFCORE-5917

