### PR TITLE
[WFCORE-6815] Add removed import that is required by WFCORE-6819

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -164,6 +164,7 @@ import org.jboss.as.server.RuntimeExpressionResolver;
 import org.jboss.as.server.controller.resources.VersionModelInitializer;
 import org.jboss.as.server.deployment.ContentCleanerService;
 import org.jboss.as.server.mgmt.UndertowHttpManagementService;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;


### PR DESCRIPTION
WFCORE-6815 (https://github.com/wildfly/wildfly-core/pull/5992) removed an import required by WFCORE-6819 (https://github.com/wildfly/wildfly-core/pull/6000). Since WFCORE-6815 was merged after WFCORE-6819, it broke `main`.

Hence the fix.
Jira issue: https://issues.redhat.com/browse/WFCORE-6815


