### PR TITLE
[WFCORE-7074] Use the ModuleIdentifier.fromString() where a slot may …

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleDependency.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleDependency.java
@@ -38,7 +38,7 @@ public final class ModuleDependency implements Serializable {
         private Builder(ModuleLoader moduleLoader, String moduleName) {
             this.moduleLoader = moduleLoader;
             //noinspection deprecation
-            this.identifier = ModuleIdentifier.create(moduleName);
+            this.identifier = ModuleIdentifier.fromString(moduleName);
         }
 
         /**
@@ -149,7 +149,7 @@ public final class ModuleDependency implements Serializable {
      * @param userSpecified {@code true} if this dependency was specified by the user, {@code false} if it was automatically added
      */
     public ModuleDependency(final ModuleLoader moduleLoader, final String identifier, final boolean optional, final boolean export, final boolean importServices, final boolean userSpecified) {
-        this(moduleLoader, ModuleIdentifier.create(identifier), optional, export, importServices, userSpecified, null);
+        this(moduleLoader, ModuleIdentifier.fromString(identifier), optional, export, importServices, userSpecified, null);
     }
 
     /**
@@ -167,7 +167,7 @@ public final class ModuleDependency implements Serializable {
      */
     @Deprecated(forRemoval = true)
     public ModuleDependency(final ModuleLoader moduleLoader, final String identifier, final boolean optional, final boolean export, final boolean importServices, final boolean userSpecified, String reason) {
-        this(moduleLoader, ModuleIdentifier.create(identifier), optional, export, importServices, userSpecified, reason);
+        this(moduleLoader, ModuleIdentifier.fromString(identifier), optional, export, importServices, userSpecified, reason);
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -281,7 +281,7 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
 
         ModuleLoader moduleLoader = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER);
         for (final String aliasName : moduleSpecification.getModuleAliases()) {
-            final ModuleIdentifier alias = ModuleIdentifier.create(aliasName);
+            final ModuleIdentifier alias = ModuleIdentifier.fromString(aliasName);
             final ServiceName moduleSpecServiceName = ServiceModuleLoader.moduleSpecServiceName(alias);
             final ModuleSpec spec = ModuleSpec.buildAlias(aliasName, moduleIdentifier.getName()).create();
 

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
@@ -402,7 +402,7 @@ public class ModuleSpecification extends SimpleAttachable {
      */
     @Deprecated(forRemoval = true)
     public List<ModuleIdentifier> getAliases() {
-        return aliases.stream().map(ModuleIdentifier::create).collect(Collectors.toList());
+        return aliases.stream().map(ModuleIdentifier::fromString).collect(Collectors.toList());
     }
 
     /**
@@ -461,7 +461,7 @@ public class ModuleSpecification extends SimpleAttachable {
      */
     @Deprecated(forRemoval = true)
     public Set<ModuleIdentifier> getNonexistentExcludedDependencies() {
-        return getFictitiousExcludedDependencies().stream().map(ModuleIdentifier::create).collect(Collectors.toSet());
+        return getFictitiousExcludedDependencies().stream().map(ModuleIdentifier::fromString).collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
…be used in a string module name.

https://issues.redhat.com/browse/WFCORE-7074
