### PR TITLE
[WFCORE-6755] Move the org.wildfly.security:wildfly-elytron-dynamic-ssl artifact into its own module

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-base/main/module.xml
@@ -34,7 +34,6 @@
         <artifact name="${org.wildfly.security:wildfly-elytron-credential-source-impl}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-credential-store}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-digest}"/>
-        <artifact name="${org.wildfly.security:wildfly-elytron-dynamic-ssl}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-encryption}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http}"/>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-basic}"/>
@@ -112,5 +111,6 @@
         modules use the parser, they need to have visibility to this module.
         -->
         <module name="org.wildfly.client.config" export="true"/>
+        <module name="org.wildfly.security.elytron-dynamic-ssl" export="true" optional="true"/>
     </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-dynamic-ssl/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-dynamic-ssl/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-dynamic-ssl">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+        <property name="jboss.stability" value="community"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly.security:wildfly-elytron-dynamic-ssl}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+        <module name="org.jboss.logging" />
+        <module name="org.jboss.logmanager" />
+        <module name="org.wildfly.security.elytron-base"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.client.config"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/galleon-common/src/main/resources/layers/standalone/elytron/layer-spec.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/layers/standalone/elytron/layer-spec.xml
@@ -17,5 +17,9 @@
         <!-- required by default configuration-->
         <package name="org.wildfly.extension.elytron.jaas-realm"/>
         <package name="org.wildfly.openssl"/>
+        <!-- In case the feature-pack containing this package is constrained at build time
+             to a level that doesn't imply 'community', this package will be not packaged inside the feature-pack.
+             'valid-for-stability' attribute allows to keep this dependency that will be ignored at provisioning time. -->
+        <package name="org.wildfly.security.elytron-dynamic-ssl" optional="true" valid-for-stability="community"/>
     </packages>
 </layer-spec>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DynamicSSLContextHelper.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DynamicSSLContextHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.elytron;
+
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.dynamic.ssl.DynamicSSLContext;
+import org.wildfly.security.dynamic.ssl.DynamicSSLContextImpl;
+import org.wildfly.security.dynamic.ssl.DynamicSSLContextException;
+
+import javax.net.ssl.SSLContext;
+import java.security.GeneralSecurityException;
+import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
+
+/**
+ * Helper class for obtaining an instance of DynamicSSLContext created from the provided AuthenticationContext
+ */
+class DynamicSSLContextHelper {
+
+    /**
+     * Get DynamicSSLContext instance from the provided authentication context
+     * @param authenticationContext authentication context to use with the DynamicSSLContext
+     * @return DynamicSSLContext instance
+     */
+    static SSLContext getDynamicSSLContextInstance(AuthenticationContext authenticationContext) {
+        try {
+            return new DynamicSSLContext(new DynamicSSLContextImpl(authenticationContext));
+        } catch (DynamicSSLContextException |  GeneralSecurityException e) {
+            throw ROOT_LOGGER.unableToObtainDynamicSSLContext();
+        }
+    }
+}

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -728,6 +728,8 @@ public interface ElytronSubsystemMessages extends BasicLogger {
             "use Elytron Tool command `filesystem-realm-encrypt`")
     OperationFailedException addSecretKeyToInitializedFilesystemRealm();
 
+    @Message(id = 1221, value = "Unable to obtain DynamicSSLContext from the provided authentication context")
+    RuntimeException unableToObtainDynamicSSLContext();
     /*
      * Don't just add new errors to the end of the file, there may be an appropriate section above for the resource.
      *


### PR DESCRIPTION
Supersedes https://github.com/wildfly/wildfly-core/pull/5947

Jira issue: https://issues.redhat.com/browse/WFCORE-6755

See https://wildfly.zulipchat.com/#narrow/stream/174184-wildfly-developers/topic/Layers.20and.20optional.20packages.

This PR includes #5947 but removes the community stability property configuration from `org.wildfly.security.elytron-dynamic-ssl` JBoss Modules module and adds its package as required for the Elytron layer. Until getting a better approach for this case, this will fix the issue reported by the test case where this module was not provisioned when using Elytron Galleon Layer and ensure we can use `default` stability level out of the box when the server is built targetting this stability level.