### PR TITLE
[WFCORE-7006] Upgrade WildFly Elytron to 2.6.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.5.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.6.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.3.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.0.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7006

        Release Notes - WildFly Elytron - Version 2.6.0.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2704'>ELY-2704</a>] -         Missing keystore password does not throw a meaningful exception
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2767'>ELY-2767</a>] -         CredentialStoreCommandTest.testGenerateKeyPairDSA fails when using Java 22
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2771'>ELY-2771</a>] -         maven-javadoc-plugin version upgrade required
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2780'>ELY-2780</a>] -         Logging in aggregaterealm changes authentication and authorization flow
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2811'>ELY-2811</a>] -         Add missing scope to dynamic-ssl pom.xml for wildfly-elytron-tests-common
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2082'>ELY-2082</a>] -         Optimise Tool Help Text
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2731'>ELY-2731</a>] -         CWE-330: Update BSDUnixDESCryptPasswordImpl so that SecureRandom is used to create the salt instead of ThreadLocalRandom
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2738'>ELY-2738</a>] -         DynamicSSLTestUtils class should use CAGenerationTool to generate certificates
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2741'>ELY-2741</a>] -         Enhance TRACE logging for the EXTERNAL HTTP mechanism
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2778'>ELY-2778</a>] -         Replace string literals inside the OidcJsonConfiguration class with constants
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2805'>ELY-2805</a>] -         Revert ELY-2547 due to CI failures
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2662'>ELY-2662</a>] -         Upgrade jakarta.json:jakarta.json-api from 2.0.0 to 2.1.2
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2790'>ELY-2790</a>] -         Upgrade commons-lang3 to 3.15.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2794'>ELY-2794</a>] -         Upgrade the keycloak-services and keycloak test dependencies to the versions 23.0.7 and 25.0.2
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2795'>ELY-2795</a>] -         Upgrade io.rest-assured from 4.3.3 to 5.5.0
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2809'>ELY-2809</a>] -         Upgrade XNIO to 3.8.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2810'>ELY-2810</a>] -         Upgrade com.nimbusds:nimbus-jose-jwt to 9.37.3
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/ELY-2770'>ELY-2770</a>] -         Fix deprecation suggestion/hints
</li>
<li>[<a href='https://issues.redhat.com/browse/ELY-2777'>ELY-2777</a>] -         Also ignore the .vscode directory
</li>
</ul>
                                                                                                
