### PR TITLE
Fix for WFCORE-6762, Upgrade to Galleon 6.0.0.Beta5 and Galleon Plugins 7.0.0.Beta6

### DIFF
--- a/core-feature-pack/galleon-feature-pack/pom.xml
+++ b/core-feature-pack/galleon-feature-pack/pom.xml
@@ -232,9 +232,9 @@
                             <release-name>WildFly Core</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
-                            <minimum-stability>experimental</minimum-stability>
-                            <config-stability>community</config-stability>
-                            <package-stability>experimental</package-stability>
+                            <minimum-stability-level>experimental</minimum-stability-level>
+                            <config-stability-level>community</config-stability-level>
+                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
         <!-- Non-default maven plugin versions and configuration -->
         <version.buildhelper.plugin>3.4.0</version.buildhelper.plugin>
         <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
-        <version.org.jboss.galleon>6.0.0.Beta4</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.0.Beta5</version.org.jboss.galleon>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>7.0.0.Beta5</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.0.0.Beta6</version.org.wildfly.galleon-plugins>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <!-- wildfly-maven-plugin-->
         <version.wildfly.plugin>5.0.0.Beta3</version.wildfly.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6762
The reason of this upgrade is the rename of galleon plugins Maven plugin stability options (suffixed with '-level').
