### PR TITLE
[23.x] [WFCORE-6695] CVE-2023-4639 Upgrade Undertow to 2.3.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.105.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.6</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.10.Final</version.io.undertow>
+        <version.io.undertow>2.3.11.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Backport #5858 to 23.x

Jira issue: https://issues.redhat.com/browse/WFCORE-6695

