### PR TITLE
[WFCORE-6745] Upgrade log4j2 from 2.22.1 to 2.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.org.apache.kerby>2.0.3</version.org.apache.kerby>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
-        <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
+        <version.org.apache.logging.log4j>2.23.1</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.12.1</version.org.apache.sshd>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6745
