### PR TITLE
[WFCORE-6722] Standardize the error message shown when the server is launched with an valid but empty option

### DIFF
--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -220,7 +220,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        STDERR.println(ServerLogger.ROOT_LOGGER.noArgValue(arg));
+                        STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                         usage(productConfig);
                         return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
@@ -272,7 +272,7 @@ public final class Main {
                     startModeSet = true;
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        STDERR.println(ServerLogger.ROOT_LOGGER.noArgValue(arg));
+                        STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                         usage(productConfig);
                         return new ServerEnvironmentWrapper(ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
@@ -295,7 +295,7 @@ public final class Main {
                 } else if (arg.startsWith(CommandLineConstants.GRACEFUL_STARTUP)) {
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        STDERR.println(ServerLogger.ROOT_LOGGER.noArgValue(arg));
+                        STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                         usage(productConfig);
                         return new ServerEnvironmentWrapper(ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }


### PR DESCRIPTION
Hello,
This PR is fixing the following issue:

https://issues.redhat.com/browse/WFCORE-6722

It is trying to unify error messages when no value was specified for an option.