### PR TITLE
[WFCORE-6936] Allow the maven.test.redirectTestOutputToFile system pr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
             ${surefire.jacoco.args} -Djava.io.tmpdir=${project.build.directory}</surefire.jvm.args>
         <surefire.system.args>${surefire.jpda.args} ${surefire.jvm.args}</surefire.system.args>
         <test.level>INFO</test.level>
+        <!-- The maven.test.redirectTestOutputToFile is used by the surefire-maven-plugin and failsafe-maven-plugin to
+             redirect stdout and stderr to a file. We use testLogToFile as shorthand for this setting and default to
+             true. You can override this from the command line by passing false to either of these properties.
+         -->
+        <testLogToFile>true</testLogToFile>
+        <maven.test.redirectTestOutputToFile>${testLogToFile}</maven.test.redirectTestOutputToFile>
 
         <!-- This overrides default surefire plugin version specified in parent pom - reason is to enable TCP/IP communication,
              see https://maven.apache.org/surefire/maven-surefire-plugin/examples/process-communication.html -->
@@ -339,7 +345,6 @@
                     </dependencies>
                     <configuration>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <enableAssertions>true</enableAssertions>
                         <systemPropertyVariables>
                             <org.jboss.model.test.cache.root>${org.jboss.model.test.cache.root}</org.jboss.model.test.cache.root>

--- a/testsuite/client-old-server/pom.xml
+++ b/testsuite/client-old-server/pom.xml
@@ -94,7 +94,6 @@
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args} -Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -253,7 +253,6 @@
                         <configuration>
                             <failIfNoTests>false</failIfNoTests>
                             <!-- parallel>none</parallel -->
-                            <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
                             <!-- System properties to forked surefire JVM which runs clients. -->
                             <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args} -Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -178,7 +178,6 @@
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args}</argLine>

--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -75,7 +75,6 @@
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
                     <!-- Always use a new fork so each test gets it's own embedded environment -->
                     <forkCount>1</forkCount>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -306,8 +306,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <failIfNoTests>false</failIfNoTests>
-			<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-                        <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
                         <systemPropertyVariables>
                             <jboss.dist>${jboss.dist}</jboss.dist>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -197,7 +197,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <parallel>none</parallel>
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <wildfly.debug>${ts.debug}</wildfly.debug>
                         <wildfly.debug.port>8787</wildfly.debug.port>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -62,7 +62,6 @@
                 <configuration>
                     <skip>${skipTests}</skip>
                     <failIfNoTests>false</failIfNoTests>
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <reuseForks>true</reuseForks>
 
                     <systemPropertyVariables>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -171,7 +171,6 @@
                     </excludes>
                     <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args} -Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>

--- a/testsuite/unstable-api-annotation/tests/pom.xml
+++ b/testsuite/unstable-api-annotation/tests/pom.xml
@@ -39,7 +39,6 @@
                     </excludes>
                     <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
 
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args} -Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>


### PR DESCRIPTION
…operty work as well as the testLogToFile property. Remove the duplication of the <redirectTestOutputToFile/> setting in the various POM's.

https://issues.redhat.com/browse/WFCORE-6936