### PR TITLE
[WFCORE-6775] Upgrade Eclipse Parsson from 1.1.5 to 1.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <version.org.bouncycastle>1.77</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.8.0.202311291450-r</version.org.eclipse.jgit>
-        <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>
+        <version.org.eclipse.parsson>1.1.6</version.org.eclipse.parsson>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.jboss.byteman>4.0.22</version.org.jboss.byteman>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6775
