### PR TITLE
[WFCORE-5386] Revert "[WFCORE-5922] Ignore RemotingLegacySubsystemTestCase#testSubsystemWithConnectorPropertyChange test case"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.13.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.14.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -48,7 +48,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.extension.io.WorkerService;
 import org.wildfly.io.IOServiceDescriptor;
@@ -132,7 +131,6 @@ public class RemotingLegacySubsystemTestCase extends AbstractRemotingSubsystemBa
     }
 
     @Test
-    @Ignore("https://issues.redhat.com/browse/WFCORE-5386")
     public void testSubsystemWithConnectorPropertyChange() throws Exception {
         KernelServices services = createKernelServicesBuilder(createRuntimeAdditionalInitialization(false))
                 .setSubsystemXmlResource("remoting-with-connector.xml")


### PR DESCRIPTION
Built on top of https://github.com/wildfly/wildfly-core/pull/5977, this PR reverts [WFCORE-5922](https://github.com/wildfly/wildfly-core/pull/5112) that was done to ignore the intermittent failures on `RemotingLegacySubsystemTestCase` due to an XNIO issue.

Jira issue: https://issues.redhat.com/browse/WFCORE-5386
