### PR TITLE
[WFCORE-7030] Upgrade Undertow to 2.3.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.114.Final</version.io.netty>
         <version.io.smallrye.jandex>3.2.2</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.17.Final</version.io.undertow>
+        <version.io.undertow>2.3.18.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFCORE-7030

main PR: #6219 

release notes (WIP)