### PR TITLE
[WFCORE-6749] Fix incorrect output from standalone.sh -v

### DIFF
--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -212,6 +212,10 @@ public final class Main {
                         value = arg.substring(idx + 1);
                     }
                     systemProperties.setProperty(name, value);
+                    if (ServerEnvironment.HOME_DIR.equals(name)) {
+                        // Re-create using updated properties
+                        productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), value, systemProperties);
+                    }
                 } else if (arg.startsWith(CommandLineConstants.PUBLIC_BIND_ADDRESS)) {
 
                     int idx = arg.indexOf('=');
@@ -448,6 +452,10 @@ public final class Main {
          try {
              url = makeURL(urlSpec);
              systemProperties.load(url.openConnection().getInputStream());
+             if (systemProperties.getProperty(ServerEnvironment.HOME_DIR) != null) {
+                 // Re-create using updated properties
+                 productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), systemProperties.getProperty(ServerEnvironment.HOME_DIR), systemProperties);
+             }
              return true;
          } catch (MalformedURLException e) {
              STDERR.println(ServerLogger.ROOT_LOGGER.malformedCommandLineURL(urlSpec, arg));


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6749 Fix incorrect output from standalone.sh -v

This handles the argument `version` late and recreate `productConfig` using updated properties