### PR TITLE
[WFCORE-6973][CVE-2024-7885] Upgrade Undertow to 2.3.17.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.112.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.2</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.16.Final</version.io.undertow>
+        <version.io.undertow>2.3.17.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-6973

        Release Notes - Undertow - Version 2.3.17.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2429'>UNDERTOW-2429</a>] -          CVE-2024-7885 undertow: Improper State Management in Proxy Protocol parsing causes information leakage
</li>
</ul>
                                                                                                                                                                                                                                                                            
