### PR TITLE
WFCORE-7067 Remove unused STRUCTURE_APP_CLIENT Phase

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -209,7 +209,6 @@ public enum Phase {
     public static final int STRUCTURE_JBOSS_EJB_CLIENT_XML_PARSE        = 0x0C00;
     public static final int STRUCTURE_EJB_EAR_APPLICATION_NAME          = 0x0D00;
     public static final int STRUCTURE_EAR                               = 0x0E00;
-    public static final int STRUCTURE_APP_CLIENT                        = 0x0F00;
     public static final int STRUCTURE_SERVICE_MODULE_LOADER             = 0x1000;
     public static final int STRUCTURE_ANNOTATION_INDEX                  = 0x1100;
     public static final int STRUCTURE_EJB_JAR_IN_EAR                    = 0x1200;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7067

This PR removes the STRUCTURE_APP_CLIENT constant that is now no longer used by WildFly (see WFLY-19758 for reference).