### PR TITLE
[WFCORE-6758] Upgrade WildFly Elytron to 2.4.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.3.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.4.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6758

Depends on https://github.com/wildfly/wildfly/pull/17755


        Release Notes - WildFly Elytron - Version 2.4.0.CR1
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2724'>ELY-2724</a>] -         TLS13AuthenticationTest needs to be updated to run with SE 21
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2725'>ELY-2725</a>] -         Update CommunicationSuiteChild so it can run with SE 21
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2726'>ELY-2726</a>] -         Update AlternateSecurityManagerTest to be able to run with SE 21
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2728'>ELY-2728</a>] -         Update japicmp-maven-plugin to a more recent version
</li>
</ul>
                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1996'>ELY-1996</a>] -         [Community] SSLContext to support delegation to alternate instances based on peer information.
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2574'>ELY-2574</a>] -         oidc: add ability to configure additional scope for authentication request
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-1815'>ELY-1815</a>] -         Unable to set custom AUTHENTICATION_TIMEOUT value 
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2545'>ELY-2545</a>] -         referral-mode=&quot;ignore&quot; and filter-base-dn=rootDN cause javax.naming.PartialResultException
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2714'>ELY-2714</a>] -         Attempting to read address data from an OIDC id token causes ClassCastException
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2319'>ELY-2319</a>] -         Delete the deprecated org.wildfly.security.auth.util.GSSCredentialSecurityFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2557'>ELY-2557</a>] -         Add an afterclass method to do clean-up after the FileSystemEncryptRealmCommandTest testBulkWithoutNames test
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2580'>ELY-2580</a>] -         Add new CVE Reporting page to the Elytron website
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2591'>ELY-2591</a>] -         Move min method into the PeriodicRotatingFileAuditEndpoint#Builder class
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2594'>ELY-2594</a>] -         Replace a switch statement in ElytronXmlParser#parseRulesType to improve readability
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2627'>ELY-2627</a>] -         Replace manual array copy in X500PrincipalUtil class with the System.arraycopy method to improve readability
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2631'>ELY-2631</a>] -         Add a test to SSLAuthenticationTest that tests the wantClientAuth option
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2638'>ELY-2638</a>] -         Simplify test assertions in SSLAuthenticationTest
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2639'>ELY-2639</a>] -         Add a test for MaskCommand.decryptMasked method
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2689'>ELY-2689</a>] -         Update 3 tests in SunUnixMD5Crypt to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2696'>ELY-2696</a>] -         Update 3 tests in PrincipalMappingSuiteChild to call a common method in order to remove duplicated code
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2705'>ELY-2705</a>] -         Update SecurityDomain#createAdHocIdentity so that it also calls SecurityDomain#transform to ensure that the securityIdentityTransformer gets used if configured
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2708'>ELY-2708</a>] -         Update the CONTRIBUTING.md file with information on Elytron&#39;s code review process and maintenance branches
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2715'>ELY-2715</a>] -         Reduce Log Level for ELY23013 and ELY23012
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2721'>ELY-2721</a>] -         Upgrade to ApacheDS AM27 and Apache Kerby KDC server
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2740'>ELY-2740</a>] -         Release WildFly Elytron 2.4.0.CR1
</li>
</ul>
                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2729'>ELY-2729</a>] -         Upgrade Jackson FasterXML to 2.5.14
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2730'>ELY-2730</a>] -         org.bitbucket.b_c:jose4j from 0.9.4 to 0.9.6
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2735'>ELY-2735</a>] -         Bump hsqldb from 2.3.1 to 2.7.1 
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2379'>ELY-2379</a>] -         Rename a local variable in FileAuditEndpoint class
</li>
</ul>
                                                                                                                                                    