### PR TITLE
[WFCORE-6973] Upgrade Undertow to 2.3.17.Final - fixing duplicity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,6 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.111.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.0</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.15.Final</version.io.undertow>
         <version.io.undertow>2.3.17.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6973