### PR TITLE
WFCORE-6663 Introduce AttributeDefinition implementations to wildfly-subsystem that can resolve directly to a ServiceDependency

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ListAttributeDefinition.java
@@ -210,7 +210,11 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
         }
 
         public Builder(ListAttributeDefinition basis) {
-            super(basis);
+            this(basis.getName(), basis);
+        }
+
+        public Builder(String attributeName, ListAttributeDefinition basis) {
+            super(attributeName, basis);
             this.elementValidator = basis.getElementValidator();
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
@@ -226,12 +226,12 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
             super(attributeName, ModelType.OBJECT, optional);
         }
 
+        public Builder(String attributeName, MapAttributeDefinition basis) {
+            super(attributeName, basis);
+        }
+
         public Builder(MapAttributeDefinition basis) {
-            super(basis);
-            this.elementValidator = basis.getElementValidator();
-            if (elementValidator instanceof NillableOrExpressionParameterValidator) {
-                this.allowNullElement = ((NillableOrExpressionParameterValidator) elementValidator).getAllowNull();
-            }
+            this(basis.getName(), basis);
         }
 
         /**

--- a/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
@@ -86,10 +86,12 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
             setElementValidator(new ModelTypeValidator(ModelType.STRING));
         }
 
-        public Builder(final StringListAttributeDefinition basic) {
-            super(basic);
-            setAttributeParser(AttributeParser.STRING_LIST);
-            setAttributeMarshaller(AttributeMarshaller.STRING_LIST);
+        public Builder(String name, StringListAttributeDefinition basis) {
+            super(name, basis);
+        }
+
+        public Builder(final StringListAttributeDefinition basis) {
+            this(basis.getName(), basis);
         }
 
         @Override

--- a/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
@@ -17,9 +17,9 @@ import org.jboss.dmr.ModelType;
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
-public final class StringListAttributeDefinition extends PrimitiveListAttributeDefinition {
+public class StringListAttributeDefinition extends PrimitiveListAttributeDefinition {
 
-    private StringListAttributeDefinition(Builder builder) {
+    protected <B extends ListAttributeDefinition.Builder<B, A>, A extends ListAttributeDefinition> StringListAttributeDefinition(ListAttributeDefinition.Builder<B, A> builder) {
         super(builder, ModelType.STRING);
     }
 
@@ -91,14 +91,12 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
         }
 
         public Builder(final StringListAttributeDefinition basis) {
-            this(basis.getName(), basis);
+            super(basis);
         }
 
         @Override
         public StringListAttributeDefinition build() {
             return new StringListAttributeDefinition(this);
         }
-
     }
-
 }

--- a/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderRegistrar.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderRegistrar.java
@@ -19,7 +19,7 @@ import org.jboss.dmr.ModelNode;
 import org.wildfly.discovery.impl.AggregateDiscoveryProvider;
 import org.wildfly.discovery.spi.DiscoveryProvider;
 import org.wildfly.subsystem.resource.ResourceDescriptor;
-import org.wildfly.subsystem.resource.capability.CapabilityReferenceRecorder;
+import org.wildfly.subsystem.resource.capability.CapabilityReference;
 import org.wildfly.subsystem.service.ResourceServiceInstaller;
 import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
@@ -33,7 +33,7 @@ public class AggregateDiscoveryProviderRegistrar extends DiscoveryProviderRegist
     static final PathElement PATH = PathElement.pathElement("aggregate-provider");
 
     private static final StringListAttributeDefinition PROVIDER_NAMES = new StringListAttributeDefinition.Builder("providers")
-            .setCapabilityReference(CapabilityReferenceRecorder.builder(DISCOVERY_PROVIDER_CAPABILITY, DISCOVERY_PROVIDER_DESCRIPTOR).build())
+            .setCapabilityReference(CapabilityReference.builder(DISCOVERY_PROVIDER_CAPABILITY, DISCOVERY_PROVIDER_DESCRIPTOR).build())
             .setFlags(Flag.RESTART_RESOURCE_SERVICES)
             .build();
 

--- a/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderRegistrar.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/AggregateDiscoveryProviderRegistrar.java
@@ -4,22 +4,20 @@
  */
 package org.wildfly.extension.discovery;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.StringListAttributeDefinition;
-import org.jboss.as.controller.registry.AttributeAccess.Flag;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.discovery.impl.AggregateDiscoveryProvider;
 import org.wildfly.discovery.spi.DiscoveryProvider;
 import org.wildfly.subsystem.resource.ResourceDescriptor;
 import org.wildfly.subsystem.resource.capability.CapabilityReference;
+import org.wildfly.subsystem.resource.capability.CapabilityReferenceListAttributeDefinition;
 import org.wildfly.subsystem.service.ResourceServiceInstaller;
 import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
@@ -32,10 +30,7 @@ public class AggregateDiscoveryProviderRegistrar extends DiscoveryProviderRegist
 
     static final PathElement PATH = PathElement.pathElement("aggregate-provider");
 
-    private static final StringListAttributeDefinition PROVIDER_NAMES = new StringListAttributeDefinition.Builder("providers")
-            .setCapabilityReference(CapabilityReference.builder(DISCOVERY_PROVIDER_CAPABILITY, DISCOVERY_PROVIDER_DESCRIPTOR).build())
-            .setFlags(Flag.RESTART_RESOURCE_SERVICES)
-            .build();
+    private static final CapabilityReferenceListAttributeDefinition<DiscoveryProvider> PROVIDER_NAMES = new CapabilityReferenceListAttributeDefinition.Builder<>("providers", CapabilityReference.builder(DISCOVERY_PROVIDER_CAPABILITY, DISCOVERY_PROVIDER_DESCRIPTOR).build()).build();
 
     static final Collection<AttributeDefinition> ATTRIBUTES = List.of(PROVIDER_NAMES);
 
@@ -45,19 +40,12 @@ public class AggregateDiscoveryProviderRegistrar extends DiscoveryProviderRegist
 
     @Override
     public ResourceServiceInstaller configure(OperationContext context, ModelNode model) throws OperationFailedException {
-        List<String> providers = PROVIDER_NAMES.unwrap(context, model);
-        List<ServiceDependency<DiscoveryProvider>> dependencies = new ArrayList<>(providers.size());
-        for (String provider : providers) {
-            dependencies.add(ServiceDependency.on(DISCOVERY_PROVIDER_DESCRIPTOR, provider));
-        }
-        Supplier<DiscoveryProvider> factory = new Supplier<>() {
+        ServiceDependency<DiscoveryProvider> provider = PROVIDER_NAMES.resolve(context, model).map(new Function<>() {
             @Override
-            public DiscoveryProvider get() {
-                return new AggregateDiscoveryProvider(dependencies.stream().map(Supplier::get).toArray(DiscoveryProvider[]::new));
+            public DiscoveryProvider apply(List<DiscoveryProvider> providers) {
+                return new AggregateDiscoveryProvider(providers.toArray(DiscoveryProvider[]::new));
             }
-        };
-        return CapabilityServiceInstaller.builder(DISCOVERY_PROVIDER_CAPABILITY, factory)
-                .requires(dependencies)
-                .build();
+        });
+        return CapabilityServiceInstaller.builder(DISCOVERY_PROVIDER_CAPABILITY, provider).build();
     }
 }

--- a/io/spi/src/main/java/org/wildfly/io/IOServiceDescriptor.java
+++ b/io/spi/src/main/java/org/wildfly/io/IOServiceDescriptor.java
@@ -19,5 +19,7 @@ public interface IOServiceDescriptor {
     /** Describes the default worker */
     NullaryServiceDescriptor<XnioWorker> DEFAULT_WORKER = NullaryServiceDescriptor.of("org.wildfly.io.default-worker", XnioWorker.class);
     /** Describes a named worker */
-    UnaryServiceDescriptor<XnioWorker> WORKER = UnaryServiceDescriptor.of("org.wildfly.io.worker", DEFAULT_WORKER);
+    UnaryServiceDescriptor<XnioWorker> NAMED_WORKER = UnaryServiceDescriptor.of("org.wildfly.io.worker", XnioWorker.class);
+    /** Resolves to a named or default worker **/
+    UnaryServiceDescriptor<XnioWorker> WORKER = UnaryServiceDescriptor.of(NAMED_WORKER.getName(), DEFAULT_WORKER);
 }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemRegistrar.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemRegistrar.java
@@ -9,21 +9,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.ResourceRegistration;
-import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 import org.wildfly.common.function.Functions;
 import org.wildfly.io.IOServiceDescriptor;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
@@ -31,11 +27,13 @@ import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
 import org.wildfly.subsystem.resource.ResourceDescriptor;
 import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.capability.CapabilityReference;
+import org.wildfly.subsystem.resource.capability.CapabilityReferenceAttributeDefinition;
 import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
 import org.wildfly.subsystem.service.ResourceServiceConfigurator;
 import org.wildfly.subsystem.service.ResourceServiceInstaller;
 import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
+import org.xnio.XnioWorker;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -52,10 +50,8 @@ class IOSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar, Reso
 
     static final ModelNode LEGACY_DEFAULT_WORKER = new ModelNode("default");
 
-    static final AttributeDefinition DEFAULT_WORKER = new SimpleAttributeDefinitionBuilder("default-worker", ModelType.STRING)
+    static final CapabilityReferenceAttributeDefinition<XnioWorker> DEFAULT_WORKER = new CapabilityReferenceAttributeDefinition.Builder<>("default-worker", CapabilityReference.builder(DEFAULT_WORKER_CAPABILITY, IOServiceDescriptor.NAMED_WORKER).build())
             .setRequired(false)
-            .setCapabilityReference(CapabilityReference.builder(DEFAULT_WORKER_CAPABILITY, IOServiceDescriptor.WORKER).build())
-            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     // Tracks max-threads for all workers
@@ -84,11 +80,11 @@ class IOSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar, Reso
         WorkerAdd.checkWorkerConfiguration(context, workers);
 
         List<ResourceServiceInstaller> installers = new ArrayList<>(2);
-        installers.add(CapabilityServiceInstaller.builder(IOSubsystemRegistrar.MAX_THREADS_CAPABILITY, AtomicInteger::intValue, Functions.constantSupplier(this.maxThreads)).build());
+        installers.add(CapabilityServiceInstaller.builder(MAX_THREADS_CAPABILITY, AtomicInteger::intValue, Functions.constantSupplier(this.maxThreads)).build());
 
-        String defaultWorker = IOSubsystemRegistrar.DEFAULT_WORKER.resolveModelAttribute(context, model).asStringOrNull();
-        if (defaultWorker != null) {
-            installers.add(CapabilityServiceInstaller.builder(IOSubsystemRegistrar.DEFAULT_WORKER_CAPABILITY, ServiceDependency.on(IOServiceDescriptor.WORKER, defaultWorker)).build());
+        ServiceDependency<XnioWorker> defaultWorker = DEFAULT_WORKER.resolve(context, model);
+        if (defaultWorker.isPresent()) {
+            installers.add(CapabilityServiceInstaller.builder(DEFAULT_WORKER_CAPABILITY, defaultWorker).build());
         }
 
         return ResourceServiceInstaller.combine(installers);

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemRegistrar.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemRegistrar.java
@@ -30,7 +30,7 @@ import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
 import org.wildfly.subsystem.resource.ResourceDescriptor;
 import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
-import org.wildfly.subsystem.resource.capability.CapabilityReferenceRecorder;
+import org.wildfly.subsystem.resource.capability.CapabilityReference;
 import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
 import org.wildfly.subsystem.service.ResourceServiceConfigurator;
 import org.wildfly.subsystem.service.ResourceServiceInstaller;
@@ -54,7 +54,7 @@ class IOSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar, Reso
 
     static final AttributeDefinition DEFAULT_WORKER = new SimpleAttributeDefinitionBuilder("default-worker", ModelType.STRING)
             .setRequired(false)
-            .setCapabilityReference(CapabilityReferenceRecorder.builder(DEFAULT_WORKER_CAPABILITY, IOServiceDescriptor.WORKER).build())
+            .setCapabilityReference(CapabilityReference.builder(DEFAULT_WORKER_CAPABILITY, IOServiceDescriptor.WORKER).build())
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 

--- a/service/src/main/java/org/wildfly/service/Dependency.java
+++ b/service/src/main/java/org/wildfly/service/Dependency.java
@@ -85,6 +85,23 @@ public interface Dependency<B extends ServiceBuilder<?>, V> extends Consumer<B>,
         };
     }
 
+    /**
+     * Indicates whether this dependency will never provide a value.
+     * @return true, if this dependency will not provide a value, false otherwise.
+     */
+    default boolean isEmpty() {
+        return false;
+    }
+
+    /**
+     * Indicates whether this dependency will provide a value.
+     * This method is the direct inverse of {@link #isEmpty()}.
+     * @return true, if this dependency will provide a value, false otherwise.
+     */
+    default boolean isPresent() {
+        return !this.isEmpty();
+    }
+
     class SimpleDependency<B extends ServiceBuilder<?>, V> implements Dependency<B, V> {
 
         private final V value;
@@ -96,6 +113,11 @@ public interface Dependency<B extends ServiceBuilder<?>, V> extends Consumer<B>,
         @Override
         public V get() {
             return this.value;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.value == null;
         }
 
         @Override

--- a/service/src/main/java/org/wildfly/service/ServiceDependency.java
+++ b/service/src/main/java/org/wildfly/service/ServiceDependency.java
@@ -71,21 +71,30 @@ public interface ServiceDependency<V> extends Dependency<ServiceBuilder<?>, V> {
     }
 
     /**
+     * Returns an empty pseudo-dependency whose {@link #get()} returns null.
+     * @param <V> the value type
+     * @return an empty service dependency
+     */
+    @SuppressWarnings("unchecked")
+    static <V> ServiceDependency<V> empty() {
+        return (ServiceDependency<V>) SimpleServiceDependency.EMPTY;
+    }
+
+    /**
      * Returns a pseudo-dependency whose {@link #get()} returns the specified value.
      * @param <V> the value type
      * @param value a service value
-     * @return a service dependency
+     * @return a pseudo-dependency whose {@link #get()} returns the specified value.
      */
-    @SuppressWarnings("unchecked")
     static <V> ServiceDependency<V> of(V value) {
-        return (value != null) ? new SimpleServiceDependency<>(value) : (ServiceDependency<V>) SimpleServiceDependency.NULL;
+        return (value != null) ? new SimpleServiceDependency<>(value) : empty();
     }
 
     /**
      * Returns a pseudo-dependency whose {@link #get()} returns the value from the specified supplier.
      * @param <V> the value type
      * @param supplier a service value supplier
-     * @return a service dependency
+     * @return a pseudo-dependency whose {@link #get()} returns the value from the specified supplier.
      * @throws NullPointerException if {@code supplier} was null
      */
     static <V> ServiceDependency<V> from(Supplier<V> supplier) {
@@ -100,11 +109,11 @@ public interface ServiceDependency<V> extends Dependency<ServiceBuilder<?>, V> {
      * @return a service dependency
      */
     static <V> ServiceDependency<V> on(ServiceName name) {
-        return (name != null) ? new DefaultServiceDependency<>(name) : of(null);
+        return (name != null) ? new DefaultServiceDependency<>(name) : empty();
     }
 
     class SimpleServiceDependency<V> extends SimpleDependency<ServiceBuilder<?>, V> implements ServiceDependency<V> {
-        static final ServiceDependency<Object> NULL = new SimpleServiceDependency<>(null);
+        static final ServiceDependency<Object> EMPTY = new SimpleServiceDependency<>(null);
 
         SimpleServiceDependency(V value) {
             super(value);

--- a/service/src/main/java/org/wildfly/service/descriptor/BinaryServiceDescriptor.java
+++ b/service/src/main/java/org/wildfly/service/descriptor/BinaryServiceDescriptor.java
@@ -6,8 +6,6 @@ package org.wildfly.service.descriptor;
 
 import java.util.Map;
 
-import org.wildfly.common.Assert;
-
 /**
  * Describes a service by its name, provided value type, and dynamic name resolution mechanism.
  * @author Paul Ferraro
@@ -19,13 +17,10 @@ public interface BinaryServiceDescriptor<T> extends ServiceDescriptor<T> {
      * Resolves the dynamic name of the service using the specified segments.
      * @param parent the first dynamic segment
      * @param child the second dynamic segment
-     * @return a tuple containing the resolved name and dynamic segments
+     * @return a tuple containing the resolved name and dynamic segments, or null if segments are not resolvable.
      */
     default Map.Entry<String, String[]> resolve(String parent, String child) {
-        return Map.entry(this.getName(), new String[] {
-                Assert.checkNotNullParamWithNullPointerException("parent", parent),
-                Assert.checkNotNullParamWithNullPointerException("child", child)
-        });
+        return (parent != null) && (child != null) ? Map.entry(this.getName(), new String[] { parent, child }) : null;
     }
 
     @Override

--- a/service/src/main/java/org/wildfly/service/descriptor/QuaternaryServiceDescriptor.java
+++ b/service/src/main/java/org/wildfly/service/descriptor/QuaternaryServiceDescriptor.java
@@ -6,8 +6,6 @@ package org.wildfly.service.descriptor;
 
 import java.util.Map;
 
-import org.wildfly.common.Assert;
-
 /**
  * Describes a service by its name, provided value type, and dynamic name resolution mechanism.
  * @author Paul Ferraro
@@ -21,15 +19,10 @@ public interface QuaternaryServiceDescriptor<T> extends ServiceDescriptor<T> {
      * @param grandparent the second dynamic segment
      * @param parent the third dynamic segment
      * @param child the fourth dynamic segment
-     * @return a tuple containing the resolved name and dynamic segments
+     * @return a tuple containing the resolved name and dynamic segments, or null if segments are not resolvable.
      */
     default Map.Entry<String, String[]> resolve(String greatGrandparent, String grandparent, String parent, String child) {
-        return Map.entry(this.getName(), new String[] {
-                Assert.checkNotNullParamWithNullPointerException("greatGrandparent", greatGrandparent),
-                Assert.checkNotNullParamWithNullPointerException("grandparent", grandparent),
-                Assert.checkNotNullParamWithNullPointerException("parent", parent),
-                Assert.checkNotNullParamWithNullPointerException("child", child)
-        });
+        return (greatGrandparent != null) && (grandparent != null) && (parent != null) && (child != null) ? Map.entry(this.getName(), new String[] { greatGrandparent, grandparent, parent, child }) : null;
     }
 
     @Override

--- a/service/src/main/java/org/wildfly/service/descriptor/TernaryServiceDescriptor.java
+++ b/service/src/main/java/org/wildfly/service/descriptor/TernaryServiceDescriptor.java
@@ -6,8 +6,6 @@ package org.wildfly.service.descriptor;
 
 import java.util.Map;
 
-import org.wildfly.common.Assert;
-
 /**
  * Describes a service by its name, provided value type, and dynamic name resolution mechanism.
  * @author Paul Ferraro
@@ -20,14 +18,10 @@ public interface TernaryServiceDescriptor<T> extends ServiceDescriptor<T> {
      * @param grandparent the first dynamic segment
      * @param parent the second dynamic segment
      * @param child the third dynamic segment
-     * @return a tuple containing the resolved name and dynamic segments
+     * @return a tuple containing the resolved name and dynamic segments, or null if segments are not resolvable.
      */
     default Map.Entry<String, String[]> resolve(String grandparent, String parent, String child) {
-        return Map.entry(this.getName(), new String[] {
-                Assert.checkNotNullParamWithNullPointerException("grandparent", grandparent),
-                Assert.checkNotNullParamWithNullPointerException("parent", parent),
-                Assert.checkNotNullParamWithNullPointerException("child", child)
-        });
+        return (grandparent != null) && (parent != null) && (child != null) ? Map.entry(this.getName(), new String[] { grandparent, parent, child }) : null;
     }
 
     @Override

--- a/service/src/main/java/org/wildfly/service/descriptor/UnaryServiceDescriptor.java
+++ b/service/src/main/java/org/wildfly/service/descriptor/UnaryServiceDescriptor.java
@@ -6,8 +6,6 @@ package org.wildfly.service.descriptor;
 
 import java.util.Map;
 
-import org.wildfly.common.Assert;
-
 /**
  * Describes a service by its name, provided value type, and dynamic name resolution mechanism.
  * @author Paul Ferraro
@@ -18,12 +16,10 @@ public interface UnaryServiceDescriptor<T> extends ServiceDescriptor<T> {
     /**
      * Resolves the dynamic name of the service using the specified segment.
      * @param reference a dynamic segment
-     * @return a tuple containing the resolved name and dynamic segments
+     * @return a tuple containing the resolved name and dynamic segments, or null if segment is not resolvable.
      */
     default Map.Entry<String, String[]> resolve(String reference) {
-        return Map.entry(this.getName(), new String[] {
-                Assert.checkNotNullParamWithNullPointerException("reference", reference)
-        });
+        return (reference != null) ? Map.entry(this.getName(), new String[] { reference }) : null;
     }
 
     @Override

--- a/service/src/test/java/org/wildfly/service/descriptor/ServiceDescriptorTestCase.java
+++ b/service/src/test/java/org/wildfly/service/descriptor/ServiceDescriptorTestCase.java
@@ -49,9 +49,15 @@ public class ServiceDescriptorTestCase {
         Assert.assertSame(this.quaternaryDescriptor.getName(), resolved.getKey());
         Assert.assertArrayEquals(quaternary, resolved.getValue());
 
-        Assert.assertThrows(NullPointerException.class, () -> this.unaryDescriptor.resolve(null));
-        Assert.assertThrows(NullPointerException.class, () -> this.binaryDescriptor.resolve("foo", null));
-        Assert.assertThrows(NullPointerException.class, () -> this.ternaryDescriptor.resolve("foo", "bar", null));
-        Assert.assertThrows(NullPointerException.class, () -> this.quaternaryDescriptor.resolve("foo", "bar", "baz", null));
+        Assert.assertNull(this.unaryDescriptor.resolve(null));
+        Assert.assertNull(this.binaryDescriptor.resolve("foo", null));
+        Assert.assertNull(this.binaryDescriptor.resolve(null, "bar"));
+        Assert.assertNull(this.ternaryDescriptor.resolve("foo", "bar", null));
+        Assert.assertNull(this.ternaryDescriptor.resolve("foo", null, "baz"));
+        Assert.assertNull(this.ternaryDescriptor.resolve(null, "bar", "baz"));
+        Assert.assertNull(this.quaternaryDescriptor.resolve("foo", "bar", "baz", null));
+        Assert.assertNull(this.quaternaryDescriptor.resolve("foo", "bar", null, "qux"));
+        Assert.assertNull(this.quaternaryDescriptor.resolve("foo", null, "baz", "qux"));
+        Assert.assertNull(this.quaternaryDescriptor.resolve(null, "bar", "baz", "qux"));
     }
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/ResourceDescriptor.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/ResourceDescriptor.java
@@ -33,7 +33,7 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.wildfly.common.iteration.CompositeIterable;
-import org.wildfly.subsystem.resource.capability.ResourceCapabilityReferenceRecorder;
+import org.wildfly.subsystem.resource.capability.ResourceCapabilityReference;
 import org.wildfly.subsystem.resource.operation.AddResourceOperationStepHandlerDescriptor;
 import org.wildfly.subsystem.resource.operation.OperationStepHandlerDescriptor;
 import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
@@ -75,7 +75,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
      * Returns a mapping of capability references to an ancestor resource.
      * @return a tuple of capability references and requirement resolvers.
      */
-    default Set<ResourceCapabilityReferenceRecorder<?>> getResourceCapabilityReferences() {
+    default Set<ResourceCapabilityReference<?>> getResourceCapabilityReferences() {
         return Collections.emptySet();
     }
 
@@ -164,7 +164,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
         private final Map<PathElement, ResourceRegistration> requiredChildren;
         private final Map<PathElement, ResourceRegistration> requiredSingletonChildren;
         private final Map<AttributeDefinition, AttributeTranslation> attributeTranslations;
-        private final Set<ResourceCapabilityReferenceRecorder<?>> resourceCapabilityReferences;
+        private final Set<ResourceCapabilityReference<?>> resourceCapabilityReferences;
         private final Map<String, UnaryOperator<OperationStepHandler>> operationTransformers;
         private final UnaryOperator<OperationStepHandler> defaultOperationTransformer;
         private final UnaryOperator<Resource> resourceTransformer;
@@ -231,7 +231,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
         }
 
         @Override
-        public Set<ResourceCapabilityReferenceRecorder<?>> getResourceCapabilityReferences() {
+        public Set<ResourceCapabilityReference<?>> getResourceCapabilityReferences() {
             return this.resourceCapabilityReferences;
         }
 
@@ -474,7 +474,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
          * @param reference a capability reference recorder
          * @return a reference to this configurator
          */
-        default C addResourceCapabilityReference(ResourceCapabilityReferenceRecorder<?> reference) {
+        default C addResourceCapabilityReference(ResourceCapabilityReference<?> reference) {
             return this.addResourceCapabilityReferences(Set.of(reference));
         }
 
@@ -483,7 +483,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
          * @param references a collection of capability reference recorders
          * @return a reference to this configurator
          */
-        C addResourceCapabilityReferences(Collection<ResourceCapabilityReferenceRecorder<?>> references);
+        C addResourceCapabilityReferences(Collection<? extends ResourceCapabilityReference<?>> references);
 
         /**
          * Applies the specified transformation to the {@value ModelDescriptionConstants#ADD} operation of this resource.
@@ -626,7 +626,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
         private Map<PathElement, ResourceRegistration> requiredChildren = Map.of();
         private Map<PathElement, ResourceRegistration> requiredSingletonChildren = Map.of();
         private Map<AttributeDefinition, AttributeTranslation> attributeTranslations = Map.of();
-        private Set<ResourceCapabilityReferenceRecorder<?>> resourceCapabilityReferences = Set.of();
+        private Set<ResourceCapabilityReference<?>> resourceCapabilityReferences = Set.of();
         private Map<String, UnaryOperator<OperationStepHandler>> operationTransformers = Map.of();
         private UnaryOperator<OperationStepHandler> defaultOperationTransformer = UnaryOperator.identity();
         private UnaryOperator<Resource> resourceTransformer = UnaryOperator.identity();
@@ -721,7 +721,7 @@ public interface ResourceDescriptor extends AddResourceOperationStepHandlerDescr
         }
 
         @Override
-        public C addResourceCapabilityReferences(Collection<ResourceCapabilityReferenceRecorder<?>> references) {
+        public C addResourceCapabilityReferences(Collection<? extends ResourceCapabilityReference<?>> references) {
             this.resourceCapabilityReferences = references.isEmpty() ? Set.copyOf(references) : concat(this.resourceCapabilityReferences, references.stream());
             return this.self();
         }

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/ResourceModelResolver.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/ResourceModelResolver.java
@@ -7,12 +7,18 @@ package org.wildfly.subsystem.resource;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 
 /**
  * Resolves a value from a resource model.
  */
-public interface ResourceModelResolver<T> {
+public interface ResourceModelResolver<T> extends ResourceResolver<T> {
+
+    @Override
+    default T resolve(OperationContext context, Resource resource) throws OperationFailedException {
+        return this.resolve(context, resource.getModel());
+    }
 
     /**
      * Resolves a value from the specified resource model, using the specified operation context.

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/ResourceResolver.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/ResourceResolver.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.registry.Resource;
+
+/**
+ * Resolves a value from a resource.
+ */
+public interface ResourceResolver<T> {
+
+    /**
+     * Resolves a value from the specified resource, using the specified operation context.
+     * @param context an operation context
+     * @param resource a resource
+     * @return the resolved value
+     * @throws OperationFailedException if the value could not be resolved
+     */
+    T resolve(OperationContext context, Resource resource) throws OperationFailedException;
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/SimpleResource.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/SimpleResource.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource;
+
+import java.util.Set;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * An immutable resource facade for an existing leaf resource model, i.e. with no children.
+ */
+public class SimpleResource implements Resource {
+    private final ModelNode model;
+
+    public SimpleResource(ModelNode model) {
+        this.model = model;
+    }
+
+    @Override
+    public ModelNode getModel() {
+        return this.model;
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public void writeModel(ModelNode newModel) {
+        if (newModel != this.model) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public boolean isModelDefined() {
+        return this.model.isDefined();
+    }
+
+    @Override
+    public boolean hasChild(PathElement element) {
+        return false;
+    }
+
+    @Override
+    public Resource getChild(PathElement element) {
+        return null;
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public Resource requireChild(PathElement element) {
+        throw new NoSuchResourceException(element);
+    }
+
+    @Override
+    public boolean hasChildren(String childType) {
+        return false;
+    }
+
+    /**
+     * @throws UnsupportedOperationException if {@code address} is not empty;
+     */
+    @Override
+    public Resource navigate(PathAddress address) {
+        if (address.size() == 0) return this;
+        throw new NoSuchResourceException(address.getElement(0));
+    }
+
+    @Override
+    public Set<String> getChildTypes() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<String> getChildrenNames(String childType) {
+        return Set.of();
+    }
+
+    @Override
+    public Set<ResourceEntry> getChildren(String childType) {
+        return Set.of();
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public void registerChild(PathElement address, Resource resource) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public void registerChild(PathElement address, int index, Resource resource) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public Resource removeChild(PathElement address) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> getOrderedChildTypes() {
+        return Set.of();
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return false;
+    }
+
+    @Override
+    public boolean isProxy() {
+        return false;
+    }
+
+    @Override
+    public Resource clone() {
+        return new SimpleResource(this.model.clone());
+    }
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReference.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReference.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.subsystem.resource.capability;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityReferenceRecorder;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.Resource;
+import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+import org.wildfly.service.descriptor.QuaternaryServiceDescriptor;
+import org.wildfly.service.descriptor.ServiceDescriptor;
+import org.wildfly.service.descriptor.TernaryServiceDescriptor;
+import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+
+/**
+ * A {@link CapabilityReferenceRecorder} whose requirement is specified as a {@link ServiceDescriptor}.
+ * @param <T> the requirement type
+ * @author Paul Ferraro
+ */
+public interface CapabilityReference<T> extends CapabilityReferenceRecorder {
+
+    /**
+     * Returns the dependent capability.
+     * @return a capability
+     */
+    RuntimeCapability<Void> getDependent();
+
+    /**
+     * Returns the service descriptor required by the dependent capability.
+     * @return a service descriptor
+     */
+    ServiceDescriptor<T> getRequirement();
+
+    @Override
+    default String getBaseRequirementName() {
+        return this.getRequirement().getName();
+    }
+
+    @Override
+    default String getBaseDependentName() {
+        return this.getDependent().getName();
+    }
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     */
+    static <T> Builder<T> builder(RuntimeCapability<Void> capability, UnaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement);
+    }
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement.
+     * By default, the requirement's parent segment derives from the path of the current resource.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     */
+    static <T> ParentPathProvider<T> builder(RuntimeCapability<Void> capability, BinaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement);
+    }
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement.
+     * By default, the requirement's grandparent and parent segments derive from the path of the parent and current resources, respectively.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     */
+    static <T> GrandparentPathProvider<T> builder(RuntimeCapability<Void> capability, TernaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement);
+    }
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement.
+     * By default, the requirement's great-grandparent, grandparent, and parent segments derive from the path of the grandparent, parent, and current resources, respectively.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     */
+    static <T> GreatGrandparentPathProvider<T> builder(RuntimeCapability<Void> capability, QuaternaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement);
+    }
+
+    interface Builder<T> {
+        /**
+         * Builds a capability reference recorder.
+         * @return a capability reference recorder
+         */
+        CapabilityReference<T> build();
+    }
+
+    interface ParentAttributeProvider<T> {
+        /**
+         * Specifies the attribute used to resolves the parent segment of the requirement.
+         * @param attribute the attribute used to resolve the parent segment of the requirement.
+         * @return a reference to this builder
+         */
+        Builder<T> withParentAttribute(AttributeDefinition attribute);
+    }
+
+    interface ParentPathProvider<T> extends ParentAttributeProvider<T> {
+        /**
+         * Specifies the path for the parent segment of the requirement.
+         * @param path a path element used to construct the capability name pattern for this reference
+         * @param resolver a path resolver
+         * @return a reference to this builder
+         */
+        default Builder<T> withParentPath(PathElement path) {
+            return this.withParentPath(path, DefaultBuilder.CHILD_PATH);
+        }
+
+        /**
+         * Specifies the path and resolver for the parent segment of the requirement.
+         * @param path a path element used to construct the capability name pattern for this reference
+         * @param resolver a path resolver
+         * @return a reference to this builder
+         */
+        Builder<T> withParentPath(PathElement path, Function<PathAddress, PathElement> resolver);
+    }
+
+    interface GrandparentAttributeProvider<T> {
+        /**
+         * Specifies the attribute used to resolves the grandparent segment of the requirement.
+         * @param attribute the attribute used to resolve the parent segment of the requirement.
+         * @return a reference to this builder
+         */
+        ParentAttributeProvider<T> withGrandparentAttribute(AttributeDefinition attribute);
+    }
+
+    interface GrandparentPathProvider<T> extends GrandparentAttributeProvider<T> {
+        /**
+         * Specifies the path for the grandparent segment of the requirement.
+         * @param path a path element used to construct the capability name pattern for this reference
+         * @param resolver a path resolver
+         * @return a reference to this builder
+         */
+        default ParentPathProvider<T> withGrandparentPath(PathElement path) {
+            return this.withGrandparentPath(path, DefaultBuilder.PARENT_PATH);
+        }
+
+        /**
+         * Specifies the path and resolver for the grandparent segment of the requirement.
+         * @param path a path element used to construct the capability name pattern for this reference
+         * @param resolver a path resolver
+         * @return a reference to this builder
+         */
+        ParentPathProvider<T> withGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver);
+    }
+
+    interface GreatGrandparentAttributeProvider<T> {
+        /**
+         * Specifies the attribute used to resolves the great-grandparent segment of the requirement.
+         * @param attribute the attribute used to resolve the parent segment of the requirement.
+         * @return a reference to this builder
+         */
+        GrandparentAttributeProvider<T> withGreatGrandparentAttribute(AttributeDefinition attribute);
+    }
+
+    interface GreatGrandparentPathProvider<T> extends GreatGrandparentAttributeProvider<T> {
+        /**
+         * Specifies the path for the great-grandparent segment of the requirement.
+         * @param path a path element used to construct the capability name pattern for this reference
+         * @return a reference to this builder
+         */
+        default GrandparentPathProvider<T> withGreatGrandparentPath(PathElement path) {
+            return this.withGreatGrandparentPath(path, DefaultBuilder.GRANDPARENT_PATH);
+        }
+
+        /**
+         * Specifies the path and resolver for the great-grandparent segment of the requirement.
+         * @param path a path element used to construct the capability name pattern for this reference
+         * @param resolver a path resolver
+         * @return a reference to this builder
+         */
+        GrandparentPathProvider<T> withGreatGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver);
+    }
+
+    class DefaultBuilder<T> implements GreatGrandparentPathProvider<T>, GrandparentPathProvider<T>, ParentPathProvider<T>, Builder<T> {
+        static final Function<PathAddress, PathElement> CHILD_PATH = PathAddress::getLastElement;
+        static final Function<PathAddress, PathElement> PARENT_PATH = CHILD_PATH.compose(PathAddress::getParent);
+        static final Function<PathAddress, PathElement> GRANDPARENT_PATH = PARENT_PATH.compose(PathAddress::getParent);
+        private static final RequirementNameSegmentResolver CHILD_REQUIREMENT_NAME_SEGMENT_RESOLVER = (context, resource, value) -> value;
+        private static final UnaryOperator<String> CHILD_REQUIREMENT_PATTERN_SEGMENT_RESOLVER = UnaryOperator.identity();
+
+        private final RuntimeCapability<Void> capability;
+        private final ServiceDescriptor<T> requirement;
+        private final List<RequirementNameSegmentResolver> requirementNameSegmentResolvers = new ArrayList<>(4);
+        private final List<UnaryOperator<String>> requirementPatternSegmentResolvers= new ArrayList<>(4);
+
+        DefaultBuilder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement) {
+            this.capability = capability;
+            this.requirement = requirement;
+        }
+
+        @Override
+        public GrandparentAttributeProvider<T> withGreatGrandparentAttribute(AttributeDefinition attribute) {
+            return this.addAttributeResolver(attribute);
+        }
+
+        @Override
+        public ParentAttributeProvider<T> withGrandparentAttribute(AttributeDefinition attribute) {
+            return this.addAttributeResolver(attribute);
+        }
+
+        @Override
+        public Builder<T> withParentAttribute(AttributeDefinition attribute) {
+            return this.addAttributeResolver(attribute);
+        }
+
+        @Override
+        public GrandparentPathProvider<T> withGreatGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver) {
+            return this.addPathResolver(path, resolver);
+        }
+
+        @Override
+        public ParentPathProvider<T> withGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver) {
+            return this.addPathResolver(path, resolver);
+        }
+
+        @Override
+        public Builder<T> withParentPath(PathElement path, Function<PathAddress, PathElement> resolver) {
+            return this.addPathResolver(path, resolver);
+        }
+
+        private DefaultBuilder<T> addAttributeResolver(AttributeDefinition attribute) {
+            this.requirementNameSegmentResolvers.add(createRequirementNameSegmentResolver(attribute));
+            this.requirementPatternSegmentResolvers.add(createRequirementPatternSegmentResolver(attribute));
+            return this;
+        }
+
+        private DefaultBuilder<T> addPathResolver(PathElement path, Function<PathAddress, PathElement> resolver) {
+            this.requirementNameSegmentResolvers.add(createRequirementNameSegmentResolver(resolver));
+            this.requirementPatternSegmentResolvers.add(createRequirementPatternSegmentResolver(path));
+            return this;
+        }
+
+        private static RequirementNameSegmentResolver createRequirementNameSegmentResolver(AttributeDefinition attribute) {
+            return new RequirementNameSegmentResolver() {
+                @Override
+                public String resolve(OperationContext context, Resource resource, String value) {
+                    try {
+                        return attribute.resolveModelAttribute(context, resource.getModel()).asString();
+                    } catch (OperationFailedException e) {
+                        throw new IllegalArgumentException(e);
+                    }
+                }
+            };
+        }
+
+        private static RequirementNameSegmentResolver createRequirementNameSegmentResolver(Function<PathAddress, PathElement> resolver) {
+            return new RequirementNameSegmentResolver() {
+                @Override
+                public String resolve(OperationContext context, Resource resource, String value) {
+                    return resolver.apply(context.getCurrentAddress()).getValue();
+                }
+            };
+        }
+
+        private static UnaryOperator<String> createRequirementPatternSegmentResolver(AttributeDefinition attribute) {
+            return new UnaryOperator<>() {
+                @Override
+                public String apply(String name) {
+                    return attribute.getName();
+                }
+            };
+        }
+
+        private static UnaryOperator<String> createRequirementPatternSegmentResolver(PathElement path) {
+            return new UnaryOperator<>() {
+                @Override
+                public String apply(String name) {
+                    return path.getKey();
+                }
+            };
+        }
+
+        @Override
+        public CapabilityReference<T> build() {
+            this.requirementNameSegmentResolvers.add(CHILD_REQUIREMENT_NAME_SEGMENT_RESOLVER);
+            this.requirementPatternSegmentResolvers.add(CHILD_REQUIREMENT_PATTERN_SEGMENT_RESOLVER);
+            return new ServiceDescriptorReference<>(this.capability, this.requirement, this.requirementNameSegmentResolvers, this.requirementPatternSegmentResolvers);
+        }
+    }
+
+    abstract class AbstractServiceDescriptorReference<T> implements CapabilityReference<T> {
+
+        private final RuntimeCapability<Void> capability;
+        private final ServiceDescriptor<T> requirement;
+
+        AbstractServiceDescriptorReference(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement) {
+            this.capability = capability;
+            this.requirement = requirement;
+        }
+
+        @Override
+        public RuntimeCapability<Void> getDependent() {
+            return this.capability;
+        }
+
+        @Override
+        public ServiceDescriptor<T> getRequirement() {
+            return this.requirement;
+        }
+
+        String resolveDependentName(OperationContext context) {
+            return this.capability.isDynamicallyNamed() ? this.capability.getDynamicName(context.getCurrentAddress()) : this.capability.getName();
+        }
+
+        @Override
+        public int hashCode() {
+            return this.capability.getName().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            return (object instanceof CapabilityReference) ? this.getDependent().equals(((CapabilityReference<?>) object).getDependent()) : false;
+        }
+    }
+
+    class ServiceDescriptorReference<T> extends AbstractServiceDescriptorReference<T> {
+
+        private final List<RequirementNameSegmentResolver> requirementNameSegmentResolvers;
+        private final List<UnaryOperator<String>> requirementPatternSegmentResolvers;
+
+        ServiceDescriptorReference(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, List<RequirementNameSegmentResolver> requirementNameSegmentResolvers, List<UnaryOperator<String>> requirementPatternSegmentResolvers) {
+            super(capability, requirement);
+            this.requirementNameSegmentResolvers = List.copyOf(requirementNameSegmentResolvers);
+            this.requirementPatternSegmentResolvers = List.copyOf(requirementPatternSegmentResolvers);
+        }
+
+        @Override
+        public void addCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... values) {
+            String dependentName = this.resolveDependentName(context);
+            for (String value : values) {
+                // Do not register requirement if undefined
+                if (value != null) {
+                    context.registerAdditionalCapabilityRequirement(this.resolveRequirementName(context, resource, value), dependentName, attributeName);
+                }
+            }
+        }
+
+        @Override
+        public void removeCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... values) {
+            String dependentName = this.resolveDependentName(context);
+            for (String value : values) {
+                // We did not register a requirement if undefined
+                if (value != null) {
+                    context.deregisterCapabilityRequirement(this.resolveRequirementName(context, resource, value), dependentName, attributeName);
+                }
+            }
+        }
+
+        private String resolveRequirementName(OperationContext context, Resource resource, String value) {
+            String[] segments = new String[this.requirementNameSegmentResolvers.size()];
+            ListIterator<RequirementNameSegmentResolver> resolvers = this.requirementNameSegmentResolvers.listIterator();
+            while (resolvers.hasNext()) {
+                segments[resolvers.nextIndex()] = resolvers.next().resolve(context, resource, value);
+            }
+            return RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), segments);
+        }
+
+        @Override
+        public String[] getRequirementPatternSegments(String name, PathAddress address) {
+            String[] segments = new String[this.requirementPatternSegmentResolvers.size()];
+            ListIterator<UnaryOperator<String>> resolvers = this.requirementPatternSegmentResolvers.listIterator();
+            while (resolvers.hasNext()) {
+                segments[resolvers.nextIndex()] = resolvers.next().apply(name);
+            }
+            return segments;
+        }
+    }
+
+    interface RequirementNameSegmentResolver {
+        String resolve(OperationContext context, Resource resource, String value);
+    }
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceAttributeDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceAttributeDefinition.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource.capability;
+
+import java.util.Map;
+
+import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.AttributeAccess.Flag;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.subsystem.resource.SimpleResource;
+import org.wildfly.subsystem.resource.ResourceModelResolver;
+import org.wildfly.subsystem.service.ServiceDependency;
+
+/**
+ * An attribute definition referencing some capability.
+ * Resolves directly to a {@link ServiceDependency} via {@link #resolve(OperationContext, ModelNode)}.
+ */
+public class CapabilityReferenceAttributeDefinition<T> extends SimpleAttributeDefinition implements ResourceModelResolver<ServiceDependency<T>> {
+
+    private final CapabilityReferenceResolver<T> resolver;
+
+    CapabilityReferenceAttributeDefinition(Builder<T> builder) {
+        super(builder);
+        this.resolver = builder.resolver;
+    }
+
+    @Override
+    public ServiceDependency<T> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
+        String value = this.resolveModelAttribute(context, model).asStringOrNull();
+        Map.Entry<String, String[]> resolved = this.resolver.resolve(context, new SimpleResource(model), value);
+        return (resolved != null) ? ServiceDependency.on(resolved.getKey(), this.resolver.getRequirement().getType(), resolved.getValue()) : ServiceDependency.empty();
+    }
+
+    public static class Builder<T> extends AbstractAttributeDefinitionBuilder<Builder<T>, CapabilityReferenceAttributeDefinition<T>> {
+
+        final CapabilityReferenceResolver<T> resolver;
+
+        public Builder(String attributeName, CapabilityReference<T> reference) {
+            super(attributeName, ModelType.STRING);
+            // Capability references never allow expressions
+            this.setAllowExpression(false);
+            this.setAttributeParser(AttributeParser.SIMPLE);
+            this.setCapabilityReference(reference);
+            this.setFlags(Flag.RESTART_RESOURCE_SERVICES);
+            this.setValidator(new StringLengthValidator(1));
+            this.resolver = reference;
+        }
+
+        public Builder(String attributeName, CapabilityReferenceAttributeDefinition<T> basis) {
+            super(attributeName, basis);
+            this.resolver = basis.resolver;
+        }
+
+        /**
+         * Capability references should never define a default value.
+         * @throws UnsupportedOperationException if caller attempts to define a default value for this attribute.
+         */
+        @Override
+        public Builder<T> setDefaultValue(ModelNode defaultValue) {
+            // A capability reference must not specify a default value
+            if ((defaultValue != null) && defaultValue.isDefined()) {
+                throw new UnsupportedOperationException();
+            }
+            return this;
+        }
+
+        /**
+         * Capability references should never allow expressions.
+         * @throws UnsupportedOperationException if caller attempts to enable expressions for this attribute.
+         */
+        @Override
+        public Builder<T> setAllowExpression(boolean allowExpression) {
+            // A capability reference must not allow expressions
+            if (allowExpression) {
+                throw new UnsupportedOperationException();
+            }
+            return this;
+        }
+
+        @Override
+        public CapabilityReferenceAttributeDefinition<T> build() {
+            return new CapabilityReferenceAttributeDefinition<>(this);
+        }
+    }
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceListAttributeDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceListAttributeDefinition.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource.capability;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.RequirementServiceBuilder;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.as.controller.registry.AttributeAccess.Flag;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.subsystem.resource.SimpleResource;
+import org.wildfly.subsystem.resource.ResourceModelResolver;
+import org.wildfly.subsystem.service.ServiceDependency;
+
+/**
+ * A list attribute definition whose elements (of type {@link ModelType#STRING}) reference a capability.
+ * Resolves directly to a {@link ServiceDependency} via {@link #resolve(OperationContext, ModelNode)}.
+ */
+public class CapabilityReferenceListAttributeDefinition<T> extends StringListAttributeDefinition implements ResourceModelResolver<ServiceDependency<List<T>>> {
+
+    private final CapabilityReferenceResolver<T> resolver;
+
+    CapabilityReferenceListAttributeDefinition(Builder<T> builder) {
+        super(builder);
+        this.resolver = builder.resolver;
+    }
+
+    @Override
+    public ServiceDependency<List<T>> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
+        List<ModelNode> values = this.resolveModelAttribute(context, model).asListOrEmpty();
+        if (!values.isEmpty()) {
+            List<ServiceDependency<T>> dependencies = new ArrayList<>(values.size());
+            for (ModelNode value : values) {
+                Map.Entry<String, String[]> resolved = this.resolver.resolve(context, new SimpleResource(model), value.asString());
+                if (resolved != null) {
+                    dependencies.add(ServiceDependency.on(resolved.getKey(), this.resolver.getRequirement().getType(), resolved.getValue()));
+                }
+            }
+            if (!dependencies.isEmpty()) {
+                return new ServiceDependency<>() {
+                    @Override
+                    public void accept(RequirementServiceBuilder<?> builder) {
+                        for (ServiceDependency<T> dependency : dependencies) {
+                            dependency.accept(builder);
+                        }
+                    }
+
+                    @Override
+                    public List<T> get() {
+                        List<T> values = new ArrayList<>();
+                        for (ServiceDependency<T> dependency : dependencies) {
+                            values.add(dependency.get());
+                        }
+                        return values;
+                    }
+                };
+            }
+        }
+        return ServiceDependency.of(List.of());
+    }
+
+    public static class Builder<T> extends ListAttributeDefinition.Builder<Builder<T>, CapabilityReferenceListAttributeDefinition<T>> {
+
+        final CapabilityReferenceResolver<T> resolver;
+
+        public Builder(String attributeName, CapabilityReference<T> reference) {
+            super(attributeName);
+            this.setAttributeParser(AttributeParser.STRING_LIST);
+            this.setAttributeMarshaller(AttributeMarshaller.STRING_LIST);
+            this.setElementValidator(new ModelTypeValidator(ModelType.STRING));
+            // Capability references never allow expressions
+            this.setAllowExpression(false);
+            this.setCapabilityReference(reference);
+            this.setFlags(Flag.RESTART_RESOURCE_SERVICES);
+            this.resolver = reference;
+        }
+
+        public Builder(String attributeName, CapabilityReferenceListAttributeDefinition<T> basis) {
+            super(attributeName, basis);
+            this.resolver = basis.resolver;
+        }
+
+        /**
+         * Capability references should never define a default value.
+         * @throws UnsupportedOperationException if caller attempts to define a default value for this attribute.
+         */
+        @Override
+        public Builder<T> setDefaultValue(ModelNode defaultValue) {
+            // A capability reference must not specify a default value
+            if ((defaultValue != null) && defaultValue.isDefined()) {
+                throw new UnsupportedOperationException();
+            }
+            return this;
+        }
+
+        /**
+         * Capability references should never allow expressions.
+         * @throws UnsupportedOperationException if caller attempts to enable expressions for this attribute.
+         */
+        @Override
+        public Builder<T> setAllowExpression(boolean allowExpression) {
+            // A capability reference must not allow expressions
+            if (allowExpression) {
+                throw new UnsupportedOperationException();
+            }
+            return this;
+        }
+
+        @Override
+        public CapabilityReferenceListAttributeDefinition<T> build() {
+            return new CapabilityReferenceListAttributeDefinition<>(this);
+        }
+    }
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceRecorder.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceRecorder.java
@@ -2,17 +2,13 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package org.wildfly.subsystem.resource.capability;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ListIterator;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -24,38 +20,20 @@ import org.wildfly.service.descriptor.TernaryServiceDescriptor;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
 
 /**
- * A {@link org.jboss.as.controller.CapabilityReferenceRecorder} whose requirement is specified as a {@link ServiceDescriptor}.
- * @author Paul Ferraro
+ * A {@link org.jboss.as.controller.CapabilityReferenceRecorder} whose requirement is specified as a {@link org.wildfly.service.descriptor.ServiceDescriptor}.
+ * @param <T> the requirement type
+ * @deprecated Replaced by {@link CapabilityReference}.
  */
-public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.CapabilityReferenceRecorder {
-
-    /**
-     * Returns the dependent capability.
-     * @return a capability
-     */
-    RuntimeCapability<Void> getDependent();
-
-    /**
-     * Returns the service descriptor required by the dependent capability.
-     * @return a service descriptor
-     */
-    ServiceDescriptor<T> getRequirement();
-
-    @Override
-    default String getBaseRequirementName() {
-        return this.getRequirement().getName();
-    }
-
-    @Override
-    default String getBaseDependentName() {
-        return this.getDependent().getName();
-    }
+@Deprecated(forRemoval = true, since = "26.0.0")
+public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
 
     /**
      * Creates a new reference between the specified capability and the specified requirement.
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
+     * @deprecated Superseded by {@link CapabilityReference#builder(RuntimeCapability, UnaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> Builder<T> builder(RuntimeCapability<Void> capability, UnaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement);
     }
@@ -65,7 +43,9 @@ public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.
      * By default, the requirement's parent segment derives from the path of the current resource.
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
+     * @deprecated Superseded by {@link CapabilityReference#builder(RuntimeCapability, BinaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> ParentPathProvider<T> builder(RuntimeCapability<Void> capability, BinaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement);
     }
@@ -75,7 +55,9 @@ public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.
      * By default, the requirement's grandparent and parent segments derive from the path of the parent and current resources, respectively.
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
+     * @deprecated Superseded by {@link CapabilityReference#builder(RuntimeCapability, TernaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> GrandparentPathProvider<T> builder(RuntimeCapability<Void> capability, TernaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement);
     }
@@ -85,37 +67,45 @@ public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.
      * By default, the requirement's great-grandparent, grandparent, and parent segments derive from the path of the grandparent, parent, and current resources, respectively.
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
+     * @deprecated Superseded by {@link CapabilityReference#builder(RuntimeCapability, QuaternaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> GreatGrandparentPathProvider<T> builder(RuntimeCapability<Void> capability, QuaternaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement);
     }
 
-    interface Builder<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface Builder<T> extends CapabilityReference.Builder<T> {
         /**
          * Builds a capability reference recorder.
          * @return a capability reference recorder
          */
+        @Override
         CapabilityReferenceRecorder<T> build();
     }
 
-    interface ParentAttributeProvider<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface ParentAttributeProvider<T> extends CapabilityReference.ParentAttributeProvider<T> {
         /**
          * Specifies the attribute used to resolves the parent segment of the requirement.
          * @param attribute the attribute used to resolve the parent segment of the requirement.
          * @return a reference to this builder
          */
+        @Override
         Builder<T> withParentAttribute(AttributeDefinition attribute);
     }
 
-    interface ParentPathProvider<T> extends ParentAttributeProvider<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface ParentPathProvider<T> extends CapabilityReference.ParentPathProvider<T>, ParentAttributeProvider<T> {
         /**
          * Specifies the path for the parent segment of the requirement.
          * @param path a path element used to construct the capability name pattern for this reference
          * @param resolver a path resolver
          * @return a reference to this builder
          */
+        @Override
         default Builder<T> withParentPath(PathElement path) {
-            return this.withParentPath(path, DefaultBuilder.CHILD_PATH);
+            return this.withParentPath(path, CapabilityReference.DefaultBuilder.CHILD_PATH);
         }
 
         /**
@@ -124,27 +114,32 @@ public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.
          * @param resolver a path resolver
          * @return a reference to this builder
          */
+        @Override
         Builder<T> withParentPath(PathElement path, Function<PathAddress, PathElement> resolver);
     }
 
-    interface GrandparentAttributeProvider<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface GrandparentAttributeProvider<T> extends CapabilityReference.GrandparentAttributeProvider<T>{
         /**
          * Specifies the attribute used to resolves the grandparent segment of the requirement.
          * @param attribute the attribute used to resolve the parent segment of the requirement.
          * @return a reference to this builder
          */
+        @Override
         ParentAttributeProvider<T> withGrandparentAttribute(AttributeDefinition attribute);
     }
 
-    interface GrandparentPathProvider<T> extends GrandparentAttributeProvider<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface GrandparentPathProvider<T> extends CapabilityReference.GrandparentPathProvider<T>, GrandparentAttributeProvider<T> {
         /**
          * Specifies the path for the grandparent segment of the requirement.
          * @param path a path element used to construct the capability name pattern for this reference
          * @param resolver a path resolver
          * @return a reference to this builder
          */
+        @Override
         default ParentPathProvider<T> withGrandparentPath(PathElement path) {
-            return this.withGrandparentPath(path, DefaultBuilder.PARENT_PATH);
+            return this.withGrandparentPath(path, CapabilityReference.DefaultBuilder.PARENT_PATH);
         }
 
         /**
@@ -153,26 +148,31 @@ public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.
          * @param resolver a path resolver
          * @return a reference to this builder
          */
+        @Override
         ParentPathProvider<T> withGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver);
     }
 
-    interface GreatGrandparentAttributeProvider<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface GreatGrandparentAttributeProvider<T> extends CapabilityReference.GreatGrandparentAttributeProvider<T> {
         /**
          * Specifies the attribute used to resolves the great-grandparent segment of the requirement.
          * @param attribute the attribute used to resolve the parent segment of the requirement.
          * @return a reference to this builder
          */
+        @Override
         GrandparentAttributeProvider<T> withGreatGrandparentAttribute(AttributeDefinition attribute);
     }
 
-    interface GreatGrandparentPathProvider<T> extends GreatGrandparentAttributeProvider<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface GreatGrandparentPathProvider<T> extends CapabilityReference.GreatGrandparentPathProvider<T>, GreatGrandparentAttributeProvider<T> {
         /**
          * Specifies the path for the great-grandparent segment of the requirement.
          * @param path a path element used to construct the capability name pattern for this reference
          * @return a reference to this builder
          */
+        @Override
         default GrandparentPathProvider<T> withGreatGrandparentPath(PathElement path) {
-            return this.withGreatGrandparentPath(path, DefaultBuilder.GRANDPARENT_PATH);
+            return this.withGreatGrandparentPath(path, CapabilityReference.DefaultBuilder.GRANDPARENT_PATH);
         }
 
         /**
@@ -181,209 +181,100 @@ public interface CapabilityReferenceRecorder<T> extends org.jboss.as.controller.
          * @param resolver a path resolver
          * @return a reference to this builder
          */
+        @Override
         GrandparentPathProvider<T> withGreatGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver);
     }
 
-    class DefaultBuilder<T> implements GreatGrandparentPathProvider<T>, GrandparentPathProvider<T>, ParentPathProvider<T>, Builder<T> {
-        private static final Function<PathAddress, PathElement> CHILD_PATH = PathAddress::getLastElement;
-        private static final Function<PathAddress, PathElement> PARENT_PATH = CHILD_PATH.compose(PathAddress::getParent);
-        private static final Function<PathAddress, PathElement> GRANDPARENT_PATH = PARENT_PATH.compose(PathAddress::getParent);
-        private static final RequirementNameSegmentResolver CHILD_REQUIREMENT_NAME_SEGMENT_RESOLVER = (context, resource, value) -> value;
-        private static final UnaryOperator<String> CHILD_REQUIREMENT_PATTERN_SEGMENT_RESOLVER = UnaryOperator.identity();
-
-        private final RuntimeCapability<Void> capability;
-        private final ServiceDescriptor<T> requirement;
-        private final List<RequirementNameSegmentResolver> requirementNameSegmentResolvers = new ArrayList<>(4);
-        private final List<UnaryOperator<String>> requirementPatternSegmentResolvers= new ArrayList<>(4);
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    class DefaultBuilder<T> extends CapabilityReference.DefaultBuilder<T> implements GreatGrandparentPathProvider<T>, GrandparentPathProvider<T>, ParentPathProvider<T>, Builder<T> {
 
         DefaultBuilder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement) {
-            this.capability = capability;
-            this.requirement = requirement;
+            super(capability, requirement);
         }
 
         @Override
         public GrandparentAttributeProvider<T> withGreatGrandparentAttribute(AttributeDefinition attribute) {
-            this.setAttribute(attribute);
+            super.withGreatGrandparentAttribute(attribute);
             return this;
         }
 
         @Override
         public ParentAttributeProvider<T> withGrandparentAttribute(AttributeDefinition attribute) {
-            this.setAttribute(attribute);
+            super.withGrandparentAttribute(attribute);
             return this;
         }
 
         @Override
         public Builder<T> withParentAttribute(AttributeDefinition attribute) {
-            this.setAttribute(attribute);
+            super.withParentAttribute(attribute);
             return this;
         }
 
         @Override
         public GrandparentPathProvider<T> withGreatGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver) {
-            this.setPath(path, resolver);
+            super.withGreatGrandparentPath(path, resolver);
             return this;
         }
 
         @Override
         public ParentPathProvider<T> withGrandparentPath(PathElement path, Function<PathAddress, PathElement> resolver) {
-            this.setPath(path, resolver);
+            super.withGrandparentPath(path, resolver);
             return this;
         }
 
         @Override
         public Builder<T> withParentPath(PathElement path, Function<PathAddress, PathElement> resolver) {
-            this.setPath(path, resolver);
+            super.withParentPath(path, resolver);
             return this;
-        }
-
-        private void setAttribute(AttributeDefinition attribute) {
-            this.requirementNameSegmentResolvers.add(createRequirementNameSegmentResolver(attribute));
-            this.requirementPatternSegmentResolvers.add(createRequirementPatternSegmentResolver(attribute));
-        }
-
-        private void setPath(PathElement path, Function<PathAddress, PathElement> resolver) {
-            this.requirementNameSegmentResolvers.add(createRequirementNameSegmentResolver(resolver));
-            this.requirementPatternSegmentResolvers.add(createRequirementPatternSegmentResolver(path));
-        }
-
-        private static RequirementNameSegmentResolver createRequirementNameSegmentResolver(AttributeDefinition attribute) {
-            return new RequirementNameSegmentResolver() {
-                @Override
-                public String resolve(OperationContext context, Resource resource, String value) {
-                    try {
-                        return attribute.resolveModelAttribute(context, resource.getModel()).asString();
-                    } catch (OperationFailedException e) {
-                        throw new IllegalArgumentException(e);
-                    }
-                }
-            };
-        }
-
-        private static RequirementNameSegmentResolver createRequirementNameSegmentResolver(Function<PathAddress, PathElement> resolver) {
-            return new RequirementNameSegmentResolver() {
-                @Override
-                public String resolve(OperationContext context, Resource resource, String value) {
-                    return resolver.apply(context.getCurrentAddress()).getValue();
-                }
-            };
-        }
-
-        private static UnaryOperator<String> createRequirementPatternSegmentResolver(AttributeDefinition attribute) {
-            return new UnaryOperator<>() {
-                @Override
-                public String apply(String name) {
-                    return attribute.getName();
-                }
-            };
-        }
-
-        private static UnaryOperator<String> createRequirementPatternSegmentResolver(PathElement path) {
-            return new UnaryOperator<>() {
-                @Override
-                public String apply(String name) {
-                    return path.getKey();
-                }
-            };
         }
 
         @Override
         public CapabilityReferenceRecorder<T> build() {
-            this.requirementNameSegmentResolvers.add(CHILD_REQUIREMENT_NAME_SEGMENT_RESOLVER);
-            this.requirementPatternSegmentResolvers.add(CHILD_REQUIREMENT_PATTERN_SEGMENT_RESOLVER);
-            return new CapabilityServiceDescriptorReferenceRecorder<>(this.capability, this.requirement, this.requirementNameSegmentResolvers, this.requirementPatternSegmentResolvers);
+            return new CapabilityServiceDescriptorReferenceRecorder<>(super.build());
         }
     }
 
-    abstract class AbstractCapabilityServiceDescriptorReferenceRecorder<T> implements CapabilityReferenceRecorder<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    class CapabilityServiceDescriptorReferenceRecorder<T> implements CapabilityReferenceRecorder<T> {
+        private final CapabilityReference<T> reference;
 
-        private final RuntimeCapability<Void> capability;
-        private final ServiceDescriptor<T> requirement;
-
-        AbstractCapabilityServiceDescriptorReferenceRecorder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement) {
-            this.capability = capability;
-            this.requirement = requirement;
+        CapabilityServiceDescriptorReferenceRecorder(CapabilityReference<T> reference) {
+            this.reference = reference;
         }
 
         @Override
         public RuntimeCapability<Void> getDependent() {
-            return this.capability;
+            return this.reference.getDependent();
         }
 
         @Override
         public ServiceDescriptor<T> getRequirement() {
-            return this.requirement;
-        }
-
-        String resolveDependentName(OperationContext context) {
-            return this.capability.isDynamicallyNamed() ? this.capability.getDynamicName(context.getCurrentAddress()) : this.capability.getName();
+            return this.reference.getRequirement();
         }
 
         @Override
-        public int hashCode() {
-            return this.capability.getName().hashCode();
+        public void addCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... attributeValues) {
+            this.reference.addCapabilityRequirements(context, resource, attributeName, attributeValues);
         }
 
         @Override
-        public boolean equals(Object object) {
-            return (object instanceof CapabilityReferenceRecorder) ? this.getDependent().equals(((CapabilityReferenceRecorder<?>) object).getDependent()) : false;
-        }
-    }
-
-    class CapabilityServiceDescriptorReferenceRecorder<T> extends AbstractCapabilityServiceDescriptorReferenceRecorder<T> {
-
-        private final List<RequirementNameSegmentResolver> requirementNameSegmentResolvers;
-        private final List<UnaryOperator<String>> requirementPatternSegmentResolvers;
-
-        CapabilityServiceDescriptorReferenceRecorder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, List<RequirementNameSegmentResolver> requirementNameSegmentResolvers, List<UnaryOperator<String>> requirementPatternSegmentResolvers) {
-            super(capability, requirement);
-            this.requirementNameSegmentResolvers = List.copyOf(requirementNameSegmentResolvers);
-            this.requirementPatternSegmentResolvers = List.copyOf(requirementPatternSegmentResolvers);
-        }
-
-        @Override
-        public void addCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... values) {
-            String dependentName = this.resolveDependentName(context);
-            for (String value : values) {
-                // Do not register requirement if undefined
-                if (value != null) {
-                    context.registerAdditionalCapabilityRequirement(this.resolveRequirementName(context, resource, value), dependentName, attributeName);
-                }
-            }
-        }
-
-        @Override
-        public void removeCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... values) {
-            String dependentName = this.resolveDependentName(context);
-            for (String value : values) {
-                // We did not register a requirement if undefined
-                if (value != null) {
-                    context.deregisterCapabilityRequirement(this.resolveRequirementName(context, resource, value), dependentName, attributeName);
-                }
-            }
-        }
-
-        private String resolveRequirementName(OperationContext context, Resource resource, String value) {
-            String[] segments = new String[this.requirementNameSegmentResolvers.size()];
-            ListIterator<RequirementNameSegmentResolver> resolvers = this.requirementNameSegmentResolvers.listIterator();
-            while (resolvers.hasNext()) {
-                segments[resolvers.nextIndex()] = resolvers.next().resolve(context, resource, value);
-            }
-            return RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), segments);
+        public void removeCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... attributeValues) {
+            this.reference.removeCapabilityRequirements(context, resource, attributeName, attributeValues);
         }
 
         @Override
         public String[] getRequirementPatternSegments(String name, PathAddress address) {
-            String[] segments = new String[this.requirementPatternSegmentResolvers.size()];
-            ListIterator<UnaryOperator<String>> resolvers = this.requirementPatternSegmentResolvers.listIterator();
-            while (resolvers.hasNext()) {
-                segments[resolvers.nextIndex()] = resolvers.next().apply(name);
-            }
-            return segments;
+            return this.reference.getRequirementPatternSegments(name, address);
         }
-    }
 
-    interface RequirementNameSegmentResolver {
-        String resolve(OperationContext context, Resource resource, String value);
+        @Override
+        public int hashCode() {
+            return this.reference.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            return this.reference.equals(object);
+        }
     }
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceRecorder.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceRecorder.java
@@ -5,6 +5,7 @@
 
 package org.wildfly.subsystem.resource.capability;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -35,7 +36,7 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> Builder<T> builder(RuntimeCapability<Void> capability, UnaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement));
     }
 
     /**
@@ -47,7 +48,7 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> ParentPathProvider<T> builder(RuntimeCapability<Void> capability, BinaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement));
     }
 
     /**
@@ -59,7 +60,7 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> GrandparentPathProvider<T> builder(RuntimeCapability<Void> capability, TernaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement));
     }
 
     /**
@@ -71,7 +72,7 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> GreatGrandparentPathProvider<T> builder(RuntimeCapability<Void> capability, QuaternaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement));
     }
 
     @Deprecated(forRemoval = true, since = "26.0.0")
@@ -188,7 +189,7 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
     @Deprecated(forRemoval = true, since = "26.0.0")
     class DefaultBuilder<T> extends CapabilityReference.DefaultBuilder<T> implements GreatGrandparentPathProvider<T>, GrandparentPathProvider<T>, ParentPathProvider<T>, Builder<T> {
 
-        DefaultBuilder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement) {
+        DefaultBuilder(RuntimeCapability<Void> capability, NaryServiceDescriptor<T> requirement) {
             super(capability, requirement);
         }
 
@@ -243,7 +244,7 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
         }
 
         @Override
-        public String[] resolve(OperationContext context, Resource resource, String value) {
+        public Map.Entry<String, String[]> resolve(OperationContext context, Resource resource, String value) {
             return this.reference.resolve(context, resource, value);
         }
 

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceRecorder.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceRecorder.java
@@ -243,6 +243,11 @@ public interface CapabilityReferenceRecorder<T> extends CapabilityReference<T> {
         }
 
         @Override
+        public String[] resolve(OperationContext context, Resource resource, String value) {
+            return this.reference.resolve(context, resource, value);
+        }
+
+        @Override
         public RuntimeCapability<Void> getDependent() {
             return this.reference.getDependent();
         }

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceResolver.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource.capability;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.registry.Resource;
+import org.wildfly.service.descriptor.ServiceDescriptor;
+
+/**
+ * Resolves a capability reference.
+ * @param <T> the requirement type
+ */
+public interface CapabilityReferenceResolver<T> {
+    /**
+     * Returns the service descriptor required by the dependent capability.
+     * @return a service descriptor
+     */
+    ServiceDescriptor<T> getRequirement();
+
+    /**
+     * Resolves the dynamic segments of this capability reference.
+     * @param context an operation context
+     * @param resource the resource
+     * @param value the attribute value
+     * @return an array of dynamic name segments
+     */
+    String[] resolve(OperationContext context, Resource resource, String value);
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceResolver.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceResolver.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.subsystem.resource.capability;
 
+import java.util.Map;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.registry.Resource;
 import org.wildfly.service.descriptor.ServiceDescriptor;
@@ -25,7 +27,7 @@ public interface CapabilityReferenceResolver<T> {
      * @param context an operation context
      * @param resource the resource
      * @param value the attribute value
-     * @return an array of dynamic name segments
+     * @return a map entry containing the requirement name and array of dynamic name segments
      */
-    String[] resolve(OperationContext context, Resource resource, String value);
+    Map.Entry<String, String[]> resolve(OperationContext context, Resource resource, String value);
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/NaryServiceDescriptor.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/NaryServiceDescriptor.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource.capability;
+
+import java.util.Map;
+
+import org.wildfly.common.Assert;
+import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+import org.wildfly.service.descriptor.NullaryServiceDescriptor;
+import org.wildfly.service.descriptor.QuaternaryServiceDescriptor;
+import org.wildfly.service.descriptor.ServiceDescriptor;
+import org.wildfly.service.descriptor.TernaryServiceDescriptor;
+import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+
+/**
+ * A variable segment service descriptor.
+ * @param <T> the service type
+ */
+interface NaryServiceDescriptor<T> extends ServiceDescriptor<T> {
+
+    /**
+     * Resolves the specified reference segments.
+     * @param references a number of reference segments.
+     * @return a map entry of name and segments.
+     */
+    Map.Entry<String, String[]> resolve(String[] references);
+
+    static <T> NaryServiceDescriptor<T> of(NullaryServiceDescriptor<T> descriptor) {
+        return new NaryServiceDescriptor<>() {
+            @Override
+            public String getName() {
+                return descriptor.getName();
+            }
+
+            @Override
+            public Class<T> getType() {
+                return descriptor.getType();
+            }
+
+            @Override
+            public <U extends T> NaryServiceDescriptor<U> asType(Class<U> type) {
+                return of(descriptor.asType(type));
+            }
+
+            @Override
+            public Map.Entry<String, String[]> resolve(String[] references) {
+                Assert.checkArrayBounds(references, 0, 0);
+                return descriptor.resolve();
+            }
+        };
+    }
+
+    static <T> NaryServiceDescriptor<T> of(UnaryServiceDescriptor<T> descriptor) {
+        return new NaryServiceDescriptor<>() {
+            @Override
+            public String getName() {
+                return descriptor.getName();
+            }
+
+            @Override
+            public Class<T> getType() {
+                return descriptor.getType();
+            }
+
+            @Override
+            public <U extends T> NaryServiceDescriptor<U> asType(Class<U> type) {
+                return of(descriptor.asType(type));
+            }
+
+            @Override
+            public Map.Entry<String, String[]> resolve(String[] references) {
+                Assert.checkArrayBounds(references, 0, 1);
+                return descriptor.resolve(references[0]);
+            }
+        };
+    }
+
+    static <T> NaryServiceDescriptor<T> of(BinaryServiceDescriptor<T> descriptor) {
+        return new NaryServiceDescriptor<>() {
+            @Override
+            public String getName() {
+                return descriptor.getName();
+            }
+
+            @Override
+            public Class<T> getType() {
+                return descriptor.getType();
+            }
+
+            @Override
+            public <U extends T> NaryServiceDescriptor<U> asType(Class<U> type) {
+                return of(descriptor.asType(type));
+            }
+
+            @Override
+            public Map.Entry<String, String[]> resolve(String[] references) {
+                Assert.checkArrayBounds(references, 0, 2);
+                return descriptor.resolve(references[0], references[1]);
+            }
+        };
+    }
+
+    static <T> NaryServiceDescriptor<T> of(TernaryServiceDescriptor<T> descriptor) {
+        return new NaryServiceDescriptor<>() {
+            @Override
+            public String getName() {
+                return descriptor.getName();
+            }
+
+            @Override
+            public Class<T> getType() {
+                return descriptor.getType();
+            }
+
+            @Override
+            public <U extends T> NaryServiceDescriptor<U> asType(Class<U> type) {
+                return of(descriptor.asType(type));
+            }
+
+            @Override
+            public Map.Entry<String, String[]> resolve(String[] references) {
+                Assert.checkArrayBounds(references, 0, 3);
+                return descriptor.resolve(references[0], references[1], references[2]);
+            }
+        };
+    }
+
+    static <T> NaryServiceDescriptor<T> of(QuaternaryServiceDescriptor<T> descriptor) {
+        return new NaryServiceDescriptor<>() {
+            @Override
+            public String getName() {
+                return descriptor.getName();
+            }
+
+            @Override
+            public Class<T> getType() {
+                return descriptor.getType();
+            }
+
+            @Override
+            public <U extends T> NaryServiceDescriptor<U> asType(Class<U> type) {
+                return of(descriptor.asType(type));
+            }
+
+            @Override
+            public Map.Entry<String, String[]> resolve(String[] references) {
+                Assert.checkArrayBounds(references, 0, 4);
+                return descriptor.resolve(references[0], references[1], references[2], references[3]);
+            }
+        };
+    }
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReference.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReference.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.subsystem.resource.capability;
+
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.capability.BinaryCapabilityNameResolver;
+import org.jboss.as.controller.capability.QuaternaryCapabilityNameResolver;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.TernaryCapabilityNameResolver;
+import org.jboss.as.controller.capability.UnaryCapabilityNameResolver;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+import org.wildfly.service.descriptor.NullaryServiceDescriptor;
+import org.wildfly.service.descriptor.QuaternaryServiceDescriptor;
+import org.wildfly.service.descriptor.ServiceDescriptor;
+import org.wildfly.service.descriptor.TernaryServiceDescriptor;
+import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+import org.wildfly.subsystem.resource.ResourceModelResolver;
+
+/**
+ * A {@link CapabilityReference} specialization that records requirements of a resource, rather than an attribute.
+ * @param <T> the requirement type
+ * @author Paul Ferraro
+ */
+public interface ResourceCapabilityReference<T> extends CapabilityReference<T> {
+
+    /**
+     * Returns the resolver of the requirement name from a path address.
+     * @return a requirement name resolver
+     */
+    Function<PathAddress, String[]> getRequirementNameResolver();
+
+    /**
+     * Registers capability requirements for the specified resource.
+     * @param context the context
+     * @param resource the resource on which requirements are gathered
+     */
+    void addCapabilityRequirements(OperationContext context, Resource resource);
+
+    /**
+     * Unregisters capability requirements for the specified resource.
+     * @param context the context
+     * @param resource the resource on which requirements were gathered
+     */
+    void removeCapabilityRequirements(OperationContext context, Resource resource);
+
+    @Override
+    default void addCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... attributeValues) {
+        this.addCapabilityRequirements(context, resource);
+    }
+
+    @Override
+    default void removeCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... attributeValues) {
+        this.removeCapabilityRequirements(context, resource);
+    }
+
+    /**
+     * Creates a builder for a new reference between the specified capability and the specified requirement.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     */
+    static <T> Builder<T> builder(RuntimeCapability<Void> capability, NullaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement, ResourceCapabilityServiceDescriptorReference.EMPTY_RESOLVER);
+    }
+
+    /**
+     * Creates a builder for a new reference between the specified capability and the specified requirement.
+     * By default, the requirement name will resolve against the path of the current resource.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     */
+    static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, UnaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement, UnaryCapabilityNameResolver.DEFAULT);
+    }
+
+    /**
+     * Creates a builder for a new reference between the specified capability and the specified requirement.
+     * By default, the requirement name will resolve against the paths of the parent and current resources, respectively.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     * @param requirementNameResolver function for resolving the dynamic components of the requirement name
+     */
+    static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, BinaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement, BinaryCapabilityNameResolver.PARENT_CHILD);
+    }
+
+    /**
+     * Creates a builder for a new reference between the specified capability and the specified requirement.
+     * By default, the requirement name will resolve against the paths of the grandparent, parent, and current resources, respectively.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     * @param requirementNameResolver function for resolving the dynamic components of the requirement name
+     */
+    static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, TernaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement, TernaryCapabilityNameResolver.GRANDPARENT_PARENT_CHILD);
+    }
+
+    /**
+     * Creates a builder for a new reference between the specified capability and the specified requirement.
+     * By default, the requirement name will resolve against the paths of the great-grandparent, grandparent, parent, and current resources, respectively.
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     * @param requirementNameResolver function for resolving the dynamic components of the requirement name
+     */
+    static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, QuaternaryServiceDescriptor<T> requirement) {
+        return new DefaultBuilder<>(capability, requirement, QuaternaryCapabilityNameResolver.GREATGRANDPARENT_GRANDPARENT_PARENT_CHILD);
+    }
+
+    interface Builder<T> {
+        /**
+         * Only reference the provided capability if value of the specified attribute complies with the specified predicate.
+         * @param attribute an attribute of the resource to use for conditional registration
+         * @param predicate conditionally determines whether to require this capability, depending on the resolve value of the specified attribute
+         * @return a reference to this builder
+         */
+        default Builder<T> when(AttributeDefinition attribute, Predicate<ModelNode> predicate) {
+            return this.when(attribute::resolveModelAttribute, predicate);
+        }
+
+        /**
+         * Only reference the provided capability if value of the specified attribute complies with the specified predicate.
+         * @param resolver a resolver of the resource to use for conditional registration
+         * @param predicate conditionally determines whether to require this capability, depending on the resolve value
+         * @return a reference to this builder
+         */
+        <V> Builder<T> when(ResourceModelResolver<V> resolver, Predicate<V> predicate);
+
+        /**
+         * Builds the configured capability reference recorder.
+         * @return a capability reference recorder
+         */
+        ResourceCapabilityReference<T> build();
+    }
+
+    interface NaryBuilder<T> extends Builder<T> {
+        /**
+         * Overrides the default requirement name resolver.
+         * @param requirementNameResolver a capability name resolver
+         * @return a reference to this builder
+         */
+        Builder<T> withRequirementNameResolver(Function<PathAddress, String[]> requirementNameResolver);
+    }
+
+    static class DefaultBuilder<T> implements NaryBuilder<T> {
+        private final RuntimeCapability<Void> capability;
+        private final ServiceDescriptor<T> requirement;
+
+        private Function<PathAddress, String[]> requirementNameResolver;
+        private BiPredicate<OperationContext, Resource> predicate = ResourceCapabilityServiceDescriptorReference.ALWAYS;
+
+        DefaultBuilder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> defaultRequirementNameResolver) {
+            this.capability = capability;
+            this.requirement = requirement;
+            this.requirementNameResolver = defaultRequirementNameResolver;
+        }
+
+        @Override
+        public Builder<T> withRequirementNameResolver(Function<PathAddress, String[]> requirementNameResolver) {
+            this.requirementNameResolver = requirementNameResolver;
+            return this;
+        }
+
+        @Override
+        public <V> Builder<T> when(ResourceModelResolver<V> resolver, Predicate<V> predicate) {
+            this.predicate = new BiPredicate<>() {
+                @Override
+                public boolean test(OperationContext context, Resource resource) {
+                    try {
+                        return predicate.test(resolver.resolve(context, resource.getModel()));
+                    } catch (OperationFailedException e) {
+                        // OFE would be due to an expression that can't be resolved right now (OperationContext.Stage.MODEL).
+                        // Very unlikely an expression is used and that it uses a resolution source not available in MODEL.
+                        return true;
+                    }
+                }
+            };
+            return this;
+        }
+
+        @Override
+        public ResourceCapabilityReference<T> build() {
+            return new ResourceCapabilityServiceDescriptorReference<>(this.capability, this.requirement, this.requirementNameResolver, this.predicate);
+        }
+    }
+
+    abstract class AbstractResourceCapabilityServiceDescriptorReference<T> extends AbstractServiceDescriptorReference<T> implements org.wildfly.subsystem.resource.capability.ResourceCapabilityReference<T> {
+        private final Function<PathAddress, String[]> requirementNameResolver;
+
+        public AbstractResourceCapabilityServiceDescriptorReference(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> requirementNameResolver) {
+            super(capability, requirement);
+            this.requirementNameResolver = requirementNameResolver;
+        }
+
+        @Override
+        public Function<PathAddress, String[]> getRequirementNameResolver() {
+            return this.requirementNameResolver;
+        }
+
+        @Override
+        public String[] getRequirementPatternSegments(String name, PathAddress address) {
+            String[] segments = this.requirementNameResolver.apply(address);
+            for (int i = 0; i < segments.length; ++i) {
+                String segment = segments[i];
+                if (segment.charAt(0) == '$') {
+                    segments[i] = segment.substring(1);
+                }
+            }
+            return segments;
+        }
+    }
+
+    class ResourceCapabilityServiceDescriptorReference<T> extends AbstractResourceCapabilityServiceDescriptorReference<T> {
+        static final Function<PathAddress, String[]> EMPTY_RESOLVER = address -> new String[0];
+        private static final BiPredicate<OperationContext, Resource> ALWAYS = (context, resource) -> true;
+
+        private final BiPredicate<OperationContext, Resource> predicate;
+
+        ResourceCapabilityServiceDescriptorReference(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> requirementNameResolver, BiPredicate<OperationContext, Resource> predicate) {
+            super(capability, requirement, requirementNameResolver);
+            this.predicate = predicate;
+        }
+
+        @Override
+        public void addCapabilityRequirements(OperationContext context, Resource resource) {
+            if (this.predicate.test(context, resource)) {
+                context.registerAdditionalCapabilityRequirement(this.resolveRequirementName(context), this.resolveDependentName(context), null);
+            }
+        }
+
+        @Override
+        public void removeCapabilityRequirements(OperationContext context, Resource resource) {
+            if (this.predicate.test(context, resource)) {
+                context.deregisterCapabilityRequirement(this.resolveRequirementName(context), this.resolveDependentName(context));
+            }
+        }
+
+        private String resolveRequirementName(OperationContext context) {
+            String[] segments = this.getRequirementNameResolver().apply(context.getCurrentAddress());
+            return (segments.length > 0) ? RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), segments) : this.getBaseRequirementName();
+        }
+    }
+}

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReference.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReference.java
@@ -231,6 +231,11 @@ public interface ResourceCapabilityReference<T> extends CapabilityReference<T> {
         }
 
         @Override
+        public String[] resolve(OperationContext context, Resource resource, String value) {
+            return this.getRequirementNameResolver().apply(context.getCurrentAddress());
+        }
+
+        @Override
         public void addCapabilityRequirements(OperationContext context, Resource resource) {
             if (this.predicate.test(context, resource)) {
                 context.registerAdditionalCapabilityRequirement(this.resolveRequirementName(context), this.resolveDependentName(context), null);
@@ -245,7 +250,7 @@ public interface ResourceCapabilityReference<T> extends CapabilityReference<T> {
         }
 
         private String resolveRequirementName(OperationContext context) {
-            String[] segments = this.getRequirementNameResolver().apply(context.getCurrentAddress());
+            String[] segments = this.resolve(context, null, null);
             return (segments.length > 0) ? RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), segments) : this.getBaseRequirementName();
         }
     }

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReferenceRecorder.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReferenceRecorder.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.BinaryCapabilityNameResolver;
 import org.jboss.as.controller.capability.QuaternaryCapabilityNameResolver;
@@ -21,9 +22,9 @@ import org.jboss.dmr.ModelNode;
 import org.wildfly.service.descriptor.BinaryServiceDescriptor;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 import org.wildfly.service.descriptor.QuaternaryServiceDescriptor;
-import org.wildfly.service.descriptor.ServiceDescriptor;
 import org.wildfly.service.descriptor.TernaryServiceDescriptor;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+import org.wildfly.subsystem.service.ServiceDependency;
 
 /**
  * A {@link CapabilityReference} specialization that records requirements of a resource, rather than an attribute.
@@ -41,7 +42,7 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> Builder<T> builder(RuntimeCapability<Void> capability, NullaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement, ResourceCapabilityReference.ResourceCapabilityServiceDescriptorReference.EMPTY_RESOLVER);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement), ResourceCapabilityReference.ResourceCapabilityServiceDescriptorReference.EMPTY_RESOLVER);
     }
 
     /**
@@ -53,7 +54,7 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, UnaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement, UnaryCapabilityNameResolver.DEFAULT);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement), UnaryCapabilityNameResolver.DEFAULT);
     }
 
     /**
@@ -66,7 +67,7 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, BinaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement, BinaryCapabilityNameResolver.PARENT_CHILD);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement), BinaryCapabilityNameResolver.PARENT_CHILD);
     }
 
     /**
@@ -79,7 +80,7 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, TernaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement, TernaryCapabilityNameResolver.GRANDPARENT_PARENT_CHILD);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement), TernaryCapabilityNameResolver.GRANDPARENT_PARENT_CHILD);
     }
 
     /**
@@ -92,7 +93,7 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
      */
     @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, QuaternaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement, QuaternaryCapabilityNameResolver.GREATGRANDPARENT_GRANDPARENT_PARENT_CHILD);
+        return new DefaultBuilder<>(capability, NaryServiceDescriptor.of(requirement), QuaternaryCapabilityNameResolver.GREATGRANDPARENT_GRANDPARENT_PARENT_CHILD);
     }
 
     @Deprecated(forRemoval = true, since = "26.0.0")
@@ -128,7 +129,7 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
     @Deprecated(forRemoval = true, since = "26.0.0")
     static class DefaultBuilder<T> extends ResourceCapabilityReference.DefaultBuilder<T> implements NaryBuilder<T> {
 
-        DefaultBuilder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> defaultRequirementNameResolver) {
+        DefaultBuilder(RuntimeCapability<Void> capability, NaryServiceDescriptor<T> requirement, Function<PathAddress, String[]> defaultRequirementNameResolver) {
             super(capability, requirement, defaultRequirementNameResolver);
         }
 
@@ -157,6 +158,11 @@ public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabili
         ResourceCapabilityServiceDescriptorReference(ResourceCapabilityReference<T> reference) {
             super(reference);
             this.reference = reference;
+        }
+
+        @Override
+        public ServiceDependency<T> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
+            return this.reference.resolve(context, model);
         }
 
         @Override

--- a/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReferenceRecorder.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/resource/capability/ResourceCapabilityReferenceRecorder.java
@@ -2,15 +2,14 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package org.wildfly.subsystem.resource.capability;
 
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.BinaryCapabilityNameResolver;
 import org.jboss.as.controller.capability.QuaternaryCapabilityNameResolver;
@@ -27,48 +26,22 @@ import org.wildfly.service.descriptor.TernaryServiceDescriptor;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
 
 /**
- * A {@link CapabilityReferenceRecorder} specialization that records requirements of a resource, rather than an attribute.
- * @author Paul Ferraro
+ * A {@link CapabilityReference} specialization that records requirements of a resource, rather than an attribute.
+ * @param <T> the requirement type
+ * @deprecated Replaced by {@link ResourceCapabilityReference}.
  */
-public interface ResourceCapabilityReferenceRecorder<T> extends CapabilityReferenceRecorder<T> {
-
-    /**
-     * Returns the resolver of the requirement name from a path address.
-     * @return a requirement name resolver
-     */
-    Function<PathAddress, String[]> getRequirementNameResolver();
-
-    /**
-     * Registers capability requirements for the specified resource.
-     * @param context the context
-     * @param resource the resource on which requirements are gathered
-     */
-    void addCapabilityRequirements(OperationContext context, Resource resource);
-
-    /**
-     * Unregisters capability requirements for the specified resource.
-     * @param context the context
-     * @param resource the resource on which requirements were gathered
-     */
-    void removeCapabilityRequirements(OperationContext context, Resource resource);
-
-    @Override
-    default void addCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... attributeValues) {
-        this.addCapabilityRequirements(context, resource);
-    }
-
-    @Override
-    default void removeCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... attributeValues) {
-        this.removeCapabilityRequirements(context, resource);
-    }
+@Deprecated(forRemoval = true, since = "26.0.0")
+public interface ResourceCapabilityReferenceRecorder<T> extends ResourceCapabilityReference<T> {
 
     /**
      * Creates a builder for a new reference between the specified capability and the specified requirement.
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
+     * @deprecated Superseded by {@link ResourceCapabilityReference#builder(RuntimeCapability, NullaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> Builder<T> builder(RuntimeCapability<Void> capability, NullaryServiceDescriptor<T> requirement) {
-        return new DefaultBuilder<>(capability, requirement, ResourceCapabilityServiceDescriptorReference.EMPTY_RESOLVER);
+        return new DefaultBuilder<>(capability, requirement, ResourceCapabilityReference.ResourceCapabilityServiceDescriptorReference.EMPTY_RESOLVER);
     }
 
     /**
@@ -76,7 +49,9 @@ public interface ResourceCapabilityReferenceRecorder<T> extends CapabilityRefere
      * By default, the requirement name will resolve against the path of the current resource.
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
+     * @deprecated Superseded by {@link ResourceCapabilityReference#builder(RuntimeCapability, UnaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, UnaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement, UnaryCapabilityNameResolver.DEFAULT);
     }
@@ -87,7 +62,9 @@ public interface ResourceCapabilityReferenceRecorder<T> extends CapabilityRefere
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
      * @param requirementNameResolver function for resolving the dynamic components of the requirement name
+     * @deprecated Superseded by {@link ResourceCapabilityReference#builder(RuntimeCapability, BinaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, BinaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement, BinaryCapabilityNameResolver.PARENT_CHILD);
     }
@@ -98,7 +75,9 @@ public interface ResourceCapabilityReferenceRecorder<T> extends CapabilityRefere
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
      * @param requirementNameResolver function for resolving the dynamic components of the requirement name
+     * @deprecated Superseded by {@link ResourceCapabilityReference#builder(RuntimeCapability, NullaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, TernaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement, TernaryCapabilityNameResolver.GRANDPARENT_PARENT_CHILD);
     }
@@ -109,132 +88,90 @@ public interface ResourceCapabilityReferenceRecorder<T> extends CapabilityRefere
      * @param capability the capability referencing the specified requirement
      * @param requirement the requirement of the specified capability
      * @param requirementNameResolver function for resolving the dynamic components of the requirement name
+     * @deprecated Superseded by {@link ResourceCapabilityReference#builder(RuntimeCapability, QuaternaryServiceDescriptor)}
      */
+    @Deprecated(forRemoval = true, since = "26.0.0")
     static <T> NaryBuilder<T> builder(RuntimeCapability<Void> capability, QuaternaryServiceDescriptor<T> requirement) {
         return new DefaultBuilder<>(capability, requirement, QuaternaryCapabilityNameResolver.GREATGRANDPARENT_GRANDPARENT_PARENT_CHILD);
     }
 
-    interface Builder<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface Builder<T> extends ResourceCapabilityReference.Builder<T> {
         /**
          * Only reference the provided capability if value of the specified attribute complies with the specified predicate.
          * @param attribute an attribute of the resource to use for conditional registration
          * @param predicate conditionally determines whether to require this capability, depending on the resolve value of the specified attribute
          * @return a reference to this builder
          */
+        @Override
         Builder<T> when(AttributeDefinition attribute, Predicate<ModelNode> predicate);
 
         /**
          * Builds the configured capability reference recorder.
          * @return a capability reference recorder
          */
+        @Override
         org.wildfly.subsystem.resource.capability.ResourceCapabilityReferenceRecorder<T> build();
     }
 
-    interface NaryBuilder<T> extends Builder<T> {
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    interface NaryBuilder<T> extends ResourceCapabilityReference.NaryBuilder<T>, Builder<T> {
         /**
          * Overrides the default requirement name resolver.
          * @param requirementNameResolver a capability name resolver
          * @return a reference to this builder
          */
+        @Override
         Builder<T> withRequirementNameResolver(Function<PathAddress, String[]> requirementNameResolver);
     }
 
-    static class DefaultBuilder<T> implements NaryBuilder<T> {
-        private final RuntimeCapability<Void> capability;
-        private final ServiceDescriptor<T> requirement;
-
-        private Function<PathAddress, String[]> requirementNameResolver;
-        private BiPredicate<OperationContext, Resource> predicate = ResourceCapabilityServiceDescriptorReference.ALWAYS;
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    static class DefaultBuilder<T> extends ResourceCapabilityReference.DefaultBuilder<T> implements NaryBuilder<T> {
 
         DefaultBuilder(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> defaultRequirementNameResolver) {
-            this.capability = capability;
-            this.requirement = requirement;
-            this.requirementNameResolver = defaultRequirementNameResolver;
+            super(capability, requirement, defaultRequirementNameResolver);
         }
 
         @Override
         public Builder<T> withRequirementNameResolver(Function<PathAddress, String[]> requirementNameResolver) {
-            this.requirementNameResolver = requirementNameResolver;
+            super.withRequirementNameResolver(requirementNameResolver);
             return this;
         }
 
         @Override
         public Builder<T> when(AttributeDefinition attribute, Predicate<ModelNode> predicate) {
-            this.predicate = new BiPredicate<>() {
-                @Override
-                public boolean test(OperationContext context, Resource resource) {
-                    try {
-                        return predicate.test(attribute.resolveModelAttribute(context, resource.getModel()));
-                    } catch (OperationFailedException e) {
-                        // OFE would be due to an expression that can't be resolved right now (OperationContext.Stage.MODEL).
-                        // Very unlikely an expression is used and that it uses a resolution source not available in MODEL.
-                        return true;
-                    }
-                }
-            };
+            super.when(attribute, predicate);
             return this;
         }
 
         @Override
         public org.wildfly.subsystem.resource.capability.ResourceCapabilityReferenceRecorder<T> build() {
-            return new ResourceCapabilityServiceDescriptorReference<>(this.capability, this.requirement, this.requirementNameResolver, this.predicate);
+            return new ResourceCapabilityServiceDescriptorReference<>(super.build());
         }
     }
 
-    abstract class AbstractResourceCapabilityServiceDescriptorReference<T> extends AbstractCapabilityServiceDescriptorReferenceRecorder<T> implements org.wildfly.subsystem.resource.capability.ResourceCapabilityReferenceRecorder<T> {
-        private final Function<PathAddress, String[]> requirementNameResolver;
+    @Deprecated(forRemoval = true, since = "26.0.0")
+    class ResourceCapabilityServiceDescriptorReference<T> extends CapabilityReferenceRecorder.CapabilityServiceDescriptorReferenceRecorder<T> implements org.wildfly.subsystem.resource.capability.ResourceCapabilityReferenceRecorder<T> {
+        private final ResourceCapabilityReference<T> reference;
 
-        public AbstractResourceCapabilityServiceDescriptorReference(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> requirementNameResolver) {
-            super(capability, requirement);
-            this.requirementNameResolver = requirementNameResolver;
+        ResourceCapabilityServiceDescriptorReference(ResourceCapabilityReference<T> reference) {
+            super(reference);
+            this.reference = reference;
         }
 
         @Override
         public Function<PathAddress, String[]> getRequirementNameResolver() {
-            return this.requirementNameResolver;
-        }
-
-        @Override
-        public String[] getRequirementPatternSegments(String name, PathAddress address) {
-            String[] segments = this.requirementNameResolver.apply(address);
-            for (int i = 0; i < segments.length; ++i) {
-                String segment = segments[i];
-                if (segment.charAt(0) == '$') {
-                    segments[i] = segment.substring(1);
-                }
-            }
-            return segments;
-        }
-    }
-
-    class ResourceCapabilityServiceDescriptorReference<T> extends AbstractResourceCapabilityServiceDescriptorReference<T> {
-        private static final Function<PathAddress, String[]> EMPTY_RESOLVER = address -> new String[0];
-        private static final BiPredicate<OperationContext, Resource> ALWAYS = (context, resource) -> true;
-
-        private final BiPredicate<OperationContext, Resource> predicate;
-
-        ResourceCapabilityServiceDescriptorReference(RuntimeCapability<Void> capability, ServiceDescriptor<T> requirement, Function<PathAddress, String[]> requirementNameResolver, BiPredicate<OperationContext, Resource> predicate) {
-            super(capability, requirement, requirementNameResolver);
-            this.predicate = predicate;
+            return this.reference.getRequirementNameResolver();
         }
 
         @Override
         public void addCapabilityRequirements(OperationContext context, Resource resource) {
-            if (this.predicate.test(context, resource)) {
-                context.registerAdditionalCapabilityRequirement(this.resolveRequirementName(context), this.resolveDependentName(context), null);
-            }
+            this.reference.addCapabilityRequirements(context, resource);
         }
 
         @Override
         public void removeCapabilityRequirements(OperationContext context, Resource resource) {
-            if (this.predicate.test(context, resource)) {
-                context.deregisterCapabilityRequirement(this.resolveRequirementName(context), this.resolveDependentName(context));
-            }
-        }
-
-        private String resolveRequirementName(OperationContext context) {
-            String[] segments = this.getRequirementNameResolver().apply(context.getCurrentAddress());
-            return (segments.length > 0) ? RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), segments) : this.getBaseRequirementName();
+            this.reference.removeCapabilityRequirements(context, resource);
         }
     }
 }

--- a/subsystem/src/main/java/org/wildfly/subsystem/service/ServiceDependency.java
+++ b/subsystem/src/main/java/org/wildfly/subsystem/service/ServiceDependency.java
@@ -80,21 +80,30 @@ public interface ServiceDependency<V> extends Dependency<RequirementServiceBuild
     }
 
     /**
-     * Returns a pseudo-dependency whose {@link #get()} returns the specified value.
-     * @param <T> the value type
-     * @param value a service value
-     * @return a service dependency
+     * Returns an empty pseudo-dependency whose {@link #get()} returns null.
+     * @param <V> the value type
+     * @return an empty service dependency
      */
     @SuppressWarnings("unchecked")
-    static <T> ServiceDependency<T> of(T value) {
-        return (value != null) ? new SimpleServiceDependency<>(value) : (ServiceDependency<T>) SimpleServiceDependency.NULL;
+    static <V> ServiceDependency<V> empty() {
+        return (ServiceDependency<V>) SimpleServiceDependency.EMPTY;
+    }
+
+    /**
+     * Returns a pseudo-dependency whose {@link #get()} returns the specified value.
+     * @param <V> the value type
+     * @param value a service value
+     * @return a pseudo-dependency whose {@link #get()} returns the specified value.
+     */
+    static <V> ServiceDependency<V> of(V value) {
+        return (value != null) ? new SimpleServiceDependency<>(value) : empty();
     }
 
     /**
      * Returns a pseudo-dependency whose {@link #get()} returns the value from the specified supplier.
      * @param <V> the value type
      * @param factory a service value supplier
-     * @return a service dependency
+     * @return a pseudo-dependency whose {@link #get()} returns the value from the specified supplier.
      * @throws NullPointerException if {@code supplier} was null
      */
     static <V> ServiceDependency<V> from(Supplier<V> supplier) {
@@ -109,7 +118,7 @@ public interface ServiceDependency<V> extends Dependency<RequirementServiceBuild
      * @return a service dependency
      */
     static <T> ServiceDependency<T> on(ServiceName name) {
-        return (name != null) ? new DefaultServiceDependency<>(name) : of(null);
+        return (name != null) ? new DefaultServiceDependency<>(name) : empty();
     }
 
     /**
@@ -268,7 +277,7 @@ public interface ServiceDependency<V> extends Dependency<RequirementServiceBuild
     }
 
     class SimpleServiceDependency<V> extends SimpleDependency<RequirementServiceBuilder<?>, V> implements ServiceDependency<V> {
-        static final ServiceDependency<Object> NULL = new SimpleServiceDependency<>(null);
+        static final ServiceDependency<Object> EMPTY = new SimpleServiceDependency<>(null);
 
         SimpleServiceDependency(V value) {
             super(value);

--- a/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceAttributeDefinitionTestCase.java
+++ b/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceAttributeDefinitionTestCase.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource.capability;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.RequirementServiceBuilder;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+import org.wildfly.service.descriptor.NullaryServiceDescriptor;
+import org.wildfly.service.descriptor.QuaternaryServiceDescriptor;
+import org.wildfly.service.descriptor.TernaryServiceDescriptor;
+import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+
+/**
+ * Unit test for {@link CapabilityReferenceAttributeDefinition}.
+ */
+public class CapabilityReferenceAttributeDefinitionTestCase {
+
+    @Test
+    public void testUnary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", Object.class);
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, unaryRequirement).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verifyNoInteractions(builder);
+
+        ModelNode value = new ModelNode("foo");
+        model.get(attribute.getName()).set(value);
+
+        Mockito.doReturn(value).when(context).resolveExpressions(value);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("unary", Object.class, "foo");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testUnaryWithDefault() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        NullaryServiceDescriptor<Object> nullaryRequirement = NullaryServiceDescriptor.of("nullary", Object.class);
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", nullaryRequirement);
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, unaryRequirement).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("nullary", Object.class);
+        Mockito.verifyNoMoreInteractions(builder);
+
+        ModelNode value = new ModelNode("foo");
+        model.get(attribute.getName()).set(value);
+
+        Mockito.doReturn(value).when(context).resolveExpressions(value);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("unary", Object.class, "foo");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testBinary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", Object.class);
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", Object.class);
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, unaryRequirement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, binaryRequirement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode foo = new ModelNode("foo");
+        ModelNode bar = new ModelNode("bar");
+        model.get(parentAttribute.getName()).set(foo);
+
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(foo).when(context).resolveExpressions(foo);
+        Mockito.doReturn(bar).when(context).resolveExpressions(bar);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(bar);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("binary", Object.class, "foo", "bar");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testBinaryWithDefault() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", Object.class);
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", unaryRequirement);
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, unaryRequirement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, binaryRequirement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode foo = new ModelNode("foo");
+        ModelNode bar = new ModelNode("bar");
+        model.get(parentAttribute.getName()).set(foo);
+
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(foo).when(context).resolveExpressions(foo);
+        Mockito.doReturn(bar).when(context).resolveExpressions(bar);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("unary", Object.class, "foo");
+        Mockito.verifyNoMoreInteractions(builder);
+
+        model.get(attribute.getName()).set(bar);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("binary", Object.class, "foo", "bar");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testTernary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", Object.class);
+        TernaryServiceDescriptor<Object> ternaryRequirement = TernaryServiceDescriptor.of("ternary", Object.class);
+        Function<PathAddress, PathElement> lastElement = PathAddress::getLastElement;
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, binaryRequirement).withParentPath(PathElement.pathElement("component"), lastElement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, ternaryRequirement).withGrandparentPath(PathElement.pathElement("component"), lastElement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode bar = new ModelNode("bar");
+        ModelNode baz = new ModelNode("baz");
+
+        Mockito.doReturn(PathAddress.pathAddress(List.of(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test"), PathElement.pathElement("component", "foo")))).when(context).getCurrentAddress();
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(bar).when(context).resolveExpressions(bar);
+        Mockito.doReturn(baz).when(context).resolveExpressions(baz);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verifyNoInteractions(builder);
+
+        model.get(parentAttribute.getName()).set(bar);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(baz);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("ternary", Object.class, "foo", "bar", "baz");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testTernaryWithDefault() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", Object.class);
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", unaryRequirement);
+        TernaryServiceDescriptor<Object> ternaryRequirement = TernaryServiceDescriptor.of("ternary", binaryRequirement);
+        Function<PathAddress, PathElement> lastElement = PathAddress::getLastElement;
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, binaryRequirement).withParentPath(PathElement.pathElement("component"), lastElement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, ternaryRequirement).withGrandparentPath(PathElement.pathElement("component"), lastElement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode bar = new ModelNode("bar");
+        ModelNode baz = new ModelNode("baz");
+
+        Mockito.doReturn(PathAddress.pathAddress(List.of(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test"), PathElement.pathElement("component", "foo")))).when(context).getCurrentAddress();
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(bar).when(context).resolveExpressions(bar);
+        Mockito.doReturn(baz).when(context).resolveExpressions(baz);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("unary", Object.class, "foo");
+        Mockito.verifyNoMoreInteractions(builder);
+
+        model.get(parentAttribute.getName()).set(bar);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("binary", Object.class, "foo", "bar");
+        Mockito.verifyNoMoreInteractions(builder);
+
+        model.get(attribute.getName()).set(baz);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("ternary", Object.class, "foo", "bar", "baz");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testQuaternary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        TernaryServiceDescriptor<Object> ternaryRequirement = TernaryServiceDescriptor.of("ternary", Object.class);
+        QuaternaryServiceDescriptor<Object> quaternaryRequirement = QuaternaryServiceDescriptor.of("quaternary", Object.class);
+        UnaryOperator<PathAddress> parent = PathAddress::getParent;
+        Function<PathAddress, PathElement> lastElement = PathAddress::getLastElement;
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, ternaryRequirement).withGrandparentPath(PathElement.pathElement("component"), parent.andThen(lastElement)).withParentPath(PathElement.pathElement("child"), PathAddress::getLastElement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, quaternaryRequirement).withGreatGrandparentPath(PathElement.pathElement("component"), parent.andThen(lastElement)).withGrandparentPath(PathElement.pathElement("child"), PathAddress::getLastElement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode baz = new ModelNode("baz");
+        ModelNode qux = new ModelNode("qux");
+
+        Mockito.doReturn(PathAddress.pathAddress(List.of(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test"), PathElement.pathElement("component", "foo"), PathElement.pathElement("child", "bar")))).when(context).getCurrentAddress();
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(baz).when(context).resolveExpressions(baz);
+        Mockito.doReturn(qux).when(context).resolveExpressions(qux);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verifyNoInteractions(builder);
+
+        model.get(parentAttribute.getName()).set(baz);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(qux);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("quaternary", Object.class, "foo", "bar", "baz", "qux");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testQuaternaryWithDefault() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", Object.class);
+        TernaryServiceDescriptor<Object> ternaryRequirement = TernaryServiceDescriptor.of("ternary", binaryRequirement);
+        QuaternaryServiceDescriptor<Object> quaternaryRequirement = QuaternaryServiceDescriptor.of("quaternary", ternaryRequirement);
+        UnaryOperator<PathAddress> parent = PathAddress::getParent;
+        Function<PathAddress, PathElement> lastElement = PathAddress::getLastElement;
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, ternaryRequirement).withGrandparentPath(PathElement.pathElement("component"), parent.andThen(lastElement)).withParentPath(PathElement.pathElement("child"), PathAddress::getLastElement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, quaternaryRequirement).withGreatGrandparentPath(PathElement.pathElement("component"), parent.andThen(lastElement)).withGrandparentPath(PathElement.pathElement("child"), PathAddress::getLastElement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode baz = new ModelNode("baz");
+        ModelNode qux = new ModelNode("qux");
+
+        Mockito.doReturn(PathAddress.pathAddress(List.of(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test"), PathElement.pathElement("component", "foo"), PathElement.pathElement("child", "bar")))).when(context).getCurrentAddress();
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(baz).when(context).resolveExpressions(baz);
+        Mockito.doReturn(qux).when(context).resolveExpressions(qux);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("binary", Object.class, "foo", "bar");
+        Mockito.verifyNoMoreInteractions(builder);
+
+        model.get(parentAttribute.getName()).set(baz);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("ternary", Object.class, "foo", "bar", "baz");
+        Mockito.verifyNoMoreInteractions(builder);
+
+        model.get(attribute.getName()).set(qux);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("quaternary", Object.class, "foo", "bar", "baz", "qux");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+}

--- a/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceListAttributeDefinitionTestCase.java
+++ b/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceListAttributeDefinitionTestCase.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.subsystem.resource.capability;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.RequirementServiceBuilder;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+import org.wildfly.service.descriptor.QuaternaryServiceDescriptor;
+import org.wildfly.service.descriptor.TernaryServiceDescriptor;
+import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+
+/**
+ * Unit test for {@link CapabilityReferenceAttributeDefinition}.
+ */
+public class CapabilityReferenceListAttributeDefinitionTestCase {
+
+    @Test
+    public void testUnary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", Object.class);
+        CapabilityReferenceListAttributeDefinition<Object> attribute = new CapabilityReferenceListAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, unaryRequirement).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode foo = new ModelNode("foo");
+        ModelNode bar = new ModelNode("bar");
+        ModelNode list = new ModelNode();
+        list.add(foo);
+        list.add(bar);
+
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+        Mockito.doReturn(list).when(context).resolveExpressions(list);
+
+        attribute.resolve(context, model).accept(builder);
+
+        verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(list);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("unary", Object.class, "foo");
+        Mockito.verify(builder).requiresCapability("unary", Object.class, "bar");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testBinary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        UnaryServiceDescriptor<Object> unaryRequirement = UnaryServiceDescriptor.of("unary", Object.class);
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", Object.class);
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, unaryRequirement).build()).setRequired(false).build();
+        CapabilityReferenceListAttributeDefinition<Object> attribute = new CapabilityReferenceListAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, binaryRequirement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode foo = new ModelNode("foo");
+        ModelNode bar = new ModelNode("bar");
+        ModelNode baz = new ModelNode("baz");
+        ModelNode list = new ModelNode();
+        list.add(bar);
+        list.add(baz);
+        model.get(parentAttribute.getName()).set(foo);
+
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(foo).when(context).resolveExpressions(foo);
+        Mockito.doReturn(list).when(context).resolveExpressions(list);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(list);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("binary", Object.class, "foo", "bar");
+        Mockito.verify(builder).requiresCapability("binary", Object.class, "foo", "baz");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testTernary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        BinaryServiceDescriptor<Object> binaryRequirement = BinaryServiceDescriptor.of("binary", Object.class);
+        TernaryServiceDescriptor<Object> ternaryRequirement = TernaryServiceDescriptor.of("ternary", Object.class);
+        Function<PathAddress, PathElement> lastElement = PathAddress::getLastElement;
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("parent-attribute", CapabilityReference.builder(capability, binaryRequirement).withParentPath(PathElement.pathElement("component"), lastElement).build()).setRequired(false).build();
+        CapabilityReferenceListAttributeDefinition<Object> attribute = new CapabilityReferenceListAttributeDefinition.Builder<>("attribute", CapabilityReference.builder(capability, ternaryRequirement).withGrandparentPath(PathElement.pathElement("component"), lastElement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode bar = new ModelNode("bar");
+        ModelNode baz = new ModelNode("baz");
+        ModelNode qux = new ModelNode("qux");
+        ModelNode list = new ModelNode();
+        list.add(baz);
+        list.add(qux);
+
+        Mockito.doReturn(PathAddress.pathAddress(List.of(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test"), PathElement.pathElement("component", "foo")))).when(context).getCurrentAddress();
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(bar).when(context).resolveExpressions(bar);
+        Mockito.doReturn(list).when(context).resolveExpressions(list);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        model.get(parentAttribute.getName()).set(bar);
+
+        attribute.resolve(context, model).accept(builder);
+
+        verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(list);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("ternary", Object.class, "foo", "bar", "baz");
+        Mockito.verify(builder).requiresCapability("ternary", Object.class, "foo", "bar", "qux");
+        Mockito.verifyNoMoreInteractions(builder);
+    }
+
+    @Test
+    public void testQuaternary() throws OperationFailedException {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of("capability").build();
+        TernaryServiceDescriptor<Object> ternaryRequirement = TernaryServiceDescriptor.of("ternary", Object.class);
+        QuaternaryServiceDescriptor<Object> quaternaryRequirement = QuaternaryServiceDescriptor.of("quaternary", Object.class);
+        UnaryOperator<PathAddress> parent = PathAddress::getParent;
+        Function<PathAddress, PathElement> lastElement = PathAddress::getLastElement;
+        CapabilityReferenceAttributeDefinition<Object> parentAttribute = new CapabilityReferenceAttributeDefinition.Builder<>("baz-attribute", CapabilityReference.builder(capability, ternaryRequirement).withGrandparentPath(PathElement.pathElement("component"), parent.andThen(lastElement)).withParentPath(PathElement.pathElement("child"), PathAddress::getLastElement).build()).setRequired(false).build();
+        CapabilityReferenceAttributeDefinition<Object> attribute = new CapabilityReferenceAttributeDefinition.Builder<>("qux-attribute", CapabilityReference.builder(capability, quaternaryRequirement).withGreatGrandparentPath(PathElement.pathElement("component"), parent.andThen(lastElement)).withGrandparentPath(PathElement.pathElement("child"), PathAddress::getLastElement).withParentAttribute(parentAttribute).build()).setRequired(false).build();
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        RequirementServiceBuilder<?> builder = Mockito.mock(RequirementServiceBuilder.class);
+        ModelNode model = new ModelNode();
+        ModelNode undefined = new ModelNode();
+        ModelNode value = new ModelNode("qux");
+        ModelNode parentValue = new ModelNode("baz");
+
+        Mockito.doReturn(PathAddress.pathAddress(List.of(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "test"), PathElement.pathElement("component", "foo"), PathElement.pathElement("child", "bar")))).when(context).getCurrentAddress();
+        Mockito.doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
+        Mockito.doReturn(model).when(resource).getModel();
+        Mockito.doReturn(value).when(context).resolveExpressions(value);
+        Mockito.doReturn(parentValue).when(context).resolveExpressions(parentValue);
+        Mockito.doReturn(undefined).when(context).resolveExpressions(undefined);
+
+        attribute.resolve(context, model).accept(builder);
+
+        verifyNoInteractions(builder);
+
+        model.get(parentAttribute.getName()).set(parentValue);
+
+        attribute.resolve(context, model).accept(builder);
+
+        verifyNoInteractions(builder);
+
+        model.get(attribute.getName()).set(value);
+
+        attribute.resolve(context, model).accept(builder);
+
+        Mockito.verify(builder).requiresCapability("quaternary", Object.class, "foo", "bar", "baz", "qux");
+    }
+}

--- a/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceTestCase.java
+++ b/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceTestCase.java
@@ -42,7 +42,8 @@ public class CapabilityReferenceTestCase {
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
-        Assert.assertSame(requirement, recorder.getRequirement());
+        Assert.assertSame(requirement.getName(), recorder.getRequirement().getName());
+        Assert.assertSame(requirement.getType(), recorder.getRequirement().getType());
         Assert.assertEquals(requirement.getName(), recorder.getBaseRequirementName());
 
         PathAddress address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "test"), PathElement.pathElement("component", "foo"));
@@ -100,7 +101,8 @@ public class CapabilityReferenceTestCase {
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
-        Assert.assertSame(requirement, recorder.getRequirement());
+        Assert.assertSame(requirement.getName(), recorder.getRequirement().getName());
+        Assert.assertSame(requirement.getType(), recorder.getRequirement().getType());
         Assert.assertEquals(requirement.getName(), recorder.getBaseRequirementName());
 
         PathAddress address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "test"), PathElement.pathElement("component", "foo"));
@@ -162,7 +164,8 @@ public class CapabilityReferenceTestCase {
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
-        Assert.assertSame(requirement, recorder.getRequirement());
+        Assert.assertSame(requirement.getName(), recorder.getRequirement().getName());
+        Assert.assertSame(requirement.getType(), recorder.getRequirement().getType());
         Assert.assertEquals(requirement.getName(), recorder.getBaseRequirementName());
 
         PathAddress address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "test"), PathElement.pathElement("component", "foo"));
@@ -173,6 +176,7 @@ public class CapabilityReferenceTestCase {
         Resource resource = mock(Resource.class);
 
         doReturn(address).when(context).getCurrentAddress();
+        doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
         doReturn(model).when(resource).getModel();
         doAnswer(invocation -> invocation.getArgument(0)).when(context).resolveExpressions(any());
 
@@ -225,7 +229,8 @@ public class CapabilityReferenceTestCase {
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
-        Assert.assertSame(requirement, recorder.getRequirement());
+        Assert.assertSame(requirement.getName(), recorder.getRequirement().getName());
+        Assert.assertSame(requirement.getType(), recorder.getRequirement().getType());
         Assert.assertEquals(requirement.getName(), recorder.getBaseRequirementName());
 
         PathAddress address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "test"), PathElement.pathElement("component", "foo"));
@@ -287,7 +292,8 @@ public class CapabilityReferenceTestCase {
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
-        Assert.assertSame(requirement, recorder.getRequirement());
+        Assert.assertSame(requirement.getName(), recorder.getRequirement().getName());
+        Assert.assertSame(requirement.getType(), recorder.getRequirement().getType());
         Assert.assertEquals(requirement.getName(), recorder.getBaseRequirementName());
 
         PathAddress address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "test"), PathElement.pathElement("component", "foo"));
@@ -298,6 +304,7 @@ public class CapabilityReferenceTestCase {
         Resource resource = mock(Resource.class);
 
         doReturn(address).when(context).getCurrentAddress();
+        doReturn(resource).when(context).readResource(PathAddress.EMPTY_ADDRESS, false);
         doAnswer(invocation -> invocation.getArgument(0)).when(context).resolveExpressions(any());
         doReturn(model).when(resource).getModel();
 

--- a/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceTestCase.java
+++ b/subsystem/src/test/java/org/wildfly/subsystem/resource/capability/CapabilityReferenceTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.subsystem.resource.capabilty;
+package org.wildfly.subsystem.resource.capability;
 
 import static org.mockito.Mockito.*;
 
@@ -26,12 +26,11 @@ import org.wildfly.service.descriptor.BinaryServiceDescriptor;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 import org.wildfly.service.descriptor.TernaryServiceDescriptor;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
-import org.wildfly.subsystem.resource.capability.CapabilityReferenceRecorder;
 
 /**
- * Unit test for {@link CapabilityReferenceRecorder}.
+ * Unit test for {@link CapabilityReference}.
  */
-public class CapabilityReferenceRecorderTestCase {
+public class CapabilityReferenceTestCase {
 
     @Test
     public void testUnary() {
@@ -39,7 +38,7 @@ public class CapabilityReferenceRecorderTestCase {
         NullaryServiceDescriptor<Object> descriptor = NullaryServiceDescriptor.of("capability", Object.class);
         RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(descriptor).build();
         UnaryServiceDescriptor<Object> requirement = UnaryServiceDescriptor.of("requirement", Object.class);
-        CapabilityReferenceRecorder<Object> recorder = CapabilityReferenceRecorder.builder(capability, requirement).build();
+        CapabilityReference<Object> recorder = CapabilityReference.builder(capability, requirement).build();
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
@@ -97,7 +96,7 @@ public class CapabilityReferenceRecorderTestCase {
         UnaryServiceDescriptor<Object> descriptor = UnaryServiceDescriptor.of("capability", Object.class);
         RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(descriptor).build();
         UnaryServiceDescriptor<Object> requirement = UnaryServiceDescriptor.of("requirement", Object.class);
-        CapabilityReferenceRecorder<Object> recorder = CapabilityReferenceRecorder.builder(capability, requirement).build();
+        CapabilityReference<Object> recorder = CapabilityReference.builder(capability, requirement).build();
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
@@ -159,7 +158,7 @@ public class CapabilityReferenceRecorderTestCase {
         NullaryServiceDescriptor<Object> descriptor = NullaryServiceDescriptor.of("capability", Object.class);
         RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(descriptor).build();
         BinaryServiceDescriptor<Object> requirement = BinaryServiceDescriptor.of("requirement", Object.class);
-        CapabilityReferenceRecorder<Object> recorder = CapabilityReferenceRecorder.builder(capability, requirement).withParentAttribute(parentAttribute).build();
+        CapabilityReference<Object> recorder = CapabilityReference.builder(capability, requirement).withParentAttribute(parentAttribute).build();
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
@@ -222,7 +221,7 @@ public class CapabilityReferenceRecorderTestCase {
         NullaryServiceDescriptor<Object> descriptor = NullaryServiceDescriptor.of("capability", Object.class);
         RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(descriptor).build();
         BinaryServiceDescriptor<Object> requirement = BinaryServiceDescriptor.of("requirement", Object.class);
-        CapabilityReferenceRecorder<Object> recorder = CapabilityReferenceRecorder.builder(capability, requirement).withParentPath(PathElement.pathElement("component")).build();
+        CapabilityReference<Object> recorder = CapabilityReference.builder(capability, requirement).withParentPath(PathElement.pathElement("component")).build();
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());
@@ -284,7 +283,7 @@ public class CapabilityReferenceRecorderTestCase {
         NullaryServiceDescriptor<Object> descriptor = NullaryServiceDescriptor.of("capability", Object.class);
         RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(descriptor).build();
         TernaryServiceDescriptor<Object> requirement = TernaryServiceDescriptor.of("requirement", Object.class);
-        CapabilityReferenceRecorder<Object> recorder = CapabilityReferenceRecorder.builder(capability, requirement).withGrandparentPath(PathElement.pathElement("component"), PathAddress::getLastElement).withParentAttribute(parentAttribute).build();
+        CapabilityReference<Object> recorder = CapabilityReference.builder(capability, requirement).withGrandparentPath(PathElement.pathElement("component"), PathAddress::getLastElement).withParentAttribute(parentAttribute).build();
 
         Assert.assertSame(capability, recorder.getDependent());
         Assert.assertEquals(capability.getName(), recorder.getBaseDependentName());


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6663

e.g.
```java
static CapabilityReferenceAttributeDefinition<Foo> FOO = new CapabilityReferenceAttributeDefinition.Builder("foo", CapabilityReference.builder(CAPABILITY, Foo.SERVICE_DESCRIPTOR).build()).build();

static CapabilityReferenceListAttributeDefinition<Bar> BAR = new CapabilityReferenceListAttributeDefinition.Builder("bar", CapabilityReference.builder(CAPABILITY, Bar.SERVICE_DESCRIPTOR).build()).build();
```

Within an operation runtime handler, we can use the context of the capability reference to resolve our attribute from the model directly to a ServiceDependency:

```java
ServiceDependency<Foo> foo = FOO.resolve(context, model);

ServiceDependency<List<Bar>> bars = BAR.resolve(context, model);
```

If FOO is not required, the resulting ServiceDependency will either return a null, or, if the service descriptor provides alternate default resolution, will result to the default value.
Similarly, as a multi-value attribute, BAR resolves to a service dependency providing an empty list if not required.