### PR TITLE
[WFCORE-6888] Upgrade WildFly Elytron to 2.5.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.5.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.5.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.0.Beta1</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6888


        Release Notes - WildFly Elytron - Version 2.5.0.Final
                                                                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2776'>ELY-2776</a>] -         Add tests to the OIDC testsuite to test for cases where request/request_uri parameters are not supported by the OpenID provider
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2782'>ELY-2782</a>] -         Release Elytron 2.5.0.Final
</li>
</ul>
                                                                                                                                                    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2774'>ELY-2774</a>] -         Move CAGenerationTool to PKCS#12
</li>
</ul>
                                                                                                