### PR TITLE
[WFCORE-6952] Upgrade WildFly Elytron to 2.5.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.5.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.5.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.0.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6952


        Release Notes - WildFly Elytron - Version 2.5.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2789'>ELY-2789</a>] -         OIDCSecurityContext deserialization issue
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2796'>ELY-2796</a>] -         Release WildFly Elytron 2.5.1.Final
</li>
</ul>
                                                                                                                                                    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2775'>ELY-2775</a>] -         Rename the wildfly-ssl-test-config-v*.xml Files
</li>
</ul>
                                                                                                