### PR TITLE
[25.x][WFCORE-6968] Upgrade WildFly Elytron to 2.5.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.5.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.5.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.0.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6968

Upstream PR: https://github.com/wildfly/wildfly-core/pull/6150