### PR TITLE
[WFCORE-6904] Bump the kernel management API version to 28.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -81,7 +81,8 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY30("WildFly30.0", KernelAPIVersion.VERSION_23_0),
         WILDFLY31("WildFly31.0", KernelAPIVersion.VERSION_24_0),
         WILDFLY32("WildFly32.0", KernelAPIVersion.VERSION_25_0),
-        WILDFLY33("WildFly33.0", KernelAPIVersion.VERSION_26_0);
+        WILDFLY33("WildFly33.0", KernelAPIVersion.VERSION_26_0),
+        WILDFLY34("WildFly34.0", KernelAPIVersion.VERSION_27_0);
 
         private static final Map<String, KnownRelease> map = new HashMap<>();
         static {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -81,6 +81,8 @@ public enum KernelAPIVersion {
     VERSION_25_0(25, 0, 0),
     // WildFly 33.0.0
     VERSION_26_0(26, 0, 0),
+    // WildFly 34.0.0
+    VERSION_27_0(27, 0, 0),
 
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -18,7 +18,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 27;
+    public static final int MANAGEMENT_MAJOR_VERSION = 28;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6904

