### PR TITLE
[WFCORE-6692] Upgrade WildFly Elytron to 2.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.2.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.3.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6692


        Release Notes - WildFly Elytron - Version 2.3.0.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1700'>ELY-1700</a>] -         Intermittently failing AttributeMappingSuiteChild
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2576'>ELY-2576</a>] -         Make it possible to use DigestPasswords when using the DIGEST-SHA-256 and DIGEST-SHA-512-256 HTTP Digest authentication mechanisms
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2658'>ELY-2658</a>] -         Remove the unassigned call to the constructor in X500AttributePrincipalDecoderTest#testDecodeWithConcatenation
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2717'>ELY-2717</a>] -         Ensure that the credential algorithm for the DIGEST mechanism is set to digest-md5
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2166'>ELY-2166</a>] -         Add javadoc for org.wildfly.security.sasl.util.SaslMechanismInformation.Names class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2167'>ELY-2167</a>] -         Add javadoc for SNI related classes
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2174'>ELY-2174</a>] -         Add tests for the BEARER authentication mechanism.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2329'>ELY-2329</a>] -         Utilize the simple implementation of HttpServerCookie
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2349'>ELY-2349</a>] -         Clean up ElytronXmlParser code.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2412'>ELY-2412</a>] -         Update link to Elytron&#39;s Jira issues in README.adoc
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2507'>ELY-2507</a>] -         Move appropriate methods in AbstractDigestMechanism into &quot;DigestWrapper&quot;.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2508'>ELY-2508</a>] -         Add tests for DigestMechanismFactory 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2511'>ELY-2511</a>] -         Add test that verifies that digest response prefix is case insensitive
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2512'>ELY-2512</a>] -         Move assertions from test methods that have expected exception defined
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2550'>ELY-2550</a>] -         Add option to skip certificate verification with the realm when using SASL EXTERNAL
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2570'>ELY-2570</a>] -         Add newly added constants for bearer-only support to org.wildfly.security.http.oidc.Oidc
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2573'>ELY-2573</a>] -         Fix version.org.jboss.logging.tools
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2577'>ELY-2577</a>] -         OIDC testsuite relies on localhost being in /etc/hosts
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2581'>ELY-2581</a>] -         Update Elytron&#39;s SECURITY.md file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2583'>ELY-2583</a>] -         Make requestURI and Source-Address available from RealmSuccessfulAuthenticationEvent and RealmFailedAuthenticationEvent
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2592'>ELY-2592</a>] -         Update the SyslogAuditEndpoint constructor to no longer use a ternary statement
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2593'>ELY-2593</a>] -         Update the CompositePrincipal constructor to no longer use a ternary statement
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2595'>ELY-2595</a>] -         Remove unused method parameter in FileSystemSecurityRealm#requiredVersion
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2596'>ELY-2596</a>] -         Add missing @Override annotation to the FileSystemSecurityRealm#Identity class dispose method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2597'>ELY-2597</a>] -         Merge an if statement in verifyCertificate in X509EvidenceVerifier with its enclosing if statement
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2599'>ELY-2599</a>] -         Update assertEquals calls in RegexRoleMapperTest so that the expected value and actual value are passed in the correct order
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2601'>ELY-2601</a>] -         Declare newMap on a separate line in PasswordKeyStoreSpi
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2602'>ELY-2602</a>] -         Update assertEquals calls in ElytronXmlParserTest so that the expected value and actual value are passed in the correct order
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2603'>ELY-2603</a>] -         Replace a switch statement in ElytronXmlParser#parseCertificateRevocationLists to improve readability 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2604'>ELY-2604</a>] -         Make the constructor for FailoverRealmIdentity to “protected” since it is an abstract class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2605'>ELY-2605</a>] -         Make two fields in the CredentialStoreCommand class final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2606'>ELY-2606</a>] -         Make two fields in the ElytronTool class final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2607'>ELY-2607</a>] -         Directly append iterationCount instead of using String.valueOf()
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2608'>ELY-2608</a>] -         Use a constant for the mask prefix in VaultCommand
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2609'>ELY-2609</a>] -         Replace if-then-else statement with a single return statement in OidcPrincipal
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2610'>ELY-2610</a>] -         The getAccessTokenHash method can be moved into the AtHashValidator class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2612'>ELY-2612</a>] -         Update 4 tests in BasicScramSelfTest to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2613'>ELY-2613</a>] -         Update an assertEquals call in ScramServerCompatibilityTest#testAllowedAuthorizationId so that the expected value and actual value are passed in the correct order
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2614'>ELY-2614</a>] -         Update 3 tests in KeyStoreUtilTest to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2615'>ELY-2615</a>] -         Add a test class that tests creating and making use of a custom NameRewriter
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2616'>ELY-2616</a>] -         Replace this &quot;switch&quot; statement by &quot;if&quot; statements to increase readability.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2617'>ELY-2617</a>] -         Add a default case to this switch in DigestMechanismFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2618'>ELY-2618</a>] -         Replace this if-then-else statement by a single return statement in OidcClientConfiguration
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2619'>ELY-2619</a>] -         Immediately return this expression instead of assigning it to the temporary variable
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2620'>ELY-2620</a>] -         Add a test that makes use of the RoleMapper#and method to RoleMappingTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2621'>ELY-2621</a>] -         Add a test that makes use of the RoleMapper#or method to RoleMappingTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2622'>ELY-2622</a>] -         Add a new test class that makes use of the BearerMechanismFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2623'>ELY-2623</a>] -         Add a new test methods testing that the verifyEvidence method of identity obtained from DistributedSecurityRealm works as expected
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2624'>ELY-2624</a>] -         Update the JavaDoc for the PrincipalDecoder#aggregate method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2625'>ELY-2625</a>] -         Add a test to X500AttributePrincipalDecoderTest that makes use of the PrincipalDecoder#aggregate method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2628'>ELY-2628</a>] -         Move the method LongNameSetPermissionCollection#permissionFor to the inner class Iter
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2629'>ELY-2629</a>] -         move the method IntNameSetPermissionCollection#permissionFor to the inner class Iter
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2632'>ELY-2632</a>] -         Add a test testing that the exception is thrown when incorrect &quot;response&quot; field is provided by the SASL client
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2635'>ELY-2635</a>] -         Update README to specify 2.x instead of the 1.x branch
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2640'>ELY-2640</a>] -         Simplify assertion in maskCompatibilityCheck test in MaskCommandTest class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2641'>ELY-2641</a>] -         Simplify assersions in MaskCommandTest#testMissingSaltAndIteration method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2642'>ELY-2642</a>] -         Simplify assertion in testMissingIteration method of MaskCommandTest class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2643'>ELY-2643</a>] -         Simplify assertions in testIterationAsStringValue method in MaskCommandTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2644'>ELY-2644</a>] -         Simplify assertions in testIterationAsLongMax method in MaskCommandTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2645'>ELY-2645</a>] -         Simplify assertions in testIterationAsNegativeValue method in MaskCommandTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2647'>ELY-2647</a>] -         Add a link to elytron-examples repository to wildfly-elytron README file
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2676'>ELY-2676</a>] -         Merge if statement with the enclosing one in AcmeClientSpi#getRetryAfter
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2677'>ELY-2677</a>] -         Merge if statement with the enclosing one in X500#createX509CertificateChain
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2678'>ELY-2678</a>] -          Replace assert in VaultCommandTest with a proper check
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2679'>ELY-2679</a>] -          Replace assert in VaultCommandTest with a proper check
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2681'>ELY-2681</a>] -         Refactor OAuth2SaslClientV10Test to use common method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2682'>ELY-2682</a>] -         Refactor OAuth2SaslClientV11Test to use common method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2683'>ELY-2683</a>] -         Refactor OAuth2SaslClientV11Test to use common method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2684'>ELY-2684</a>] -         Update 3 tests in OTPTest to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2685'>ELY-2685</a>] -          Replace assert in PasswordBasedEncryptionUtilTest with a proper check
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2686'>ELY-2686</a>] -         Merge an if statement with the enclosing one in X509EvidenceVerifier
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2687'>ELY-2687</a>] -         Merge an if statement with the enclosing one in ServerAuthenticationContext
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2688'>ELY-2688</a>] -         Merge an if statement with the enclosing one in RequestAuthenticator#authenticate
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2690'>ELY-2690</a>] -         Merge an if statement with the enclosing one in SSLUtils
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2691'>ELY-2691</a>] -         Merge if statement with the enclosing one in X509RevocationTrustManager#checkCertPathLength
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2692'>ELY-2692</a>] -         Merge an if statement with the enclosing one in X509RevocationTrustManager
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2693'>ELY-2693</a>] -         Update 3 tests in JwtSecurityRealmTest to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2694'>ELY-2694</a>] -         Update assertEquals calls in CommandCredentialSourceTest so that the expected value and actual value are passed in the correct order
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2695'>ELY-2695</a>] -         Update the import statement in CommandCredentialSourceTest for the Assert class objects to import them explicitly
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2697'>ELY-2697</a>] -         Update 4 tests in CompatibilityServerTest to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2699'>ELY-2699</a>] -         Update 4 tests in DigestTest to call a common method in order to remove duplicated code
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2718'>ELY-2718</a>] -         Release Elytron 2.3.0.Final
</li>
</ul>
                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2578'>ELY-2578</a>] -         Upgrade nimbus-jose-jwt from 8.2.1 to 9.31
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2582'>ELY-2582</a>] -         Upgrade Jackson FasterXML to version 2.15.2 - resolves CVE PRISMA-2023-0067
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2650'>ELY-2650</a>] -         Upgrade sshd-common from 2.9.2 to 2.10.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2660'>ELY-2660</a>] -         Upgrade commons-cli:commons-cli from 1.4 to 1.5.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2661'>ELY-2661</a>] -         Upgrade jakarta.enterprise:jakarta.enterprise.cdi-api from 2.0.2 to 4.0.1
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2664'>ELY-2664</a>] -         Upgrade org.apache.httpcomponents:httpclient from 4.5.13	to 4.5.14
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2665'>ELY-2665</a>] -         Upgrade org.apache.httpcomponents:httpcore from 4.4.15 to 4.4.16
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2666'>ELY-2666</a>] -         Upgrade org.apache.sshd:sshd-common from 2.9.2 to 2.10.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2667'>ELY-2667</a>] -         Upgrade org.jboss.logging:jboss-logging from 3.4.3.Final to 3.5.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2668'>ELY-2668</a>] -         Upgrade org.jboss.logmanager:jboss-logmanager from 2.1.18.Final to 2.1.19.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2669'>ELY-2669</a>] -         Upgrade org.jboss.modules:jboss-modules from 1.9.2.Final to 1.12.2.Final	
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2670'>ELY-2670</a>] -         Upgrade org.jboss.slf4j:slf4j-jboss-logmanager from 1.0.4.GA to 1.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2671'>ELY-2671</a>] -         Upgrade org.jboss.threads:jboss-threads from 2.4.0.Final to 3.5.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2672'>ELY-2672</a>] -         Upgrade org.kohsuke.metainf-services:metainf-services from 1.7	to 1.11
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2673'>ELY-2673</a>] -         Upgrade org.wildfly.common:wildfly-common from 1.5.4.Final to 1.6.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2700'>ELY-2700</a>] -         Bump version.com.fasterxml.jackson from 2.15.2 to 2.15.3
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2703'>ELY-2703</a>] -         Upgrade Apache Commons CLI from 1.5.0 to 1.6.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2706'>ELY-2706</a>] -         Upgrade commons-lang3 from 3.13.0 to 3.14.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2710'>ELY-2710</a>] -         Bump org.bitbucket.b_c:jose4j from 0.9.3 to 0.9.4
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2716'>ELY-2716</a>] -         Upgrade Apache SSHD to version 2.12.0
</li>
</ul>
                                                                   