### PR TITLE
[WFCORE-6531] Wrap server options in double quotes

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/domain.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.sh
@@ -24,7 +24,7 @@ do
           exit 1
           ;;
       *)
-          SERVER_OPTS="$SERVER_OPTS '$1'"
+          SERVER_OPTS="$SERVER_OPTS \"$1\""
           ;;
     esac
     shift
@@ -112,7 +112,7 @@ if $linux; then
     for var in $HOST_CONTROLLER_OPTS
     do
        # Remove quotes
-      p=`echo $var | tr -d "'"`
+      p=`echo $var | tr -d "'" | tr -d "\""`
       case $p in
         -Djboss.domain.base.dir=*)
              JBOSS_BASE_DIR=`readlink -m ${p#*=}`
@@ -134,7 +134,7 @@ if $solaris; then
     for var in $HOST_CONTROLLER_OPTS
     do
        # Remove quotes
-      p=`echo $var | tr -d "'"`
+      p=`echo $var | tr -d "'" | tr -d "\""`
       case $p in
         -Djboss.domain.base.dir=*)
              JBOSS_BASE_DIR=`echo $p | awk -F= '{print $2}'`
@@ -157,7 +157,7 @@ if $darwin || $other ; then
     for var in $HOST_CONTROLLER_OPTS
     do
        # Remove quotes
-       p=`echo $var | tr -d "'"`
+       p=`echo $var | tr -d "'" | tr -d "\""`
        case $p in
         -Djboss.domain.base.dir=*)
              JBOSS_BASE_DIR=`cd ${p#*=} ; pwd -P`

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.sh
@@ -34,7 +34,7 @@ do
           shift
           break;;
       *)
-          SERVER_OPTS="$SERVER_OPTS '$1'"
+          SERVER_OPTS="$SERVER_OPTS \"$1\""
           ;;
     esac
     shift
@@ -144,7 +144,7 @@ if $linux; then
     for var in $CONSOLIDATED_OPTS
     do
        # Remove quotes
-       p=`echo $var | tr -d "'"`
+       p=`echo $var | tr -d "'" | tr -d "\""`
        case $p in
          -Djboss.server.base.dir=*)
               JBOSS_BASE_DIR=`readlink -m ${p#*=}`
@@ -165,8 +165,8 @@ if $solaris; then
     # process the standalone options
     for var in $CONSOLIDATED_OPTS
     do
-       # Remove quotes
-       p=`echo $var | tr -d "'"`
+      # Remove quotes
+      p=`echo $var | tr -d "'" | tr -d "\""`
       case $p in
         -Djboss.server.base.dir=*)
              JBOSS_BASE_DIR=`echo $p | awk -F= '{print $2}'`
@@ -189,7 +189,7 @@ if $darwin || $freebsd || $other ; then
     for var in $CONSOLIDATED_OPTS
     do
        # Remove quotes
-       p=`echo $var | tr -d "'"`
+       p=`echo $var | tr -d "'" | tr -d "\""`
        case $p in
          -Djboss.server.base.dir=*)
               JBOSS_BASE_DIR=`cd ${p#*=} ; pwd -P`


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6531

The SERVER_OPTS were being wrapped in single quotes, which does not prevent a misuse using eval. Wrap them in double quotes.