### PR TITLE
[23.x] [WFCORE-6676] CVE-2023-48795 Upgrade SSHD from 2.11.0 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
-        <version.org.apache.sshd>2.11.0</version.org.apache.sshd>
+        <version.org.apache.sshd>2.12.0</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
         <version.org.bouncycastle>1.77</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>


### PR DESCRIPTION
upstream: #5844 

Jira issue: https://issues.redhat.com/browse/WFCORE-6676

