### PR TITLE
[WFCORE-7106] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Logging

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/deployments/LoggingDependencyDeploymentProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/LoggingDependencyDeploymentProcessor.java
@@ -37,7 +37,7 @@ public class LoggingDependencyDeploymentProcessor implements DeploymentUnitProce
             try {
                 LoggingLogger.ROOT_LOGGER.tracef("Adding module '%s' to deployment '%s'", moduleId, deploymentUnit.getName());
                 moduleLoader.loadModule(moduleId);
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleId, false, false, moduleDep.isImportServices(), false));
+                moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleId).setImportServices(moduleDep.isImportServices()).build());
             } catch (ModuleLoadException ex) {
                 LoggingLogger.ROOT_LOGGER.debugf("Module not found: %s", moduleId);
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7106