### PR TITLE
[WFCORE-6695] CVE-2023-4639 Upgrade Undertow to 2.3.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.106.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.6</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.10.Final</version.io.undertow>
+        <version.io.undertow>2.3.11.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6695


        Release Notes - Undertow - Version 2.3.11.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2304'>UNDERTOW-2304</a>] -         Prevent repeating SslConduit.doUnwrap under task thread exhaustion conditions
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2309'>UNDERTOW-2309</a>] -         Possible memory leak in DefaultByteBufferPool
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2330'>UNDERTOW-2330</a>] -         &quot;UT000131: Buffer pool is closed&quot; when server is stopping
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2337'>UNDERTOW-2337</a>] -         Multipart form-data larger than 16KiB is not available through Servlet getParameter API
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2338'>UNDERTOW-2338</a>] -         NullPointerException in io.undertow.servlet.spec.ServletOutputStreamImpl.setWriteListener
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2342'>UNDERTOW-2342</a>] -         CVE-2023-4639 Ignore cookie with improper quotes
</li>
</ul>
                                                                                                            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2331'>UNDERTOW-2331</a>] -         RapidResetDDoSUnitTestCase test fails sporadically
</li>
</ul>
                                                                                                                                                    