### PR TITLE
[WFCORE-7008] Use concrete log per child class, request sockets to be closed inmediately

### DIFF
--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -31,9 +31,9 @@
         <!--
         <byteman.jvm.args>-javaagent:${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar} -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose=true</byteman.jvm.args>
         -->
-								
+
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>jakarta.inject</groupId>
@@ -583,7 +583,7 @@
                                         <!-- restart the server -->
                                         <exclude>org.jboss.as.test.manualmode.deployment.DeploymentScannerRedeploymentTestCase</exclude>
                                         <exclude>org.jboss.as.test.manualmode.deployment.DeploymentScannerUnitTestCase</exclude>
-                                        
+
                                         <!-- restart the server -->
                                         <exclude>org.jboss.as.test.manualmode.logging.LoggingDependenciesTestCase</exclude>
                                         <exclude>org.jboss.as.test.manualmode.logging.LoggingPreferencesTestCase</exclude>
@@ -598,7 +598,7 @@
                                         <exclude>org.jboss.as.test.manualmode.provisioning.InstallationManagerBootTestCase</exclude>
                                         <!-- restart the server -->
                                         <exclude>org.jboss.as.test.manualmode.management.*TestCase</exclude>
-                                        
+
                                         <exclude>org.jboss.as.test.manualmode.management.cli.ManagementOpTimeoutTestCase</exclude>
                                         <exclude>org.jboss.as.test.manualmode.management.cli.ShutdownTestCase</exclude>
 
@@ -615,21 +615,20 @@
                                         <exclude>org.jboss.as.test.manualmode.management.cli.RemoveManagementRealmTestCase</exclude>
                                         <!-- no git support -->
                                         <exclude>org.jboss.as.test.manualmode.management.persistence.*TestCase</exclude>
-                                        
+
                                         <!-- replace config file -->
                                         <exclude>org.jboss.as.test.manualmode.mgmt.elytron.ElytronModelControllerClientTestCase</exclude>
-                                        
+
                                         <!--- remove a module after having closed the server -->
                                         <exclude>org.jboss.as.test.manualmode.expressions.CredentialStoreExpressionsTestCase</exclude>
-                                        
+
                                         <!-- admin mode -->
-                                        <exclude>org.wildfly.core.test.standalone.mgmt.ManagementInterfaceResourcesTestCase</exclude>
                                         <exclude>org.jboss.as.test.manualmode.adminonly.auditlog.*TestCase.java</exclude>
                                         <exclude>org.jboss.as.test.manualmode.cli.boot.ops.CliBootOperationsTestCase.java</exclude>
 
                                         <!-- start /stop, and install extension before start -->
                                         <exclude>org.wildfly.core.test.standalone.mgmt.PreparedResponseTestCase</exclude>
-                                        
+
                                         <!-- start/stop/start the server -->
                                         <exclude>org.wildfly.core.test.standalone.mgmt.events.*TestCase</exclude>
                                         <!-- Requires modification of the process-uuid file inside the Jar -->

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
@@ -62,6 +62,7 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
                 try {
                     sockets[i] = new Socket();
                     sockets[i].connect(targetAddress, 5000);
+                    sockets[i].setSoLinger(true, 0);
                     assertTrue("Socket is connected.", sockets[i].isConnected());
                     socketsOpened++;
                 } catch (IOException e) {
@@ -99,6 +100,7 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
                 try {
                     sockets[i] = new Socket();
                     sockets[i].connect(targetAddress, 5000);
+                    sockets[i].setSoLinger(true, 0);
                     assertTrue("Socket is connected.", sockets[i].isConnected());
                     socketsOpened++;
                 } catch (IOException e) {

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
@@ -39,6 +39,11 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
     @Inject
     protected static ServerController controller;
 
+    @Test
+    public void testNothing() throws Exception {
+        runTest(60000, () -> {});
+    }
+
     /**
      * Test that the management interface will not accept new connections when the number of active connections reaches the
      * high water mark.  After the number of open connections has been reduced to the low watermark it will test that connections

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.jboss.as.test.shared.TimeoutUtil.adjust;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionRunnable;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildFlyRunner;
+
+import jakarta.inject.Inject;
+
+/**
+ * Test case to test resource limits and clean up of management interface connections.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@RunWith(WildFlyRunner.class)
+@ServerControl(manual = true)
+public abstract class AbstractManagementInterfaceResourcesTestCase {
+    protected static final Logger LOG = Logger.getLogger(ManagementInterfaceResourcesTestCase.class.getName());
+
+
+    @Inject
+    protected static ServerController controller;
+
+    /**
+     * Test that the management interface will not accept new connections when the number of active connections reaches the
+     * high water mark.  After the number of open connections has been reduced to the low watermark it will test that connections
+     * are accepted again.
+     */
+    @Test
+    public void testWatermarks() throws Exception {
+        runTest(60000, () -> {
+            String mgmtAddress = TestSuiteEnvironment.getServerAddress();
+            int mgmtPort = TestSuiteEnvironment.getServerPort();
+            LOG.info(mgmtAddress + ":" + mgmtPort);
+            SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
+
+            int socketsOpened = 0;
+            boolean oneFailed = false;
+            Socket[] sockets = new Socket[9];
+            for (int i = 0 ; i < 9 ; i++) {
+                LOG.info("Opening socket " + i + " socketsOpened=" + socketsOpened);
+                try {
+                    sockets[i] = new Socket();
+                    sockets[i].connect(targetAddress, 5000);
+                    socketsOpened++;
+                } catch (IOException e) {
+                    LOG.log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
+                    assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
+                    oneFailed = true;
+                }
+            }
+            assertTrue("Opening of one socket was expected to fail.", oneFailed);
+
+            // Now close the connections and we should be able to connect again.
+            for (int i = 0 ; i < socketsOpened ; i++) {
+                sockets[i].close();
+            }
+
+            Socket goodSocket = new Socket();
+            // This needs a reasonable time to give the server time to respond to the closed connections.
+            goodSocket.connect(targetAddress, 10000);
+            goodSocket.close();
+        });
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        runTest(10000, () -> {
+            String mgmtAddress = TestSuiteEnvironment.getServerAddress();
+            int mgmtPort = TestSuiteEnvironment.getServerPort();
+            SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
+
+            int socketsOpened = 0;
+            boolean oneFailed = false;
+            Socket[] sockets = new Socket[9];
+            for (int i = 0 ; i < 9 ; i++) {
+                LOG.info("Opening socket " + i + " socketsOpened=" + socketsOpened);
+                try {
+                    sockets[i] = new Socket();
+                    sockets[i].connect(targetAddress, 5000);
+                    socketsOpened++;
+                } catch (IOException e) {
+                    LOG.log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
+                    assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
+                    oneFailed = true;
+                }
+            }
+            assertTrue("Opening of one socket was expected to fail.", oneFailed);
+
+            // Notice that the exception received when we tried to open a new socket could have been a timeout (SocketTimeoutException)
+            // or a connection refused (IOException). It depends on the OS and the network configuration.
+            // So, we could also have had 5000ms for each bad socket that triggered a SocketTimeoutException.
+            Thread.sleep(adjust(12000));
+
+            Socket goodSocket = new Socket();
+            // This needs to be longer than 500ms to give the server time to respond to the closed connections.
+            goodSocket.connect(targetAddress, 10000);
+            goodSocket.close();
+
+            // Clean up remaining sockets
+            for (int i = 0 ; i < socketsOpened ; i++) {
+                sockets[i].close();
+            }
+        });
+    }
+
+    protected abstract void runTest(int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception;
+
+}

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/AbstractManagementInterfaceResourcesTestCase.java
@@ -33,9 +33,6 @@ import jakarta.inject.Inject;
 @RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public abstract class AbstractManagementInterfaceResourcesTestCase {
-    protected static final Logger LOG = Logger.getLogger(ManagementInterfaceResourcesTestCase.class.getName());
-
-
     @Inject
     protected static ServerController controller;
 
@@ -54,20 +51,21 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
         runTest(60000, () -> {
             String mgmtAddress = TestSuiteEnvironment.getServerAddress();
             int mgmtPort = TestSuiteEnvironment.getServerPort();
-            LOG.info(mgmtAddress + ":" + mgmtPort);
+            log().info(mgmtAddress + ":" + mgmtPort);
             SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
 
             int socketsOpened = 0;
             boolean oneFailed = false;
             Socket[] sockets = new Socket[9];
-            for (int i = 0 ; i < 9 ; i++) {
-                LOG.info("Opening socket " + i + " socketsOpened=" + socketsOpened);
+            for (int i = 0; i < 9; i++) {
+                log().info("Opening socket " + i + " socketsOpened=" + socketsOpened);
                 try {
                     sockets[i] = new Socket();
                     sockets[i].connect(targetAddress, 5000);
+                    assertTrue("Socket is connected.", sockets[i].isConnected());
                     socketsOpened++;
                 } catch (IOException e) {
-                    LOG.log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
+                    log().log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
                     assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
                     oneFailed = true;
                 }
@@ -75,7 +73,7 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
             assertTrue("Opening of one socket was expected to fail.", oneFailed);
 
             // Now close the connections and we should be able to connect again.
-            for (int i = 0 ; i < socketsOpened ; i++) {
+            for (int i = 0; i < socketsOpened; i++) {
                 sockets[i].close();
             }
 
@@ -96,14 +94,15 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
             int socketsOpened = 0;
             boolean oneFailed = false;
             Socket[] sockets = new Socket[9];
-            for (int i = 0 ; i < 9 ; i++) {
-                LOG.info("Opening socket " + i + " socketsOpened=" + socketsOpened);
+            for (int i = 0; i < 9; i++) {
+                log().info("Opening socket " + i + " socketsOpened=" + socketsOpened);
                 try {
                     sockets[i] = new Socket();
                     sockets[i].connect(targetAddress, 5000);
+                    assertTrue("Socket is connected.", sockets[i].isConnected());
                     socketsOpened++;
                 } catch (IOException e) {
-                    LOG.log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
+                    log().log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
                     assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
                     oneFailed = true;
                 }
@@ -121,7 +120,7 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
             goodSocket.close();
 
             // Clean up remaining sockets
-            for (int i = 0 ; i < socketsOpened ; i++) {
+            for (int i = 0; i < socketsOpened; i++) {
                 sockets[i].close();
             }
         });
@@ -129,4 +128,5 @@ public abstract class AbstractManagementInterfaceResourcesTestCase {
 
     protected abstract void runTest(int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception;
 
+    abstract Logger log();
 }

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesCommunityTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesCommunityTestCase.java
@@ -9,6 +9,8 @@ import static org.jboss.as.controller.client.helpers.Operations.createAddress;
 import static org.jboss.as.controller.client.helpers.Operations.createWriteAttributeOperation;
 import static org.jboss.as.test.integration.management.util.ServerReload.executeReloadAndWaitForCompletion;
 
+import java.util.logging.Logger;
+
 import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
@@ -19,12 +21,13 @@ import org.wildfly.test.stability.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Test case to test resource limits and clean up of management interface connections.
- *
+ * <p>
  * This test case uses attributes defined directly on the HTTP management interface resource for configuration.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class ManagementInterfaceResourcesCommunityTestCase extends AbstractManagementInterfaceResourcesTestCase {
+    protected static final Logger LOG = Logger.getLogger(ManagementInterfaceResourcesCommunityTestCase.class.getName());
 
     /*
     * Attribute names
@@ -45,14 +48,14 @@ public class ManagementInterfaceResourcesCommunityTestCase extends AbstractManag
         try {
             task.setup(client);
             test.run();
-            controller.reload();
         } finally {
+            controller.reload();
             task.tearDown(client);
             controller.stop();
         }
     }
 
-    class ManagementInterfaceSetUpTask extends StabilityServerSetupSnapshotRestoreTasks.Community {
+    static class ManagementInterfaceSetUpTask extends StabilityServerSetupSnapshotRestoreTasks.Community {
 
         private final int noRequestTimeout;
 
@@ -77,5 +80,10 @@ public class ManagementInterfaceResourcesCommunityTestCase extends AbstractManag
             managementClient.executeForResult(writeOp);
         }
 
+    }
+
+    @Override
+    Logger log() {
+        return LOG;
     }
 }

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesCommunityTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesCommunityTestCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.jboss.as.controller.client.helpers.Operations.createAddress;
+import static org.jboss.as.controller.client.helpers.Operations.createWriteAttributeOperation;
+import static org.jboss.as.test.integration.management.util.ServerReload.executeReloadAndWaitForCompletion;
+
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.version.Stability;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.common.function.ExceptionRunnable;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.test.stability.StabilityServerSetupSnapshotRestoreTasks;
+
+/**
+ * Test case to test resource limits and clean up of management interface connections.
+ *
+ * This test case uses attributes defined directly on the HTTP management interface resource for configuration.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ManagementInterfaceResourcesCommunityTestCase extends AbstractManagementInterfaceResourcesTestCase {
+
+    /*
+    * Attribute names
+    */
+    private static final String BACKLOG_ATTRIBUTE = "backlog";
+    private static final String CONNECTION_HIGH_WATER_ATTRIBUTE = "connection-high-water";
+    private static final String CONNECTION_LOW_WATER_ATTRIBUTE = "connection-low-water";
+    private static final String NO_REQUEST_TIMEOUT_ATTRIBUTE = "no-request-timeout";
+
+    private static final ModelNode HTTP_INTERFACE_ADDRESS = createAddress("core-service", "management", "management-interface", "http-interface");
+
+    protected void runTest(int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception {
+        controller.start();
+        ManagementClient client = controller.getClient();
+
+        ServerSetupTask task = new ManagementInterfaceSetUpTask(noRequestTimeout);
+
+        try {
+            task.setup(client);
+            test.run();
+            controller.reload();
+        } finally {
+            task.tearDown(client);
+            controller.stop();
+        }
+    }
+
+    class ManagementInterfaceSetUpTask extends StabilityServerSetupSnapshotRestoreTasks.Community {
+
+        private final int noRequestTimeout;
+
+        public ManagementInterfaceSetUpTask(int noRequestTimeout) {
+            this.noRequestTimeout = noRequestTimeout;
+        }
+
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            writeAttribute(managementClient, BACKLOG_ATTRIBUTE, 2);
+            writeAttribute(managementClient, CONNECTION_HIGH_WATER_ATTRIBUTE, 6);
+            writeAttribute(managementClient, CONNECTION_LOW_WATER_ATTRIBUTE, 3);
+            writeAttribute(managementClient, NO_REQUEST_TIMEOUT_ATTRIBUTE, noRequestTimeout);
+
+            // Execute the reload
+            ServerReload.Parameters parameters = new ServerReload.Parameters()
+                .setStability(Stability.COMMUNITY);
+            executeReloadAndWaitForCompletion(managementClient.getControllerClient(), parameters);
+        }
+
+        private void writeAttribute(final ManagementClient managementClient, final String attributeName, final int value) throws Exception {
+            ModelNode writeOp = createWriteAttributeOperation(HTTP_INTERFACE_ADDRESS, attributeName, value);
+            managementClient.executeForResult(writeOp);
+        }
+
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
@@ -5,17 +5,20 @@
 
 package org.wildfly.core.test.standalone.mgmt;
 
+import java.util.logging.Logger;
+
 import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.wildfly.common.function.ExceptionRunnable;
 
 /**
  * Test case to test resource limits and clean up of management interface connections.
- *
+ * <p>
  * This test case uses system properties for configuration.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class ManagementInterfaceResourcesTestCase extends AbstractManagementInterfaceResourcesTestCase {
+    protected static final Logger LOG = Logger.getLogger(ManagementInterfaceResourcesTestCase.class.getName());
 
     /*
      * System Properties
@@ -56,4 +59,8 @@ public class ManagementInterfaceResourcesTestCase extends AbstractManagementInte
         }
     }
 
+    @Override
+    Logger log() {
+        return LOG;
+    }
 }

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
@@ -5,36 +5,17 @@
 
 package org.wildfly.core.test.standalone.mgmt;
 
-import static org.jboss.as.test.shared.TimeoutUtil.adjust;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.inject.Inject;
-
 import org.jboss.as.test.integration.management.util.CLIWrapper;
-import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionRunnable;
-import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildFlyRunner;
 
 /**
  * Test case to test resource limits and clean up of management interface connections.
  *
+ * This test case uses system properties for configuration.
+ *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-@RunWith(WildFlyRunner.class)
-@ServerControl(manual = true)
-public class ManagementInterfaceResourcesTestCase {
-    private static final Logger LOG = Logger.getLogger(ManagementInterfaceResourcesTestCase.class.getName());
+public class ManagementInterfaceResourcesTestCase extends AbstractManagementInterfaceResourcesTestCase {
 
     /*
      * System Properties
@@ -44,133 +25,18 @@ public class ManagementInterfaceResourcesTestCase {
     private static final String CONNECTION_LOW_WATER_PROPERTY = "org.wildfly.management.connection-low-water";
     private static final String NO_REQUEST_TIMEOUT_PROPERTY = "org.wildfly.management.no-request-timeout";
     /*
-    * Attribute names
-    */
-    private static final String BACKLOG_ATTRIBUTE = "backlog";
-    private static final String CONNECTION_HIGH_WATER_ATTRIBUTE = "connection-high-water";
-    private static final String CONNECTION_LOW_WATER_ATTRIBUTE = "connection-low-water";
-    private static final String NO_REQUEST_TIMEOUT_ATTRIBUTE = "no-request-timeout";
-    /*
      * Command Templates
      */
-    private static final String HTTP_INTERFACE_READ_ATTRIBUTE = "/core-service=management/management-interface=http-interface:read-attribute(name=%s)";
-    private static final String HTTP_INTERFACE_WRITE_ATTRIBUTE = "/core-service=management/management-interface=http-interface:write-attribute(name=%s, value=%d)";
-    private static final String HTTP_INTERFACE_UNDEFINE_ATTRIBUTE = "/core-service=management/management-interface=http-interface:undefine-attribute(name=%s)";
     private static final String SYSTEM_PROPERTY_ADD = "/system-property=%s:add(value=%d)";
     private static final String SYSTEM_PROPERTY_REMOVE = "/system-property=%s:remove()";
 
-    @Inject
-    protected static ServerController controller;
-
-    /**
-     * Test that the management interface will not accept new connections when the number of active connections reaches the
-     * high water mark.  After the number of open connections has been reduced to the low watermark it will test that connections
-     * are accepted again.
-     */
-    @Test
-    public void testWatermarks() throws Exception {
-        runTest(60000, () -> {
-            String mgmtAddress = TestSuiteEnvironment.getServerAddress();
-            int mgmtPort = TestSuiteEnvironment.getServerPort();
-            LOG.info(mgmtAddress + ":" + mgmtPort);
-            SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
-
-            int socketsOpened = 0;
-            boolean oneFailed = false;
-            Socket[] sockets = new Socket[9];
-            for (int i = 0 ; i < 9 ; i++) {
-                LOG.info("Opening socket " + i + " socketsOpened=" + socketsOpened);
-                try {
-                    sockets[i] = new Socket();
-                    sockets[i].connect(targetAddress, 5000);
-                    socketsOpened++;
-                } catch (IOException e) {
-                    LOG.log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
-                    assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
-                    oneFailed = true;
-                }
-            }
-            assertTrue("Opening of one socket was expected to fail.", oneFailed);
-
-            // Now close the connections and we should be able to connect again.
-            for (int i = 0 ; i < socketsOpened ; i++) {
-                sockets[i].close();
-            }
-
-            Socket goodSocket = new Socket();
-            // This needs a reasonable time to give the server time to respond to the closed connections.
-            goodSocket.connect(targetAddress, 10000);
-            goodSocket.close();
-        });
-    }
-
-    @Test
-    public void testTimeout() throws Exception {
-        runTest(10000, () -> {
-            String mgmtAddress = TestSuiteEnvironment.getServerAddress();
-            int mgmtPort = TestSuiteEnvironment.getServerPort();
-            SocketAddress targetAddress = new InetSocketAddress(mgmtAddress, mgmtPort);
-
-            int socketsOpened = 0;
-            boolean oneFailed = false;
-            Socket[] sockets = new Socket[9];
-            for (int i = 0 ; i < 9 ; i++) {
-                LOG.info("Opening socket " + i + " socketsOpened=" + socketsOpened);
-                try {
-                    sockets[i] = new Socket();
-                    sockets[i].connect(targetAddress, 5000);
-                    socketsOpened++;
-                } catch (IOException e) {
-                    LOG.log(Level.SEVERE, "Probably an expected exception trying to open a new connection", e);
-                    assertTrue("Less sockets than low watermark opened.", socketsOpened > 3);
-                    oneFailed = true;
-                }
-            }
-            assertTrue("Opening of one socket was expected to fail.", oneFailed);
-
-            // Notice that the exception received when we tried to open a new socket could have been a timeout (SocketTimeoutException)
-            // or a connection refused (IOException). It depends on the OS and the network configuration.
-            // So, we could also have had 5000ms for each bad socket that triggered a SocketTimeoutException.
-            Thread.sleep(adjust(12000));
-
-            Socket goodSocket = new Socket();
-            // This needs to be longer than 500ms to give the server time to respond to the closed connections.
-            goodSocket.connect(targetAddress, 10000);
-            goodSocket.close();
-
-            // Clean up remaining sockets
-            for (int i = 0 ; i < socketsOpened ; i++) {
-                sockets[i].close();
-            }
-        });
-    }
-
-    private void runTest(int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception {
-        runTest(true, noRequestTimeout, test);
-        runTest(false, noRequestTimeout, test);
-    }
-
-    private void runTest(boolean useSystemProperties, int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception {
-        controller.startInAdminMode();
+    protected void runTest(int noRequestTimeout, ExceptionRunnable<Exception> test) throws Exception {
+        controller.start();
         try (CLIWrapper cli = new CLIWrapper(true)) {
-            if (useSystemProperties) {
-                cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, BACKLOG_PROPERTY, 2));
-                cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, CONNECTION_HIGH_WATER_PROPERTY, 6));
-                cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, CONNECTION_LOW_WATER_PROPERTY, 3));
-                cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, NO_REQUEST_TIMEOUT_PROPERTY, noRequestTimeout));
-            } else {
-                cli.sendLine(String.format(HTTP_INTERFACE_READ_ATTRIBUTE, BACKLOG_ATTRIBUTE), true);
-                String response = cli.readOutput();
-                if (response.contains("WFLYCTL0201")) {
-                    LOG.info("Attribute \"backlog\" not found - assuming the attributes are not available at the server's stability level" );
-                    controller.stop();
-                    return;
-                }
-                cli.sendLine(String.format(HTTP_INTERFACE_WRITE_ATTRIBUTE, BACKLOG_ATTRIBUTE, 2));
-                cli.sendLine(String.format(HTTP_INTERFACE_WRITE_ATTRIBUTE, CONNECTION_HIGH_WATER_ATTRIBUTE, 6));
-                cli.sendLine(String.format(HTTP_INTERFACE_WRITE_ATTRIBUTE, CONNECTION_LOW_WATER_ATTRIBUTE, 3));
-                cli.sendLine(String.format(HTTP_INTERFACE_WRITE_ATTRIBUTE, NO_REQUEST_TIMEOUT_ATTRIBUTE, noRequestTimeout));
-            }
+            cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, BACKLOG_PROPERTY, 2));
+            cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, CONNECTION_HIGH_WATER_PROPERTY, 6));
+            cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, CONNECTION_LOW_WATER_PROPERTY, 3));
+            cli.sendLine(String.format(SYSTEM_PROPERTY_ADD, NO_REQUEST_TIMEOUT_PROPERTY, noRequestTimeout));
         }
 
         try {
@@ -181,17 +47,10 @@ public class ManagementInterfaceResourcesTestCase {
             controller.reload();
 
             try (CLIWrapper cli = new CLIWrapper(true)) {
-                if (useSystemProperties) {
-                    cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, BACKLOG_PROPERTY));
-                    cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, CONNECTION_HIGH_WATER_PROPERTY));
-                    cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, CONNECTION_LOW_WATER_PROPERTY));
-                    cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, NO_REQUEST_TIMEOUT_PROPERTY));
-                } else {
-                    cli.sendLine(String.format(HTTP_INTERFACE_UNDEFINE_ATTRIBUTE, BACKLOG_ATTRIBUTE));
-                    cli.sendLine(String.format(HTTP_INTERFACE_UNDEFINE_ATTRIBUTE, CONNECTION_HIGH_WATER_ATTRIBUTE));
-                    cli.sendLine(String.format(HTTP_INTERFACE_UNDEFINE_ATTRIBUTE, CONNECTION_LOW_WATER_ATTRIBUTE));
-                    cli.sendLine(String.format(HTTP_INTERFACE_UNDEFINE_ATTRIBUTE, NO_REQUEST_TIMEOUT_ATTRIBUTE));
-                }
+                cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, BACKLOG_PROPERTY));
+                cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, CONNECTION_HIGH_WATER_PROPERTY));
+                cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, CONNECTION_LOW_WATER_PROPERTY));
+                cli.sendLine(String.format(SYSTEM_PROPERTY_REMOVE, NO_REQUEST_TIMEOUT_PROPERTY));
             }
             controller.stop();
         }

--- a/testsuite/shared/src/main/java/org/wildfly/test/stability/StabilityServerSetupSnapshotRestoreTasks.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/stability/StabilityServerSetupSnapshotRestoreTasks.java
@@ -87,7 +87,9 @@ public abstract class StabilityServerSetupSnapshotRestoreTasks implements Server
 
     @Override
     public void tearDown(ManagementClient managementClient) throws Exception {
-        snapshot.close();
+        if (snapshot != null) {
+            snapshot.close();
+        }
     }
 
     private boolean checkReloadEnhancedOperationIsAvailable(ManagementClient managementClient) throws Exception {


### PR DESCRIPTION
This follows up on #6199

Just to see if closing the sockets immediately helps to test stability

Jira issue https://issues.redhat.com/browse/WFCORE-7008