### PR TITLE
[WFCORE-6860][WFCORE-6861][WFCORE-6862] CVE-2024-6162 CVE-2024-27316 Upgrade Undertow, XNIO and JBoss Remoting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.1.0.Final</version.org.jboss.stdio>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.15.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.16.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mock-server.mockserver-netty>5.8.1</version.org.mock-server.mockserver-netty>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>2.1.4.SP1</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>2.1.5.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.5.5.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>5.0.28.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>5.0.29.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.1.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>2.0.1.Final</version.org.jboss.slf4j.slf4j-jboss-logmanager>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.111.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.0</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.13.Final</version.io.undertow>
+        <version.io.undertow>2.3.14.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jiras:
https://issues.redhat.com/browse/WFCORE-6860
https://issues.redhat.com/browse/WFCORE-6861
https://issues.redhat.com/browse/WFCORE-6862


        Release Notes - XNIO - Version 3.8.16.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/XNIO-434'>XNIO-434</a>] -         Make wakeupReads and wakeWrites invoke listener in closed channels (XNIO-427 Breaks wakeup calls contract)
</li>
</ul>
                                                                                                                                                                                                                                                                            

        Release Notes - JBoss Remoting (3+) - Version 5.0.29.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-413'>REM3-413</a>] -         ClosedChannelException when NioSocketConduit.handleReady invokes write listener after read listener closes connection
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-402'>REM3-402</a>] -         Add README and other community documents
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-411'>REM3-411</a>] -         For the 5.x+ branches bring the WildFly Elytron version inline with WildFly (2.4.2.Final)
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/REM3-409'>REM3-409</a>] -         Test Remoting on JDK21
</li>
<li>[<a href='https://issues.redhat.com/browse/REM3-412'>REM3-412</a>] -         For testing individual Elytron dependencies should be listed instead of the shaded jar
</li>
</ul>
    
                                                                                            
        Release Notes - Undertow - Version 2.3.14.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2400'>UNDERTOW-2400</a>] -         ResponseWriterTestCase fails because ServletinputStream is closed before read
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2332'>UNDERTOW-2332</a>] -         CachingResource mishandling with TTL =0 and FS exhaustion
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2334'>UNDERTOW-2334</a>] -         CVE-2024-6162 url-encoded request path information can be broken on ajp-listener
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2378'>UNDERTOW-2378</a>] -         Adjust properly session timeout also in case when custom auth mechanisms are used
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2383'>UNDERTOW-2383</a>] -         Canonicalized query string in redirect location can break included links
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2385'>UNDERTOW-2385</a>] -         Memory leak in ThreadLocalCache
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2389'>UNDERTOW-2389</a>] -         DefaultByteBufferPool leaks buffers for released threads
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2405'>UNDERTOW-2405</a>] -         CVE-2024-27316 HTTP-2: httpd: CONTINUATION frames DoS
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2407'>UNDERTOW-2407</a>] -         NullPointerException on DefaultByteBufferPool.close
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2409'>UNDERTOW-2409</a>] -         Adjust properly session timeout also in case when GET requests with custom auth mechanisms are used
</li>
</ul>
                                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2391'>UNDERTOW-2391</a>] -         CVE-2023-5685 Upgrade XNIO to 3.8.16.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2408'>UNDERTOW-2408</a>] -         Make fields final in DefaultByteBufferPool when appliable
</li>
</ul>
                                                                                                
