### PR TITLE
[WFCORE-6712] Ensure the JBoss Modules ModuleLoggerFinder is activate…

### DIFF
--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
@@ -31,7 +31,7 @@ import org.wildfly.core.embedded.EmbeddedProcessStartException;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @SuppressWarnings("Convert2Lambda")
-class AbstractTestCase {
+public class AbstractTestCase {
 
     static final ModelNode EMPTY_ADDRESS = new ModelNode().addEmptyList();
 
@@ -51,12 +51,12 @@ class AbstractTestCase {
         service.shutdownNow();
     }
 
-    void startAndWaitFor(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check) throws TimeoutException, InterruptedException, EmbeddedProcessStartException {
+    protected void startAndWaitFor(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check) throws TimeoutException, InterruptedException, EmbeddedProcessStartException {
         server.start();
         waitFor(server, check);
     }
 
-    void waitFor(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check) throws TimeoutException, InterruptedException {
+    protected void waitFor(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check) throws TimeoutException, InterruptedException {
         final Callable<Boolean> callable = new Callable<Boolean>() {
             @Override
             public Boolean call() throws InterruptedException {
@@ -84,7 +84,7 @@ class AbstractTestCase {
         }
     }
 
-    static final Function<EmbeddedManagedProcess, Boolean> STANDALONE_CHECK = new Function<EmbeddedManagedProcess, Boolean>() {
+    protected static final Function<EmbeddedManagedProcess, Boolean> STANDALONE_CHECK = new Function<EmbeddedManagedProcess, Boolean>() {
         private final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state");
 
         @Override
@@ -103,7 +103,7 @@ class AbstractTestCase {
         }
     };
 
-    static final Function<EmbeddedManagedProcess, Boolean> HOST_CONTROLLER_CHECK = new Function<EmbeddedManagedProcess, Boolean>() {
+    protected static final Function<EmbeddedManagedProcess, Boolean> HOST_CONTROLLER_CHECK = new Function<EmbeddedManagedProcess, Boolean>() {
         @Override
         public Boolean apply(final EmbeddedManagedProcess server) {
 
@@ -122,7 +122,7 @@ class AbstractTestCase {
         }
     };
 
-    static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op) throws IOException {
+    protected static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op) throws IOException {
         return executeOperation(client, OperationBuilder.create(op).build());
     }
 

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
@@ -45,7 +45,7 @@ public class Environment {
         TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
     }
 
-    static Configuration.Builder createConfigBuilder() {
+    public static Configuration.Builder createConfigBuilder() {
         return Configuration.Builder.of(JBOSS_HOME)
                 .setModulePath(MODULE_PATH.toString());
     }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/SystemLoggerHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/SystemLoggerHostControllerTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.core.test.embedded.host.controller;
+
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.embedded.EmbeddedProcessFactory;
+import org.wildfly.core.embedded.HostController;
+import org.wildfly.core.test.embedded.AbstractTestCase;
+import org.wildfly.core.test.embedded.Environment;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemLoggerHostControllerTestCase extends AbstractTestCase {
+
+
+    /**
+     * Tests that a {@link System.Logger} logs messages. This is a regression test for WFCORE-6712.
+     *
+     * @throws Exception if an error occurs in the test
+     */
+    @Test
+    public void hostController() throws Exception {
+        // Configure the log manager settings
+        final String logFileName = "test-hc-system-logger.log";
+        System.setProperty("test.log.file", logFileName);
+        System.setProperty("logging.configuration", getClass().getResource("/jbl-logging.properties").toExternalForm());
+        System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+        // We need to explicitly override the JBoss Logging provider property as it's set in surefire
+        final Configuration.LoggerHint loggerHint = Configuration.LoggerHint.JBOSS_LOG_MANAGER;
+        System.setProperty("org.jboss.logging.provider", loggerHint.getProviderCode());
+
+        // Create the embedded process
+        final Configuration configuration = Environment.createConfigBuilder()
+                .setLoggerHint(loggerHint)
+                .build();
+        final HostController server = EmbeddedProcessFactory.createHostController(configuration);
+        startAndWaitFor(server, HOST_CONTROLLER_CHECK);
+
+        // Log a simple message with a System.Logger
+        final System.Logger logger = System.getLogger(SystemLoggerHostControllerTestCase.class.getName());
+        final String msg = "This is a test message from " + SystemLoggerHostControllerTestCase.class.getName() + " HostController.";
+        logger.log(System.Logger.Level.INFO, msg);
+
+        // Read all lines from the log file and look for the test message
+        final List<String> logLines = Files.readAllLines(Environment.LOG_DIR.resolve(logFileName));
+        Assert.assertTrue(String.format("Failed to find line \"%s\". Logs found%n: %s", msg, logLines), logLines.stream()
+                .anyMatch(line -> line.endsWith(msg)));
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/SystemLoggerStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/SystemLoggerStandaloneTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.core.test.embedded.standalone;
+
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.embedded.EmbeddedProcessFactory;
+import org.wildfly.core.embedded.StandaloneServer;
+import org.wildfly.core.test.embedded.AbstractTestCase;
+import org.wildfly.core.test.embedded.Environment;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemLoggerStandaloneTestCase extends AbstractTestCase {
+
+    /**
+     * Tests that a {@link System.Logger} logs messages. This is a regression test for WFCORE-6712.
+     *
+     * @throws Exception if an error occurs in the test
+     */
+    @Test
+    public void standalone() throws Exception {
+        // Configure the log manager settings
+        final String logFileName = "test-standalone-system-logger.log";
+        System.setProperty("test.log.file", logFileName);
+        System.setProperty("logging.configuration", getClass().getResource("/jbl-logging.properties").toExternalForm());
+        System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+        // We need to explicitly override the JBoss Logging provider property as it's set in surefire
+        final Configuration.LoggerHint loggerHint = Configuration.LoggerHint.JBOSS_LOG_MANAGER;
+        System.setProperty("org.jboss.logging.provider", loggerHint.getProviderCode());
+
+        // Create the embedded process
+        final Configuration configuration = Environment.createConfigBuilder()
+                .setLoggerHint(loggerHint)
+                .build();
+        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(configuration);
+        startAndWaitFor(server, STANDALONE_CHECK);
+
+        // Log a simple message with a System.Logger
+        final System.Logger logger = System.getLogger(SystemLoggerStandaloneTestCase.class.getName());
+        final String msg = "This is a test message from " + SystemLoggerStandaloneTestCase.class.getName() + " standalone.";
+        logger.log(System.Logger.Level.INFO, msg);
+
+        // Read all lines from the log file and look for the test message
+        final List<String> logLines = Files.readAllLines(Environment.LOG_DIR.resolve(logFileName));
+        Assert.assertTrue(String.format("Failed to find line \"%s\". Logs found%n: %s", msg, logLines), logLines.stream()
+                .anyMatch(line -> line.endsWith(msg)));
+    }
+}


### PR DESCRIPTION
…d after the log manager is configured.

https://issues.redhat.com/browse/WFCORE-6712

Please note we could wait for https://github.com/jboss-modules/jboss-modules/pull/328 to be merged, then upgrade JBoss Modules and simply replace the reflection calls with `ModuleLoggerFinder.activate()`. However, I figured I'd send this for now just in case we want a fix sooner or one that is backwards compatible with other versions of JBoss Modules.
