### PR TITLE
Fix for WFCORE-6853, Upgrade to Galleon Plugins 7.1.0.Final

### DIFF
--- a/core-feature-pack/galleon-feature-pack/pom.xml
+++ b/core-feature-pack/galleon-feature-pack/pom.xml
@@ -232,9 +232,6 @@
                             <release-name>WildFly Core</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
-                            <minimum-stability-level>experimental</minimum-stability-level>
-                            <config-stability-level>community</config-stability-level>
-                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/core-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/core-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
+<build xmlns="urn:wildfly:feature-pack-build:3.4" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
     <default-packages>
         <package name="modules.all"/>
         <package name="docs"/>
@@ -13,6 +13,11 @@
         <group name="org.wildfly.core"/>
     </package-schemas>
 
+    <stability-levels>
+        <minimum-stability-level>experimental</minimum-stability-level>
+        <config-stability-level>community</config-stability-level>
+        <package-stability-level>experimental</package-stability-level>
+    </stability-levels>
     <config name="standalone.xml" model="standalone">
         <!-- config name is the resulting xml file name which can be changed by setting the property below
         <props>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
         <version.org.jboss.galleon>6.0.0.Final</version.org.jboss.galleon>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <!-- wildfly-maven-plugin-->
         <version.wildfly.plugin>5.0.0.Final</version.wildfly.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6853

The stability information currently located in the maven plugin configuration has been moved to the wildfly-feature-pack-build.xml file. These are not options you should control from Maven.
