### PR TITLE
WFCORE-6716 Drop obsolete default getStability() method…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnit.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnit.java
@@ -6,7 +6,6 @@
 package org.jboss.as.server.deployment;
 
 import org.jboss.as.controller.FeatureRegistry;
-import org.jboss.as.version.Stability;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 
@@ -43,10 +42,4 @@ public interface DeploymentUnit extends Attachable, FeatureRegistry {
      * @return the service registry
      */
     ServiceRegistry getServiceRegistry();
-
-    // TODO Remove this once integrated into WF-full
-    @Override
-    default Stability getStability() {
-        return Stability.DEFAULT;
-    }
 }


### PR DESCRIPTION
… now that WFCORE-6650 is available in WF full.

https://issues.redhat.com/browse/WFCORE-6716