### PR TITLE
[WFCORE-7088]: Add a trace when restartRequired is ignored because of booting.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -1242,6 +1242,7 @@ abstract class AbstractOperationContext implements OperationContext, AutoCloseab
     @Override
     public final void restartRequired() {
         if (isBooting()) {
+            MGMT_OP_LOGGER.debug("Server is booting so we didn't set the restart required flag");
             return;
         }
         activeStep.setRestartStamp(processState.setRestartRequired());


### PR DESCRIPTION
* debug trace added.

Jira: https://issues.redhat.com/browse/WFCORE-7088
Related issue: https://issues.redhat.com/browse/WFCORE-7038

Related comment https://github.com/wildfly/wildfly-core/pull/6225#discussion_r1882306024
