### PR TITLE
WFCORE-6765 Schema version comparison should require compatible stability level

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/xml/SimpleVersionedNamespace.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/SimpleVersionedNamespace.java
@@ -5,7 +5,6 @@
 package org.jboss.as.controller.xml;
 
 import org.jboss.as.version.Stability;
-import org.jboss.staxmapper.Versioned;
 
 /**
  * Simple {@link VersionedNamespace} implementation.
@@ -13,7 +12,7 @@ import org.jboss.staxmapper.Versioned;
  * @param <V> the namespace version
  * @param <N> the namespace type
  */
-public class SimpleVersionedNamespace<V extends Comparable<V>, N extends Versioned<V, N>> extends SimpleNamespace implements VersionedNamespace<V, N> {
+public class SimpleVersionedNamespace<V extends Comparable<V>, N extends VersionedFeature<V, N>> extends SimpleNamespace implements VersionedNamespace<V, N> {
 
     private final V version;
     private final Stability stability;

--- a/controller/src/main/java/org/jboss/as/controller/xml/VersionedFeature.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/VersionedFeature.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+import org.jboss.as.controller.Feature;
+import org.jboss.staxmapper.Versioned;
+
+/**
+ * A versioned feature.
+ * @param <V> the version type
+ * @param <F> the versioned feature type
+ */
+public interface VersionedFeature<V extends Comparable<V>, F extends VersionedFeature<V, F>> extends Versioned<V, F>, Feature {
+
+    @Override
+    default boolean since(F feature) {
+        // Also ensure that our stability enables the stability of the feature
+        return Versioned.super.since(feature) && this.getStability().enables(feature.getStability());
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/xml/VersionedNamespace.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/VersionedNamespace.java
@@ -7,17 +7,15 @@ package org.jboss.as.controller.xml;
 import java.util.List;
 import java.util.function.Function;
 
-import org.jboss.as.controller.FeatureRegistry;
 import org.jboss.as.version.Stability;
 import org.jboss.staxmapper.Namespace;
-import org.jboss.staxmapper.Versioned;
 import org.wildfly.common.iteration.CompositeIterable;
 
 /**
  * A versioned namespace.
  * @author Paul Ferraro
  */
-public interface VersionedNamespace<V extends Comparable<V>, N extends Versioned<V, N>> extends Versioned<V, N>, Namespace, FeatureRegistry {
+public interface VersionedNamespace<V extends Comparable<V>, N extends VersionedFeature<V, N>> extends VersionedFeature<V, N>, Namespace {
 
     /**
      * Equivalent to {@link #createURN(List, Comparable, Function)} using {@link Object#toString()}.
@@ -27,7 +25,7 @@ public interface VersionedNamespace<V extends Comparable<V>, N extends Versioned
      * @param version a version
      * @return a versioned URN
      */
-    static <V extends Comparable<V>, N extends Versioned<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, V version) {
+    static <V extends Comparable<V>, N extends VersionedFeature<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, V version) {
         return createURN(identifiers, Stability.DEFAULT, version);
     }
 
@@ -40,7 +38,7 @@ public interface VersionedNamespace<V extends Comparable<V>, N extends Versioned
      * @param version a version
      * @return a versioned URN
      */
-    static <V extends Comparable<V>, N extends Versioned<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, Stability stability, V version) {
+    static <V extends Comparable<V>, N extends VersionedFeature<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, Stability stability, V version) {
         return createURN(identifiers, stability, version, Object::toString);
     }
 
@@ -53,7 +51,7 @@ public interface VersionedNamespace<V extends Comparable<V>, N extends Versioned
      * @param versionFormatter a version formatter
      * @return a versioned URN
      */
-    static <V extends Comparable<V>, N extends Versioned<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, V version, Function<V, String> versionFormatter) {
+    static <V extends Comparable<V>, N extends VersionedFeature<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, V version, Function<V, String> versionFormatter) {
         return createURN(identifiers, Stability.DEFAULT, version, versionFormatter);
     }
 
@@ -67,7 +65,7 @@ public interface VersionedNamespace<V extends Comparable<V>, N extends Versioned
      * @param versionFormatter a version formatter
      * @return a versioned URN
      */
-    static <V extends Comparable<V>, N extends Versioned<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, Stability stability, V version, Function<V, String> versionFormatter) {
+    static <V extends Comparable<V>, N extends VersionedFeature<V, N>> VersionedNamespace<V, N> createURN(List<String> identifiers, Stability stability, V version, Function<V, String> versionFormatter) {
         return new SimpleVersionedNamespace<>(String.join(":", new CompositeIterable<>(List.of("urn"), identifiers, !Stability.DEFAULT.enables(stability) ? List.of(stability.toString(), versionFormatter.apply(version)) : List.of(versionFormatter.apply(version)))), version, stability);
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/xml/VersionedSchema.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/VersionedSchema.java
@@ -4,16 +4,14 @@
  */
 package org.jboss.as.controller.xml;
 
-import org.jboss.as.controller.Feature;
 import org.jboss.as.controller.FeatureRegistry;
 import org.jboss.as.version.Stability;
-import org.jboss.staxmapper.Versioned;
 
 /**
  * A versioned schema, whose namespace is a versioned namespace.
  * @author Paul Ferraro
  */
-public interface VersionedSchema<V extends Comparable<V>, S extends VersionedSchema<V, S>> extends Versioned<V, S>, Schema, Feature, FeatureRegistry {
+public interface VersionedSchema<V extends Comparable<V>, S extends VersionedFeature<V, S>> extends VersionedFeature<V, S>, Schema, FeatureRegistry {
 
     /**
      * Returns the versioned namespace of this attribute/element.

--- a/controller/src/main/java/org/jboss/as/controller/xml/VersionedURN.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/VersionedURN.java
@@ -7,7 +7,6 @@ package org.jboss.as.controller.xml;
 import java.util.List;
 
 import org.jboss.staxmapper.IntVersion;
-import org.jboss.staxmapper.Versioned;
 import org.wildfly.common.iteration.CompositeIterable;
 
 /**
@@ -16,7 +15,7 @@ import org.wildfly.common.iteration.CompositeIterable;
  * @deprecated Use {@link IntVersionSchema#createURN(List, IntVersion) instead.
  */
 @Deprecated(forRemoval = true)
-public class VersionedURN<N extends Versioned<IntVersion, N>> extends SimpleVersionedNamespace<IntVersion, N> {
+public class VersionedURN<N extends VersionedFeature<IntVersion, N>> extends SimpleVersionedNamespace<IntVersion, N> {
     public static final String JBOSS_IDENTIFIER = IntVersionSchema.JBOSS_IDENTIFIER;
     public static final String WILDFLY_IDENTIFIER = IntVersionSchema.WILDFLY_IDENTIFIER;
 

--- a/controller/src/test/java/org/jboss/as/controller/xml/VersionedNamespaceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/xml/VersionedNamespaceTestCase.java
@@ -4,7 +4,9 @@
  */
 package org.jboss.as.controller.xml;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.SubsystemSchema;
 import org.jboss.as.version.Stability;
@@ -18,15 +20,46 @@ import org.junit.Test;
  */
 public class VersionedNamespaceTestCase {
 
-    @Test
-    public void test() {
-        Assert.assertEquals("urn:foo:bar:1", VersionedNamespace.createURN(List.of("foo", "bar"), new IntVersion(1)).getUri());
-        Assert.assertEquals("urn:foo:bar:1", VersionedNamespace.createURN(List.of("foo", "bar"), Stability.DEFAULT, new IntVersion(1)).getUri());
-        Assert.assertEquals("urn:foo:bar:experimental:1.0.0", VersionedNamespace.createURN(List.of("foo", "bar"), Stability.EXPERIMENTAL, new IntVersion(1), IntVersionSchema.MAJOR_MINOR_MICRO).getUri());
+    enum Schema implements VersionedSchema<IntVersion, Schema> {
+        VERSION_1_DEFAULT(1, Stability.DEFAULT),
+        VERSION_1_COMMUNITY(1, Stability.COMMUNITY),
+        VERSION_1_PREVIEW(1, Stability.PREVIEW),
+        VERSION_1_EXPERIMENTAL(1, Stability.EXPERIMENTAL),
 
-        Assert.assertEquals("urn:foo:bar:2.0", IntVersionSchema.createURN(List.of("foo", "bar"), new IntVersion(2)).getUri());
-        Assert.assertEquals("urn:foo:bar:2.0", IntVersionSchema.createURN(List.of("foo", "bar"), Stability.DEFAULT, new IntVersion(2)).getUri());
-        Assert.assertEquals("urn:foo:bar:preview:2.0", IntVersionSchema.createURN(List.of("foo", "bar"), Stability.PREVIEW, new IntVersion(2)).getUri());
+        VERSION_2_EXPERIMENTAL(2, Stability.EXPERIMENTAL),
+        VERSION_2_PREVIEW(2, Stability.PREVIEW),
+        VERSION_2_COMMUNITY(2, Stability.COMMUNITY),
+        VERSION_2_DEFAULT(2, Stability.DEFAULT),
+        ;
+
+        private final VersionedNamespace<IntVersion, Schema> namespace;
+
+        Schema(int version, Stability stability) {
+            this.namespace = VersionedNamespace.createURN(List.of("foo", "bar"), stability, new IntVersion(version));
+        }
+
+        @Override
+        public String getLocalName() {
+            return "";
+        }
+
+        @Override
+        public VersionedNamespace<IntVersion, Schema> getNamespace() {
+            return this.namespace;
+        }
+    }
+
+    @Test
+    public void uri() {
+        Assert.assertEquals("urn:foo:bar:1", Schema.VERSION_1_DEFAULT.getNamespace().getUri());
+        Assert.assertEquals("urn:foo:bar:community:1", Schema.VERSION_1_COMMUNITY.getNamespace().getUri());
+        Assert.assertEquals("urn:foo:bar:preview:1", Schema.VERSION_1_PREVIEW.getNamespace().getUri());
+        Assert.assertEquals("urn:foo:bar:experimental:1", Schema.VERSION_1_EXPERIMENTAL.getNamespace().getUri());
+
+        Assert.assertEquals("urn:foo:bar:2", Schema.VERSION_2_DEFAULT.getNamespace().getUri());
+        Assert.assertEquals("urn:foo:bar:community:2", Schema.VERSION_2_COMMUNITY.getNamespace().getUri());
+        Assert.assertEquals("urn:foo:bar:preview:2", Schema.VERSION_2_PREVIEW.getNamespace().getUri());
+        Assert.assertEquals("urn:foo:bar:experimental:2", Schema.VERSION_2_EXPERIMENTAL.getNamespace().getUri());
 
         Assert.assertEquals("urn:jboss:domain:foo:1.0", SubsystemSchema.createLegacySubsystemURN("foo", new IntVersion(1)).getUri());
         Assert.assertEquals("urn:jboss:domain:foo:1.0", SubsystemSchema.createLegacySubsystemURN("foo", Stability.DEFAULT, new IntVersion(1)).getUri());
@@ -35,5 +68,30 @@ public class VersionedNamespaceTestCase {
         Assert.assertEquals("urn:wildfly:foo:2.0", SubsystemSchema.createSubsystemURN("foo", new IntVersion(2)).getUri());
         Assert.assertEquals("urn:wildfly:foo:2.0", SubsystemSchema.createSubsystemURN("foo", Stability.DEFAULT, new IntVersion(2)).getUri());
         Assert.assertEquals("urn:wildfly:foo:preview:2.0", SubsystemSchema.createSubsystemURN("foo", Stability.PREVIEW, new IntVersion(2)).getUri());
+    }
+
+    @Test
+    public void stability() {
+        Assert.assertSame(Schema.VERSION_1_COMMUNITY.getStability(), Stability.COMMUNITY);
+        Assert.assertSame(Schema.VERSION_1_COMMUNITY.getNamespace().getStability(), Stability.COMMUNITY);
+    }
+
+    @Test
+    public void since() {
+        since(Schema.VERSION_1_DEFAULT, EnumSet.allOf(Schema.class));
+        since(Schema.VERSION_1_COMMUNITY, EnumSet.complementOf(EnumSet.of(Schema.VERSION_1_DEFAULT, Schema.VERSION_2_DEFAULT)));
+        since(Schema.VERSION_1_PREVIEW, EnumSet.of(Schema.VERSION_1_EXPERIMENTAL, Schema.VERSION_2_EXPERIMENTAL, Schema.VERSION_1_PREVIEW, Schema.VERSION_2_PREVIEW));
+        since(Schema.VERSION_1_EXPERIMENTAL, EnumSet.of(Schema.VERSION_1_EXPERIMENTAL, Schema.VERSION_2_EXPERIMENTAL));
+        since(Schema.VERSION_2_EXPERIMENTAL, EnumSet.of(Schema.VERSION_2_EXPERIMENTAL));
+        since(Schema.VERSION_2_PREVIEW, EnumSet.of(Schema.VERSION_2_EXPERIMENTAL, Schema.VERSION_2_PREVIEW));
+        since(Schema.VERSION_2_PREVIEW, EnumSet.of(Schema.VERSION_2_EXPERIMENTAL, Schema.VERSION_2_PREVIEW));
+        since(Schema.VERSION_2_COMMUNITY, EnumSet.of(Schema.VERSION_2_EXPERIMENTAL, Schema.VERSION_2_PREVIEW, Schema.VERSION_2_COMMUNITY));
+        since(Schema.VERSION_2_DEFAULT, EnumSet.of(Schema.VERSION_2_EXPERIMENTAL, Schema.VERSION_2_PREVIEW, Schema.VERSION_2_COMMUNITY, Schema.VERSION_2_DEFAULT));
+    }
+
+    private static void since(Schema testSchema, Set<Schema> since) {
+        for (Schema schema : EnumSet.allOf(Schema.class)) {
+            Assert.assertEquals(schema.name(), since.contains(schema), schema.since(testSchema));
+        }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6765

It's become clear to me that schema namespace comparisons should be stability-aware.
See jira for details.