### PR TITLE
[WFCORE-6831] Upgrade WildFly Elytron to 2.4.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.4.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.4.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6831


        Release Notes - WildFly Elytron - Version 2.4.2.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2723'>ELY-2723</a>] -         Fix failures in SSLAuthenticationTestCase with SE 21
</li>
</ul>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2340'>ELY-2340</a>] -         Query parameters lost on redirect to keycloak OIDC
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2752'>ELY-2752</a>] -         Ensure it&#39;s possible to make use of a custom principal-attribute value for OIDC 
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2722'>ELY-2722</a>] -         Resolve test failures with SE 21
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2727'>ELY-2727</a>] -         Update CI to also run with SE 21
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2758'>ELY-2758</a>] -         Release WildFly Elytron 2.4.2.Final
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2755'>ELY-2755</a>] -         Upgrade fasterxml to 2.17.0
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-489'>ELY-489</a>] -         Add JavaDoc for the &#39;org.wildfly.security.mechanism&#39; package and sub packages.
</li>
</ul>
                                                                                        