### PR TITLE
[WFCORE-6981] fix incorrect alternatives in reply-properties inherited from basis attribute

### DIFF
--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -395,6 +395,7 @@ public class DeploymentAttributes {
     /** Return type for the upload-deployment-xxx operaions */
     private static final SimpleAttributeDefinition UPLOAD_HASH_REPLY = SimpleAttributeDefinitionBuilder.create(CONTENT_HASH)
             .setRequired(true)
+            .setAlternatives()
             .build();
 
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-6981 

[WFCORE-6981] fix incorrect alternatives in `reply-properties `inherited from basis attribute