### PR TITLE
[WFCORE-7030] Upgrade Undertow to 2.3.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.114.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.2</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.17.Final</version.io.undertow>
+        <version.io.undertow>2.3.18.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-7030

26.x PR: #6220 


        Release Notes - Undertow - Version 2.3.18.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2333'>UNDERTOW-2333</a>] -         Undertow read/write timeout should not apply to WebSockets or SSE
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2412'>UNDERTOW-2412</a>] -         Read stored json with default UTF-8 encoding
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2422'>UNDERTOW-2422</a>] -         Response Status Line protocol is hard-coded to &quot;HTTP/1.1&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2436'>UNDERTOW-2436</a>] -         Race condition for HttpServerExchange state allows missed FLAG_REQUEST_TERMINATED flag with async requests and subsequent connection stall
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2444'>UNDERTOW-2444</a>] -         H2 violation of protocol specification in RST_STREAM scenarios
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2445'>UNDERTOW-2445</a>] -         CI Build is broken: actions/upload-artifact v1 and v2 are deprecated
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2446'>UNDERTOW-2446</a>] -         HttpServletRequestImpl.getParts may throw exception after already loading parts
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2448'>UNDERTOW-2448</a>] -         Broken responses after UNDERTOW-2425
</li>
</ul>
                                                                                                                                                                                                                                                                            