### PR TITLE
[WFCORE-6834] wildfly-elytron-integration jar duplicated in server modules

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/jaas-realm/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/jaas-realm/main/module.xml
@@ -33,10 +33,6 @@
         <exclude path="org/wildfly/extension/elytron/JaasCustomSecurityRealmWrapper"/>
     </exports>
 
-    <resources>
-        <artifact name="${org.wildfly.core:wildfly-elytron-integration}"/>
-    </resources>
-
     <dependencies>
         <module name="java.logging"/>
         <module name="java.xml"/>
@@ -48,5 +44,6 @@
         <module name="org.jboss.logmanager"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private" export="true"/>
+        <module name="org.wildfly.extension.elytron"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6834

Requires [WFLY-19378](https://issues.redhat.com/browse/WFLY-19378) https://github.com/wildfly/wildfly/pull/17928 to pass CI.
