### PR TITLE
[WFCORE-6774][CVE-2024-29857][CVE-2024-30171][CVE-2024-30172] Upgrade BouncyCastle from 1.77 to 1.78

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpg/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpg/main/module.xml
@@ -17,5 +17,6 @@
 
     <dependencies>
         <module name="org.bouncycastle.bcprov"/>
+        <module name="org.bouncycastle.bcutil"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.12.1</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
-        <version.org.bouncycastle>1.77</version.org.bouncycastle>
+        <version.org.bouncycastle>1.78</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.8.0.202311291450-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6774

Artifacts were released but the tag was not provided yet, so adding a hold label until that situation gets resolved:, see https://github.com/bcgit/bc-java/issues/1618

This release comes with the following security advisories, see: https://www.bouncycastle.org/releasenotes.html#r1rv78
CVE-2024-29857 - Importing an EC certificate with specially crafted F2m parameters can cause high CPU usage during parameter evaluation.
CVE-2024-30171 - Possible timing based leakage in RSA based handshakes due to exception processing eliminated.
CVE-2024-30172 - Crafted signature and public key can be used to trigger an infinite loop in the Ed25519 verification code.
CVE-2024-301XX - When endpoint identification is enabled and an SSL socket is not created with an explicit hostname (as happens with HttpsURLConnection), hostname verification could be performed against a DNS-resolved IP address. This has been fixed.
