### PR TITLE
[WFCORE-6833] Upgrade XNIO to 3.8.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.14.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.15.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6833
24.x PR: #6008 
Blocks: #6004 / #6003 

        Release Notes - XNIO - Version 3.8.15.Final
                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-433'>XNIO-433</a>] -         The high and low water mark configuration values have been inverted
</li>
</ul>
                                                                                                                                                                                                                                                                