### PR TITLE
Fix for WFCORE-6776, Can't specify a stability level when starting a bootable JAR.

### DIFF
--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Arguments.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/Arguments.java
@@ -99,6 +99,8 @@ final class Arguments {
              } else if (ConfigurationExtensionFactory.isConfigurationExtensionSupported()
                     && ConfigurationExtensionFactory.commandLineContainsArgument(a)) {
                 serverArguments.add(a);
+            } else if (a.startsWith(CommandLineConstants.STABILITY)) {
+                serverArguments.add(a);
             } else {
                 throw BootableJarLogger.ROOT_LOGGER.unknownArgument(a);
             }

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/BootableJar.java
@@ -53,6 +53,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.RUNTIME_NAME;
 import org.jboss.as.process.CommandLineConstants;
 import org.jboss.as.process.ExitCodes;
+import org.jboss.as.version.ProductConfig;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.Configurator;
 import org.jboss.logmanager.LogContext;
@@ -313,16 +314,17 @@ public final class BootableJar implements ShutdownHandler {
         setTccl(moduleClassLoader);
         // Initialize the environment
         final BootableEnvironment environment = BootableEnvironment.of(jbossHome);
+        ProductConfig productConfig = ProductConfig.fromFilesystemSlot(moduleLoader, jbossHome.toString(), null);
         Arguments arguments;
         try {
             arguments = Arguments.parseArguments(args, environment);
         } catch (Throwable ex) {
             System.err.println(ex);
-            CmdUsage.printUsage(System.out);
+            CmdUsage.printUsage(productConfig, System.out);
             return;
         }
         if (arguments.isHelp()) {
-            CmdUsage.printUsage(System.out);
+            CmdUsage.printUsage(productConfig, System.out);
             return;
         }
 

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/CmdUsage.java
@@ -9,6 +9,7 @@ import org.jboss.as.controller.persistence.ConfigurationExtensionFactory;
 
 import org.jboss.as.process.CommandLineArgumentUsage;
 import org.jboss.as.process.CommandLineConstants;
+import org.jboss.as.version.ProductConfig;
 import org.wildfly.core.jar.runtime._private.BootableJarLogger;
 
 /**
@@ -16,7 +17,7 @@ import org.wildfly.core.jar.runtime._private.BootableJarLogger;
  * @author jdenise
  */
 final class CmdUsage extends CommandLineArgumentUsage {
-    public static void init() {
+    public static void init(ProductConfig productConfig) {
 
         addArguments(Constants.DEPLOYMENT_ARG + "=<value>");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argDeployment());
@@ -48,6 +49,11 @@ final class CmdUsage extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SECMGR);
         instructions.add(BootableJarLogger.ROOT_LOGGER.argSecurityManager());
 
+        if (productConfig.getStabilitySet().size() > 1) {
+            addArguments(CommandLineConstants.STABILITY + "=<value>");
+            instructions.add(BootableJarLogger.ROOT_LOGGER.argStability(productConfig.getStabilitySet(), productConfig.getDefaultStability()));
+        }
+
         addArguments(CommandLineConstants.SECURITY_PROP + "<name>[=<value>]");
         instructions.add(BootableJarLogger.ROOT_LOGGER.argSecurityProperty());
 
@@ -63,8 +69,8 @@ final class CmdUsage extends CommandLineArgumentUsage {
         }
     }
 
-    public static void printUsage(final PrintStream out) {
-        init();
+    public static void printUsage(ProductConfig config, final PrintStream out) {
+        init(config);
         out.print(customUsage("java -jar <bootable jar>"));
     }
 }

--- a/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
+++ b/bootable-jar/runtime/src/main/java/org/wildfly/core/jar/runtime/_private/BootableJarLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.core.jar.runtime._private;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
+import org.jboss.as.version.Stability;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
@@ -139,6 +141,9 @@ public interface BootableJarLogger extends BasicLogger {
 
     @Message(id = Message.NONE, value = "Activate the SecurityManager")
     String argSecurityManager();
+
+    @Message(id = Message.NONE, value = "Runs the server using a specific stability level. Possible values: %s, Default = %s")
+    String argStability(Set<Stability> levels, Stability defaultLevel);
 
     @Message(id = Message.NONE, value = "Set a security property")
     String argSecurityProperty();


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6776