### PR TITLE
[WFCORE-6707][WFCORE-6708][WFCORE-6709] CVE-2023-5379 CVE-2024-1459 CVE-2024-1635 Upgrade Undertow, XNIO and JBoss Remoting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.12.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.13.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.1.3.SP1</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.1.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.5.2.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.27.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.28.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.1.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>2.0.1.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.107.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.6</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.11.Final</version.io.undertow>
+        <version.io.undertow>2.3.12.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
23.x PR: #5876 

Jiras:
https://issues.redhat.com/browse/WFCORE-6707 - relates to CVE-2024-1635
https://issues.redhat.com/browse/WFCORE-6708 - relates to CVE-2024-1635
https://issues.redhat.com/browse/WFCORE-6709 - fixes CVE-2023-5379 CVE-2024-1459 CVE-2024-1635


        Release Notes - XNIO - Version 3.8.13.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-427'>XNIO-427</a>] -         ClosedChannelException when NioSocketConduit.handleReady invokes write listener after read listener closes connection
</li>
</ul>
                                                                                                                                                                                                                                                                


        Release Notes - JBoss Remoting (3+) - Version 5.0.28.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-404'>REM3-404</a>] -         Remoting connections closed during greetings exchange after HTTP upgrade are not properly cleaned after closed
</li>
</ul>
                                                                                                            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-405'>REM3-405</a>] -         Improve performance of server accept
</li>
</ul>



        Release Notes - Undertow - Version 2.3.12.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2280'>UNDERTOW-2280</a>] -         CVE-2023-5379 AJP request which exceed max-header-size cause JBoss EAP to be marked as error status in httpd as a reverse-proxy
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2336'>UNDERTOW-2336</a>] -         CVE-2024-1635 At Http upgrade to remoting, WriteTimeoutStreamSinkConduit leaks connections if RemotingConnection is closed by Remoting ServerConnectionOpenListener
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2339'>UNDERTOW-2339</a>] -         CVE-2024-1459 Directory traversal vulnerability when accessed via proxy
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2345'>UNDERTOW-2345</a>] -         ClientEndpointConfig stored SSLContext is ignored by Undertow implementation
</li>
</ul>
                                                                                                                                                                                                                                                                
                                                                                                                                                    