### PR TITLE
WFCORE-7083 ModuleNameValidator fails if module name contains a dash

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/ModuleNameValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/ModuleNameValidator.java
@@ -20,7 +20,7 @@ import org.jboss.dmr.ModelType;
 public class ModuleNameValidator extends ModelTypeValidator {
     public static final ParameterValidator INSTANCE = new ModuleNameValidator();
     // Ensure module name is valid with filesystem module repository, permitting deprecated slot, if present
-    private static final Predicate<String> MODULE_NAME_TESTER = Pattern.compile("(?:^\\w+|\\w+\\.\\w+|\\w+\\Q\\:\\E\\w+)+(?:\\:(?:\\w+|\\w+\\.\\w+))?$").asMatchPredicate();
+    private static final Predicate<String> MODULE_NAME_TESTER = Pattern.compile("(?:^\\w+|\\w+[\\.\\-]\\w+|\\w+\\Q\\:\\E\\w+)+(?:\\:(?:\\w+|\\w+[\\.\\-]\\w+))?$").asMatchPredicate();
 
     private ModuleNameValidator() {
         super(ModelType.STRING);

--- a/controller/src/test/java/org/jboss/as/controller/operation/validation/ModuleNameValidatorTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operation/validation/ModuleNameValidatorTestCase.java
@@ -25,6 +25,7 @@ public class ModuleNameValidatorTestCase {
         validator.validateParameter("valid", new ModelNode("org.jboss.modules:main"));
         validator.validateParameter("valid", new ModelNode("org.jboss.modules:1.9"));
         validator.validateParameter("escaped", new ModelNode("org.jboss.modules.foo\\:bar:main"));
+        validator.validateParameter("dash", new ModelNode("org.infinispan.hibernate-cache"));
 
         Assert.assertThrows(OperationFailedException.class, () -> validator.validateParameter("invalid", new ModelNode(".foo.bar")));
         Assert.assertThrows(OperationFailedException.class, () -> validator.validateParameter("invalid", new ModelNode("foo..bar")));

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/AbstractCollectionOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/AbstractCollectionOperationsTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.jboss.as.controller.operation.global;
+package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
@@ -19,8 +19,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
-import org.jboss.as.controller.operations.global.GlobalNotifications;
-import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.test.AbstractControllerTestBase;
 import org.jboss.dmr.ModelNode;

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/CollectionOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/CollectionOperationsTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.jboss.as.controller.operation.global;
+package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/EnhancedSyntaxTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/EnhancedSyntaxTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.jboss.as.controller.operation.global;
+package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
@@ -33,8 +33,6 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
-import org.jboss.as.controller.operations.global.GlobalNotifications;
-import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.test.AbstractControllerTestBase;
 import org.jboss.dmr.ModelNode;

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/StorageRuntimeCollectionOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/StorageRuntimeCollectionOperationsTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.jboss.as.controller.operation.global;
+package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 

--- a/controller/src/test/java/org/jboss/as/controller/operations/validation/ModelTypeValidatorUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/validation/ModelTypeValidatorUnitTestCase.java
@@ -2,7 +2,7 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.jboss.as.controller.operation.validation;
+package org.jboss.as.controller.operations.validation;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -12,7 +12,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.ValueExpression;

--- a/controller/src/test/java/org/jboss/as/controller/operations/validation/ModuleNameValidatorTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/validation/ModuleNameValidatorTestCase.java
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.jboss.as.controller.operation.validation;
+package org.jboss.as.controller.operations.validation;
 
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.operations.validation.ModuleNameValidator;
-import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7083