### PR TITLE
[WFCORE-6847] Upgrade io.smallrye:jandex from 3.1.8 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <version.commons-lang3>3.14.0</version.commons-lang3>
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.110.Final</version.io.netty>
-        <version.io.smallrye.jandex>3.1.8</version.io.smallrye.jandex>
+        <version.io.smallrye.jandex>3.2.0</version.io.smallrye.jandex>
         <version.io.undertow>2.3.13.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6847
