### PR TITLE
[WFCORE-6867] Upgrade WildFly Elytron to 2.5.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.4.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.5.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.0.Beta1</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6867

        Release Notes - WildFly Elytron - Version 2.5.0.CR1
                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2584'>ELY-2584</a>] -         Add the ability to specify that the OIDC Authentication Request should include request and request_uri parameters
</li>
</ul>
                            
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2779'>ELY-2779</a>] -         Release WildFly Elytron 2.5.0.CR1
</li>
</ul>
                                                                                                                                                    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2773'>ELY-2773</a>] -         After using the CAGenerationTool we should be able to use this to load key and trust managers
</li>
</ul>
                                                                                                