### PR TITLE
[WFCORE-7011] Use 'default' stability level when the remote host controller do not advertise its current stability level

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -502,7 +502,7 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                  * This value does not require locking during use, as {@link org.jboss.as.host.controller.mgmt.HostInfo createLocalHostHostInfo()} uses
                  * '/domain-controller', which is read-only, and '/core-service=ignored-resources/ignored-resource-type' which has handlers on
                  * add, remove and write-attribute that will place the host into reload-required.
-                 * @return
+                 * @return A ModelNode containing the metadata of the local Host Controller
                  */
                 @Override
                 public ModelNode createLocalHostInfo() {
@@ -517,7 +517,7 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                 @Override
                 public boolean applyDomainModel(final List<ModelNode> bootOperations) {
                     // Apply the model..
-                    final HostInfo info = HostInfo.fromModelNode(createLocalHostInfo(), null, productConfig);
+                    final HostInfo info = HostInfo.fromModelNode(createLocalHostInfo(), null);
                     return applyRemoteDomainModel(bootOperations, info);
                 }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -419,7 +419,7 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
 
         private synchronized void initialize(final String hostName, final ModelNode hostInfo, final ManagementRequestContext<RegistrationContext> responseChannel) {
             this.hostName = hostName;
-            this.hostInfo = HostInfo.fromModelNode(hostInfo, domainHostExcludeRegistry, domainController.getLocalHostInfo().getProductConfig());
+            this.hostInfo = HostInfo.fromModelNode(hostInfo, domainHostExcludeRegistry);
             this.responseChannel = responseChannel;
         }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostInfo.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostInfo.java
@@ -96,12 +96,12 @@ public class HostInfo implements Transformers.ResourceIgnoredTransformationRegis
         return info;
     }
 
-    public static HostInfo fromModelNode(final ModelNode hostInfo, ProductConfig productConfig) {
-        return fromModelNode(hostInfo, null, productConfig);
+    public static HostInfo fromModelNode(final ModelNode hostInfo) {
+        return fromModelNode(hostInfo, null);
     }
 
-    public static HostInfo fromModelNode(final ModelNode hostInfo, DomainHostExcludeRegistry hostIgnoreRegistry, ProductConfig productConfig) {
-        return new HostInfo(hostInfo, hostIgnoreRegistry, productConfig);
+    public static HostInfo fromModelNode(final ModelNode hostInfo, DomainHostExcludeRegistry hostIgnoreRegistry) {
+        return new HostInfo(hostInfo, hostIgnoreRegistry);
     }
 
     private final String hostName;
@@ -122,7 +122,7 @@ public class HostInfo implements Transformers.ResourceIgnoredTransformationRegis
     // GuardedBy this
     private ReadMasterDomainModelUtil.RequiredConfigurationHolder requiredConfigurationHolder;
 
-    private HostInfo(final ModelNode hostInfo, DomainHostExcludeRegistry hostIgnoreRegistry, ProductConfig productConfig) {
+    private HostInfo(final ModelNode hostInfo, DomainHostExcludeRegistry hostIgnoreRegistry) {
         hostName = hostInfo.require(NAME).asString();
         releaseVersion = hostInfo.require(RELEASE_VERSION).asString();
         releaseCodeName = hostInfo.require(RELEASE_CODENAME).asString();
@@ -134,7 +134,7 @@ public class HostInfo implements Transformers.ResourceIgnoredTransformationRegis
         remoteConnectionId = hostInfo.hasDefined(RemoteDomainConnectionService.DOMAIN_CONNECTION_ID)
                 ? hostInfo.get(RemoteDomainConnectionService.DOMAIN_CONNECTION_ID).asLong() : null;
         // Legacy hosts may return null - if so, assume default stability per our ProductConfig
-        this.stability = Optional.ofNullable(hostInfo.get(ModelDescriptionConstants.STABILITY).asStringOrNull()).map(Stability::valueOf).orElse(productConfig.getDefaultStability());
+        this.stability = Optional.ofNullable(hostInfo.get(ModelDescriptionConstants.STABILITY).asStringOrNull()).map(Stability::valueOf).orElse(Stability.DEFAULT);
 
         Set<String> domainIgnoredExtensions = null;
         Set<String> domainActiveServerGroups = null;

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadPrimaryDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadPrimaryDomainModelHandlerTestCase.java
@@ -16,6 +16,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_CODENAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WILDCARD;
 
 import java.util.Collections;
@@ -74,7 +75,7 @@ public class ReadPrimaryDomainModelHandlerTestCase {
         Assert.assertEquals("value", original.get("profile", "not-ignored", "subsystem", "thingy", "attr").asString());
         Assert.assertEquals("value", original.get("profile", "ignored", "subsystem", "thingy", "attr").asString());
 
-
+        ProductConfig productConfig = new ProductConfig("name", "version", "slot");
         ModelNode hostInfo = new ModelNode();
         hostInfo.get(NAME).set("kabirs-macbook-pro.local");
         hostInfo.get(RELEASE_VERSION).set("8.0.0.Alpha1-SNAPSHOT");
@@ -88,9 +89,10 @@ public class ReadPrimaryDomainModelHandlerTestCase {
         hostInfo.get(IGNORED_RESOURCES, EXTENSION, NAMES).add("ignored");
         hostInfo.get(IGNORE_UNUSED_CONFIG).set(false);
         hostInfo.get(INITIAL_SERVER_GROUPS).setEmptyObject();
+        hostInfo.get(STABILITY).set(productConfig.getDefaultStability().name());
         hostInfo.get("domain-connection-id").set(1361470170404L);
 
-        Resource transformedResource = transformResource(registry, resourceRoot, resourceRegistration, HostInfo.fromModelNode(hostInfo, new ProductConfig("name", "version", "slot")));
+        Resource transformedResource = transformResource(registry, resourceRoot, resourceRegistration, HostInfo.fromModelNode(hostInfo));
         ModelNode transformed = Resource.Tools.readModel(transformedResource);
 
         Assert.assertEquals("value", transformed.get("extension", "not-ignored", "attr").asString());

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
@@ -860,7 +860,7 @@ public class SyncModelServerStateTestCase extends AbstractControllerTestBase  {
                             HostInfo.createLocalHostHostInfo(hostControllerInfo,
                                     cfg,
                                     ignoredDomainResourceRegistry,
-                                    hostResource), cfg);
+                                    hostResource));
             final SyncDomainModelOperationHandler handler =
                     new SyncDomainModelOperationHandler(hostInfo, parameters);
             context.addStep(syncOperation, handler, OperationContext.Stage.MODEL, true);

--- a/host-controller/src/test/java/org/jboss/as/host/controller/mgmt/HostInfoUnitTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/mgmt/HostInfoUnitTestCase.java
@@ -47,7 +47,7 @@ public class HostInfoUnitTestCase {
         Assert.assertEquals(new ModelNode().setEmptyObject(), model.get(INITIAL_SERVER_GROUPS));
 
 
-        HostInfo testee = HostInfo.fromModelNode(model, productConfig);
+        HostInfo testee = HostInfo.fromModelNode(model);
         Assert.assertEquals("test", testee.getHostName());
         Assert.assertEquals("product", testee.getProductName());
         Assert.assertEquals("version", testee.getProductVersion());
@@ -61,7 +61,7 @@ public class HostInfoUnitTestCase {
         productConfig = new ProductConfig(null, null, "main");
         model = HostInfo.createLocalHostHostInfo(lch, productConfig, ignoredRegistry, Resource.Factory.create());
         model.get(RemoteDomainConnectionService.DOMAIN_CONNECTION_ID).set(1L);
-        testee = HostInfo.fromModelNode(model, productConfig);
+        testee = HostInfo.fromModelNode(model);
         Assert.assertNull(testee.getProductName());
         Assert.assertNull(testee.getProductVersion());
         Assert.assertNotNull(testee.getRemoteConnectionId());
@@ -132,7 +132,7 @@ public class HostInfoUnitTestCase {
 
         ModelNode model = HostInfo.createLocalHostHostInfo(lch, productConfig, ignoredRegistry, Resource.Factory.create());
 
-        HostInfo testee = HostInfo.fromModelNode(model, productConfig);
+        HostInfo testee = HostInfo.fromModelNode(model);
 
         Assert.assertTrue(testee.isResourceTransformationIgnored(PathAddress.pathAddress(PathElement.pathElement("wildcard", "ignored"))));
         Assert.assertTrue(testee.isResourceTransformationIgnored(PathAddress.pathAddress(PathElement.pathElement("list", "ignored"))));

--- a/server/src/test/java/org/jboss/as/server/ServerEnvironmentTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/ServerEnvironmentTestCase.java
@@ -7,9 +7,8 @@ package org.jboss.as.server;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.jboss.as.server.ServerEnvironment.HOME_DIR;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.jboss.as.server.ServerEnvironment.HOME_DIR;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -22,6 +21,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Properties;
+
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.version.ProductConfig;
@@ -131,7 +131,7 @@ public class ServerEnvironmentTestCase {
 
         // default stability = DEFAULT
         ProductConfig productConfig = new ProductConfig(null, null, null);
-        assertEquals(Stability.DEFAULT, productConfig.getDefaultStability());
+        Assume.assumeTrue(Stability.DEFAULT.equals(productConfig.getDefaultStability()));
 
         Exception exception = assertThrows(IllegalStateException.class, () -> {
             createServerEnvironment(props, "lb", productConfig);

--- a/version/src/main/java/org/jboss/as/version/ProductConfig.java
+++ b/version/src/main/java/org/jboss/as/version/ProductConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -150,8 +151,10 @@ public class ProductConfig implements Serializable {
         this.name = productName;
         this.version = productVersion;
         this.consoleSlot = consoleSlot;
-        this.defaultStability = Stability.DEFAULT;
-        this.stabilities = EnumSet.of(this.defaultStability);
+        this.defaultStability = Stability.COMMUNITY;
+        this.stabilities = EnumSet.allOf(Stability.class).stream()
+                .filter(this.defaultStability::enables)
+                .collect(Collectors.toUnmodifiableSet());
         this.banner = null;
     }
 


### PR DESCRIPTION
Built on top of https://github.com/wildfly/wildfly-core/pull/6201

Jira issue: https://issues.redhat.com/browse/WFCORE-7011

It is expected that mixed domain tests fail with this change. I opened it as a draft since this change still requires some discussions to decide whether we want to allow DC -- HC mixed domains under community -- default stability levels