### PR TITLE
[WFCORE-7058]: CachingRealm should start lazily in admin only mode.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -341,6 +341,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 49, value = "Entry is not defined.")
     StartException jaasEntryNotDefined();
 
+    @Message(id = 50, value = "The realm is not available. You can't flush the cache.")
+    OperationFailedException cachedRealmServiceNotAvailable();
+
     /*
      * Credential Store Section.
      */


### PR DESCRIPTION
 * updating the start mode to LAZY if the server is in admin-mode
 * adding a proper error message if the caching realm service is not UP when the user tries to clear the cache.

Issue: https://issues.redhat.com/browse/WFCORE-7058