### PR TITLE
[WFCORE-7091] Create the ModelTestModelControllerService variants for the WF 31 controllers

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
@@ -29,6 +29,7 @@ import org.jboss.as.core.model.test.TestParser;
 import org.jboss.as.host.controller.HostRunningModeControl;
 import org.jboss.as.host.controller.RestartMode;
 import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLMapper;
 
@@ -51,6 +52,28 @@ public class ChildFirstClassLoaderKernelServicesFactory {
 
         RunningModeControl runningModeControl = new HostRunningModeControl(RunningMode.ADMIN_ONLY, RestartMode.HC_ONLY);
         ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, runningModeControl);
+        return AbstractKernelServicesImpl.create(ProcessType.HOST_CONTROLLER, runningModeControl, validateOpsFilter, bootOperations, testParser, legacyModelVersion, type, modelInitializer, extensionRegistry, null);
+    }
+
+    public static KernelServices create(List<ModelNode> bootOperations, ModelTestOperationValidatorFilter validateOpsFilter, ModelVersion legacyModelVersion,
+                                        List<LegacyModelInitializerEntry> modelInitializerEntries, String stabilityStr) throws Exception {
+
+        Stability stability = Stability.fromString(stabilityStr);
+        TestModelType type = TestModelType.DOMAIN;
+        XMLMapper xmlMapper = XMLMapper.Factory.create();
+        TestParser testParser = TestParser.create(stability, null, xmlMapper, type);
+        ModelInitializer modelInitializer = null;
+        if (modelInitializerEntries != null && !modelInitializerEntries.isEmpty()) {
+            modelInitializer = new LegacyModelInitializer(modelInitializerEntries);
+        }
+
+        RunningModeControl runningModeControl = new HostRunningModeControl(RunningMode.ADMIN_ONLY, RestartMode.HC_ONLY);
+
+        ExtensionRegistry extensionRegistry = ExtensionRegistry.builder(ProcessType.HOST_CONTROLLER)
+                .withRunningMode(runningModeControl.getRunningMode())
+                .withStability(stability)
+                .build();
+
         return AbstractKernelServicesImpl.create(ProcessType.HOST_CONTROLLER, runningModeControl, validateOpsFilter, bootOperations, testParser, legacyModelVersion, type, modelInitializer, extensionRegistry, null);
     }
 

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/local/ScopedKernelServicesBootstrap.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/local/ScopedKernelServicesBootstrap.java
@@ -14,21 +14,22 @@ import org.jboss.as.core.model.bridge.impl.ClassLoaderObjectConverterImpl;
 import org.jboss.as.core.model.bridge.impl.LegacyControllerKernelServicesProxy;
 import org.jboss.as.core.model.test.LegacyModelInitializerEntry;
 import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 
 /**
- *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class ScopedKernelServicesBootstrap {
+    Stability stability;
     ClassLoader legacyChildFirstClassLoader;
     ClassLoaderObjectConverter objectConverter;
 
-    public ScopedKernelServicesBootstrap(ClassLoader legacyChildFirstClassLoader) {
+    public ScopedKernelServicesBootstrap(ClassLoader legacyChildFirstClassLoader, Stability stability) {
         this.legacyChildFirstClassLoader = legacyChildFirstClassLoader;
         this.objectConverter = new ClassLoaderObjectConverterImpl(this.getClass().getClassLoader(), legacyChildFirstClassLoader);
+        this.stability = stability;
     }
-
 
     public LegacyControllerKernelServicesProxy createKernelServices(List<ModelNode> bootOperations, ModelTestOperationValidatorFilter validateOpsFilter, ModelVersion legacyModelVersion, List<LegacyModelInitializerEntry> modelInitializerEntries) throws Exception {
 
@@ -36,36 +37,66 @@ public class ScopedKernelServicesBootstrap {
         return new LegacyControllerKernelServicesProxy(legacyChildFirstClassLoader, childClassLoaderKernelServices, objectConverter);
     }
 
-    private Object createChildClassLoaderKernelServices(List<ModelNode> bootOperations, ModelTestOperationValidatorFilter validateOpsFilter, ModelVersion legacyModelVersion, List<LegacyModelInitializerEntry> modelInitializerEntries){
+    private Object createChildClassLoaderKernelServices(List<ModelNode> bootOperations, ModelTestOperationValidatorFilter validateOpsFilter, ModelVersion legacyModelVersion, List<LegacyModelInitializerEntry> modelInitializerEntries) {
         try {
             Class<?> clazz = legacyChildFirstClassLoader.loadClass(ChildFirstClassLoaderKernelServicesFactory.class.getName());
+            List<Object> convertedBootOps = getConvertedBootOps(bootOperations);
+            List<Object> convertedModelInitializerEntries = convertModelInitializer(modelInitializerEntries);
 
-            Method m = clazz.getMethod("create",
-                    List.class,
-                    legacyChildFirstClassLoader.loadClass(ModelTestOperationValidatorFilter.class.getName()),
-                    legacyChildFirstClassLoader.loadClass(ModelVersion.class.getName()),
-                    List.class);
+            Object convertedValidationFilter = objectConverter.convertValidateOperationsFilterToChildCl(validateOpsFilter);
+            Object convertedLegacyModelVersion = objectConverter.convertModelVersionToChildCl(legacyModelVersion);
 
-            List<Object> convertedBootOps = new ArrayList<Object>();
-            for (int i = 0 ; i < bootOperations.size() ; i++) {
-                ModelNode node = bootOperations.get(i);
-                if (node != null) {
-                    convertedBootOps.add(objectConverter.convertModelNodeToChildCl(node));
-                }
+            if (!Stability.DEFAULT.equals(stability)) {
+                Method m = clazz.getMethod("create",
+                        List.class,
+                        legacyChildFirstClassLoader.loadClass(ModelTestOperationValidatorFilter.class.getName()),
+                        legacyChildFirstClassLoader.loadClass(ModelVersion.class.getName()),
+                        List.class,
+                        String.class);
+
+                return m.invoke(null,
+                        convertedBootOps,
+                        convertedValidationFilter,
+                        convertedLegacyModelVersion,
+                        convertedModelInitializerEntries,
+                        stability.toString());
+            } else {
+                Method m = clazz.getMethod("create",
+                        List.class,
+                        legacyChildFirstClassLoader.loadClass(ModelTestOperationValidatorFilter.class.getName()),
+                        legacyChildFirstClassLoader.loadClass(ModelVersion.class.getName()),
+                        List.class);
+
+                return m.invoke(null,
+                        convertedBootOps,
+                        convertedValidationFilter,
+                        convertedLegacyModelVersion,
+                        convertedModelInitializerEntries);
             }
-
-            List<Object> convertedModelInitializerEntries = null;
-            if (modelInitializerEntries != null) {
-                convertedModelInitializerEntries = new ArrayList<Object>();
-                for (LegacyModelInitializerEntry entry : modelInitializerEntries) {
-                    convertedModelInitializerEntries.add(objectConverter.convertLegacyModelInitializerEntryToChildCl(entry));
-                }
-            }
-
-            return m.invoke(null, convertedBootOps, objectConverter.convertValidateOperationsFilterToChildCl(validateOpsFilter), objectConverter.convertModelVersionToChildCl(legacyModelVersion), convertedModelInitializerEntries);
-
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
+
+    private List<Object> convertModelInitializer(List<LegacyModelInitializerEntry> modelInitializerEntries) {
+        List<Object> converted = null;
+        if (modelInitializerEntries != null) {
+            converted = new ArrayList<>();
+            for (LegacyModelInitializerEntry entry : modelInitializerEntries) {
+                converted.add(objectConverter.convertLegacyModelInitializerEntryToChildCl(entry));
+            }
+        }
+        return converted;
+    }
+
+    private List<Object> getConvertedBootOps(List<ModelNode> bootOperations) {
+        List<Object> converted = new ArrayList<>();
+        for (ModelNode node : bootOperations) {
+            if (node != null) {
+                converted.add(objectConverter.convertModelNodeToChildCl(node));
+            }
+        }
+        return converted;
+    }
 }
+

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -94,6 +94,7 @@ import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLMapper;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.wildfly.common.xml.XMLInputFactoryUtil;
 import org.wildfly.legacy.test.spi.Version;
 
@@ -691,6 +692,7 @@ public class CoreModelTestDelegate {
         private ModelTestOperationValidatorFilter.Builder operationValidationExcludeFilterBuilder;
 
         LegacyKernelServicesInitializerImpl(ModelVersion modelVersion, ModelTestControllerVersion version) {
+            Assume.assumeFalse("This model controller version is ignored for this server.", version.isIgnored());
             this.classLoaderBuilder = new ChildFirstClassLoaderBuilder(version.isEap());
             this.modelVersion = modelVersion;
             this.testControllerVersion = version;

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deployment/DomainDeploymentTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deployment/DomainDeploymentTransformersTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -66,6 +67,9 @@ public class DomainDeploymentTransformersTestCase extends AbstractCoreModelTest 
             KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
             Assert.assertTrue("Legacy services didn't boot for version " + modelVersion, legacyServices.isSuccessfulBoot());
             checkCoreModelTransformation(mainServices, modelVersion);
+        } catch (AssumptionViolatedException ex) {
+            // If the test is ignored, we want to propagate the exception
+            throw ex;
         } catch (Exception ex) {
             throw new RuntimeException("Error for version " + modelVersion + " " + ex.getMessage(), ex);
         }
@@ -86,10 +90,13 @@ public class DomainDeploymentTransformersTestCase extends AbstractCoreModelTest 
 
             List<ModelNode> operations = builder.parseXmlResource("domain-exploded-deployments.xml");
             //removing the ading of "management-client-content" => "rollout-plans
-            operations = operations.subList(0, operations.size() -2);
+            operations = operations.subList(0, operations.size() - 2);
             ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, operations, getConfig());
+        } catch (AssumptionViolatedException ex) {
+            // If the test is ignored, we want to propagate the exception
+            throw ex;
         } catch (Exception ex) {
-            throw new RuntimeException("Error for version " + modelVersion + " " + ex.getMessage(), ex);
+            throw new Exception("Error for version " + modelVersion + " " + ex.getMessage(), ex);
         }
     }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -46,6 +46,8 @@ public class TransformersTestParameter extends ClassloaderParameter {
         //we only test EAP 7.4 and newer
         data.add(new TransformersTestParameter(ModelVersion.create(16, 0, 0), ModelTestControllerVersion.EAP_7_4_0));
         data.add(new TransformersTestParameter(ModelVersion.create(22, 0, 0), ModelTestControllerVersion.EAP_8_0_0));
+        // Requires an update of the wildfly legacy test version
+        // data.add(new TransformersTestParameter(ModelVersion.create(24, 0, 0), ModelTestControllerVersion.WILDFLY_31_0_0));
         return data;
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -111,9 +111,11 @@ public class SubsystemTransformerTestCase extends AbstractElytronSubsystemBaseTe
     }
 
     private KernelServices buildKernelServices(String xml, ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {
-        KernelServicesBuilder builder = this.createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXml(xml);
+        AdditionalInitialization additionalInitialization = AdditionalInitialization.fromModelTestControllerVersion(controllerVersion);
 
-        builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, version)
+        KernelServicesBuilder builder = this.createKernelServicesBuilder(additionalInitialization).setSubsystemXml(xml);
+
+        builder.createLegacyKernelServicesBuilder(additionalInitialization, controllerVersion, version)
                 .addMavenResourceURL(mavenResourceURLs)
                 .skipReverseControllerCheck()
                 .addParentFirstClassPattern("org.jboss.as.controller.logging.ControllerLogger*")
@@ -151,8 +153,8 @@ public class SubsystemTransformerTestCase extends AbstractElytronSubsystemBaseTe
         ModelVersion elytronVersion = controllerVersion.getSubsystemModelVersion(getMainSubsystemName());
 
         //Boot up empty controllers with the resources needed for the ops coming from the xml to work
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.withCapabilities(
-                RuntimeCapability.buildDynamicCapabilityName(Capabilities.DATA_SOURCE_CAPABILITY_NAME, "ExampleDS")
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.withCapabilities(controllerVersion.getStability(),
+                        RuntimeCapability.buildDynamicCapabilityName(Capabilities.DATA_SOURCE_CAPABILITY_NAME, "ExampleDS")
         ));
         builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, elytronVersion)
                 .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-elytron-integration:" + controllerVersion.getCoreVersion())

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -42,12 +42,15 @@ public enum ModelTestControllerVersion {
     private final String artifactIdPrefix;
     private final Map<String, ModelVersion> subsystemModelVersions = new LinkedHashMap<>();
     private final Stability stability;
+    private final boolean ignored;
 
     ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String realVersionName) {
         this(mavenGavVersion, eap, testControllerVersion, null, realVersionName);
     }
-
     ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String coreVersion, String realVersionName) {
+        this(mavenGavVersion, eap, testControllerVersion, coreVersion, realVersionName, false);
+    }
+    ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String coreVersion, String realVersionName, boolean ignored) {
         this.mavenGavVersion = mavenGavVersion;
         this.testControllerVersion = testControllerVersion;
         this.eap = eap;
@@ -55,6 +58,7 @@ public enum ModelTestControllerVersion {
         this.validLegacyController = testControllerVersion != null;
         this.coreVersion = coreVersion == null? mavenGavVersion : coreVersion; //full == core
         this.realVersionName = realVersionName;
+        this.ignored = ignored;
         if (eap) {
             if (coreVersion != null) { //eap 7+ has core version defined
                 this.coreMavenGroupId = "org.wildfly.core";
@@ -169,5 +173,9 @@ public enum ModelTestControllerVersion {
 
     public Stability getStability() {
         return stability;
+    }
+
+    public boolean isIgnored() {
+        return ignored;
     }
 }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -9,19 +9,25 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.version.Stability;
 import org.wildfly.legacy.version.LegacyVersions;
 
 
+/**
+ * Represents the versions of the legacy controllers that are available for testing.
+ */
 public enum ModelTestControllerVersion {
-    //AS releases
-
+    // Release version under test
     MASTER (CurrentVersion.VERSION, false, null, "master" ),
 
     //EAP releases
     EAP_7_4_0("7.4.0.GA-redhat-00005", true, "23.0.0", "15.0.2.Final-redhat-00001", "7.4.0"),
     EAP_8_0_0("8.0.0.GA-redhat-00011", true, "29.0.0", "21.0.5.Final-redhat-00001", "8.0.0"),
     EAP_XP_4("4.0.0.GA-redhat-00003", true, "23.0.0", "15.0.26.Final-redhat-00001", "xp4"),
-    EAP_XP_5("5.0.0.GA-redhat-00005", true, "29.0.0", "21.0.5.Final-redhat-00001", "xp5");
+    EAP_XP_5("5.0.0.GA-redhat-00005", true, "29.0.0", "21.0.5.Final-redhat-00001", "xp5"),
+
+    //WildFly releases
+    WILDFLY_31_0_0("31.0.0.Final", false, "31.0.0", "23.0.1.Final", "wf31");
 
     private final String mavenGavVersion;
     private final String testControllerVersion;
@@ -35,6 +41,7 @@ public enum ModelTestControllerVersion {
     private final String realVersionName;
     private final String artifactIdPrefix;
     private final Map<String, ModelVersion> subsystemModelVersions = new LinkedHashMap<>();
+    private final Stability stability;
 
     ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String realVersionName) {
         this(mavenGavVersion, eap, testControllerVersion, null, realVersionName);
@@ -44,6 +51,7 @@ public enum ModelTestControllerVersion {
         this.mavenGavVersion = mavenGavVersion;
         this.testControllerVersion = testControllerVersion;
         this.eap = eap;
+        this.stability = eap ? Stability.DEFAULT : Stability.COMMUNITY;
         this.validLegacyController = testControllerVersion != null;
         this.coreVersion = coreVersion == null? mavenGavVersion : coreVersion; //full == core
         this.realVersionName = realVersionName;
@@ -159,4 +167,7 @@ public enum ModelTestControllerVersion {
 
     }
 
+    public Stability getStability() {
+        return stability;
+    }
 }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -181,6 +181,60 @@ public abstract class ModelTestModelControllerService extends AbstractController
         this.runningModeControl = runningModeControl;
     }
 
+    /**
+     * This is the constructor to use for WildFly 31.0.0 core model tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, Stability stability, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition rootResourceDefinition, final ControlledProcessState processState,
+                                              final ExpressionResolver expressionResolver, final CapabilityRegistry capabilityRegistry, final Controller31x version) {
+        super(null,
+                null,
+                processType,
+                stability,
+                runningModeControl,
+                persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootResourceDefinition,
+                null,
+                expressionResolver,
+                AuditLogger.NO_OP_LOGGER,
+                new DelegatingConfigurableAuthorizer(),
+                new ManagementSecurityIdentitySupplier(),
+                capabilityRegistry,
+                null);
+
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for WildFly 31.0.0 subsystem tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, Stability stability, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition resourceDefinition, final ExpressionResolver expressionResolver, final ControlledProcessState processState,
+                                              final CapabilityRegistry capabilityRegistry, final Controller31x version) {
+        super(null,
+                null,
+                processType,
+                stability,
+                runningModeControl,
+                persister,
+                processState == null ? new ControlledProcessState(true) : processState,
+                resourceDefinition, null,
+                expressionResolver != null ? expressionResolver : ExpressionResolver.TEST_RESOLVER,
+                AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer(),
+                new ManagementSecurityIdentitySupplier(),
+                capabilityRegistry,
+                null);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
 
     /**
      * This is the constructor to use for current core model tests
@@ -479,6 +533,12 @@ public abstract class ModelTestModelControllerService extends AbstractController
     public static class Controller29x {
         public static Controller29x INSTANCE = new Controller29x();
         private Controller29x() {
+        }
+    }
+
+    public static class Controller31x {
+        public static Controller31x INSTANCE = new Controller31x();
+        private Controller31x() {
         }
     }
 }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
@@ -5,6 +5,7 @@
 package org.jboss.as.subsystem.bridge.impl;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ModelVersion;
@@ -18,6 +19,7 @@ import org.jboss.as.subsystem.test.AbstractKernelServicesImpl;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.TestParser;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -36,6 +38,25 @@ public class ChildFirstClassLoaderKernelServicesFactory {
         }
 
         ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.DOMAIN_SERVER, new RunningModeControl(RunningMode.ADMIN_ONLY));
+        ModelTestParser testParser = new TestParser(mainSubsystemName, extensionRegistry);
+        return AbstractKernelServicesImpl.create(null, mainSubsystemName, additionalInit, validateOpsFilter,
+                extensionRegistry, bootOperations, testParser, extension, legacyModelVersion, false, persistXml);
+    }
+
+    public static KernelServices create(String mainSubsystemName, String extensionClassName, AdditionalInitialization additionalInit, ModelTestOperationValidatorFilter validateOpsFilter,
+                                        List<ModelNode> bootOperations, ModelVersion legacyModelVersion, boolean persistXml, String stabilityStr) throws Exception {
+        Objects.requireNonNull(additionalInit,"additionalInit is required");
+        Stability stability = Stability.fromString(stabilityStr);
+
+        Extension extension = (Extension) Class.forName(extensionClassName)
+                .getDeclaredConstructor()
+                .newInstance();
+
+        ExtensionRegistry extensionRegistry = ExtensionRegistry.builder(ProcessType.DOMAIN_SERVER)
+                .withRunningMode(RunningMode.ADMIN_ONLY)
+                .withStability(stability)
+                .build();
+
         ModelTestParser testParser = new TestParser(mainSubsystemName, extensionRegistry);
         return AbstractKernelServicesImpl.create(null, mainSubsystemName, additionalInit, validateOpsFilter,
                 extensionRegistry, bootOperations, testParser, extension, legacyModelVersion, false, persistXml);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AdditionalInitialization.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AdditionalInitialization.java
@@ -18,6 +18,7 @@ import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestModelDescriptionValidator.AttributeOrParameterArbitraryDescriptorValidator;
 import org.jboss.as.subsystem.test.ModelDescriptionValidator.ValidationConfiguration;
 import org.jboss.as.version.Stability;
@@ -76,6 +77,10 @@ public class AdditionalInitialization extends AdditionalParsers implements Featu
             this(schema.getStability());
         }
 
+        public ManagementAdditionalInitialization(ModelTestControllerVersion version) {
+            this(version.getStability());
+        }
+
         public ManagementAdditionalInitialization(Stability stability) {
             this.stability = stability;
         }
@@ -110,6 +115,16 @@ public class AdditionalInitialization extends AdditionalParsers implements Featu
         }
     }
 
+    /**
+     * Creates a {@link org.jboss.as.subsystem.test.AdditionalInitialization.ManagementAdditionalInitialization} with
+     * the given {@link org.jboss.as.model.test.ModelTestControllerVersion version} stability level.
+     *
+     * @param version ModelTestController version
+     * @return the additional initialization
+     */
+    public static AdditionalInitialization fromModelTestControllerVersion(ModelTestControllerVersion version) {
+        return new ManagementAdditionalInitialization(version);
+    }
 
     /**
      * Creates a {@link org.jboss.as.subsystem.test.AdditionalInitialization.ManagementAdditionalInitialization} with
@@ -122,6 +137,27 @@ public class AdditionalInitialization extends AdditionalParsers implements Featu
      */
     public static AdditionalInitialization withCapabilities(final String... capabilities) {
         return new ManagementAdditionalInitialization() {
+
+            @Override
+            protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
+                super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
+                registerCapabilities(capabilityRegistry, capabilities);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link org.jboss.as.subsystem.test.AdditionalInitialization.ManagementAdditionalInitialization} with
+     * the given {@link org.jboss.as.controller.capability.RuntimeCapability capabilities} registered, making it
+     * possible for subsystems under test to require them. No runtime API will be available, but that should not
+     * be needed for a {@link org.jboss.as.controller.RunningMode#ADMIN_ONLY} test.
+     *
+     * @param stability the desired stability level of the installed controller
+     * @param capabilities the capabilities
+     * @return the additional initialization
+     */
+    public static AdditionalInitialization withCapabilities(final Stability stability, final String... capabilities) {
+        return new ManagementAdditionalInitialization(stability) {
 
             @Override
             protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -114,7 +114,7 @@ final class SubsystemTestDelegate {
     private final Class<?> testClass;
     private final List<KernelServices> kernelServices = new ArrayList<>();
 
-    protected final String mainSubsystemName;
+    private final String mainSubsystemName;
     private final Extension mainExtension;
     private final Comparator<PathAddress> removeOrderComparator;
 
@@ -222,11 +222,14 @@ final class SubsystemTestDelegate {
 
         // Use ProcessType.HOST_CONTROLLER for this ExtensionRegistry so we don't need to provide
         // a PathManager via the ExtensionContext. All we need the Extension to do here is register the xml writers
-        ExtensionRegistry outputExtensionRegistry = ExtensionRegistry.builder(ProcessType.HOST_CONTROLLER).withStability(this.stability).build();
+        ExtensionRegistry outputExtensionRegistry = ExtensionRegistry.builder(ProcessType.HOST_CONTROLLER)
+                .withStability(this.stability)
+                .build();
+
         outputExtensionRegistry.setWriterRegistry(persister);
 
-        Extension extension = mainExtension.getClass().newInstance();
-        extension.initialize(outputExtensionRegistry.getExtensionContext("Test", MOCK_RESOURCE_REG, ExtensionRegistryType.SLAVE));
+        Extension extension = mainExtension.getClass().getDeclaredConstructor().newInstance();
+        extension.initialize(outputExtensionRegistry.getExtensionContext("Test", stability, MOCK_RESOURCE_REG, ExtensionRegistryType.SLAVE));
 
         ConfigurationPersister.PersistenceResource resource = persister.store(model, Collections.emptySet());
         resource.commit();
@@ -254,7 +257,7 @@ final class SubsystemTestDelegate {
     }
 
     /**
-     * Checks that the subystem resources can be removed, i.e. that people have registered
+     * Checks that the subsystem resources can be removed, i.e. that people have registered
      * working 'remove' operations for every 'add' level.
      *
      * @param kernelServices the kernel services used to access the controller
@@ -264,7 +267,7 @@ final class SubsystemTestDelegate {
     }
 
     /**
-     * Checks that the subystem resources can be removed, i.e. that people have registered
+     * Checks that the subsystem resources can be removed, i.e. that people have registered
      * working 'remove' operations for every 'add' level.
      *
      * @param kernelServices        the kernel services used to access the controller
@@ -430,7 +433,11 @@ final class SubsystemTestDelegate {
     }
 
     private ExtensionRegistry cloneExtensionRegistry(AdditionalInitialization additionalInit) {
-        final ExtensionRegistry clone = ExtensionRegistry.builder(additionalInit.getProcessType()).withRunningMode(additionalInit.getExtensionRegistryRunningMode()).withStability(additionalInit.getStability()).build();
+        final ExtensionRegistry clone = ExtensionRegistry.builder(additionalInit.getProcessType())
+                .withRunningMode(additionalInit.getExtensionRegistryRunningMode())
+                .withStability(additionalInit.getStability())
+                .build();
+
         for (String extension : extensionParsingRegistry.getExtensionModuleNames()) {
             ExtensionParsingContext epc = clone.getExtensionParsingContext(extension, null);
             for (Map.Entry<String, SubsystemInformation> entry : extensionParsingRegistry.getAvailableSubsystems(extension).entrySet()) {
@@ -546,7 +553,7 @@ final class SubsystemTestDelegate {
             bootOperationBuilder.validateNotAlreadyBuilt();
             List<ModelNode> bootOperations = bootOperationBuilder.build();
             AbstractKernelServicesImpl kernelServices = AbstractKernelServicesImpl.create(testClass, mainSubsystemName, additionalInit, ModelTestOperationValidatorFilter.createValidateAll(), cloneExtensionRegistry(additionalInit), bootOperations,
-                    testParser, mainExtension, null, legacyControllerInitializers.size() > 0, true);
+                    testParser, mainExtension, null, !legacyControllerInitializers.isEmpty(), true);
             SubsystemTestDelegate.this.kernelServices.add(kernelServices);
             validateDescriptionProviders(additionalInit, kernelServices);
             ImmutableManagementResourceRegistration subsystemReg = kernelServices.getRootRegistration().getSubModel(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, mainSubsystemName)));
@@ -559,7 +566,7 @@ final class SubsystemTestDelegate {
             for (Map.Entry<ModelVersion, LegacyKernelServiceInitializerImpl> entry : legacyControllerInitializers.entrySet()) {
                 LegacyKernelServiceInitializerImpl legacyInitializer = entry.getValue();
 
-                List<ModelNode> transformedBootOperations = new ArrayList<ModelNode>();
+                List<ModelNode> transformedBootOperations = new ArrayList<>();
                 for (ModelNode op : bootOperations) {
 
                     TransformedOperation transformedOp = kernelServices.transformOperation(entry.getKey(), op);
@@ -619,8 +626,8 @@ final class SubsystemTestDelegate {
         private final AdditionalInitialization additionalInit;
         private final ModelTestControllerVersion testControllerVersion;
         private String extensionClassName;
-        private ModelVersion modelVersion;
-        private ChildFirstClassLoaderBuilder classLoaderBuilder;
+        private final ModelVersion modelVersion;
+        private final ChildFirstClassLoaderBuilder classLoaderBuilder;
         private ModelTestOperationValidatorFilter.Builder operationValidationExcludeBuilder;
         private boolean persistXml = true;
         private boolean skipReverseCheck;

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -28,6 +28,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -550,6 +551,7 @@ final class SubsystemTestDelegate {
         }
 
         public KernelServices build() throws Exception {
+
             bootOperationBuilder.validateNotAlreadyBuilt();
             List<ModelNode> bootOperations = bootOperationBuilder.build();
             AbstractKernelServicesImpl kernelServices = AbstractKernelServicesImpl.create(testClass, mainSubsystemName, additionalInit, ModelTestOperationValidatorFilter.createValidateAll(), cloneExtensionRegistry(additionalInit), bootOperations,
@@ -636,6 +638,7 @@ final class SubsystemTestDelegate {
         private OperationFixer reverseCheckOperationFixer = operation -> operation;
 
         public LegacyKernelServiceInitializerImpl(AdditionalInitialization additionalInit, ModelTestControllerVersion version, ModelVersion modelVersion) {
+            Assume.assumeFalse("This model controller version is ignored for this server.", version.isIgnored());
             this.classLoaderBuilder = new ChildFirstClassLoaderBuilder(version.isEap());
             this.additionalInit = additionalInit == null ? AdditionalInitialization.MANAGEMENT : additionalInit;
             this.testControllerVersion = version;

--- a/version/src/main/java/org/jboss/as/version/ProductConfig.java
+++ b/version/src/main/java/org/jboss/as/version/ProductConfig.java
@@ -148,10 +148,15 @@ public class ProductConfig implements Serializable {
 
     /** Solely for use in unit testing */
     public ProductConfig(final String productName, final String productVersion, final String consoleSlot) {
+        this(productName, productVersion, consoleSlot, Stability.DEFAULT);
+    }
+
+    /** Solely for use in unit testing */
+    public ProductConfig(final String productName, final String productVersion, final String consoleSlot, final Stability defaultStability) {
         this.name = productName;
         this.version = productVersion;
         this.consoleSlot = consoleSlot;
-        this.defaultStability = Stability.COMMUNITY;
+        this.defaultStability = defaultStability;
         this.stabilities = EnumSet.allOf(Stability.class).stream()
                 .filter(this.defaultStability::enables)
                 .collect(Collectors.toUnmodifiableSet());


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7091


@kabir / @pferraro This is preliminary work to prepare WildFly Core for the usage of the incoming WildFly Legacy Test release. Basically:
- Prepare all the stuff to be able to move the stability level to the classes that will bootstrap the legacy controllers.
- In the case of subsystem-tests, the desired stability level will be driven by the AdditionalInitialization class from the ModelTestControllerVersion in use.
- In the case of the core-tests, the stability will be driven directly
- At the product level, we can control which tests will be executed using the ignored property of the ModelTestControllerVersion, it is not too flexible,but enough to what we need at this moment.

Once this PR gets approved, we will release a WildFly Core version, we will upgrade wildfly legacy tests with that released WildFly core version, and we will later bump it in WIldFly Core. We can avoid this intermediate step, if we release wildfly legacy tests compiled with a WildlFly Core snapshot version, but I am more in favor of using a released one.