### PR TITLE
[CVE-2024-4029] [WFCORE-6825] Options to control resources used for incomming connections.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -72,6 +72,12 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
     public static final String JBOSS_REMOTING = "jboss-remoting";
     public static final String MANAGEMENT_ENDPOINT = "management-endpoint";
 
+    private static final String PROPERTY_BASE = "org.wildfly.management.";
+    private static final String BACKLOG_PROPERTY = PROPERTY_BASE + "backlog";
+    private static final String CONNECTION_HIGH_WATER_PROPERTY = PROPERTY_BASE + "connection-high-water";
+    private static final String CONNECTION_LOW_WATER_PROPERTY = PROPERTY_BASE + "connection-low-water";
+    private static final String NO_REQUEST_TIMEOUT_PROPERTY = PROPERTY_BASE + "no-request-timeout";
+
     private final Consumer<HttpManagement> httpManagementConsumer;
     private final Supplier<ListenerRegistry> listenerRegistrySupplier;
     private final Supplier<ModelController> modelControllerSupplier;
@@ -339,6 +345,11 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
             }
         }
 
+        final Integer backlog = Integer.getInteger(BACKLOG_PROPERTY, 50);
+        final Integer connectionHighWater = Integer.getInteger(CONNECTION_HIGH_WATER_PROPERTY, 100);
+        final Integer connectionLowWater = Integer.getInteger(CONNECTION_LOW_WATER_PROPERTY, 75);
+        final Integer noRequestTimeout = Integer.getInteger(NO_REQUEST_TIMEOUT_PROPERTY, 60000);
+
         try {
             ManagementHttpServer.Builder serverManagementBuilder = ManagementHttpServer.builder()
                     .setBindAddress(bindAddress)
@@ -353,7 +364,12 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
                     .setWorker(workerSupplier.get())
                     .setExecutor(executorSupplier.get())
                     .setConstantHeaders(constantHeaders)
-                    .setConsoleAvailability(consoleAvailability);
+                    .setConsoleAvailability(consoleAvailability)
+                    .setBacklog(backlog)
+                    .setConnectionHighWater(connectionHighWater)
+                    .setConnectionLowWater(connectionLowWater)
+                    .setNoRequestTimeout(noRequestTimeout)
+                    ;
 
             if (virtualSecurityDomainSupplier != null && virtualMechanismFactorySupplier != null) {
                 // use a virtual http authentication factory instead

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import jakarta.inject.Inject;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionRunnable;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildFlyRunner;
+
+/**
+ * Test case to test resource limits and clean up of management interface connections.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@RunWith(WildFlyRunner.class)
+@ServerControl(manual = true)
+public class ManagementInterfaceResourcesTestCase {
+
+    private static final String BACKLOG_PROPERTY = "org.wildfly.management.backlog";
+    private static final String CONNECTION_HIGH_WATER_PROPERTY = "org.wildfly.management.connection-high-water";
+    private static final String CONNECTION_LOW_WATER_PROPERTY = "org.wildfly.management.connection-low-water";
+    private static final String NO_REQUEST_TIMEOUT_PROPERTY = "org.wildfly.management.no-request-timeout";
+
+    @Inject
+    protected static ServerController controller;
+
+    /**
+     * Test that the management interface will not accept new connections when the number of active connections reaches the
+     * high water mark.  After the number of open connections has been reduced to the low watermark it will test that connections
+     * are accepted again.
+     */
+    @Test
+    public void testWatermarks() throws Exception {
+        runTest(60000, () -> {
+            String mgmtAddress = controller.getClient().getMgmtAddress();
+            int mgmtPort = controller.getClient().getMgmtPort();
+            SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
+
+            int socketsOpened = 0;
+            boolean oneFailed = false;
+            Socket[] sockets = new Socket[9];
+            for (int i = 0 ; i < 9 ; i++) {
+                try {
+                    sockets[i] = new Socket();
+                    sockets[i].connect(targetAddress, 1000);
+                    socketsOpened++;
+                } catch (IOException e) {
+                    assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
+                    oneFailed = true;
+                }
+            }
+            assertTrue("Opening of one socket was expected to fail.", oneFailed);
+
+            // Now close the connections and we should be able to connect again.
+            for (int i = 0 ; i < socketsOpened ; i++) {
+                sockets[i].close();
+            }
+
+            Socket goodSocket = new Socket();
+            // This needs a reasonable time to give the server time to respond to the closed connections.
+            goodSocket.connect(targetAddress, 10000);
+            goodSocket.close();
+        });
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        runTest(5000, () -> {
+            String mgmtAddress = controller.getClient().getMgmtAddress();
+            int mgmtPort = controller.getClient().getMgmtPort();
+            SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
+
+            int socketsOpened = 0;
+            boolean oneFailed = false;
+            Socket[] sockets = new Socket[9];
+            for (int i = 0 ; i < 9 ; i++) {
+                try {
+                    sockets[i] = new Socket();
+                    sockets[i].connect(targetAddress, 1000);
+                    socketsOpened++;
+                } catch (IOException e) {
+                    assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
+                    oneFailed = true;
+                }
+            }
+            assertTrue("Opening of one socket was expected to fail.", oneFailed);
+
+            Thread.sleep(5000); // We also had 1000ms on the bad socket so we know we are past the timeout.
+
+            Socket goodSocket = new Socket();
+            // This needs to be longer than 500ms to give the server time to respond to the closed connections.
+            goodSocket.connect(targetAddress, 10000);
+            goodSocket.close();
+
+            // Clean up remaining sockets
+            for (int i = 0 ; i < socketsOpened ; i++) {
+                sockets[i].close();
+            }
+        });
+    }
+
+    private void runTest(int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception {
+        controller.startInAdminMode();
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            cli.sendLine(String.format("/system-property=%s:add(value=%d)", BACKLOG_PROPERTY, 2));
+            cli.sendLine(String.format("/system-property=%s:add(value=%d)", CONNECTION_HIGH_WATER_PROPERTY, 6));
+            cli.sendLine(String.format("/system-property=%s:add(value=%d)", CONNECTION_LOW_WATER_PROPERTY, 3));
+            cli.sendLine(String.format("/system-property=%s:add(value=%d)", NO_REQUEST_TIMEOUT_PROPERTY, 5000));
+        }
+
+        try {
+            controller.reload();
+
+            test.run();
+        } finally {
+            controller.reload();
+
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/system-property=%s:remove()", BACKLOG_PROPERTY));
+                cli.sendLine(String.format("/system-property=%s:remove()", CONNECTION_HIGH_WATER_PROPERTY));
+                cli.sendLine(String.format("/system-property=%s:remove()", CONNECTION_LOW_WATER_PROPERTY));
+                cli.sendLine(String.format("/system-property=%s:remove()", NO_REQUEST_TIMEOUT_PROPERTY));
+            }
+            controller.stop();
+        }
+    }
+
+}


### PR DESCRIPTION
Add options to control how many management connections can be accepted and how long until they are closed after the last HTTP request.

https://issues.redhat.com/browse/WFCORE-6825

Testing will also need https://issues.redhat.com/browse/XNIO-433 as high and low watermarks are inverted.