### PR TITLE
[WFCORE-7086] Upgrade the WildFly Launcher to 1.0.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.3.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.installation-manager.installation-manager-api>1.1.1.Final</version.org.wildfly.installation-manager.installation-manager-api>
-        <version.org.wildfly.launcher>1.0.0.Beta3</version.org.wildfly.launcher>
+        <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.legacy.test>8.0.2.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.2.5.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7086

Tag: https://github.com/wildfly/wildfly-launcher/releases/tag/v1.0.0.Final