### PR TITLE
WFCORE-6930 Remove usage of deprecated AbstractWriteAttributeHandler constructors in testsuite

### DIFF
--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/NewExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/NewExtension.java
@@ -167,7 +167,7 @@ public class NewExtension implements Extension {
 
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            resourceRegistration.registerReadWriteAttribute(TEST, null, new ModelOnlyWriteAttributeHandler());
+            resourceRegistration.registerReadWriteAttribute(TEST, null, ModelOnlyWriteAttributeHandler.INSTANCE);
             //Custom write handler to attach the old value
             resourceRegistration.registerReadWriteAttribute(PROPERTIES, null, new ModelOnlyWriteAttributeHandler(){
                 @Override

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/OldExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/OldExtension.java
@@ -75,7 +75,7 @@ public class OldExtension implements Extension {
 
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            resourceRegistration.registerReadWriteAttribute(TEST, null, new ModelOnlyWriteAttributeHandler());
+            resourceRegistration.registerReadWriteAttribute(TEST, null, ModelOnlyWriteAttributeHandler.INSTANCE);
         }
 
         @Override
@@ -94,7 +94,7 @@ public class OldExtension implements Extension {
 
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            resourceRegistration.registerReadWriteAttribute(VALUE, null, new ModelOnlyWriteAttributeHandler());
+            resourceRegistration.registerReadWriteAttribute(VALUE, null, ModelOnlyWriteAttributeHandler.INSTANCE);
         }
     }
 }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/similarity/SessionDefinition.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/similarity/SessionDefinition.java
@@ -53,7 +53,7 @@ public class SessionDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(final ManagementResourceRegistration registry) {
         for (AttributeDefinition attr : ATTRIBUTES) {
-            registry.registerReadWriteAttribute(attr, null, new ReloadRequiredWriteAttributeHandler(attr));
+            registry.registerReadWriteAttribute(attr, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
         }
     }
 

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/VersionedExtensionCommon.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/VersionedExtensionCommon.java
@@ -69,7 +69,7 @@ public abstract class VersionedExtensionCommon implements Extension {
         final ManagementResourceRegistration reg = registration.registerSubsystemModel(new TestResourceDefinition(SUBSYSTEM_PATH, new TestModelOnlyAddHandler(TEST_ATTRIBUTE)) {
             @Override
             public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-                resourceRegistration.registerReadWriteAttribute(TEST_ATTRIBUTE, null, new BasicAttributeWriteHandler(TEST_ATTRIBUTE));
+                resourceRegistration.registerReadWriteAttribute(TEST_ATTRIBUTE, null, new BasicAttributeWriteHandler());
             }
         });
         reg.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
@@ -127,6 +127,10 @@ public abstract class VersionedExtensionCommon implements Extension {
     };
 
     private static class BasicAttributeWriteHandler extends AbstractWriteAttributeHandler<Void> {
+
+        protected BasicAttributeWriteHandler() {
+            super(List.of());
+        }
 
         protected BasicAttributeWriteHandler(AttributeDefinition def) {
             super(def);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
@@ -57,8 +57,6 @@ public class OrderedChildResourceExtension implements Extension {
     private static final String NAMESPACE = "urn:jboss:test:extension:ordered:child:resource:1.0";
     public static final PathElement CHILD = PathElement.pathElement("child");
     private static final AttributeDefinition ATTR = new SimpleAttributeDefinitionBuilder("attr", ModelType.STRING, true).build();
-    private static final AttributeDefinition[] REQUEST_ATTRIBUTES = new AttributeDefinition[]{ATTR};
-
 
     @Override
     public void initialize(ExtensionContext context) {
@@ -83,7 +81,7 @@ public class OrderedChildResourceExtension implements Extension {
 
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            resourceRegistration.registerReadWriteAttribute(ATTR, null, new ModelOnlyWriteAttributeHandler(REQUEST_ATTRIBUTES));
+            resourceRegistration.registerReadWriteAttribute(ATTR, null, ModelOnlyWriteAttributeHandler.INSTANCE);
         }
 
         @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/RootResourceDefinition.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/RootResourceDefinition.java
@@ -38,7 +38,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        resourceRegistration.registerReadWriteAttribute(NAME, null, new ReloadRequiredWriteAttributeHandler(NAME));
+        resourceRegistration.registerReadWriteAttribute(NAME, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
     }
 
     @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SubsystemInitialization.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SubsystemInitialization.java
@@ -64,13 +64,13 @@ class SubsystemInitialization {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(definition);
 
         // Test attribute
-        registration.registerReadWriteAttribute(TEST_ATTRIBUTE, null, new BasicAttributeWriteHandler(TEST_ATTRIBUTE));
+        registration.registerReadWriteAttribute(TEST_ATTRIBUTE, null, new BasicAttributeWriteHandler());
 
         // Other basic handlers
         final AttributeDefinition integer = SimpleAttributeDefinitionBuilder.create("int", ModelType.INT, true).setAllowExpression(allowExpressions).build();
         final AttributeDefinition string = SimpleAttributeDefinitionBuilder.create("string", ModelType.STRING, true).setAllowExpression(allowExpressions).build();
-        registration.registerReadWriteAttribute(integer, null, new BasicAttributeWriteHandler(integer));
-        registration.registerReadWriteAttribute(string, null, new BasicAttributeWriteHandler(string));
+        registration.registerReadWriteAttribute(integer, null, new BasicAttributeWriteHandler());
+        registration.registerReadWriteAttribute(string, null, new BasicAttributeWriteHandler());
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         return new RegistrationResult() {
@@ -95,10 +95,6 @@ class SubsystemInitialization {
     }
 
     private static class BasicAttributeWriteHandler extends AbstractWriteAttributeHandler<Void> {
-
-        protected BasicAttributeWriteHandler(AttributeDefinition def) {
-            super(def);
-        }
 
         @Override
         protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> voidHandbackHolder) throws OperationFailedException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
@@ -100,7 +100,7 @@ public class TestHostCapableExtension implements Extension {
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
             super.registerAttributes(resourceRegistration);
-            OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(NAME, SOCKET_BINDING);
+            OperationStepHandler writeHandler = ReloadRequiredWriteAttributeHandler.INSTANCE;
             resourceRegistration.registerReadWriteAttribute(NAME, null, writeHandler);
             resourceRegistration.registerReadWriteAttribute(SOCKET_BINDING, null, writeHandler);
         }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -111,7 +111,7 @@ public class BlockerExtension implements Extension {
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
             super.registerAttributes(resourceRegistration);
-            resourceRegistration.registerReadWriteAttribute(FOO, null, new ModelOnlyWriteAttributeHandler(FOO));
+            resourceRegistration.registerReadWriteAttribute(FOO, null, ModelOnlyWriteAttributeHandler.INSTANCE);
         }
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
@@ -56,7 +56,7 @@ public class RootResourceDefinition extends PersistentResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        OperationStepHandler write = new AbstractWriteAttributeHandler<Void>(ATTRIBUTE) {
+        OperationStepHandler write = new AbstractWriteAttributeHandler<Void>() {
 
             @Override
             protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> handbackHolder) throws OperationFailedException {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ChildResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ChildResourceDefinition.java
@@ -37,7 +37,7 @@ public class ChildResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        resourceRegistration.registerReadWriteAttribute(CHILD_ATTRIBUTE, null, new ReloadRequiredWriteAttributeHandler(CHILD_ATTRIBUTE));
+        resourceRegistration.registerReadWriteAttribute(CHILD_ATTRIBUTE, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
     }
 
     private static class AddChildHandler extends AbstractAddStepHandler {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/RootResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/RootResourceDefinition.java
@@ -42,7 +42,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        resourceRegistration.registerReadWriteAttribute(ATTRIBUTE, null, new ReloadRequiredWriteAttributeHandler(ATTRIBUTE));
+        resourceRegistration.registerReadWriteAttribute(ATTRIBUTE, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
     }
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6930
