### PR TITLE
[WFCORE-7105] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Server

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/DriverDependenciesProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/DriverDependenciesProcessor.java
@@ -33,7 +33,7 @@ public class DriverDependenciesProcessor implements DeploymentUnitProcessor {
             for (ResourceRoot root : resourceRoots) {
                 VirtualFile child = root.getRoot().getChild(SERVICE_FILE_NAME);
                 if (child.exists()) {
-                    moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JTA, false, false, false, false));
+                    moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, JTA).build());
                     break;
                 }
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ManifestDependencyProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ManifestDependencyProcessor.java
@@ -104,7 +104,7 @@ public final class ManifestDependencyProcessor implements DeploymentUnitProcesso
                     }
                 }
 
-                final ModuleDependency dependency = new ModuleDependency(dependencyLoader, dependencyId, optional, export, services, true);
+                final ModuleDependency dependency = ModuleDependency.Builder.of(dependencyLoader, dependencyId.toString()).setOptional(optional).setExport(export).setImportServices(services).setUserSpecified(true).build();
                 if(metaInf) {
                     dependency.addImportFilter(PathFilters.getMetaInfSubdirectoriesFilter(), true);
                     dependency.addImportFilter(PathFilters.getMetaInfFilter(), true);

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleClassPathProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleClassPathProcessor.java
@@ -33,7 +33,7 @@ public final class ModuleClassPathProcessor implements DeploymentUnitProcessor {
         if (entries != null) {
             for (ModuleIdentifier entry : entries) {
                 //class path items are always exported to make transitive dependencies work
-                moduleSpecification.addLocalDependency(new ModuleDependency(moduleLoader, entry, false, true, true, false));
+                moduleSpecification.addLocalDependency(ModuleDependency.Builder.of(moduleLoader, entry.toString()).setExport(true).setImportServices(true).build());
             }
         }
 
@@ -48,10 +48,10 @@ public final class ModuleClassPathProcessor implements DeploymentUnitProcessor {
                 // this means that a module that references the additional module
                 // gets access to the transitive closure of its call-path entries
                 for (ModuleIdentifier entry : dependencies) {
-                    additionalModule.addLocalDependency(new ModuleDependency(moduleLoader, entry, false, true, true, false));
+                    additionalModule.addLocalDependency(ModuleDependency.Builder.of(moduleLoader, entry.toString()).setExport(true).setImportServices(true).build());
                 }
                 // add a dependency on the top ear itself for good measure
-                additionalModule.addLocalDependency(new ModuleDependency(moduleLoader, deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER), false, false, true, false));
+                additionalModule.addLocalDependency(ModuleDependency.Builder.of(moduleLoader, deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER).toString()).setImportServices(true).build());
             }
         }
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleExtensionListProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleExtensionListProcessor.java
@@ -84,7 +84,7 @@ public final class ModuleExtensionListProcessor implements DeploymentUnitProcess
         }
 
         for (ModuleIdentifier extension : allExtensionListEntries) {
-            ModuleDependency dependency = new ModuleDependency(moduleLoader, extension, false, false, true, true);
+            ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, extension.toString()).setImportServices(true).setUserSpecified(true).build();
             dependency.addImportFilter(PathFilters.getMetaInfSubdirectoriesFilter(), true);
             dependency.addImportFilter(PathFilters.getMetaInfFilter(), true);
             moduleSpecification.addLocalDependency(dependency);
@@ -105,8 +105,7 @@ public final class ModuleExtensionListProcessor implements DeploymentUnitProcess
                                     .getSpecificationVersion(), entry.getImplementationVersion(), entry
                                     .getImplementationVendorId());
                             if (extension != null) {
-                                moduleSpecification.addLocalDependency(new ModuleDependency(moduleLoader, extension, false, false,
-                                        true, false));
+                                moduleSpecification.addLocalDependency(ModuleDependency.Builder.of(moduleLoader, extension.toString()).setImportServices(true).build());
                                 nextPhaseDeps.add(ServiceModuleLoader.moduleSpecServiceName(extension.toString()));
                             } else {
                                 ServerLogger.DEPLOYMENT_LOGGER.cannotFindExtensionListEntry(entry, resourceRoot);

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -289,7 +289,7 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
 
             HashSet<ModuleDependency> dependencies = new HashSet<>(moduleSpecification.getAllDependencies());
             //we need to add the module we are aliasing as a dependency, to make sure that it will be resolved
-            dependencies.add(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, false, false));
+            dependencies.add(ModuleDependency.Builder.of(moduleLoader, moduleIdentifier.toString()).build());
             ModuleDefinition moduleDefinition = new ModuleDefinition(alias, dependencies, spec);
 
             final ServiceBuilder sb = phaseContext.getServiceTarget().addService(moduleSpecServiceName);

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
@@ -38,7 +38,7 @@ public class ServerDependenciesProcessor implements DeploymentUnitProcessor {
         for (String moduleName : DEFAULT_MODULES) {
             try {
                 moduleLoader.loadModule(moduleName);
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleName, false, false, false, false));
+                moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleName).build());
             } catch (ModuleLoadException ex) {
                 ServerLogger.ROOT_LOGGER.debugf("Module not found: %s", moduleName);
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/SubDeploymentDependencyProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/SubDeploymentDependencyProcessor.java
@@ -39,7 +39,7 @@ public class SubDeploymentDependencyProcessor implements DeploymentUnitProcessor
             final ModuleIdentifier parentModule = parent.getAttachment(Attachments.MODULE_IDENTIFIER);
             if (parentModule != null) {
                 // access to ear classes
-                ModuleDependency moduleDependency = new ModuleDependency(moduleLoader, parentModule, false, false, true, false);
+                ModuleDependency moduleDependency = ModuleDependency.Builder.of(moduleLoader, parentModule.toString()).setImportServices(true).build();
                 moduleDependency.addImportFilter(PathFilters.acceptAll(), true);
                 moduleSpec.addLocalDependency(moduleDependency);
             }
@@ -47,7 +47,7 @@ public class SubDeploymentDependencyProcessor implements DeploymentUnitProcessor
 
         // make the deployment content available to any additional modules
         for (AdditionalModuleSpecification module : deploymentUnit.getAttachmentList(Attachments.ADDITIONAL_MODULES)) {
-            module.addLocalDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
+            module.addLocalDependency(ModuleDependency.Builder.of(moduleLoader, moduleIdentifier.toString()).setImportServices(true).build());
         }
 
         final List<DeploymentUnit> subDeployments = parent.getAttachmentList(Attachments.SUB_DEPLOYMENTS);
@@ -56,7 +56,7 @@ public class SubDeploymentDependencyProcessor implements DeploymentUnitProcessor
             final ModuleSpecification subModule = subDeployment.getAttachment(Attachments.MODULE_SPECIFICATION);
             if (!subModule.isPrivateModule() && (!parentModuleSpec.isSubDeploymentModulesIsolated() || subModule.isPublicModule())) {
                 String identifier = subDeployment.getAttachment(Attachments.MODULE_IDENTIFIER).toString();
-                ModuleDependency dependency = new ModuleDependency(moduleLoader, identifier, false, false, true, false);
+                ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, identifier).setImportServices(true).build();
                 dependency.addImportFilter(PathFilters.acceptAll(), true);
                 accessibleModules.add(dependency);
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
@@ -243,10 +243,13 @@ public class DeploymentStructureDescriptorParser implements DeploymentUnitProces
             }
         }
         // No more nested loop
+        ModuleDependency moduleDependency;
         for (ModuleDependency dependency : moduleDependencies) {
             String identifier = dependency.getDependencyModule();
             if (index.containsKey(identifier)) {
-                aliasDependencies.add(new ModuleDependency(dependency.getModuleLoader(), index.get(identifier).getModuleIdentifier(), dependency.isOptional(), dependency.isExport(), dependency.isImportServices(), dependency.isUserSpecified()));
+                moduleDependency = ModuleDependency.Builder.of(dependency.getModuleLoader(), index.get(identifier).getModuleIdentifier().toString())
+                        .setOptional(dependency.isOptional()).setExport(dependency.isExport()).setImportServices(dependency.isImportServices()).setUserSpecified(dependency.isUserSpecified()).build();
+                aliasDependencies.add(moduleDependency);
             }
         }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser10.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser10.java
@@ -390,8 +390,9 @@ public class JBossDeploymentStructureParser10 implements XMLElementReader<ParseR
         if (!required.isEmpty()) {
             throw missingAttributes(reader.getLocation(), required);
         }
-        ModuleDependency dependency = new ModuleDependency(moduleLoader, ModuleIdentifier.create(name, slot), optional, export,
-                services == Disposition.IMPORT, true);
+        final ModuleIdentifier identifier = ModuleIdentifier.create(name, slot);
+        ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, identifier.toString())
+                .setOptional(optional).setExport(export).setImportServices(services == Disposition.IMPORT).setUserSpecified(true).build();
         specBuilder.addModuleDependency(dependency);
         while (reader.hasNext()) {
             switch (reader.nextTag()) {

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser11.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser11.java
@@ -598,8 +598,8 @@ public class JBossDeploymentStructureParser11 implements XMLElementReader<ParseR
             throw missingAttributes(reader.getLocation(), required);
         }
         final ModuleIdentifier identifier = ModuleIdentifier.create(name, slot);
-        final ModuleDependency dependency = new ModuleDependency(moduleLoader, identifier, optional, export,
-                services == Disposition.IMPORT, true);
+        ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, identifier.toString())
+                .setOptional(optional).setExport(export).setImportServices(services == Disposition.IMPORT).setUserSpecified(true).build();
         if(annotations) {
             specBuilder.addAnnotationModule(identifier);
         }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser12.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser12.java
@@ -605,8 +605,8 @@ public class JBossDeploymentStructureParser12 implements XMLElementReader<ParseR
             throw missingAttributes(reader.getLocation(), required);
         }
         final ModuleIdentifier identifier = ModuleIdentifier.create(name, slot);
-        final ModuleDependency dependency = new ModuleDependency(moduleLoader, identifier, optional, export,
-                services == Disposition.IMPORT, true);
+        ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, identifier.toString())
+                .setOptional(optional).setExport(export).setImportServices(services == Disposition.IMPORT).setUserSpecified(true).build();
         if(annotations) {
             specBuilder.addAnnotationModule(identifier);
         }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser13.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser13.java
@@ -615,8 +615,8 @@ public class JBossDeploymentStructureParser13 implements XMLElementReader<ParseR
             throw missingAttributes(reader.getLocation(), required);
         }
         final ModuleIdentifier identifier = ModuleIdentifier.create(name, slot);
-        final ModuleDependency dependency = new ModuleDependency(moduleLoader, identifier, optional, export,
-                services == Disposition.IMPORT, true);
+        ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, identifier.toString())
+                .setOptional(optional).setExport(export).setImportServices(services == Disposition.IMPORT).setUserSpecified(true).build();
         if(annotations) {
             specBuilder.addAnnotationModule(identifier);
         }

--- a/server/src/main/java/org/jboss/as/server/deployment/service/ServiceActivatorDependencyProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/service/ServiceActivatorDependencyProcessor.java
@@ -14,7 +14,6 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceActivator;
 
 /**
@@ -24,7 +23,7 @@ import org.jboss.msc.service.ServiceActivator;
  */
 public class ServiceActivatorDependencyProcessor implements DeploymentUnitProcessor {
 
-    private static final ModuleDependency MSC_DEP = new ModuleDependency(Module.getBootModuleLoader(), ModuleIdentifier.create("org.jboss.msc"), false, false, false, false);
+    private static final ModuleDependency MSC_DEP = ModuleDependency.Builder.of(Module.getBootModuleLoader(), "org.jboss.msc").build();
 
     /**
      * Add the dependencies if the deployment contains a service activator loader entry.

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ModuleLoadService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ModuleLoadService.java
@@ -138,7 +138,7 @@ public class ModuleLoadService implements Service<Module> {
     public static ServiceName installAliases(final ServiceTarget target, final ModuleIdentifier identifier, final List<ModuleIdentifier> aliases) {
         final ArrayList<ModuleDependency> dependencies = new ArrayList<ModuleDependency>(aliases.size());
         for (final ModuleIdentifier i : aliases) {
-            dependencies.add(new ModuleDependency(null, i, false, false, false, false));
+            dependencies.add(ModuleDependency.Builder.of(null, i.toString()).build());
         }
         final ModuleLoadService service = new ModuleLoadService(dependencies);
         return install(target, identifier.toString(), service);

--- a/server/src/test/java/org/jboss/as/server/deployment/module/ModuleSpecificationTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/deployment/module/ModuleSpecificationTestCase.java
@@ -43,7 +43,7 @@ public class ModuleSpecificationTestCase {
         return createModuleDependency(identifier, (String) null);
     }
     private static ModuleDependency createModuleDependency(String identifier, String reason) {
-        return new ModuleDependency(TEST_LOADER, identifier, false, false, true, false, reason);
+        return ModuleDependency.Builder.of(TEST_LOADER, identifier).setImportServices(true).setReason(reason).build();
     }
     private static ModuleDependency createModuleDependency(String identifier, PathFilter importFilter) {
         ModuleDependency dependency = createModuleDependency(identifier, (String) null);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7107