### PR TITLE
[WFCORE-6702]/[WFCORE-6703] Elytron component upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.3.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.3.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.0.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.3.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>4.0.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6702
https://issues.redhat.com/browse/WFCORE-6703


        Release Notes - WildFly Elytron - Version 2.3.1.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2589'>ELY-2589</a>] -         Elytron SSO does not expire other application sessions for session invalidation like Undertow SSO promptly following sessionid change
</li>
</ul>
                    
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2720'>ELY-2720</a>] -         Release WildFly Elytron 2.3.1.Final
</li>
</ul>


        Release Notes - Elytron Web - Version 4.1.0.Final
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-211'>ELYWEB-211</a>] -         Update branches in pr-ci.yaml to add 4.x
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-222'>ELYWEB-222</a>] -         Add a test for single sign on across two apps
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-231'>ELYWEB-231</a>] -         Temporarily ignore FormServletAuthenticationWithClusteredSSOTest until we release and upgrade to Elytron 2.3.1.Final
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-234'>ELYWEB-234</a>] -         Release Elytron Web 4.1.0.Final
</li>
</ul>
                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-223'>ELYWEB-223</a>] -         Upgrade nimbus-jose-jwt to 9.31
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-224'>ELYWEB-224</a>] -         Upgrade Infinispan to 14.0.22
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-225'>ELYWEB-225</a>] -         Upgrade JUnit to 4.13.2
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-226'>ELYWEB-226</a>] -         Upgrade Undertow to 2.3.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-227'>ELYWEB-227</a>] -         Upgrade XNIO to 3.8.12.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELYWEB-233'>ELYWEB-233</a>] -         Upgrade WildFly Elytron to 2.3.1.Final and unignore FormServletAuthenticationWithClusteredSSOTest
</li>
</ul>                                                                                                                                                           