### PR TITLE
[WFCORE-6972] The standard configuration files used for testsuite/domain should not include community namespaces.

### DIFF
--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -81,7 +81,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-            <subsystem xmlns="urn:wildfly:elytron:community:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <subsystem xmlns="urn:wildfly:elytron:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
                 <providers>
                     <aggregate-providers name="combined-providers">
                         <providers name="elytron"/>
@@ -219,7 +219,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
-            <subsystem xmlns="urn:wildfly:elytron:community:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <subsystem xmlns="urn:wildfly:elytron:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
                 <providers>
                     <aggregate-providers name="combined-providers">
                         <providers name="elytron"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-primary.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-primary.xml
@@ -135,7 +135,7 @@
 
     <profile>
         <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-        <subsystem xmlns="urn:wildfly:elytron:community:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+        <subsystem xmlns="urn:wildfly:elytron:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
             <providers>
                 <aggregate-providers name="combined-providers">
                     <providers name="elytron"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-secondary.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secondary.xml
@@ -116,7 +116,7 @@
 
 
     <profile>
-        <subsystem xmlns="urn:wildfly:elytron:community:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+        <subsystem xmlns="urn:wildfly:elytron:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
             <authentication-client>
                 <!-- corresponding secret: <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" /> -->
                 <authentication-configuration name="secondaryHostAConfiguration"  authentication-name="secondary" realm="ManagementRealm" sasl-mechanism-selector="DIGEST-MD5">


### PR DESCRIPTION
The use of namespaces for lower stability levels should be reserved for stability level specific tests.

https://issues.redhat.com/browse/WFCORE-6972