### PR TITLE
[WFCORE-6895] Add a grace period to Management CLI Installer Windows …

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
@@ -7,7 +7,6 @@ package org.jboss.as.cli.handlers;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.as.cli.AwaiterModelControllerClient;
@@ -177,11 +176,6 @@ public class ShutdownHandler extends BaseOperationCommand {
 
             if(isLocalClient) {
                 ctx.printLine("The JBoss CLI session will be closed automatically to allow the server be updated. Once the server has been restarted, you can relaunch the JBoss CLI session.", false);
-                try {
-                    TimeUnit.SECONDS.sleep(3);
-                } catch (InterruptedException e) {
-                    // Ignored
-                }
                 // We are using a CLI which was launched from the server installation we have requested to be updated.
                 // In order to prevent keeping using a jboss-modules.jar that could have been updated, we finish the CLI process
                 // Once the server has been restarted the user will launch again the CLI that will use the most recent updates

--- a/core-feature-pack/common/src/main/resources/content/bin/domain.conf.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.conf.bat
@@ -90,3 +90,9 @@ rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=tr
 rem # Sample JPDA settings for shared memory debugging
 rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
 rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
+
+rem # Uncomment the following line to enable debug traces for the Management CLI script file
+rem set "INST_MGR_SCRIPT_DEBUG=true"
+
+rem # Uncomment the following line to configure the grace period (in seconds) before applying a candidate server
+rem set "INST_MGR_SCRIPT_WINDOWS_COUNTDOWN=10"

--- a/core-feature-pack/common/src/main/resources/content/bin/domain.conf.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/domain.conf.ps1
@@ -83,9 +83,12 @@ if ($HOST_CONTROLLER_JAVA_OPTS -eq $null) {
 }
 
 # Sample JPDA settings for remote socket debuging.
-#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8788,server=y,suspend=n"
-#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+# $PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8788,server=y,suspend=n"
+# $HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
-#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+# $PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+# $HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+
+# Uncomment the following line to configure the grace period (in seconds) before applying a candidate server
+# $INST_MGR_SCRIPT_WINDOWS_COUNTDOWN=10

--- a/core-feature-pack/common/src/main/resources/content/bin/installation-manager.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/installation-manager.bat
@@ -39,7 +39,7 @@ if "%INST_MGR_STATUS%" neq "PREPARED" (
     goto EOF
 )
 
-IF NOT DEFINED %INST_MGR_COMMAND (
+IF NOT DEFINED INST_MGR_COMMAND (
     echo ERROR: Installation Manager command was not set.
 
     goto EOF
@@ -52,6 +52,11 @@ set "INST_MGR_COMMAND=!INST_MGR_COMMAND:\\=\!"
 setlocal DisableDelayedExpansion
 
 set JAVA_OPTS=-Dlogging.configuration=file:"%INST_MGR_LOG_PROPERTIES%" %JAVA_OPTS%
+
+IF NOT DEFINED INST_MGR_SCRIPT_WINDOWS_COUNTDOWN set INST_MGR_SCRIPT_WINDOWS_COUNTDOWN=10
+echo Waiting %INST_MGR_SCRIPT_WINDOWS_COUNTDOWN% seconds before applying the Candidate Server...
+timeout /T %INST_MGR_SCRIPT_WINDOWS_COUNTDOWN% /NOBREAK >nul
+
 call %INST_MGR_COMMAND%
 set INST_MGR_RESULT=%errorlevel%
 

--- a/core-feature-pack/common/src/main/resources/content/bin/installation-manager.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/installation-manager.ps1
@@ -78,8 +78,15 @@ if ($INST_MGR_COMMAND -eq $null) {
 $JAVA_OPTS="-Dlogging.configuration=file:$instMgrLogProperties $JAVA_OPTS"
 Write-Host "$INST_MGR_COMMAND"
 
+if ($INST_MGR_SCRIPT_WINDOWS_COUNTDOWN -eq $null) {
+  $INST_MGR_SCRIPT_WINDOWS_COUNTDOWN=10
+}
+
 try
 {
+    Write-Host "Waiting $INST_MGR_SCRIPT_WINDOWS_COUNTDOWN seconds before applying the Candidate Server..."
+    Start-Sleep -Seconds $INST_MGR_SCRIPT_WINDOWS_COUNTDOWN
+
     Invoke-Expression "& $INST_MGR_COMMAND 2>&1"
 
     $exitCode = if ($?) {0} else {1}

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.bat
@@ -99,3 +99,9 @@ rem set "DISABLE_JDK_SERIAL_FILTER=true"
 rem # Uncomment to add a Java agent. If an agent is added to the module options, then jboss-modules.jar is added as an agent
 rem # on the JVM. This allows things like the log manager or security manager to be configured before the agent is invoked.
 rem set "MODULE_OPTS=-javaagent:agent.jar"
+
+rem # Uncomment the following line to enable debug traces for the Management CLI script file
+rem set "INST_MGR_SCRIPT_DEBUG=true"
+
+rem # Uncomment the following line to configure the grace period (in seconds) before applying a candidate server
+rem set "INST_MGR_SCRIPT_WINDOWS_COUNTDOWN=10"

--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.conf.ps1
@@ -97,3 +97,6 @@ if (-Not $JAVA_OPTS) {
 # Uncomment to add a Java agent. If an agent is added to the module options, then jboss-modules.jar is added as an agent
 # on the JVM. This allows things like the log manager or security manager to be configured before the agent is invoked.
 # $MODULE_OPTS="-javaagent:agent.jar"
+
+# Uncomment the following line to configure the grace period (in seconds) before applying a candidate server
+# $INST_MGR_SCRIPT_WINDOWS_COUNTDOWN=10


### PR DESCRIPTION
…script

Jira issue: https://issues.redhat.com/browse/WFCORE-6895

This just adds a configurable grace period to help prevent locking file errors on Windows when using Management CLI Installer
