### PR TITLE
[WFCORE-3502]: Fix debug options in test-runner.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
 
         <!-- Surefire args -->
         <surefire.jpda.args></surefire.jpda.args>
-        <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -Duser.timezone=America/Chicago -XX:MaxMetaspaceSize=256m
-            ${surefire.jpda.args} ${surefire.jacoco.args} -Djava.io.tmpdir=${project.build.directory}
-        </surefire.system.args>
+        <surefire.jvm.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -Duser.timezone=America/Chicago -XX:MaxMetaspaceSize=256m
+            ${surefire.jacoco.args} -Djava.io.tmpdir=${project.build.directory}</surefire.jvm.args>
+        <surefire.system.args>${surefire.jpda.args} ${surefire.jvm.args}</surefire.system.args>
         <test.level>INFO</test.level>
 
         <!-- This overrides default surefire plugin version specified in parent pom - reason is to enable TCP/IP communication,

--- a/testsuite/client-old-server/pom.xml
+++ b/testsuite/client-old-server/pom.xml
@@ -105,7 +105,7 @@
 
                     <systemPropertyVariables>
                         <jboss.home>${wildfly.home}</jboss.home>
-                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.jvm.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -190,7 +190,7 @@
                     <systemPropertyVariables>
                         <cli.jvm.args>${modular.jdk.args}</cli.jvm.args>
                         <jboss.home>${wildfly.home}</jboss.home>
-                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.jvm.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -92,7 +92,7 @@
                         <org.jboss.logging.provider>jdk</org.jboss.logging.provider>
                         <jboss.test.start.timeout>${jboss.test.start.timeout}</jboss.test.start.timeout>
                         <jboss.test.log.dir>${project.build.directory}${file.separator}test-logs</jboss.test.log.dir>
-                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.jvm.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                         <maven.repo.local>${settings.localRepository}</maven.repo.local>
                     </systemPropertyVariables>
                 </configuration>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -287,7 +287,7 @@
                                 <byteman.server.port>${byteman.port}</byteman.server.port>
                                 <jboss.home>${wildfly.home}</jboss.home>
                                 <module.path>${wildfly.home}/modules/</module.path>
-                                <jvm.args>${byteman.jvm.args} -Dorg.jboss.byteman.verbose=true -Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                                <jvm.args>${byteman.jvm.args} -Dorg.jboss.byteman.verbose=true -Dmaven.repo.local=${settings.localRepository} ${surefire.jvm.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                                 <cli.jvm.args>${modular.jdk.args} -Dmaven.repo.local=${settings.localRepository}</cli.jvm.args>
                                 <cli.jvm.args.non-modular>-Dmaven.repo.local=${settings.localRepository}</cli.jvm.args.non-modular>
                                 <javax.net.ssl.trustStore>${basedir}/target/test-classes/ssl/jbossClient.truststore</javax.net.ssl.trustStore>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -119,7 +119,8 @@
         <surefire.memory.args>-Xmx512m -XX:MetaspaceSize=128m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
-        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} ${modular.jdk.args} ${modular.jdk.props} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Djava.io.tmpdir=${project.build.directory}</surefire.system.args>
+        <surefire.jvm.args>${surefire.memory.args} ${modular.jdk.args} ${modular.jdk.props} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Djava.io.tmpdir=${project.build.directory}</surefire.jvm.args>
+        <surefire.system.args>${surefire.jpda.args} ${surefire.jvm.args}</surefire.system.args>
         <surefire.forked.process.timeout>1500</surefire.forked.process.timeout>
 
         <!-- If servers should be killed before the test suite is run-->

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -202,7 +202,7 @@
                         <wildfly.debug>${ts.debug}</wildfly.debug>
                         <wildfly.debug.port>8787</wildfly.debug.port>
                         <server.config>standalone.xml</server.config>
-                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args}</jvm.args>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.jvm.args}</jvm.args>
                     </systemPropertyVariables>
                 </configuration>
                 <executions combine.children="append">

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -187,7 +187,7 @@
                         <jboss.home>${wildfly.home}</jboss.home>
                         <!-- This is required so JBoss Modules knows which repository to use -->
                         <maven.repo.local>${settings.localRepository}</maven.repo.local>
-                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.jvm.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
* Excluding the jpda profile surefire parameters from the jmv.args system property so it doesn't interfer with the server args.

Jira: https://issues.redhat.com/browse/WFCORE-3502