### PR TITLE
[WFCORE-6739] Allow ordering of ServerActivity execution by registerin…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/suspend/ServerActivity.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/ServerActivity.java
@@ -8,10 +8,54 @@ package org.jboss.as.server.suspend;
 /**
  * A server activity that may have to finish before the server can shut down gracefully.
  *
- *
  * @author Stuart Douglas
  */
 public interface ServerActivity {
+
+    /**
+     * The lowest valid value to return from {@link #getExecutionGroup()}.
+     */
+    @SuppressWarnings("unused")
+    int LOWEST_EXECUTION_GROUP = 1;
+    /**
+     * The default value returned from {@link #getExecutionGroup()}. Implementations should use this
+     * unless there is a clear reason to use a different value.
+     */
+    int DEFAULT_EXECUTION_GROUP = 5;
+    /**
+     * The highest valid value to return from {@link #getExecutionGroup()}.
+     */
+    @SuppressWarnings("unused")
+    int HIGHEST_EXECUTION_GROUP = 10;
+
+    /**
+     * Returns a value that indicates to which set of {@code ServerActivity} instances
+     * {@link SuspendController#registerActivity(ServerActivity) registered} with the {@link SuspendController}
+     * this activity should belong. All {@code ServerActivity} instances with the same execution group value have their
+     * {@link #preSuspend(ServerActivityCallback) preSuspend}, {@link #suspended(ServerActivityCallback) suspended}
+     * and {@link #resume() resume} methods invoked separately from activities with different execution group values.
+     * <p>
+     * The order in which execution groups will be processed depends on the method being invoked:
+     * <ul>
+     *     <li>For {@code preSuspend} and {@code suspended}, groups with a lower value are processed before those
+     *     with a higher value.</li>
+     *     <li>For {@code resume}, groups with a higher value are processed before those with a lower value.</li>
+     * </ul>
+     * <p>
+     * There is no guarantee of any ordering of method invocation between activities in the same execution group,
+     * and they may even be processed concurrently.
+     * <p>
+     * Note that {@code preSuspend} is invoked for all activity instances before the overall suspend process proceeds
+     * to calls to {@code suspended}. The unit of grouping is the individual method invocations, not the overall
+     * preSuspend/suspended process.
+     * <p>
+     * The default implementation of this method returns {@link #DEFAULT_EXECUTION_GROUP}.
+     *
+     * @return a value between {@link #LOWEST_EXECUTION_GROUP} and {@link #HIGHEST_EXECUTION_GROUP}, inclusive.
+     */
+    default int getExecutionGroup() {
+        return DEFAULT_EXECUTION_GROUP;
+    }
 
     /**
      * Invoked before the server is paused. This is the place where pause notifications should
@@ -29,7 +73,8 @@ public interface ServerActivity {
     void suspended(ServerActivityCallback listener);
 
     /**
-     * Invoked if the suspend or pre-suspened is cancelled
+     * Invoked if the suspend or pre-suspend is cancelled or if a suspended server
+     * is resumed.
      */
     void resume();
 

--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -6,9 +6,14 @@
 package org.jboss.as.server.suspend;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+
 import org.jboss.as.controller.notification.NotificationHandlerRegistry;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.msc.service.Service;
@@ -16,6 +21,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.common.Assert;
 
 /**
  * The graceful shutdown controller. This class co-ordinates the graceful shutdown and pause/resume of a
@@ -23,7 +29,7 @@ import org.jboss.msc.value.InjectedValue;
  * <p/>
  * <p/>
  * In most cases this work is delegated to the request controller subsystem.
- * however for workflows that do no correspond directly to a request model a {@link ServerActivity} instance
+ * however for workflows that do not correspond directly to a request model a {@link ServerActivity} instance
  * can be registered directly with this controller.
  *
  * @author Stuart Douglas
@@ -37,13 +43,13 @@ public class SuspendController implements Service<SuspendController> {
 
     private State state = State.SUSPENDED;
 
-    private final List<ServerActivity> activities = new ArrayList<>();
+    private final NavigableMap<Integer, List<ServerActivity>> activitiesByGroup = new TreeMap<>();
 
     private final List<OperationListener> operationListeners = new ArrayList<>();
 
     private final InjectedValue<NotificationHandlerRegistry> notificationHandlerRegistry = new InjectedValue<>();
 
-    private int outstandingCount;
+    private int groupsCount;
 
     private boolean startSuspended;
 
@@ -75,20 +81,32 @@ public class SuspendController implements Service<SuspendController> {
         for(OperationListener listener: new ArrayList<>(operationListeners)) {
             listener.suspendStarted();
         }
-        outstandingCount = activities.size();
-        if (outstandingCount == 0) {
+        groupsCount = activitiesByGroup.size();
+        if (groupsCount == 0) {
             handlePause();
         } else {
-            CountingRequestCountCallback cb = new CountingRequestCountCallback(outstandingCount, () -> {
+            // Set up the logic that will handle the 'suspended' calls when all the preSuspend calls have reported 'done'
+            CountingRequestCountCallback preSuspendGroupCallBack = new CountingRequestCountCallback(groupsCount, () -> {
                 state = State.SUSPENDING;
-                for (ServerActivity activity : activities) {
-                    activity.suspended(SuspendController.this.listener);
-                }
+                processGroups(activitiesByGroup.values().iterator(), (executionGroup, cb) -> {
+                    for (ServerActivity activity : executionGroup) {
+                        // TODO considering making this concurrent by passing this call as a task to an executor.
+                        // This would allow each activity a "fair" share of the timeout budget
+                        // Alternatively we could iterate executionGroup in reverse (LIFO) order.
+                        // But the executionGroups themselves already provide an ability for that kind of ordering
+                        activity.suspended(cb);
+                    }
+                }, SuspendController.this.listener);
             });
 
-            for (ServerActivity activity : activities) {
-                activity.preSuspend(cb);
-            }
+            // Invoke the preSuspend calls
+            processGroups(activitiesByGroup.values().iterator(), (executionGroup, cb) -> {
+                for (ServerActivity activity : executionGroup) {
+                    // TODO see the 'suspended' section comment above re possible concurrent or LIFO execution
+                    activity.preSuspend(cb);
+                }
+            }, preSuspendGroupCallBack);
+
             if (timeoutMillis > 0) {
                 timer = new Timer();
                 timer.schedule(new TimerTask() {
@@ -125,24 +143,38 @@ public class SuspendController implements Service<SuspendController> {
             timer.cancel();
             timer = null;
         }
-        for(OperationListener listener: new ArrayList<>(operationListeners)) {
+        for (OperationListener listener : new ArrayList<>(operationListeners)) {
             listener.cancelled();
         }
-        for (ServerActivity activity : activities) {
-            try {
-                activity.resume();
-            } catch (Exception e) {
-                ServerLogger.ROOT_LOGGER.failedToResume(activity, e);
+        for (List<ServerActivity> executionGroup : activitiesByGroup.descendingMap().values()) {
+            for (ServerActivity activity : executionGroup) {
+                try {
+                    activity.resume();
+                } catch (Exception e) {
+                    ServerLogger.ROOT_LOGGER.failedToResume(activity, e);
+                }
             }
         }
         state = State.RUNNING;
     }
 
+    /**
+     * Registers the given {@link ServerActivity} with this controller
+     * @param activity the activity. Cannot be {@code null}
+     * @throws IllegalArgumentException if {@code activity} is {@code null} of if its
+     *                                  {@link ServerActivity#getExecutionGroup() getExecutionGroup()} method
+     *                                  returns a value outside of that method's documented legal range.
+     */
     public synchronized void registerActivity(final ServerActivity activity) {
-        this.activities.add(activity);
+        Assert.checkNotNullParam("activity", activity);
+        Assert.checkMinimumParameter("activity.getExecutionGroup()", ServerActivity.LOWEST_EXECUTION_GROUP, activity.getExecutionGroup());
+        Assert.checkMaximumParameter("activity.getExecutionGroup()", ServerActivity.HIGHEST_EXECUTION_GROUP, activity.getExecutionGroup());
+        List<ServerActivity> executionGroup = this.activitiesByGroup.computeIfAbsent(activity.getExecutionGroup(), ArrayList::new);
+        executionGroup.add(activity);
         if(state != State.RUNNING) {
             //if the activity is added when we are not running we just immediately suspend it
             //this should only happen at boot, so there should be no outstanding requests anyway
+            // note that this means there is no execution group grouping of these calls.
             activity.suspended(() -> {
 
             });
@@ -150,7 +182,13 @@ public class SuspendController implements Service<SuspendController> {
     }
 
     public synchronized void unRegisterActivity(final ServerActivity activity) {
-        this.activities.remove(activity);
+        List<ServerActivity> executionGroup = activitiesByGroup.get(activity.getExecutionGroup());
+        if (executionGroup != null) {
+            executionGroup.remove(activity);
+            if (executionGroup.isEmpty()) {
+                activitiesByGroup.remove(activity.getExecutionGroup());
+            }
+        }
     }
 
     @Override
@@ -169,12 +207,12 @@ public class SuspendController implements Service<SuspendController> {
     }
 
     private synchronized void activityPaused() {
-        --outstandingCount;
+        --groupsCount;
         handlePause();
     }
 
     private void handlePause() {
-        if (outstandingCount == 0) {
+        if (groupsCount == 0) {
             state = State.SUSPENDED;
             if (timer != null) {
                 timer.cancel();
@@ -213,6 +251,22 @@ public class SuspendController implements Service<SuspendController> {
 
     public InjectedValue<NotificationHandlerRegistry> getNotificationHandlerRegistry() {
         return notificationHandlerRegistry;
+    }
+
+    private void processGroups(Iterator<List<ServerActivity>> iterator,
+                               BiConsumer<List<ServerActivity>, ServerActivityCallback> groupFunction,
+                               ServerActivityCallback groupsCallback) {
+        // Take the first element from the iterator and apply the groupFunction, with a callback that
+        // calls this again to take the next element when all activities from the current element are done.
+        // When no elements are left, tell the groupsCallback we are done.
+        if (iterator.hasNext()) {
+            List<ServerActivity> activityList = iterator.next();
+            CountingRequestCountCallback cb = new CountingRequestCountCallback(activityList.size(), () -> {
+                processGroups(iterator, groupFunction, groupsCallback);
+                groupsCallback.done();
+            });
+            groupFunction.accept(activityList, cb);
+        }
     }
 
     public enum State {

--- a/server/src/test/java/org/jboss/as/server/suspend/SuspendControllerTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/suspend/SuspendControllerTestCase.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.server.suspend;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.NavigableSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+/**
+ * Unit tests of {@link SuspendController}.
+ */
+public class SuspendControllerTestCase {
+
+    /**
+     * Tests that ServerActivities in different execution groups are executed in the correct order
+     * regardless of the order in which they are registered.
+     */
+    @Test
+    public void testServerActivityCallbackOrder() {
+        serverActivityCallbackOrderTest(CounterActivity.ONE, CounterActivity.TWO, CounterActivity.THREE, CounterActivity.FOUR, CounterActivity.FIVE, CounterActivity.SIX);
+        serverActivityCallbackOrderTest(CounterActivity.SIX, CounterActivity.FIVE, CounterActivity.FOUR, CounterActivity.THREE, CounterActivity.TWO, CounterActivity.ONE);
+        serverActivityCallbackOrderTest(CounterActivity.SIX, CounterActivity.ONE, CounterActivity.FIVE, CounterActivity.TWO, CounterActivity.THREE, CounterActivity.FOUR);
+        serverActivityCallbackOrderTest(CounterActivity.ONE, CounterActivity.THREE, CounterActivity.TWO, CounterActivity.FOUR, CounterActivity.FIVE, CounterActivity.SIX);
+    }
+
+    private void serverActivityCallbackOrderTest(CounterActivity... activities) {
+        SuspendController testee = new SuspendController();
+        testee.resume();
+
+        NavigableSet<CounterActivity> activitySet = new TreeSet<>();
+        for (CounterActivity activity : activities) {
+            testee.registerActivity(activity);
+            activitySet.add(activity);
+        }
+
+        testee.suspend(-1);
+        testee.resume();
+
+        orderCheck(activitySet);
+
+        // Randomly unregister some activities
+        for (CounterActivity activity : activities) {
+            if (Math.random() < 0.5) {
+                testee.unRegisterActivity(activity);
+                assertTrue(activitySet.remove(activity));
+            }
+        }
+
+        testee.suspend(-1);
+        testee.resume();
+
+        orderCheck(activitySet);
+    }
+
+    private void orderCheck(NavigableSet<CounterActivity> activities) {
+        CounterActivity lastPresuspend = null;
+        CounterActivity lastGroup = null;
+        for (CounterActivity activity : activities) {
+            if (lastPresuspend == null) {
+                // First item. Just confirm preSuspend was called
+                assertTrue(activity.getId(), activity.preSuspend > -1);
+            } else if (activity.executionGroup != lastPresuspend.executionGroup) {
+                assertTrue(activity.getId(), activity.preSuspend > lastPresuspend.preSuspend);
+                lastGroup = lastPresuspend;
+            } else if (lastGroup != null) {
+                assertTrue(activity.getId(), activity.preSuspend > lastGroup.preSuspend);
+            } else {
+                // Just confirm preSuspend was called
+                assertTrue(activity.getId(), activity.preSuspend > -1);
+            }
+            lastPresuspend = activity;
+        }
+        CounterActivity lastSuspended = null;
+        lastGroup = null;
+        for (CounterActivity activity : activities) {
+            if (lastSuspended == null) {
+                // First suspended is after all preSuspends
+                assertTrue(activity.getId(), activity.suspended > lastPresuspend.preSuspend);
+            } else if (activity.executionGroup != lastSuspended.executionGroup) {
+                assertTrue(activity.getId(), activity.suspended > lastSuspended.suspended);
+                lastGroup = lastSuspended;
+            } else if (lastGroup != null) {
+                assertTrue(activity.getId(), activity.suspended > lastGroup.suspended);
+            } else {
+                // Just confirm suspended was called
+                assertTrue(activity.getId(), activity.suspended > -1);
+            }
+            lastSuspended = activity;
+        }
+
+        Set<CounterActivity> reversed = activities.descendingSet();
+        CounterActivity lastResume = null;
+        lastGroup = null;
+        for (CounterActivity activity : reversed) {
+            if (lastResume == null) {
+                assertTrue(activity.getId(), activity.resume > lastSuspended.suspended);
+            } else if (activity.executionGroup != lastResume.executionGroup) {
+                assertTrue(activity.getId(), activity.resume > lastResume.resume);
+                lastGroup = lastResume;
+            } else if (lastGroup != null) {
+                assertTrue(activity.getId(), activity.resume > lastGroup.resume);
+            } else {
+                // Just confirm resume was called
+                assertTrue(activity.getId(), activity.resume > -1);
+            }
+            lastResume = activity;
+        }
+
+        // Reset for the next check
+        for (CounterActivity activity : activities) {
+            activity.resetCounter();
+        }
+    }
+
+    private static class CounterActivity implements ServerActivity, Comparable<CounterActivity> {
+        private static final AtomicInteger invocationCounter = new AtomicInteger();
+
+        private static final CounterActivity ONE = new CounterActivity(1,1);
+        private static final CounterActivity TWO = new CounterActivity(2,1);
+        private static final CounterActivity THREE = new CounterActivity(3,2);
+        private static final CounterActivity FOUR = new CounterActivity(4,2);
+        private static final CounterActivity FIVE = new CounterActivity(5,3);
+        private static final CounterActivity SIX = new CounterActivity(6,3);
+
+        private final Integer id;
+        private final int executionGroup;
+        private volatile int preSuspend = -1;
+        private volatile int suspended = -1;
+        private volatile int resume = -1;
+
+        private CounterActivity(int id, int executionGroup) {
+            this.id = id;
+            this.executionGroup = executionGroup;
+        }
+
+        @Override
+        public int getExecutionGroup() {
+            return executionGroup;
+        }
+
+        @Override
+        public void preSuspend(ServerActivityCallback listener) {
+            preSuspend = invocationCounter.getAndIncrement();
+            listener.done();
+        }
+
+        @Override
+        public void suspended(ServerActivityCallback listener) {
+            suspended = invocationCounter.getAndIncrement();
+            listener.done();
+        }
+
+        @Override
+        public void resume() {
+            resume = invocationCounter.getAndIncrement();
+        }
+
+        @Override
+        public int compareTo(CounterActivity o) {
+            int diff = executionGroup - o.executionGroup;
+            return diff != 0 ? diff : ((this.equals(o)) ? 0 : id - o.id);
+        }
+
+        String getId() {
+            return id.toString();
+        }
+
+        void resetCounter() {
+            preSuspend = suspended = resume = -1;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CounterActivity activity = (CounterActivity) o;
+            return Objects.equals(id, activity.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+}


### PR DESCRIPTION
…g them in distinct, ordered, 'execution groups'

https://issues.redhat.com/browse/WFCORE-6739

This is a draft pending further discussion, particularly of how suitable this is for the transaction subsystem's implementation of https://issues.redhat.com/browse/WFLY-17742.

@jmfinelli FYI.