### PR TITLE
[WFCORE-7102]: AccessDeniedException on Windows when using a read-only

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
@@ -185,7 +185,7 @@ public class ConfigurationFile {
         this.configurationExtension = configurationExtension;
         this.interactionPolicy = interactionPolicy == null ? InteractionPolicy.STANDARD : interactionPolicy;
         // If we are in a read only policy and the configurationDir cannot be written, then we use the tmpDir for temporal files and history
-        this.historyRoot = new File(tmpDir != null && this.interactionPolicy.isReadOnly() && !configurationDir.canWrite() ? tmpDir : configurationDir,
+        this.historyRoot = new File(tmpDir != null && this.interactionPolicy.isReadOnly() && !Files.isWritable(configurationDir.toPath())? tmpDir : configurationDir,
                 rawName.replace('.', '_') + "_history");
         this.currentHistory = new File(historyRoot, "current");
         this.snapshotsDirectory = new File(historyRoot, "snapshot");

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
@@ -9,6 +9,7 @@ import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.jboss.dmr.ModelNode;
 
@@ -37,7 +38,7 @@ public class ConfigurationFilePersistenceResource extends AbstractFilePersistenc
 
         if ( FilePersistenceUtils.isParentFolderWritable(fileName) ){
             tempFileName = FilePersistenceUtils.createTempFile(fileName);
-        } else if (configurationFile.getConfigurationDir().canWrite()) {
+        } else if (Files.isWritable(configurationFile.getConfigurationDir().toPath())) {
             tempFileName = FilePersistenceUtils.createTempFile(configurationFile.getConfigurationDir(), fileName.getName());
         } else {
             tempFileName = FilePersistenceUtils.createTempFile(configurationFile.getConfigurationTmpDir(), fileName.getName());

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -178,6 +178,6 @@ class FilePersistenceUtils {
         if ( !file.exists() || file.getParentFile() == null ){
             return false;
         }
-        return  file.getParentFile().canWrite();
+        return Files.isWritable(file.getParentFile().toPath());
     }
 }


### PR DESCRIPTION
configuration dir.

* Replacing java.io.File.canWrite() by java.nio.file.FIles.isWritable(Path).

Jira: https://issues.redhat.com/browse/WFCORE-7102