### PR TITLE
[5895] FOLLOW-UP Utility to reload servers started by testsuite to a desired stability level 

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -230,6 +230,7 @@ public class Util {
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";
     public static final String RELOAD = "reload";
+    public static final String RELOAD_ENHANCED = "reload-enhanced";
     public static final String REMOVE = "remove";
     public static final String REPLY_PROPERTIES = "reply-properties";
     public static final String REQUEST_PROPERTIES = "request-properties";

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -2003,7 +2003,7 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
         // if the connection loss was triggered by an instruction to restart/reload
         // then we don't disconnect yet
         if(parsedCmd.getFormat() != null) {
-            if(Util.RELOAD.equals(parsedCmd.getOperationName()) || Util.RELOAD_ENHANCED.equals(parsedCmd.getOperationName())) {
+            if(Util.RELOAD.equals(parsedCmd.getOperationName())) {
                 // do nothing
             } else if(Util.SHUTDOWN.equals(parsedCmd.getOperationName())) {
                 if(CommandFormat.INSTANCE.equals(parsedCmd.getFormat())

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -2003,7 +2003,7 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
         // if the connection loss was triggered by an instruction to restart/reload
         // then we don't disconnect yet
         if(parsedCmd.getFormat() != null) {
-            if(Util.RELOAD.equals(parsedCmd.getOperationName())) {
+            if(Util.RELOAD.equals(parsedCmd.getOperationName()) || Util.RELOAD_ENHANCED.equals(parsedCmd.getOperationName())) {
                 // do nothing
             } else if(Util.SHUTDOWN.equals(parsedCmd.getOperationName())) {
                 if(CommandFormat.INSTANCE.equals(parsedCmd.getFormat())

--- a/controller/src/main/java/org/jboss/as/controller/RunningModeControl.java
+++ b/controller/src/main/java/org/jboss/as/controller/RunningModeControl.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.controller;
 
+import org.jboss.as.version.Stability;
+
 /**
  * Provides control over the server's current {@link RunningMode}.
  *
@@ -17,6 +19,11 @@ public class RunningModeControl {
     private volatile boolean useCurrentConfig;
     private volatile String newBootFileName;
     private volatile Boolean suspend;
+
+
+    // Temporary experiment for the testsuite
+    @Deprecated
+    private volatile Stability reloadedStability;
 
     public RunningModeControl(final RunningMode initialMode) {
         this.runningMode = initialMode;
@@ -80,5 +87,23 @@ public class RunningModeControl {
      */
     public void setNewBootFileName(String newBootFileName) {
         this.newBootFileName = newBootFileName;
+    }
+
+    /**
+     * Gets the stability of the reloaded server.
+     *
+     * @return the stability of the reloaded server
+     */
+    public Stability getReloadedStability() {
+        return reloadedStability;
+    }
+
+    /**
+     * Sets the stability of the reloaded server.
+     *
+     * @param reloadedStability the stability of the reloaded server
+     */
+    public void setReloadedStability(Stability reloadedStability) {
+        this.reloadedStability = reloadedStability;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/access/constraint/SensitivityClassification.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/constraint/SensitivityClassification.java
@@ -27,6 +27,7 @@ public class SensitivityClassification extends AbstractSensitivity {
     public static final SensitivityClassification MODULE_LOADING = new SensitivityClassification("module-loading", false, false, true);
     public static final SensitivityClassification PATCHING = new SensitivityClassification("patching", false, false, true);
     public static final SensitivityClassification READ_WHOLE_CONFIG = new SensitivityClassification("read-whole-config", false, true, true);
+    public static final SensitivityClassification RELOAD_ENHANCED = new SensitivityClassification("reload-enhanced", false, false, false);
     public static final SensitivityClassification SECURITY_REALM = new SensitivityClassification("security-realm", true, true, true);
     public static final SensitivityClassification SECURITY_REALM_REF = new SensitivityClassification("security-realm-ref", true, true, true);
     public static final SensitivityClassification SECURITY_DOMAIN = new SensitivityClassification("security-domain", true, true, true);

--- a/controller/src/main/java/org/jboss/as/controller/access/management/SensitiveTargetAccessConstraintDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/management/SensitiveTargetAccessConstraintDefinition.java
@@ -35,6 +35,7 @@ public class SensitiveTargetAccessConstraintDefinition implements AccessConstrai
     public static final SensitiveTargetAccessConstraintDefinition MODULE_LOADING = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.MODULE_LOADING);
     public static final SensitiveTargetAccessConstraintDefinition PATCHING = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.PATCHING);
     public static final SensitiveTargetAccessConstraintDefinition READ_WHOLE_CONFIG = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.READ_WHOLE_CONFIG);
+    public static final SensitiveTargetAccessConstraintDefinition RELOAD_ENHANCED = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.RELOAD_ENHANCED);
     public static final SensitiveTargetAccessConstraintDefinition SECURITY_DOMAIN = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SECURITY_DOMAIN);
     public static final SensitiveTargetAccessConstraintDefinition SECURITY_DOMAIN_REF = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SECURITY_DOMAIN_REF);
     public static final SensitiveTargetAccessConstraintDefinition SECURITY_REALM = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SECURITY_REALM);

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -4,6 +4,8 @@
  */
 package org.jboss.as.controller.descriptions;
 
+import java.util.Set;
+
 /**
  * String constants frequently used in model descriptions.
  *
@@ -419,6 +421,7 @@ public class ModelDescriptionConstants {
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";
     public static final String RELOAD = "reload";
+    public static final String RELOAD_ENHANCED = "reload-enhanced";
     public static final String RELOAD_REQUIRED = "reload-required";
     public static final String REMOVE = "remove";
     public static final String REMOTE = "remote";
@@ -613,6 +616,8 @@ public class ModelDescriptionConstants {
     public static final String GIT_MASTER_BRANCH = "master";
     public static final String PRIMARY = "primary";
     public static final String PERFORM_INSTALLATION = "perform-installation";
+
+    public static final Set<String> RELOAD_OPERATIONS = Set.of(RELOAD, RELOAD_ENHANCED);
 
     private ModelDescriptionConstants() {
     }

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -118,7 +117,7 @@ public final class ExtensionRegistry implements FeatureRegistry {
         private JmxAuthorizer authorizer = NO_OP_AUTHORIZER;
         private Supplier<SecurityIdentity> securityIdentitySupplier = Functions.constantSupplier(null);
         private RuntimeHostControllerInfoAccessor hostControllerInfoAccessor = RuntimeHostControllerInfoAccessor.SERVER;
-        private AtomicReference<Stability> stabilityReference = new AtomicReference<>(Stability.DEFAULT);
+        private Supplier<Stability> stabilitySupplier = Functions.constantSupplier(Stability.DEFAULT);
 
         private Builder(ProcessType processType) {
             this.processType = processType;
@@ -185,21 +184,21 @@ public final class ExtensionRegistry implements FeatureRegistry {
 
         /**
          * Overrides the default stability level of the extension registry. This is a convenience method for
-         * {@link #withStabilityReference(AtomicReference)}.
+         * {@link #withStabilitySupplier(Supplier)}.
          * @param stability the stability level to use
          * @return a reference to this builder
          */
         public Builder withStability(Stability stability) {
-            return withStabilityReference(new AtomicReference<>(stability));
+            return withStabilitySupplier(Functions.constantSupplier(stability));
         }
 
         /**
          * Overrides the default stability level of the extension registry.
-         * @param stabilityReference an AtomicReference containing the stability level
+         * @param stabilitySupplier a Supplier returning the stability level
          * @return a reference to this builder
          */
-        public Builder withStabilityReference(AtomicReference<Stability> stabilityReference) {
-            this.stabilityReference = stabilityReference;
+        public Builder withStabilitySupplier(Supplier<Stability> stabilitySupplier) {
+            this.stabilitySupplier = stabilitySupplier;
             return this;
         }
 
@@ -220,7 +219,7 @@ public final class ExtensionRegistry implements FeatureRegistry {
     }
 
     private final ProcessType processType;
-    private final AtomicReference<Stability> stability;
+    private final Supplier<Stability> stability;
 
     private SubsystemXmlWriterRegistry writerRegistry;
     private volatile PathManager pathManager;
@@ -244,7 +243,7 @@ public final class ExtensionRegistry implements FeatureRegistry {
         this.authorizer = builder.authorizer;
         this.securityIdentitySupplier = builder.securityIdentitySupplier;
         this.hostControllerInfoAccessor = builder.hostControllerInfoAccessor;
-        this.stability = builder.stabilityReference;
+        this.stability = builder.stabilitySupplier;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
@@ -34,7 +34,7 @@ public abstract class ProcessReloadHandler<T extends RunningModeControl> impleme
     /**
      * The operation name.
      */
-    protected static final String OPERATION_NAME = "reload";
+    protected static final String OPERATION_NAME = ModelDescriptionConstants.RELOAD;
 
     protected static final AttributeDefinition ADMIN_ONLY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ADMIN_ONLY, ModelType.BOOLEAN, true)
                                                                     .setDefaultValue(ModelNode.FALSE).build();

--- a/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
@@ -16,7 +16,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
@@ -32,6 +32,7 @@ import java.net.InetSocketAddress;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -68,7 +69,12 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  */
 public class ModelControllerClientOperationHandler implements ManagementRequestHandlerFactory {
 
-    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = Set.of(RELOAD, SHUTDOWN);
+    private static final Set<String> PREPARED_RESPONSE_OPERATIONS;
+    static {
+        Set<String> ops = new HashSet<>(RELOAD_OPERATIONS);
+        ops.add(SHUTDOWN);
+        PREPARED_RESPONSE_OPERATIONS = Collections.unmodifiableSet(ops);
+    }
     private final ModelController controller;
 
     private final ManagementChannelAssociation channelAssociation;
@@ -193,7 +199,7 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
                 @Override
                 public void operationPrepared(ModelController.OperationTransaction transaction, final ModelNode preparedResult, OperationContext context) {
                     transaction.commit();
-                    if (context == null || !RELOAD.equals(operation.get(OP).asString())) { // TODO deal with shutdown as well,
+                    if (context == null || !RELOAD_OPERATIONS.contains(operation.get(OP).asString())) { // TODO deal with shutdown as well,
                                                                                            // the handlers for which have some
                                                                                            // subtleties that need thought
                         sendResponse(preparedResult);

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
@@ -15,6 +15,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOS
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
@@ -41,7 +42,6 @@ import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
 import org.jboss.as.controller.client.impl.ModelControllerProtocol;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.remote.IdentityAddressProtocolUtil.PropagatedIdentity;
 import org.jboss.as.protocol.StreamUtils;
@@ -69,7 +69,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class TransactionalProtocolOperationHandler implements ManagementRequestHandlerFactory {
-    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = ModelDescriptionConstants.RELOAD_OPERATIONS;
+    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = Set.of(RELOAD);
 
     private final ModelController controller;
     private final ManagementChannelAssociation channelAssociation;

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
@@ -15,7 +15,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOS
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
@@ -42,6 +41,7 @@ import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
 import org.jboss.as.controller.client.impl.ModelControllerProtocol;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.remote.IdentityAddressProtocolUtil.PropagatedIdentity;
 import org.jboss.as.protocol.StreamUtils;
@@ -69,7 +69,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class TransactionalProtocolOperationHandler implements ManagementRequestHandlerFactory {
-    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = Set.of(RELOAD);
+    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = ModelDescriptionConstants.RELOAD_OPERATIONS;
 
     private final ModelController controller;
     private final ManagementChannelAssociation channelAssociation;

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiHandler.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -66,7 +67,7 @@ import org.xnio.streams.ChannelInputStream;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 class DomainApiHandler implements HttpHandler {
-
+    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = ModelDescriptionConstants.RELOAD_OPERATIONS;
     private static final String JSON_PRETTY = "json.pretty";
 
     /**
@@ -309,6 +310,7 @@ class DomainApiHandler implements HttpHandler {
         }
     }
 
+
     /**
      * Determine whether the prepared response should be sent, before the operation completed. This is needed in order
      * that operations like :reload() can be executed without causing communication failures.
@@ -321,7 +323,7 @@ class DomainApiHandler implements HttpHandler {
         final String op = operation.get(OP).asString();
         final int size = address.size();
         if (size == 0) {
-            if (op.equals("reload")) {
+            if (PREPARED_RESPONSE_OPERATIONS.contains(op)) {
                 return true;
             } else if (op.equals(COMPOSITE)) {
                 // TODO
@@ -331,7 +333,7 @@ class DomainApiHandler implements HttpHandler {
             }
         } else if (size == 1) {
             if (address.getLastElement().getKey().equals(HOST)) {
-                return op.equals("reload");
+                return PREPARED_RESPONSE_OPERATIONS.contains(op);
             }
         }
         return false;

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/EarlyResponseTransactionControl.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/EarlyResponseTransactionControl.java
@@ -7,13 +7,13 @@ package org.jboss.as.domain.http.server;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.remote.EarlyResponseSendListener;
 import org.jboss.dmr.ModelNode;
 
@@ -29,7 +29,7 @@ final class EarlyResponseTransactionControl implements ModelController.Operation
 
     EarlyResponseTransactionControl(ResponseCallback callback, ModelNode operation) {
         this.callback = callback;
-        this.reload = RELOAD.equals(operation.get(OP).asString());
+        this.reload = ModelDescriptionConstants.RELOAD_OPERATIONS.contains(operation.get(OP).asString());
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -86,7 +86,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         } else {
             configuration = this.configuration;
         }
-        final ServerEnvironment serverEnvironment = configuration.getServerEnvironment().recalculateForReload(runningModeControl);
+        final ServerEnvironment serverEnvironment = configuration.getServerEnvironment();
         final ProductConfig config = serverEnvironment.getProductConfig();
         final String prettyVersion = config.getPrettyVersionString();
         ServerLogger.AS_ROOT_LOGGER.serverStarting(prettyVersion);

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -52,7 +52,7 @@ import org.jboss.threads.AsyncFuture;
 final class ApplicationServerService implements Service<AsyncFuture<ServiceContainer>> {
 
     private final List<ServiceActivator> extraServices;
-    private final Bootstrap.Configuration configuration;
+    private volatile Bootstrap.Configuration configuration;
     private final RunningModeControl runningModeControl;
     private final ControlledProcessState processState;
     private final SuspendController suspendController;
@@ -78,8 +78,15 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
 
         //Moved to AbstractControllerService.start()
         //processState.setStarting();
-        final Bootstrap.Configuration configuration = this.configuration;
-        final ServerEnvironment serverEnvironment = configuration.getServerEnvironment();
+        final Bootstrap.Configuration configuration;
+        Bootstrap.Configuration recalculatedConfiguration = this.configuration.recalculateForReload(runningModeControl);
+        if (recalculatedConfiguration != this.configuration) {
+            this.configuration = recalculatedConfiguration;
+            configuration = recalculatedConfiguration;
+        } else {
+            configuration = this.configuration;
+        }
+        final ServerEnvironment serverEnvironment = configuration.getServerEnvironment().recalculateForReload(runningModeControl);
         final ProductConfig config = serverEnvironment.getProductConfig();
         final String prettyVersion = config.getPrettyVersionString();
         ServerLogger.AS_ROOT_LOGGER.serverStarting(prettyVersion);

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -100,6 +100,19 @@ public interface Bootstrap {
             this.startTime = serverEnvironment.getStartTime();
         }
 
+        private Configuration(final Configuration original, ServerEnvironment serverEnvironment) {
+            this.serverEnvironment = serverEnvironment;
+            this.runningModeControl = original.runningModeControl;
+            this.extensionRegistry = original.extensionRegistry;
+            this.capabilityRegistry = original.capabilityRegistry;
+            this.auditLogger = original.auditLogger;
+            this.authorizer = original.authorizer;
+            this.securityIdentitySupplier = original.securityIdentitySupplier;
+            this.moduleLoader = original.moduleLoader;
+            this.configurationPersisterFactory = original.configurationPersisterFactory;
+            this.startTime = original.startTime;
+        }
+
         /**
          * Get the server environment.
          *
@@ -234,6 +247,16 @@ public interface Bootstrap {
          */
         public long getStartTime() {
             return startTime;
+        }
+
+        Configuration recalculateForReload(RunningModeControl runningModeControl) {
+            if (runningModeControl.isReloaded()) {
+                ServerEnvironment recalculatedServerEnvironment = serverEnvironment.recalculateForReload(runningModeControl);
+                if (recalculatedServerEnvironment != serverEnvironment) {
+                    return new Configuration(this, recalculatedServerEnvironment);
+                }
+            }
+            return this;
         }
     }
 

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -81,6 +81,7 @@ public interface Bootstrap {
         private final DelegatingConfigurableAuthorizer authorizer;
         private final ManagementSecurityIdentitySupplier securityIdentitySupplier;
 
+        // Used to update the stability in the supplier cached by the ExtensionRegistry
         private final AtomicReference<Stability> stabilityReference;
         private ModuleLoader moduleLoader = Module.getBootModuleLoader();
         private ConfigurationPersisterFactory configurationPersisterFactory;
@@ -96,7 +97,7 @@ public interface Bootstrap {
             this.stabilityReference = new AtomicReference<>(serverEnvironment.getStability());
             this.extensionRegistry = ExtensionRegistry.builder(serverEnvironment.getLaunchType().getProcessType())
                     .withRunningModeControl(this.runningModeControl)
-                    .withStabilityReference(this.stabilityReference)
+                    .withStabilitySupplier(stabilityReference::get)
                     .withAuditLogger(this.auditLogger)
                     .withAuthorizer(this.authorizer)
                     .withSecurityIdentitySupplier(this.securityIdentitySupplier)

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -1280,7 +1280,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
 
     ServerEnvironment recalculateForReload(RunningModeControl runningModeControl) {
         if (runningModeControl.isReloaded()) {
-            Stability stability = runningModeControl.getReloadedStability() != null ? runningModeControl.getReloadedStability() : productConfig.getDefaultStability();
+            Stability stability = runningModeControl.getReloadedStability() != null ? runningModeControl.getReloadedStability() : this.stability;
             if (stability != this.stability) {
                 System.setProperty(ProcessEnvironment.STABILITY, stability.toString());
 

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -589,6 +589,41 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         }
     }
 
+    private ServerEnvironment(ServerEnvironment original, Stability stability) {
+        this.primordialProperties = original.primordialProperties;
+        this.providedProperties = original.providedProperties;
+        this.processNameSet = original.processNameSet;
+        this.launchType = original.launchType;
+        this.hostControllerName = original.hostControllerName;
+        this.qualifiedHostName = original.qualifiedHostName;
+        this.hostName = original.hostName;
+        this.serverName = original.serverName;
+        this.nodeName = original.nodeName;
+        this.javaExtDirs = original.javaExtDirs;
+        this.homeDir = original.homeDir;
+        this.serverBaseDir = original.serverBaseDir;
+        this.serverConfigurationDir = original.serverConfigurationDir;
+        this.serverConfigurationFile = original.serverConfigurationFile;
+        this.serverLogDir = original.serverLogDir;
+        this.controllerTempDir = original.controllerTempDir;
+        this.serverDataDir = original.serverDataDir;
+        this.serverContentDir = original.serverContentDir;
+        this.serverTempDir = original.serverTempDir;
+        this.domainBaseDir = original.domainBaseDir;
+        this.domainConfigurationDir = original.domainConfigurationDir;
+        this.standalone = original.standalone;
+        this.allowModelControllerExecutor = original.allowModelControllerExecutor;
+        this.initialRunningMode = original.initialRunningMode;
+        this.productConfig = original.productConfig;
+        this.runningModeControl = original.runningModeControl;
+        this.serverUUID = original.serverUUID;
+        this.startTime = original.startTime;
+        this.startSuspended = original.startSuspended;
+        this.startGracefully = original.startGracefully;
+        this.repository = original.repository;
+        this.stability = stability;
+    }
+
     private Set<String> listIgnoredFiles(String defaultServerConfig) {
         Set<String> ignored = new LinkedHashSet<>();
         setIgnored(ignored, serverDataDir.toPath(), true, false);
@@ -1241,5 +1276,17 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
 
     ManagedAuditLogger createAuditLogger() {
         return new ManagedAuditLoggerImpl(getProductConfig().resolveVersion(), true);
+    }
+
+    ServerEnvironment recalculateForReload(RunningModeControl runningModeControl) {
+        if (runningModeControl.isReloaded()) {
+            Stability stability = runningModeControl.getReloadedStability() != null ? runningModeControl.getReloadedStability() : productConfig.getDefaultStability();
+            if (stability != this.stability) {
+                System.setProperty(ProcessEnvironment.STABILITY, stability.toString());
+
+                return new ServerEnvironment(this, stability);
+            }
+        }
+        return this;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -201,7 +201,7 @@ public final class ServerService extends AbstractControllerService {
             : ProcessType.EMBEDDED_SERVER;
     }
 
-    static Stability getStability(ServerEnvironment serverEnvironment) {
+    private static Stability getStability(ServerEnvironment serverEnvironment) {
         return serverEnvironment != null ? serverEnvironment.getStability() : Stability.DEFAULT;
     }
 

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -413,8 +413,9 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerOperationHandler(ServerDomainProcessShutdownHandler.DOMAIN_DEFINITION, new ServerDomainProcessShutdownHandler());
 
         } else {
-            final ServerProcessReloadHandler reloadHandler = new ServerProcessReloadHandler(Services.JBOSS_AS, runningModeControl, processState, serverEnvironment);
-            resourceRegistration.registerOperationHandler(ServerProcessReloadHandler.DEFINITION, reloadHandler, false);
+
+            ServerProcessReloadHandler.registerStandardReloadOperation(resourceRegistration, runningModeControl, processState, serverEnvironment);
+            ServerProcessReloadHandler.registerEnhancedReloadOperation(resourceRegistration, runningModeControl, processState, serverEnvironment);
 
             resourceRegistration.registerOperationHandler(ServerSuspendHandler.DEFINITION, ServerSuspendHandler.INSTANCE);
             resourceRegistration.registerOperationHandler(ServerResumeHandler.DEFINITION, ServerResumeHandler.INSTANCE);

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -71,6 +71,16 @@ server.reload.admin-only.deprecated=Use start-mode=admin-only instead.
 server.reload.blocking=Whether the operation should block and wait until the server is reloaded.
 server.reload.reply=The status of the server following execution of this operation.
 server.reload.deprecated=This operation may be removed from the server-config resource in a future version; use the /host=*/server= resource for server lifecycle operations.
+server.reload-enhanced=Reloads the server by shutting down all its services and starting again. The JVM itself is not restarted. This is similar to the 'reload' operation, but exposes some more advanced options.
+server.reload-enhanced.admin-only=Whether the server should start in running mode ADMIN_ONLY when it restarts. An ADMIN_ONLY server will start any configured management interfaces and accept management requests, but will not start services used for handling end user requests.
+server.reload-enhanced.use-current-server-config=Only has an effect if --read-only-server-config was specified when starting the server. In that case, if this parameter is set to false the reloaded server loads the original configuration version; if null or true the current runtime version of the model is used.
+server.reload-enhanced.server-config=Use to override the name of the server config to use for the reloaded server.  When making changes to the model after the reload, the changes will still be persisted to the original server configuration file that was first used to boot up the server. This parameter is resolved the same way as the --server-config command-line option.
+server.reload-enhanced.stability=Set to change the stability level of the reloaded server.
+server.reload-enhanced.start-mode=Can be either normal, suspend or admin-only. If it is suspend the server will be started in suspended mode, if it is admin only the server will be started in admin-only mode.
+server.reload-enhanced.admin-only.deprecated=Use start-mode=admin-only instead.
+server.reload-enhanced.blocking=Whether the operation should block and wait until the server is reloaded.
+server.reload-enhanced.reply=The status of the server following execution of this operation.
+server.reload-enhanced.deprecated=This operation may be removed from the server-config resource in a future version; use the /host=*/server= resource for server lifecycle operations.
 server.start=Start a server.
 server.start.blocking=Whether the operation should block and wait until the server is started.
 server.start.start-mode=The mode the servers should started in, can be either suspend or normal.

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
@@ -18,7 +18,6 @@ import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.security.common.CoreUtils;
-import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.WildFlyRunner;
@@ -81,12 +80,15 @@ public class KerberosHttpMgmtSaslTestCase extends AbstractKerberosMgmtSaslTestBa
         final HttpMgmtConfigurator httpMgmtConfig = httpMgmtConfigBuilder.build();
         httpMgmtConfig.create(client, null);
 
-        ServerReload.executeReloadAndWaitForCompletion(client, 30 * 1000, false, "remote",
-                TestSuiteEnvironment.getServerAddress(), PORT_NATIVE);
+        ServerReload.Parameters serverReloadParams = new ServerReload.Parameters()
+                .setTimeout(30 * 1000)
+                .setProtocol("remote")
+                .setServerPort(PORT_NATIVE);
+
+        ServerReload.executeReloadAndWaitForCompletion(client, serverReloadParams);
         return () -> {
             httpMgmtConfig.remove(client, null);
-            ServerReload.executeReloadAndWaitForCompletion(client, 30 * 1000, false, "remote",
-                    TestSuiteEnvironment.getServerAddress(), PORT_NATIVE);
+            ServerReload.executeReloadAndWaitForCompletion(client, serverReloadParams);
         };
     }
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -78,7 +78,7 @@ public class PreparedResponseTestCase {
         try (ManagementClient managementClient = getManagementClient()) {
             block(managementClient);
             long timeout = SHUTDOWN_WAITING_TIME + System.currentTimeMillis();
-            ServerReload.executeReload(managementClient.getControllerClient(), false);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), false);
             while (System.currentTimeMillis() < timeout) {
                 Thread.sleep(FREQUENCY);
                 try {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/ServerReload.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/ServerReload.java
@@ -96,6 +96,9 @@ public class ServerReload {
         } else {
             operation.get(OP).set("reload");
         }
+        if (parameters.serverConfig != null) {
+            operation.get("server-config").set(parameters.serverConfig);
+        }
 
         executeReload(client, operation);
     }
@@ -204,6 +207,8 @@ public class ServerReload {
         String serverAddress = TestSuiteEnvironment.getServerAddress();
         int serverPort = TestSuiteEnvironment.getServerPort();
 
+        String serverConfig = null;
+
         Stability stability = null;
 
         public Parameters setTimeout(int timeout) {
@@ -233,6 +238,11 @@ public class ServerReload {
 
         public Parameters setStability(Stability stability) {
             this.stability = stability;
+            return this;
+        }
+
+        public Parameters setServerConfig(String serverConfig) {
+            this.serverConfig = serverConfig;
             return this;
         }
     }

--- a/testsuite/shared/src/main/java/org/wildfly/test/snapshot/ServerSnapshot.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/snapshot/ServerSnapshot.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.test.snapshot;

--- a/testsuite/shared/src/main/java/org/wildfly/test/snapshot/ServerSnapshot.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/snapshot/ServerSnapshot.java
@@ -1,0 +1,78 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.test.snapshot;
+
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.version.Stability;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.testrunner.ManagementClient;
+
+import java.io.File;
+
+import static org.junit.Assert.fail;
+
+public class ServerSnapshot {
+    public static AutoCloseable takeSnapshot(ManagementClient client) {
+        return takeSnapshot(client, null);
+    }
+    /**
+     * Takes a snapshot of the current state of the server.
+     *
+     * Returns a AutoCloseable that can be used to restore the server state
+     * @param client The client
+     * @param reloadToStability the stability the AutoCloseable should reload to
+     * @return A closeable that can be used to restore the server
+     */
+    public static AutoCloseable takeSnapshot(ManagementClient client, Stability reloadToStability) {
+        try {
+            ModelNode node = new ModelNode();
+            node.get(ModelDescriptionConstants.OP).set("take-snapshot");
+            ModelNode result = client.getControllerClient().execute(node);
+            if (!"success".equals(result.get(ClientConstants.OUTCOME).asString())) {
+                fail("Reload operation didn't finish successfully: " + result.asString());
+            }
+            String snapshot = result.get(ModelDescriptionConstants.RESULT).asString();
+            final String fileName = snapshot.contains(File.separator) ? snapshot.substring(snapshot.lastIndexOf(File.separator) + 1) : snapshot;
+            return new AutoCloseable() {
+                @Override
+                public void close() throws Exception {
+                    ServerReload.Parameters parameters = new ServerReload.Parameters();
+                    parameters.setServerConfig(fileName);
+                    if (reloadToStability != null) {
+                        parameters.setStability(reloadToStability);
+                    }
+                    ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient(), parameters);
+
+                    ModelNode node = new ModelNode();
+                    node.get(ModelDescriptionConstants.OP).set("write-config");
+                    ModelNode result = client.getControllerClient().execute(node);
+                    if (!"success".equals(result.get(ClientConstants.OUTCOME).asString())) {
+                        fail("Failed to write config after restoring from snapshot " + result.asString());
+                    }
+                }
+            };
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to take snapshot", e);
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/stability/StabilityServerSetupSnapshotRestoreTasks.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/stability/StabilityServerSetupSnapshotRestoreTasks.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.test.stability;

--- a/testsuite/shared/src/main/java/org/wildfly/test/stability/StabilityServerSetupTasks.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/stability/StabilityServerSetupTasks.java
@@ -1,0 +1,161 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.test.stability;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.version.Stability;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_ENHANCED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
+import static org.jboss.as.server.controller.descriptions.ServerDescriptionConstants.SERVER_ENVIRONMENT;
+
+/**
+ * For tests that need to run under a specific server stability level,
+ * the server setup tasks from the inner classes can be used to change the stability level of the server to the desired level.
+ * Once the test is done, the original stability level is restored.
+ */
+public abstract class StabilityServerSetupTasks implements ServerSetupTask {
+
+    private final Stability desiredStability;
+    private volatile Stability originalStability;
+
+
+    public StabilityServerSetupTasks(Stability desiredStability) {
+        this.desiredStability = desiredStability;
+    }
+
+    @Override
+    public void setup(ManagementClient managementClient) throws Exception {
+        Set<Stability> supportedStabilityLevels = getSupportedStabilityLevels();
+        Assume.assumeTrue(
+                String.format("%s is not a supported stability level", desiredStability, supportedStabilityLevels),
+                supportedStabilityLevels.contains(desiredStability));
+
+        Assume.assumeTrue(
+                "The reload-enhanced operation is not registered at this stability level",
+                checkReloadEnhancedOperationIsAvailable(managementClient));
+
+        reloadToDesiredStability(managementClient.getControllerClient(), desiredStability);
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient) throws Exception {
+        reloadToDesiredStability(managementClient.getControllerClient(), originalStability);
+    }
+
+    private boolean checkReloadEnhancedOperationIsAvailable(ManagementClient managementClient) throws Exception {
+        ModelNode op = Util.createOperation(READ_OPERATION_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        for (ModelNode name : result.asList()) {
+            if (name.asString().equals(RELOAD_ENHANCED)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Set<Stability> getSupportedStabilityLevels() {
+        // TODO WFCORE-6731 - see https://github.com/wildfly/wildfly-core/pull/5895#discussion_r1520489808
+        // This information will be available in a management operation, For now just return a hardcoded set
+        return EnumSet.allOf(Stability.class);
+    }
+
+    private Stability reloadToDesiredStability(ModelControllerClient client, Stability stability) throws Exception {
+        // Check the stability
+        Stability currentStability = readCurrentStability(client);
+        if (originalStability == null) {
+            originalStability = currentStability;
+        }
+
+        // The stability parameter for the reload opration is only registered below the default level
+        Assume.assumeFalse("Can't reload to a different stability when server stability level is default", currentStability == Stability.DEFAULT && stability != Stability.DEFAULT);
+
+        if (currentStability == stability) {
+            return originalStability;
+        }
+
+        //Reload the server to the desired stability level
+        ServerReload.Parameters parameters = new ServerReload.Parameters()
+                .setStability(stability);
+        // Execute the reload
+        ServerReload.executeReloadAndWaitForCompletion(client, parameters);
+
+        Stability reloadedStability = readCurrentStability(client);
+        Assert.assertEquals(stability, reloadedStability);
+        return originalStability;
+    }
+
+    private Stability readCurrentStability(ModelControllerClient client) throws Exception {
+        ModelNode op = Util.getReadAttributeOperation(PathAddress.pathAddress(CORE_SERVICE, SERVER_ENVIRONMENT), STABILITY);
+        ModelNode result = ManagementOperations.executeOperation(client, op);
+        return Stability.fromString(result.asString());
+    }
+
+    /**
+     * A server setup task that sets the server stability to the default level.
+     */
+    public static class Default extends StabilityServerSetupTasks {
+        public Default() {
+            super(Stability.DEFAULT);
+        }
+    }
+
+    /**
+     * A server setup task that sets the server stability to the community level.
+     */
+    public static class Community extends StabilityServerSetupTasks {
+        public Community() {
+            super(Stability.COMMUNITY);
+        }
+    }
+
+    /**
+     * A server setup task that sets the server stability to the preview level.
+     */
+    public static class Preview extends StabilityServerSetupTasks {
+        public Preview() {
+            super(Stability.PREVIEW);
+        }
+    }
+
+    /**
+     * A server setup task that sets the server stability to the experimental level.
+     */
+    public static class Experimental extends StabilityServerSetupTasks {
+        public Experimental() {
+            super(Stability.EXPERIMENTAL);
+        }
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/DisableLocalAuthServerSetupTask.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/DisableLocalAuthServerSetupTask.java
@@ -62,7 +62,11 @@ class DisableLocalAuthServerSetupTask implements ServerSetupTask {
         executeForSuccess(client, compositeOp.build());
 
         // Use the current client to execute the reload, but the native client to ensure the reload is complete
-        ServerReload.executeReloadAndWaitForCompletion(client, ServerReload.TIMEOUT, false, protocol, host, port);
+        ServerReload.executeReloadAndWaitForCompletion(client, new ServerReload.Parameters()
+                .setProtocol(protocol)
+                .setServerAddress(host)
+                .setServerPort(port)
+        );
     }
 
     @Override

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/AbstractStabilityServerSetupTaskTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/AbstractStabilityServerSetupTaskTest.java
@@ -31,6 +31,8 @@ import org.wildfly.core.testrunner.ManagementClient;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.server.controller.descriptions.ServerDescriptionConstants.SERVER_ENVIRONMENT;
 
 public abstract class AbstractStabilityServerSetupTaskTest {
@@ -49,5 +51,19 @@ public abstract class AbstractStabilityServerSetupTaskTest {
         ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
         Stability stability = Stability.fromString(result.asString());
         Assert.assertEquals(desiredStability, stability);
+    }
+
+    @Test
+    public void testSystemPropertyWasSetByDoSetupCalls() throws Exception {
+        ModelNode read = Util.getReadAttributeOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, AbstractStabilityServerSetupTaskTest.class.getName()), VALUE);
+        ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), read);
+        Assert.assertEquals(this.getClass().getName(), result.asString());
+    }
+
+
+    protected static <T extends AbstractStabilityServerSetupTaskTest> void addSystemProperty(ManagementClient client, Class<T> clazz) throws Exception {
+        ModelNode add = Util.createAddOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, AbstractStabilityServerSetupTaskTest.class.getName()));
+        add.get(VALUE).set(clazz.getName());
+        ManagementOperations.executeOperation(client.getControllerClient(), add);
     }
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/AbstractStabilityServerSetupTaskTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/AbstractStabilityServerSetupTaskTest.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.core.test.standalone.stability;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/AbstractStabilityServerSetupTaskTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/AbstractStabilityServerSetupTaskTest.java
@@ -1,0 +1,53 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.core.test.standalone.stability;
+
+import jakarta.inject.Inject;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.version.Stability;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.core.testrunner.ManagementClient;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
+import static org.jboss.as.server.controller.descriptions.ServerDescriptionConstants.SERVER_ENVIRONMENT;
+
+public abstract class AbstractStabilityServerSetupTaskTest {
+    private final Stability desiredStability;
+
+    @Inject
+    private ManagementClient managementClient;
+
+    public AbstractStabilityServerSetupTaskTest(Stability desiredStability) {
+        this.desiredStability = desiredStability;
+    }
+
+    @Test
+    public void testStabilityMatchesSetupTask() throws Exception {
+        ModelNode op = Util.getReadAttributeOperation(PathAddress.pathAddress(CORE_SERVICE, SERVER_ENVIRONMENT), STABILITY);
+        ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        Stability stability = Stability.fromString(result.asString());
+        Assert.assertEquals(desiredStability, stability);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityCommunityServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityCommunityServerSetupTestCase.java
@@ -1,0 +1,34 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.core.test.standalone.stability;
+
+import org.jboss.as.version.Stability;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildFlyRunner;
+import org.wildfly.test.stability.StabilityServerSetupTasks;
+
+@ServerSetup(StabilityServerSetupTasks.Community.class)
+@RunWith(WildFlyRunner.class)
+public class StabilityCommunityServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
+    public StabilityCommunityServerSetupTestCase() {
+        super(Stability.COMMUNITY);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityCommunityServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityCommunityServerSetupTestCase.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.core.test.standalone.stability;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityCommunityServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityCommunityServerSetupTestCase.java
@@ -21,14 +21,27 @@ package org.wildfly.core.test.standalone.stability;
 
 import org.jboss.as.version.Stability;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildFlyRunner;
-import org.wildfly.test.stability.StabilityServerSetupTasks;
+import org.wildfly.test.stability.StabilityServerSetupSnapshotRestoreTasks;
 
-@ServerSetup(StabilityServerSetupTasks.Community.class)
+@ServerSetup(StabilityCommunityServerSetupTestCase.CommunityStabilitySetupTask.class)
 @RunWith(WildFlyRunner.class)
 public class StabilityCommunityServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
     public StabilityCommunityServerSetupTestCase() {
         super(Stability.COMMUNITY);
     }
+
+
+    public static class CommunityStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Community {
+        @Override
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            // Not really needed since the resulting written xml will be of a higher stability level
+            // than the server. Still we are doing it for experimental preview, so it doesn't hurt to
+            // do the same here.
+            AbstractStabilityServerSetupTaskTest.addSystemProperty(managementClient, StabilityCommunityServerSetupTestCase.class);
+        }
+    }
+
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityDefaultServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityDefaultServerSetupTestCase.java
@@ -1,0 +1,35 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.core.test.standalone.stability;
+
+import org.jboss.as.version.Stability;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildFlyRunner;
+import org.wildfly.test.stability.StabilityServerSetupTasks;
+
+@ServerSetup(StabilityServerSetupTasks.Default.class)
+@RunWith(WildFlyRunner.class)
+public class StabilityDefaultServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
+    public StabilityDefaultServerSetupTestCase() {
+        super(Stability.DEFAULT);
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityDefaultServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityDefaultServerSetupTestCase.java
@@ -21,15 +21,25 @@ package org.wildfly.core.test.standalone.stability;
 
 import org.jboss.as.version.Stability;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildFlyRunner;
-import org.wildfly.test.stability.StabilityServerSetupTasks;
+import org.wildfly.test.stability.StabilityServerSetupSnapshotRestoreTasks;
 
-@ServerSetup(StabilityServerSetupTasks.Default.class)
+@ServerSetup(StabilityDefaultServerSetupTestCase.DefaultStabilitySetupTask.class)
 @RunWith(WildFlyRunner.class)
 public class StabilityDefaultServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
     public StabilityDefaultServerSetupTestCase() {
         super(Stability.DEFAULT);
     }
 
+    public static class DefaultStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Default {
+        @Override
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            // Not really needed since the resulting written xml will be of a higher stability level
+            // than the server. Still we are doing it for experimental preview, so it doesn't hurt to
+            // do the same here.
+            AbstractStabilityServerSetupTaskTest.addSystemProperty(managementClient, StabilityDefaultServerSetupTestCase.class);
+        }
+    }
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityDefaultServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityDefaultServerSetupTestCase.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.core.test.standalone.stability;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityExperimentalServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityExperimentalServerSetupTestCase.java
@@ -21,14 +21,26 @@ package org.wildfly.core.test.standalone.stability;
 
 import org.jboss.as.version.Stability;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildFlyRunner;
-import org.wildfly.test.stability.StabilityServerSetupTasks;
+import org.wildfly.test.stability.StabilityServerSetupSnapshotRestoreTasks;
 
-@ServerSetup(StabilityServerSetupTasks.Experimental.class)
+@ServerSetup(StabilityExperimentalServerSetupTestCase.ExperimentalStabilitySetupTask.class)
 @RunWith(WildFlyRunner.class)
 public class StabilityExperimentalServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
     public StabilityExperimentalServerSetupTestCase() {
         super(Stability.EXPERIMENTAL);
     }
+
+
+    public static class ExperimentalStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Experimental {
+        @Override
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            // Write a system property so the model ges stored with a lower stability level.
+            // This is to make sure we can reload back to the higher level from the snapshot
+            AbstractStabilityServerSetupTaskTest.addSystemProperty(managementClient, StabilityExperimentalServerSetupTestCase.class);
+        }
+    }
+
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityExperimentalServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityExperimentalServerSetupTestCase.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.core.test.standalone.stability;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityExperimentalServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityExperimentalServerSetupTestCase.java
@@ -1,0 +1,34 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.core.test.standalone.stability;
+
+import org.jboss.as.version.Stability;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildFlyRunner;
+import org.wildfly.test.stability.StabilityServerSetupTasks;
+
+@ServerSetup(StabilityServerSetupTasks.Experimental.class)
+@RunWith(WildFlyRunner.class)
+public class StabilityExperimentalServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
+    public StabilityExperimentalServerSetupTestCase() {
+        super(Stability.EXPERIMENTAL);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityPreviewServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityPreviewServerSetupTestCase.java
@@ -1,20 +1,6 @@
 /*
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2024 Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.wildfly.core.test.standalone.stability;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityPreviewServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityPreviewServerSetupTestCase.java
@@ -1,0 +1,34 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2024 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wildfly.core.test.standalone.stability;
+
+import org.jboss.as.version.Stability;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildFlyRunner;
+import org.wildfly.test.stability.StabilityServerSetupTasks;
+
+@ServerSetup(StabilityServerSetupTasks.Preview.class)
+@RunWith(WildFlyRunner.class)
+public class StabilityPreviewServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
+    public StabilityPreviewServerSetupTestCase() {
+        super(Stability.PREVIEW);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityPreviewServerSetupTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/stability/StabilityPreviewServerSetupTestCase.java
@@ -21,14 +21,26 @@ package org.wildfly.core.test.standalone.stability;
 
 import org.jboss.as.version.Stability;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildFlyRunner;
-import org.wildfly.test.stability.StabilityServerSetupTasks;
+import org.wildfly.test.stability.StabilityServerSetupSnapshotRestoreTasks;
 
-@ServerSetup(StabilityServerSetupTasks.Preview.class)
+@ServerSetup(StabilityPreviewServerSetupTestCase.PreviewStabilitySetupTask.class)
 @RunWith(WildFlyRunner.class)
 public class StabilityPreviewServerSetupTestCase extends AbstractStabilityServerSetupTaskTest {
     public StabilityPreviewServerSetupTestCase() {
         super(Stability.PREVIEW);
     }
+
+
+    public static class PreviewStabilitySetupTask extends StabilityServerSetupSnapshotRestoreTasks.Preview {
+        @Override
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            // Write a system property so the model ges stored with a lower stability level.
+            // This is to make sure we can reload back to the higher level from the snapshot
+            AbstractStabilityServerSetupTaskTest.addSystemProperty(managementClient, StabilityPreviewServerSetupTestCase.class);
+        }
+    }
+
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6728
Proposal: https://github.com/wildfly/wildfly-proposals/pull/557

Includes #5895 (which has passed CI) and adds a commit adjusting how the stabiiity is set in the ExtensionRegistry following a reload