### PR TITLE
[25.x][WFCORE-6953] org.bouncycastle.bcpg JBoss Modules module requires jav…

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpg/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcpg/main/module.xml
@@ -18,5 +18,6 @@
     <dependencies>
         <module name="org.bouncycastle.bcprov"/>
         <module name="org.bouncycastle.bcutil"/>
+        <module name="java.logging"/>
     </dependencies>
 </module>


### PR DESCRIPTION
…a.logging as a dependency

#6131 backporting to `25.x` so it can be released with WIldFly 33.0.1.Final

Jira issue: https://issues.redhat.com/browse/WFCORE-6953

