### PR TITLE
[UNDERTOW-6958] Upgrade Undertow to 2.3.16.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.112.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.2</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.15.Final</version.io.undertow>
+        <version.io.undertow>2.3.16.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6958


        Release Notes - Undertow - Version 2.3.16.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2256'>UNDERTOW-2256</a>] -         Resource predicate presentation differs depending on how it is set up
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2312'>UNDERTOW-2312</a>] -         multibytes language in URL request to http/https are broken in EAP access log.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2381'>UNDERTOW-2381</a>] -         Invalid/benevolent hpack decoding of huffman-encoded string literal with EOS symbol
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2424'>UNDERTOW-2424</a>] -         Undertow produces malformed Http/1.1 responses under heavy concurrent load
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2425'>UNDERTOW-2425</a>] -         io.undertow.servlet.spec.ServletPrintWriter.close() high CPU when encoding characters on previously errored writer
</li>
</ul>
                                                                                                                                                                                                                                                                            