### PR TITLE
[WFCORE-6999] Upgrade commons-lang3 from 3.15.0 to 3.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.commons-cli>1.9.0</version.commons-cli>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-daemon>1.3.4</version.commons-daemon>
-        <version.commons-lang3>3.15.0</version.commons-lang3>
+        <version.commons-lang3>3.17.0</version.commons-lang3>
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.113.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.2</version.io.smallrye.jandex>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6999

Note: WildFly Core drives the commons-lang3 version used in WildFly Full.
The uses of this library are in Artemis, Elytron tool, and the WS stack (CXF and Apache Velocity used by CXF).