### PR TITLE
[WFCORE-6718]: Overriding socket binding attributes using yaml fails.

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/yaml/YamlConfigurationExtensionTest.java
@@ -326,6 +326,33 @@ public class YamlConfigurationExtensionTest {
         assertEquals("test", postExtensionOps.get(1).operation.get("value").asString());
     }
 
+     /**
+     * Verify that resource creation will be updated with the YAML definition.
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testAddResourceOverride() throws URISyntaxException {
+        List<ParsedBootOp> postExtensionOps = new ArrayList<>();
+        ConfigurationExtension instance = new YamlConfigurationExtension();
+        instance.load(Paths.get(this.getClass().getResource("simple_overwrite.yml").toURI()), Paths.get(this.getClass().getResource("simple_override.yml").toURI()));
+        instance.processOperations(rootRegistration, postExtensionOps);
+        assertFalse(postExtensionOps.isEmpty());
+        assertEquals(3, postExtensionOps.size());
+        assertEquals(ADD, postExtensionOps.get(0).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "aaa"), postExtensionOps.get(0).address);
+        assertTrue(postExtensionOps.get(0).operation.hasDefined("value"));
+        assertEquals("foo", postExtensionOps.get(0).operation.get("value").asString());
+        assertEquals(ADD, postExtensionOps.get(1).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(1).address);
+        assertTrue(postExtensionOps.get(1).operation.hasDefined("value"));
+        assertEquals("test", postExtensionOps.get(1).operation.get("value").asString());
+        assertEquals(WRITE_ATTRIBUTE_OPERATION, postExtensionOps.get(2).operationName);
+        assertEquals(PathAddress.pathAddress("system-property", "bbb"), postExtensionOps.get(2).address);
+        assertTrue(postExtensionOps.get(2).operation.hasDefined("value"));
+        assertEquals("test-override", postExtensionOps.get(2).operation.get("value").asString());
+    }
+
     /**
      * Verify removing a resource and adding it again.
      *

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/yaml/simple_override.yml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/yaml/simple_override.yml
@@ -1,0 +1,11 @@
+wildfly-configuration:
+    extension:
+      org.jboss.as.failure:
+        module: org.jboss.as.failure
+    system-property:
+      bbb:
+        value: test-override
+#User defined elements, must be ignored.
+org:
+    foo:
+        bar: true


### PR DESCRIPTION
 * Tracking all added resources so that we update the resource instead of trying to create it a 2nd time.

Jira: https://issues.redhat.com/browse/WFCORE-6718
