### PR TITLE
[WFCORE-6801] Use maven.compiler.release to ensure the desired binary…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,7 @@
         <!-- Keep consistent with README.md and .mvn/wrapper/maven-wrapper.properties -->
         <maven.min.version>3.6.0</maven.min.version>
         <!-- Require Java 11 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.release>11</maven.compiler.release>
 
         <!-- Standard client-side JPMS settings identified as meeting
              the needs of WildFly libraries meant for use in clients. -->


### PR DESCRIPTION
… compilation level

It also removes the `maven.compiler.target` and `maven.compiler.source` properties since they will be replaced by the `--release` option supported by the maven compiler plugin 3.6. The maven compiler plugin version is inherited from the jboss-parent maven module, so `maven.compiler.release` will be available for the project. Behind scenes, the maven compiler plugging should be ignoring the `--target` and `--source` options when `--release` is in place since `target/source` is not compatible with `release`

Jira issue: https://issues.redhat.com/browse/WFCORE-6801


