### PR TITLE
WFCORE-6927 Remove usage of deprecated AbstractWriteAttributeHandler constructors in remoting subsystem

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorChildResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorChildResource.java
@@ -105,8 +105,8 @@ abstract class ConnectorChildResource extends SimpleResourceDefinition {
 
     static class RestartConnectorWriteAttributeHandler extends RestartParentWriteAttributeHandler {
 
-        RestartConnectorWriteAttributeHandler(String parent, Collection<AttributeDefinition> attributes) {
-            super(parent, attributes);
+        RestartConnectorWriteAttributeHandler(String parent) {
+            super(parent);
         }
 
         @Override

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/PropertyResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/PropertyResource.java
@@ -44,6 +44,6 @@ public class PropertyResource extends ConnectorChildResource {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(VALUE, null, new RestartConnectorWriteAttributeHandler(parent, ATTRIBUTES));
+        resourceRegistration.registerReadWriteAttribute(VALUE, null, new RestartConnectorWriteAttributeHandler(parent));
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/SaslPolicyResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/SaslPolicyResource.java
@@ -52,7 +52,7 @@ class SaslPolicyResource extends ConnectorChildResource {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        final RestartConnectorWriteAttributeHandler writeHandler = new RestartConnectorWriteAttributeHandler(parent, ATTRIBUTES);
+        final RestartConnectorWriteAttributeHandler writeHandler = new RestartConnectorWriteAttributeHandler(parent);
         resourceRegistration.registerReadWriteAttribute(FORWARD_SECRECY, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(NO_ACTIVE, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(NO_ANONYMOUS, null, writeHandler);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/SaslResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/SaslResource.java
@@ -72,7 +72,7 @@ class SaslResource extends ConnectorChildResource {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         final RestartConnectorWriteAttributeHandler writeHandler =
-                new RestartConnectorWriteAttributeHandler(parent, ATTRIBUTES);
+                new RestartConnectorWriteAttributeHandler(parent);
         resourceRegistration.registerReadWriteAttribute(INCLUDE_MECHANISMS_ATTRIBUTE, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(QOP_ATTRIBUTE, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(STRENGTH_ATTRIBUTE, null, writeHandler);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6927