### PR TITLE
[WFCORE-6794] CVE-2023-1973 Upgrade Undertow to 2.3.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.109.Final</version.io.netty>
         <version.io.smallrye.jandex>3.1.7</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.12.Final</version.io.undertow>
+        <version.io.undertow>2.3.13.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6794


        Release Notes - Undertow - Version 2.3.13.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1926'>UNDERTOW-1926</a>] -         SenderTestCase fails sporadically with ClosedConnectionException (Premature end of message body)
</li>
</ul>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2264'>UNDERTOW-2264</a>] -         CVE-2023-1973 SessionImpl objects + location strings are created and not cleaned up on authentication failures
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2347'>UNDERTOW-2347</a>] -         Undertow client must send either http/1.1 or both http/1.1 and h2 in SSL ClientHello handshake message
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2354'>UNDERTOW-2354</a>] -         Bootstrap$WebSocketListener.contextDestroyed throws NPE after application start up error
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2373'>UNDERTOW-2373</a>] -         CVE-2023-1973 SessionImpl objects + location strings are created and not cleaned up on authentication failures
</li>
</ul>
                                                                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2291'>UNDERTOW-2291</a>] -         Shush the javadoc plugin
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2351'>UNDERTOW-2351</a>] -         NullPointerException on flawed WebSockets war deployment
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2353'>UNDERTOW-2353</a>] -         Test Undertow on JDK21
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2374'>UNDERTOW-2374</a>] -         At Http2ReceiveListener.checkRequestHeaders do not check path chars when unescaped characters are allowed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2375'>UNDERTOW-2375</a>] -         Fix typos in community files
</li>
</ul>
                                                                                        