### PR TITLE
[WFCORE-6960]: Promote Simple config export for a server as an attachment from COMMUNITY to DEFAULT.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/XmlFileMarshallingHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/XmlFileMarshallingHandler.java
@@ -9,6 +9,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUI
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.UUID;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -18,7 +19,6 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
-import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -36,7 +36,6 @@ public class XmlFileMarshallingHandler extends AbstractXmlMarshallingHandler {
             .setReplyParameters(new SimpleAttributeDefinitionBuilder(UUID, ModelType.STRING, false).build())
             .setReadOnly()
             .setRuntimeOnly()
-            .setStability(Stability.COMMUNITY)
             .build();
 
     public XmlFileMarshallingHandler(final ConfigurationPersister configPersister) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -23,6 +23,7 @@ import org.junit.runners.Suite;
         HostSuspendResumeTestCase.class,
         SyncModelOperationTestCase.class,
         ManagementReadXmlTestCase.class,
+        ManagementReadXmlAsFileTestCase.class,
         HostReloadProxyTestCase.class,
         AuditLogTestCase.class,
         ReloadWithConfigTestCase.class,


### PR DESCRIPTION
* Adding more test using the CLI.
* Moving from COMMUNITY to DEFAULT
* Renaming the ManagementReadXmlCommunityTestCase to ManagementReadXmlAsFileTestCase.

Jira: https://issues.redhat.com/browse/WFCORE-6960
Proposal: https://github.com/wildfly/wildfly-proposals/pull/594

