### PR TITLE
[WFCORE-6780] Upgrade WildFly Elytron to 2.4.0.Final for CVE-2024-1233 and CVE-2023-6236

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -23,6 +23,8 @@
         <modular.jdk.args>${standard.client.modular.jdk.args} ${modular.jdk11.args}
             --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
         </modular.jdk.args>
+        <version.com.nimbus.jose-jwt>9.37.3</version.com.nimbus.jose-jwt>
+        <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
     </properties>
 
     <dependencyManagement>
@@ -105,6 +107,32 @@
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>${version.com.nimbus.jose-jwt}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${version.com.squareup.okhttp3.mockwebserver}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -317,6 +345,13 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-sasl-plain</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-tests-common</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -88,6 +88,8 @@ import org.wildfly.security.pem.PemEntry;
  */
 class TokenRealmDefinition extends SimpleResourceDefinition {
 
+    private static final String ALLOWED_JKU_VALUES_PROPERTY_PREFIX = "wildfly.elytron.jwt.allowed.jku.values.";
+
     static final SimpleAttributeDefinition PRINCIPAL_CLAIM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRINCIPAL_CLAIM, ModelType.STRING, true)
             .setDefaultValue(new ModelNode("username"))
             .setAllowExpression(true)
@@ -332,6 +334,13 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                             } catch (KeyStoreException cause) {
                                 throw ROOT_LOGGER.unableToStartService(cause);
                             }
+                        }
+
+                        String allowedJkuValuesForTokenRealm = System.getProperty(ALLOWED_JKU_VALUES_PROPERTY_PREFIX + address);
+                        if (allowedJkuValuesForTokenRealm == null || allowedJkuValuesForTokenRealm.isEmpty()) {
+                            ROOT_LOGGER.noAllowedJkuValuesSpecifiedForTokenRealm(address, ALLOWED_JKU_VALUES_PROPERTY_PREFIX + address);
+                        } else {
+                            jwtValidatorBuilder.setAllowedJkuValues(allowedJkuValuesForTokenRealm.split("\\s+"));
                         }
 
                         return TokenSecurityRealm.builder().principalClaimName(principalClaimNode.asString())

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -654,6 +654,10 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1089, value = "Invalid file encoding '%s'.")
     OperationFailedException invalidEncodingName(String encoding);
 
+    @Message(id = 1090, value = "Allowed jku values haven't been specified for token realm '%s'. Token validation will fail if the token contains a 'jku' header parameter. The allowed jku values can be specified as a space separated string using the '%s' system property.")
+    @LogMessage(level = WARN)
+    void noAllowedJkuValuesSpecifiedForTokenRealm(String realmName, String systemPropertyName);
+
     /*
      * Expression Resolver Section
      */

--- a/elytron/src/test/java/org/wildfly/extension/elytron/JwtSecurityRealmTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/JwtSecurityRealmTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.elytron;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.security.realm.token.test.util.JwtTestUtil.createRsaJwk;
+import static org.wildfly.security.realm.token.test.util.JwtTestUtil.createTokenDispatcher;
+import static org.wildfly.security.realm.token.test.util.JwtTestUtil.jwksToJson;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.security.AccessController;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivilegedAction;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Security;
+
+import javax.net.ssl.SSLContext;
+
+import jakarta.json.JsonObject;
+
+import okhttp3.mockwebserver.MockWebServer;
+
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.evidence.BearerTokenEvidence;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.realm.token.test.util.RsaJwk;
+import org.wildfly.security.realm.token.test.util.JwtTestUtil;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class JwtSecurityRealmTestCase extends AbstractElytronSubsystemBaseTest {
+
+    private static final Provider wildFlyElytronProvider = new WildFlyElytronProvider();
+    private static final String JWT_REALM_TEST = "jwt-realm-test.xml";
+    private static final MockWebServer server = new MockWebServer();
+    private static final String JKU_ALLOWED_VALUES_PROPERTY = "wildfly.elytron.jwt.allowed.jku.values.JwtRealm";
+
+    private static KeyPair keyPair1;
+    private static KeyPair keyPair2;
+
+    private static RsaJwk jwk1;
+    private static RsaJwk jwk2;
+    private static String jwksResponse;
+
+    public JwtSecurityRealmTestCase() {
+        super(ElytronExtension.SUBSYSTEM_NAME, new ElytronExtension());
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Security.insertProviderAt(wildFlyElytronProvider, 1));
+
+        TestEnvironment.setUpKeyStores();
+
+        keyPair1 = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        jwk1 = createRsaJwk(keyPair1, "1");
+
+        keyPair2 = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        jwk2 = createRsaJwk(keyPair2, "2");
+
+        JsonObject jwks = jwksToJson(jwk1, jwk2);
+        jwksResponse = jwks.toString();
+
+        server.setDispatcher(createTokenDispatcher(jwksResponse));
+        server.start(50831);
+
+        System.setProperty(JKU_ALLOWED_VALUES_PROPERTY, "https://localhost:50832 https://localhost:50831");
+    }
+
+    @AfterClass
+    public static void cleanUp() throws IOException {
+        System.clearProperty(JKU_ALLOWED_VALUES_PROPERTY);
+        server.shutdown();
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource(JWT_REALM_TEST);
+    }
+
+    @Test
+    public void testJwtRealmWithJkuValueAllowed() throws Exception {
+        KernelServices services = createKernelServices();
+
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                JwtTestUtil.createJwt(keyPair1, 60, -1, "1", new URI("https://localhost:50831")));
+
+        SecurityRealm securityRealm = assertSecurityRealmNotNull(services, "JwtRealm");
+
+        // token validation should succeed
+        assertTrue(identityExists(securityRealm, evidence));
+    }
+
+    @Test
+    public void testJwtRealmWithJkuValueNotAllowed() throws Exception {
+        KernelServices services = createKernelServices();
+
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                JwtTestUtil.createJwt(keyPair1, 60, -1, "1", new URI("https://localhost:50834")));
+
+        SecurityRealm securityRealm = assertSecurityRealmNotNull(services, "JwtRealm");
+
+        // token validation should fail
+        assertFalse(identityExists(securityRealm, evidence));
+    }
+
+    @Test
+    public void testAllowedJkuValuesNotConfigured() throws Exception {
+        KernelServices services = createKernelServices();
+
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                JwtTestUtil.createJwt(keyPair1, 60, -1, "1", new URI("https://localhost:50831")));
+
+        SecurityRealm securityRealm = assertSecurityRealmNotNull(services, "JwtRealmWithoutAllowedJkuValues");
+
+        // token validation should fail
+        assertFalse(identityExists(securityRealm, evidence));
+    }
+
+    @Test
+    public void testTokenWithoutJkuValue() throws Exception {
+        KernelServices services = createKernelServicesWithPublicKeysConfigured();
+
+        BearerTokenEvidence evidence1 = new BearerTokenEvidence(
+                JwtTestUtil.createJwt(keyPair1, 60, -1, "1", null));
+        BearerTokenEvidence evidence2 = new BearerTokenEvidence(
+                JwtTestUtil.createJwt(keyPair2, 60, -1, "2", null));
+
+        SecurityRealm securityRealm = assertSecurityRealmNotNull(services, "JwtRealm");
+
+        // token validation should succeed
+        assertTrue(identityExists(securityRealm, evidence1));
+        assertTrue(identityExists(securityRealm, evidence2));
+    }
+
+    private SecurityRealm assertSecurityRealmNotNull(KernelServices services, String securityRealmName) {
+        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(securityRealmName);
+        SecurityRealm securityRealm = (SecurityRealm) services.getContainer().getService(serviceName).getValue();
+        assertNotNull(securityRealm);
+        return securityRealm;
+    }
+
+    private void setSSLContext(KernelServices services, String sslContextName) {
+        ServiceName serviceName = Capabilities.SSL_CONTEXT_RUNTIME_CAPABILITY.getCapabilityServiceName(sslContextName);
+        SSLContext sslContext = (SSLContext) services.getContainer().getService(serviceName).getValue();
+        assertNotNull(sslContext);
+        server.useHttps(sslContext.getSocketFactory(), false);
+    }
+
+    private KernelServices createKernelServices() throws Exception {
+        KernelServices services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXmlResource(JWT_REALM_TEST).build();
+        if (!services.isSuccessfulBoot()) {
+            if (services.getBootError() != null) {
+                fail(services.getBootError().toString());
+            }
+            fail("Failed to boot, no reason provided");
+        }
+        setSSLContext(services, "SslContext");
+        return services;
+    }
+
+    private KernelServices createKernelServicesWithPublicKeysConfigured() throws Exception {
+        KernelServices services = createKernelServices();
+
+        SecurityRealm securityRealm = assertSecurityRealmNotNull(services, "JwtRealm");
+        ModelNode keyMap = new ModelNode();
+        keyMap.get("1").set(getPemStringFromPublicKey(keyPair1));
+        keyMap.get("2").set(getPemStringFromPublicKey(keyPair2));
+
+        ModelNode write = Util.getWriteAttributeOperation(getSecurityRealmAddress("JwtRealm"), "jwt.key-map", keyMap);
+        ModelNode response = services.executeOperation(write);
+        assertEquals(response.toString(), "success", response.get("outcome").asString());
+        String realmWithConfiguredPublicKeys = services.getPersistedSubsystemXml();
+
+        services = super.createKernelServicesBuilder(new TestEnvironment()).setSubsystemXml(realmWithConfiguredPublicKeys).build();
+
+        if (!services.isSuccessfulBoot()) {
+            if (services.getBootError() != null) {
+                fail(services.getBootError().toString());
+            }
+            fail("Failed to boot, no reason provided");
+        }
+        setSSLContext(services, "SslContext");
+        return services;
+    }
+
+    private boolean identityExists(SecurityRealm realm, Evidence evidence) throws RealmUnavailableException {
+        RealmIdentity identity = realm.getRealmIdentity(evidence);
+        assertNotNull(identity);
+        return identity.exists();
+    }
+
+    private static PathAddress getSecurityRealmAddress(String securityRealmName) {
+        return PathAddress.pathAddress(SUBSYSTEM, ElytronExtension.SUBSYSTEM_NAME).append("token-realm", securityRealmName);
+    }
+
+    private static String getPemStringFromPublicKey(KeyPair keyPair) throws Exception {
+        PublicKey publicKey = keyPair.getPublic();
+        StringWriter writer = new StringWriter();
+        PemWriter pemWriter = new PemWriter(writer);
+        pemWriter.writeObject(new PemObject("PUBLIC KEY", publicKey.getEncoded()));
+        pemWriter.flush();
+        pemWriter.close();
+        return writer.toString();
+    }
+}

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/jwt-realm-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/jwt-realm-test.xml
@@ -1,0 +1,44 @@
+<!-- for JwtSecurityRealmTestCase -->
+<subsystem xmlns="urn:wildfly:elytron:18.0" initial-providers="elytron">
+    <providers>
+        <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
+    </providers>
+
+    <security-realms>
+        <token-realm name="JwtRealm" principal-claim="sub">
+            <jwt issuer="elytron-oauth2-realm" audience="my-app-valid" client-ssl-context="ClientCaSslContext" />
+        </token-realm>
+        <token-realm name="JwtRealmWithoutAllowedJkuValues" principal-claim="sub">
+            <jwt issuer="elytron-oauth2-realm" audience="my-app-valid" client-ssl-context="ClientCaSslContext" />
+        </token-realm>
+    </security-realms>
+
+    <tls>
+        <key-stores>
+            <key-store name="ElytronCaTruststore" >
+                <credential-reference clear-text="Elytron"/>
+                <implementation type="JKS" />
+                <file path="target/test-classes/org/wildfly/extension/elytron/ca.truststore"/>
+            </key-store>
+            <key-store name="keystore">
+                <credential-reference clear-text="Elytron"/>
+                <implementation type="JKS"/>
+                <file path="target/test-classes/org/wildfly/extension/elytron/localhost.keystore"/>
+            </key-store>
+        </key-stores>
+        <key-managers>
+            <key-manager name="KeyManager" key-store="keystore">
+                <credential-reference clear-text="Elytron"/>
+            </key-manager>
+        </key-managers>
+        <trust-managers>
+            <trust-manager name="CaTrustManager" key-store="ElytronCaTruststore"/>
+        </trust-managers>
+        <server-ssl-contexts>
+            <server-ssl-context name="SslContext" key-manager="KeyManager" />
+        </server-ssl-contexts>
+        <client-ssl-contexts>
+            <client-ssl-context name="ClientCaSslContext" trust-manager="CaTrustManager" />
+        </client-ssl-contexts>
+    </tls>
+</subsystem>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.4.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.4.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6780
https://issues.redhat.com/browse/WFCORE-6787


        Release Notes - WildFly Elytron - Version 2.4.0.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2743'>ELY-2743</a>] -         CVE-2023-6236: OIDC app attempting to access the second tenant, the user should be prompted to log in
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2744'>ELY-2744</a>] -         CVE-2024-1233: Validate the jku header parameter during token validation to make sure it exactly matches a value from a configured list of allowed values
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2173'>ELY-2173</a>] -         Add test for the CLIENT_CERT mechanism
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2742'>ELY-2742</a>] -         Release WildFly Elytron 2.4.0.Final
</li>
</ul>
                                                                                                                                                                                                                                            