### PR TITLE
[WFCORE-6796] Upgrade WildFly Elytron to 2.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.4.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.4.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6796


        Release Notes - WildFly Elytron - Version 2.4.1.Final
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2705'>ELY-2705</a>] -         Update SecurityDomain#createAdHocIdentity so that it also calls SecurityDomain#transform to ensure that the securityIdentityTransformer gets used if configured
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2749'>ELY-2749</a>] -         Release WildFly Elytron 2.4.1.Final
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2746'>ELY-2746</a>] -         Change keycloak version in testsuite to 24.0.1
</li>
</ul>
                                                                                                