### PR TITLE
[WFCORE-7104] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Elytron

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/DependencyProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DependencyProcessor.java
@@ -12,7 +12,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 /**
@@ -22,7 +21,7 @@ import org.jboss.modules.ModuleLoader;
  */
 class DependencyProcessor implements DeploymentUnitProcessor {
 
-    private final ModuleIdentifier elytronIdentifier = ModuleIdentifier.create("org.wildfly.security.elytron");
+    private final String elytronModuleName = "org.wildfly.security.elytron";
 
     @Override
     public void deploy(DeploymentPhaseContext context) throws DeploymentUnitProcessingException {
@@ -30,7 +29,7 @@ class DependencyProcessor implements DeploymentUnitProcessor {
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, elytronIdentifier, false, false, true, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, elytronModuleName).setImportServices(true).build());
     }
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/EESecurityDependencyProcessor.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/EESecurityDependencyProcessor.java
@@ -31,8 +31,8 @@ class EESecurityDependencyProcessor implements DeploymentUnitProcessor {
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JACC_API, false, false, true, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, AUTH_MESSAGE_API, false, false, true, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, JACC_API).setImportServices(true).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, AUTH_MESSAGE_API).setImportServices(true).build());
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7104