### PR TITLE
WFCORE-6919 Remove usage of deprecated AbstractWriteAttributeHandler constructors in core-management

### DIFF
--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ConfigurationChangeResourceDefinition.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ConfigurationChangeResourceDefinition.java
@@ -133,7 +133,6 @@ public class ConfigurationChangeResourceDefinition extends PersistentResourceDef
         private final ConfigurationChangesCollector collector;
 
         private MaxHistoryWriteHandler(ConfigurationChangesCollector collector) {
-            super(MAX_HISTORY);
             this.collector = collector;
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6919