### PR TITLE
WFCORE-7004: use custom parser over default

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -89,7 +89,7 @@ public abstract class AttributeParser {
     }
 
     public void parseElement(final AttributeDefinition attribute, final XMLExtendedStreamReader reader, ModelNode operation) throws XMLStreamException {
-
+        throw new UnsupportedOperationException();
     }
 
     public String getXmlName(final AttributeDefinition attribute){

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemExtension.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.subsystem.test.elementorder;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PersistentResourceXMLDescriptionWriter;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+import java.util.EnumSet;
+
+public class ElementOrderSubsystemExtension implements Extension {
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration subsystem = context.registerSubsystem(ElementOrderSubsystemResourceDefinition.SUBSYSTEM_NAME, ModelVersion.create(1));
+        ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new ElementOrderSubsystemResourceDefinition());
+        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+
+        subsystem.registerXMLElementWriter(new PersistentResourceXMLDescriptionWriter(ElementOrderSubsystemSchema.VERSION_1_0));
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMappings(ElementOrderSubsystemResourceDefinition.SUBSYSTEM_NAME, EnumSet.of(ElementOrderSubsystemSchema.VERSION_1_0));
+    }
+}

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemResourceDefinition.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemResourceDefinition.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.subsystem.test.elementorder;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredAddStepHandler;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.ResourceRegistration;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
+
+public class ElementOrderSubsystemResourceDefinition extends SimpleResourceDefinition {
+    static final String SUBSYSTEM_NAME = "element-order";
+    static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
+    static final ResourceRegistration GROUP_REGISTRATION = ResourceRegistration.of(PathElement.pathElement("group"));
+    static final ResourceRegistration CHILD_REGISTRATION = ResourceRegistration.of(PathElement.pathElement("child"));
+    static final ResourceRegistration CHILD_2_REGISTRATION = ResourceRegistration.of(PathElement.pathElement("child2"));
+
+    static final AttributeDefinition ATTRIBUTE = new SimpleAttributeDefinitionBuilder("attribute", ModelType.STRING)
+            .setRequired(false)
+            .build();
+
+    static final AttributeDefinition ATTRIBUTE_2 = new SimpleAttributeDefinitionBuilder("attribute2", ModelType.STRING)
+            .setRequired(false)
+            .build();
+
+    ElementOrderSubsystemResourceDefinition() {
+        super(new Parameters(PATH, NonResolvingResourceDescriptionResolver.INSTANCE)
+                .setAddHandler(ReloadRequiredAddStepHandler.INSTANCE)
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
+    }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration registration) {
+        registration.registerSubModel(new GroupResourceDefinition());
+    }
+
+    public class GroupResourceDefinition extends SimpleResourceDefinition {
+
+        GroupResourceDefinition() {
+            super(new Parameters(GROUP_REGISTRATION, NonResolvingResourceDescriptionResolver.INSTANCE)
+                    .setAddHandler(ReloadRequiredAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration registration) {
+            registration.registerReadWriteAttribute(ATTRIBUTE, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
+            registration.registerReadWriteAttribute(ATTRIBUTE_2, null, ReloadRequiredWriteAttributeHandler.INSTANCE);
+        }
+
+        @Override
+        public void registerChildren(ManagementResourceRegistration registration) {
+            registration.registerSubModel(new ChildResourceDefinition());
+            registration.registerSubModel(new Child2ResourceDefinition());
+        }
+    }
+
+    public class ChildResourceDefinition extends SimpleResourceDefinition {
+
+        ChildResourceDefinition() {
+            super(new Parameters(CHILD_REGISTRATION, NonResolvingResourceDescriptionResolver.INSTANCE)
+                    .setAddHandler(ReloadRequiredAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
+        }
+    }
+
+    public class Child2ResourceDefinition extends SimpleResourceDefinition {
+
+        Child2ResourceDefinition() {
+            super(new Parameters(CHILD_2_REGISTRATION, NonResolvingResourceDescriptionResolver.INSTANCE)
+                    .setAddHandler(ReloadRequiredAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
+        }
+    }
+
+}

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemSchema.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemSchema.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.subsystem.test.elementorder;
+
+import org.jboss.as.controller.AttributeMarshallers;
+import org.jboss.as.controller.AttributeParsers;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentSubsystemSchema;
+import org.jboss.as.controller.SubsystemSchema;
+import org.jboss.as.controller.xml.VersionedNamespace;
+import org.jboss.staxmapper.IntVersion;
+
+public enum ElementOrderSubsystemSchema implements PersistentSubsystemSchema<ElementOrderSubsystemSchema> {
+    VERSION_1_0;
+    private final VersionedNamespace<IntVersion, ElementOrderSubsystemSchema> namespace = SubsystemSchema.createSubsystemURN(ElementOrderSubsystemResourceDefinition.SUBSYSTEM_NAME, new IntVersion(1));
+
+    @Override
+    public VersionedNamespace<IntVersion, ElementOrderSubsystemSchema> getNamespace() {
+        return this.namespace;
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getXMLDescription() {
+        PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
+        PersistentResourceXMLDescription.Builder builder = factory.builder(ElementOrderSubsystemResourceDefinition.PATH);
+        PersistentResourceXMLDescription.Builder groupBuilder = factory.builder(ElementOrderSubsystemResourceDefinition.GROUP_REGISTRATION);
+        groupBuilder.addAttribute(ElementOrderSubsystemResourceDefinition.ATTRIBUTE, AttributeParsers.SIMPLE_ELEMENT, AttributeMarshallers.SIMPLE_ELEMENT);
+        groupBuilder.addAttribute(ElementOrderSubsystemResourceDefinition.ATTRIBUTE_2, AttributeParsers.SIMPLE_ELEMENT, AttributeMarshallers.SIMPLE_ELEMENT);
+        groupBuilder.addChild(factory.builder(ElementOrderSubsystemResourceDefinition.CHILD_REGISTRATION).build());
+        groupBuilder.addChild(factory.builder(ElementOrderSubsystemResourceDefinition.CHILD_2_REGISTRATION).build());
+        builder.addChild(groupBuilder.build());
+        return builder.build();
+    }
+}

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/elementorder/ElementOrderSubsystemTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.subsystem.test.elementorder;
+
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
+/**
+ *  Test for checking an XML configuration will be correctly parsed when the elements are written in non-default order if the schema allows it
+ *  Default order = attribute elements before children elements
+ */
+public class ElementOrderSubsystemTestCase extends AbstractSubsystemBaseTest {
+
+    public ElementOrderSubsystemTestCase() {
+        super(ElementOrderSubsystemResourceDefinition.SUBSYSTEM_NAME, new ElementOrderSubsystemExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("element-order-1.0.xml");
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() {
+        return "schema/wildfly-element-order_1_0.xsd";
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) {
+        // do nothing, compareXml imposes the default order
+    }
+
+    @Override
+    public void testSubsystem() throws Exception {
+        try {
+            super.testSubsystem();
+        } catch (UnsupportedOperationException | XMLStreamException e) {
+            fail("Parser failed: " + e.getMessage());
+        }
+    }
+}

--- a/subsystem-test/tests/src/test/resources/org/jboss/as/subsystem/test/elementorder/element-order-1.0.xml
+++ b/subsystem-test/tests/src/test/resources/org/jboss/as/subsystem/test/elementorder/element-order-1.0.xml
@@ -1,0 +1,20 @@
+<subsystem xmlns="urn:wildfly:element-order:1.0">
+    <group name="attrs-before-children">
+        <attribute>abc</attribute>
+        <attribute2>cdef</attribute2>
+        <child name="ijk"/>
+        <child2 name="mnop"/>
+    </group>
+    <group name="children-before-attrs">
+        <child name="abc"/>
+        <child2 name="cdef"/>
+        <attribute>ijk</attribute>
+        <attribute2>mnop</attribute2>
+    </group>
+    <group name="mixed">
+        <child name="abc"/>
+        <attribute2>cdef</attribute2>
+        <child2 name="ijk"/>
+        <attribute>mnop</attribute>
+    </group>
+</subsystem>

--- a/subsystem-test/tests/src/test/resources/schema/wildfly-element-order_1_0.xsd
+++ b/subsystem-test/tests/src/test/resources/schema/wildfly-element-order_1_0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:wildfly:element-order:1.0"
+            xmlns="urn:wildfly:element-order:1.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="group" type="group"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="group">
+        <xs:all>
+            <xs:element name="attribute" type="xs:token"/>
+            <xs:element name="attribute2" type="xs:token"/>
+            <xs:element name="child" type="child" />
+            <xs:element name="child2" type="child" />
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="child">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Issue: [WFCORE-7004](https://issues.redhat.com/browse/WFCORE-7004)

The default `parseElement` method should ideally never be accessed after this fix but in case it is I assume it's better to throw an exception rather then having one thrown by the XML reader because that makes it look like something's wrong with the XML file.