### PR TITLE
[WFCORE-7095][WFCORE-7108][WFCORE-7111][WFCORE-7112][WFCORE-7113][WFCORE-7114] Module identifier in api fixes

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/ModuleIdentifierUtilUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModuleIdentifierUtilUnitTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+import static org.jboss.as.controller.ModuleIdentifierUtil.parseModuleIdentifier;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Unit tests of {@link ModuleIdentifierUtil}.
+ */
+public class ModuleIdentifierUtilUnitTestCase {
+
+    @Test
+    public void testParsingCanonicalization() {
+        assertEquals("org.jboss.foo", canonicalModuleIdentifier("org.jboss.foo"));
+        assertEquals("org.jboss.foo", canonicalModuleIdentifier("org.jboss.foo:main"));
+        assertEquals("org.jboss.foo:bar", canonicalModuleIdentifier("org.jboss.foo:bar"));
+        // TODO these next two seem wrong, but it's what ModuleIdentifier.fromString(...).toString() does
+        assertEquals("org.jboss\\\\\\:foo", canonicalModuleIdentifier("org.jboss\\:foo"));
+        assertEquals("org.jboss\\\\\\:foo:bar", canonicalModuleIdentifier("org.jboss\\:foo:bar"));
+    }
+
+    @Test
+    public void testAppendingCanonicalization() {
+        assertEquals("org.jboss.foo", canonicalModuleIdentifier("org.jboss.foo", null));
+        assertEquals("org.jboss.foo", canonicalModuleIdentifier("org.jboss.foo", "main"));
+        assertEquals("org.jboss.foo:bar", canonicalModuleIdentifier("org.jboss.foo", "bar"));
+        // TODO these next two seem wrong, but it's what ModuleIdentifier.create(...).toString() does
+        assertEquals("org.jboss\\\\\\:foo", canonicalModuleIdentifier("org.jboss\\:foo", null));
+        assertEquals("org.jboss\\\\\\:foo:bar", canonicalModuleIdentifier("org.jboss\\:foo", "bar"));
+    }
+
+    @Test
+    public void testParsingToFunction() {
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo", ModuleIdentifierUtilUnitTestCase::biFunction),
+                null);
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo:main", ModuleIdentifierUtilUnitTestCase::biFunction),
+                "main");
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo:main", ModuleIdentifierUtilUnitTestCase::biFunction, false),
+                "main");
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo:main", ModuleIdentifierUtilUnitTestCase::biFunction, true),
+                null);
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo:main", ModuleIdentifierUtilUnitTestCase::biFunction, false, "bar"),
+                "main");
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo:main", ModuleIdentifierUtilUnitTestCase::biFunction, true, "bar"),
+                "bar");
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo", ModuleIdentifierUtilUnitTestCase::biFunction, false, "bar"),
+                "bar");
+
+        validateFunctionResult(
+                parseModuleIdentifier("org.jboss.foo", ModuleIdentifierUtilUnitTestCase::biFunction, true, "bar"),
+                "bar");
+    }
+
+    private static void validateFunctionResult(Map<String, String> result, String expectedSlot) {
+        assertNotNull(result.toString(), result);
+        assertEquals(result.toString(), 1, result.size());
+        assertTrue(result.toString(), result.containsKey("org.jboss.foo"));
+        assertEquals(result.toString(), expectedSlot == null ? "placeholder" : expectedSlot, result.get("org.jboss.foo"));
+    }
+
+    private static Map<String, String> biFunction(String name, String slot) {
+        return Map.of(name, slot == null ? "placeholder" : slot);
+    }
+}

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/deployment/PermissionsParser.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/deployment/PermissionsParser.java
@@ -31,7 +31,25 @@ import org.wildfly.extension.security.manager.logging.SecurityManagerLogger;
  */
 public class PermissionsParser {
 
+    // TODO remove this as soon as the full WF testsuite use of it is updated to use the string variant
+    /**
+     * @deprecated use {@link #parse(XMLStreamReader, ModuleLoader, String)}
+     */
+    @Deprecated(forRemoval = true)
     public static List<PermissionFactory> parse(final XMLStreamReader reader, final ModuleLoader loader, final ModuleIdentifier identifier)
+            throws XMLStreamException {
+        return parse(reader,loader, identifier.toString());
+    }
+
+    /**
+     * Parse the contents exposed by a reader into a list of {@link PermissionFactory} instances.
+     * @param reader reader of a {@code permissions.xml} or {@code jboss-permissions.xml} descriptor. Cannot be {@code null}.
+     * @param loader loader to use for loading permission classes. Cannot be {@code null}.
+     * @param moduleName canonical name of the module to use for loading permission classes. Cannot be {@code null}.
+     * @return a list of {@link PermissionFactory} instances
+     * @throws XMLStreamException if a parsing error occurs
+     */
+    public static List<PermissionFactory> parse(final XMLStreamReader reader, final ModuleLoader loader, final String moduleName)
             throws XMLStreamException {
 
         reader.require(XMLStreamConstants.START_DOCUMENT, null, null);
@@ -42,7 +60,7 @@ public class PermissionsParser {
                     Element element = Element.forName(reader.getLocalName());
                     switch (element) {
                         case PERMISSIONS: {
-                            return parsePermissions(reader, loader, identifier);
+                            return parsePermissions(reader, loader, moduleName);
                         }
                         default: {
                             throw unexpectedElement(reader);
@@ -57,7 +75,7 @@ public class PermissionsParser {
         throw unexpectedEndOfDocument(reader);
     }
 
-    private static List<PermissionFactory> parsePermissions(final XMLStreamReader reader, final ModuleLoader loader, final ModuleIdentifier identifier)
+    private static List<PermissionFactory> parsePermissions(final XMLStreamReader reader, final ModuleLoader loader, final String moduleName)
             throws XMLStreamException {
 
         List<PermissionFactory> factories = new ArrayList<PermissionFactory>();
@@ -98,7 +116,7 @@ public class PermissionsParser {
                     Element element = Element.forName(reader.getLocalName());
                     switch (element) {
                         case PERMISSION: {
-                            PermissionFactory factory = parsePermission(reader, loader, identifier);
+                            PermissionFactory factory = parsePermission(reader, loader, moduleName);
                             factories.add(factory);
                             break;
                         }
@@ -116,7 +134,7 @@ public class PermissionsParser {
         throw unexpectedEndOfDocument(reader);
     }
 
-    private static PermissionFactory parsePermission(final XMLStreamReader reader, final ModuleLoader loader, final ModuleIdentifier identifier)
+    private static PermissionFactory parsePermission(final XMLStreamReader reader, final ModuleLoader loader, final String moduleName)
             throws XMLStreamException {
 
         // permission element has no attributes.
@@ -136,7 +154,7 @@ public class PermissionsParser {
 
                     // build a permission and add it to the list.
                     PermissionFactory factory = new DeferredPermissionFactory(DeferredPermissionFactory.Type.DEPLOYMENT,
-                            loader, identifier.toString(), permissionClass, permissionName, permissionActions);
+                            loader, moduleName, permissionClass, permissionName, permissionActions);
                     return factory;
                 }
                 case XMLStreamConstants.START_ELEMENT: {

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/deployment/PermissionsParserProcessor.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/deployment/PermissionsParserProcessor.java
@@ -20,7 +20,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ExpressionStreamReaderDelegate;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.server.deployment.module.ResourceRoot;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.security.PermissionFactory;
 import org.jboss.vfs.VirtualFile;
@@ -75,7 +74,7 @@ public class PermissionsParserProcessor implements DeploymentUnitProcessor {
         final ResourceRoot deploymentRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER);
-        final ModuleIdentifier moduleIdentifier = deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER);
+        final String moduleIdentifier = deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER).toString();
         final Function<String, String> wflyResolverFunc = deploymentUnit.getAttachment(Attachments.WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION);
         final Function<String, String> specResolverFunc = deploymentUnit.getAttachment(Attachments.SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION);
 
@@ -129,13 +128,13 @@ public class PermissionsParserProcessor implements DeploymentUnitProcessor {
      *
      * @param file               the {@link VirtualFile} that contains the permissions declarations.
      * @param loader             the {@link ModuleLoader} that is to be used by the factory to instantiate the permission.
-     * @param identifier         the {@link ModuleIdentifier} that is to be used by the factory to instantiate the permission.
+     * @param moduleName         the name of the module that is to be used by the factory to instantiate the permission.
      * @param exprExpandFunction A function which will be used, if provided, to expand any expressions (of the form of {@code ${foobar}})
      *                           in the content being parsed. This function can be null, in which case the content is processed literally.
      * @return a list of {@link PermissionFactory} objects representing the parsed permissions.
      * @throws DeploymentUnitProcessingException if an error occurs while parsing the permissions.
      */
-    private List<PermissionFactory> parsePermissions(final VirtualFile file, final ModuleLoader loader, final ModuleIdentifier identifier, final Function<String, String> exprExpandFunction)
+    private List<PermissionFactory> parsePermissions(final VirtualFile file, final ModuleLoader loader, final String moduleName, final Function<String, String> exprExpandFunction)
             throws DeploymentUnitProcessingException {
 
         InputStream inputStream = null;
@@ -143,7 +142,7 @@ public class PermissionsParserProcessor implements DeploymentUnitProcessor {
             inputStream = file.openStream();
             final XMLInputFactory inputFactory = XMLInputFactoryUtil.create();
             final ExpressionStreamReaderDelegate expressionStreamReaderDelegate = new ExpressionStreamReaderDelegate(inputFactory.createXMLStreamReader(inputStream), exprExpandFunction);
-            return PermissionsParser.parse(expressionStreamReaderDelegate, loader, identifier);
+            return PermissionsParser.parse(expressionStreamReaderDelegate, loader, moduleName);
         } catch (Exception e) {
             throw new DeploymentUnitProcessingException(e.getMessage(), e);
         } finally {

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -121,8 +121,13 @@ public final class Attachments {
     public static final AttachmentKey<Manifest> MANIFEST = AttachmentKey.create(Manifest.class);
 
     /**
-     * Module identifiers for Class-Path information
+     * Module identifiers for Class-Path information.
+     * <p/>
+     * <strong>Note: This is only meant for use within the server kernel.</strong>
+     *
+     * @deprecated this will either be changed incompatibly (to provide a string) or removed altogether in the next WildFly Core major.
      */
+    @Deprecated(forRemoval = true)
     public static final AttachmentKey<AttachmentList<ModuleIdentifier>> CLASS_PATH_ENTRIES = AttachmentKey.createList(ModuleIdentifier.class);
 
     /**
@@ -191,9 +196,26 @@ public final class Attachments {
      */
     public static final AttachmentKey<AttachmentList<AdditionalModuleSpecification>> ADDITIONAL_MODULES = AttachmentKey.createList(AdditionalModuleSpecification.class);
 
+    /**
+     * A list of modules for which annotation indexes should be prepared (or, in later phases, have been prepared).
+     *
+     * @deprecated this will either be changed incompatibly (to provide a list of string) or removed altogether in the next WildFly Core major.
+     */
+    @Deprecated(forRemoval = true)
     public static final AttachmentKey<AttachmentList<ModuleIdentifier>> ADDITIONAL_ANNOTATION_INDEXES = AttachmentKey.createList(ModuleIdentifier.class);
 
+    /**
+     * Annotation indices, keyed by the identifier of the module from which they were obtained.
+     *
+     * @deprecated use {@link #ADDITIONAL_ANNOTATION_INDEXES_BY_MODULE_NAME}
+     */
+    @Deprecated(forRemoval = true)
     public static final AttachmentKey<Map<ModuleIdentifier, CompositeIndex>> ADDITIONAL_ANNOTATION_INDEXES_BY_MODULE = AttachmentKey.create(Map.class);
+
+    /**
+     * Annotation indices, keyed by the canonical name module from which they were obtained.
+     */
+    public static final AttachmentKey<Map<String, CompositeIndex>> ADDITIONAL_ANNOTATION_INDEXES_BY_MODULE_NAME = AttachmentKey.create(Map.class);
 
     public static final AttachmentKey<Map<String, MountedDeploymentOverlay>> DEPLOYMENT_OVERLAY_LOCATIONS = AttachmentKey.create(Map.class);
 
@@ -237,8 +259,16 @@ public final class Attachments {
     //
     /**
      * The module identifier.
+     *
+     * @deprecated use {@link #MODULE_NAME}
      */
+    @Deprecated(forRemoval = true)
     public static final AttachmentKey<ModuleIdentifier> MODULE_IDENTIFIER = AttachmentKey.create(ModuleIdentifier.class);
+
+    /**
+     * The canonical name of the module.
+     */
+    public static final AttachmentKey<String> MODULE_NAME = AttachmentKey.create(String.class);
 
     //
     // MODULARIZE

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentListModulesHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentListModulesHandler.java
@@ -79,15 +79,15 @@ public class DeploymentListModulesHandler implements OperationStepHandler {
 
                     final ModelNode result = new ModelNode();
                     List<ModuleDependency> dependencies = moduleLoadService.getSystemDependencies();
-                    Collections.sort(dependencies, Comparator.comparing(p -> p.getIdentifier().toString()));
+                    Collections.sort(dependencies, Comparator.comparing(ModuleDependency::getDependencyModule));
                     result.get("system-dependencies").set(buildDependenciesInfo(dependencies, verbose));
 
                     dependencies = moduleLoadService.getLocalDependencies();
-                    Collections.sort(dependencies, Comparator.comparing(p -> p.getIdentifier().toString()));
+                    Collections.sort(dependencies, Comparator.comparing(ModuleDependency::getDependencyModule));
                     result.get("local-dependencies").set(buildDependenciesInfo(dependencies, verbose));
 
                     dependencies = moduleLoadService.getUserDependencies();
-                    Collections.sort(dependencies, Comparator.comparing(p -> p.getIdentifier().toString()));
+                    Collections.sort(dependencies, Comparator.comparing(ModuleDependency::getDependencyModule));
                     result.get("user-dependencies").set(buildDependenciesInfo(dependencies, verbose));
 
                     context.getResult().set(result);
@@ -100,8 +100,7 @@ public class DeploymentListModulesHandler implements OperationStepHandler {
         ModelNode deps = new ModelNode().setEmptyList();
         for (ModuleDependency dependency : dependencies) {
             ModelNode depData = new ModelNode();
-            ModuleIdentifier identifier = dependency.getIdentifier();
-            depData.get("name").set(identifier.toString());
+            depData.get("name").set(dependency.getDependencyModule());
             if (verbose) {
                 depData.get("optional").set(dependency.isOptional());
                 depData.get("export").set(dependency.isExport());

--- a/server/src/main/java/org/jboss/as/server/deployment/annotation/CompositeIndexProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/annotation/CompositeIndexProcessor.java
@@ -9,6 +9,7 @@ import java.lang.ref.Reference;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -118,6 +119,14 @@ public class CompositeIndexProcessor implements DeploymentUnitProcessor {
             }
         }
         deploymentUnit.putAttachment(Attachments.ADDITIONAL_ANNOTATION_INDEXES_BY_MODULE, additionalAnnotationIndexes);
+        // Attach an additional map keyed by name. Next release this key will be the only map attached.
+        Map<String, CompositeIndex> additionalIndexesByName = new HashMap<>(additionalAnnotationIndexes.size());
+        for (Map.Entry<ModuleIdentifier, CompositeIndex> entry : additionalAnnotationIndexes.entrySet()) {
+            additionalIndexesByName.put(entry.getKey().toString(), entry.getValue());
+        }
+        deploymentUnit.putAttachment(Attachments.ADDITIONAL_ANNOTATION_INDEXES_BY_MODULE_NAME,
+                // This should have always been an immutable map
+                Collections.unmodifiableMap(additionalIndexesByName));
 
         final List<ResourceRoot> allResourceRoots = new ArrayList<ResourceRoot>();
         final List<ResourceRoot> resourceRoots = deploymentUnit.getAttachmentList(Attachments.RESOURCE_ROOTS);

--- a/server/src/main/java/org/jboss/as/server/deployment/annotation/CompositeIndexProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/annotation/CompositeIndexProcessor.java
@@ -150,9 +150,9 @@ public class CompositeIndexProcessor implements DeploymentUnitProcessor {
     }
 
     private Map<ModuleIdentifier, DeploymentUnit> buildSubdeploymentDependencyMap(DeploymentUnit deploymentUnit) {
-        Set<ModuleIdentifier> depModuleIdentifiers = new HashSet<>();
+        Set<String> depModuleIdentifiers = new HashSet<>();
         for (ModuleDependency dep: deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION).getAllDependencies()) {
-            depModuleIdentifiers.add(dep.getIdentifier());
+            depModuleIdentifiers.add(dep.getDependencyModule());
         }
 
         DeploymentUnit top = deploymentUnit.getParent()==null?deploymentUnit:deploymentUnit.getParent();
@@ -161,7 +161,7 @@ public class CompositeIndexProcessor implements DeploymentUnitProcessor {
         if (subDeployments != null) {
             for (DeploymentUnit subDeployment : subDeployments) {
                 ModuleIdentifier moduleIdentifier = subDeployment.getAttachment(Attachments.MODULE_IDENTIFIER);
-                if (depModuleIdentifiers.contains(moduleIdentifier)) {
+                if (depModuleIdentifiers.contains(moduleIdentifier.toString())) {
                     res.put(moduleIdentifier, subDeployment);
                 }
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/AdditionalModuleSpecification.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/AdditionalModuleSpecification.java
@@ -36,8 +36,14 @@ public class AdditionalModuleSpecification extends ModuleSpecification implement
         this.resourceRoots = new ArrayList<ResourceRoot>(resourceRoots);
     }
 
+    /** @deprecated use {@link #getModuleName()}  */
+    @Deprecated(forRemoval = true)
     public ModuleIdentifier getModuleIdentifier() {
         return moduleIdentifier;
+    }
+
+    public String getModuleName() {
+        return moduleIdentifier.toString();
     }
 
 

--- a/server/src/main/java/org/jboss/as/server/deployment/module/DeploymentVisibilityProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/DeploymentVisibilityProcessor.java
@@ -26,26 +26,26 @@ public class DeploymentVisibilityProcessor implements DeploymentUnitProcessor {
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final ModuleSpecification moduleSpec = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE_SPECIFICATION);
-        final Map<ModuleIdentifier, DeploymentUnit> deployments = new HashMap<ModuleIdentifier, DeploymentUnit>();
+        final Map<String, DeploymentUnit> deployments = new HashMap<>();
         //local classes are always first
         deploymentUnit.addToAttachmentList(Attachments.ACCESSIBLE_SUB_DEPLOYMENTS, deploymentUnit);
         buildModuleMap(deploymentUnit, deployments);
 
         for (final ModuleDependency dependency : moduleSpec.getAllDependencies()) {
-            final DeploymentUnit sub = deployments.get(dependency.getIdentifier());
+            final DeploymentUnit sub = deployments.get(dependency.getDependencyModule());
             if (sub != null) {
                 deploymentUnit.addToAttachmentList(Attachments.ACCESSIBLE_SUB_DEPLOYMENTS, sub);
             }
         }
     }
 
-    private void buildModuleMap(final DeploymentUnit deploymentUnit, final Map<ModuleIdentifier, DeploymentUnit> modules) {
+    private void buildModuleMap(final DeploymentUnit deploymentUnit, final Map<String, DeploymentUnit> modules) {
         if (deploymentUnit.getParent() == null) {
             final List<DeploymentUnit> subDeployments = deploymentUnit.getAttachmentList(org.jboss.as.server.deployment.Attachments.SUB_DEPLOYMENTS);
             for (final DeploymentUnit sub : subDeployments) {
                 final ModuleIdentifier identifier = sub.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE_IDENTIFIER);
                 if (identifier != null) {
-                    modules.put(identifier, sub);
+                    modules.put(identifier.toString(), sub);
                 }
             }
         } else {
@@ -54,14 +54,14 @@ public class DeploymentVisibilityProcessor implements DeploymentUnitProcessor {
             //add the parent description
             final ModuleIdentifier parentIdentifier = parent.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE_IDENTIFIER);
             if (parentIdentifier != null) {
-                modules.put(parentIdentifier, parent);
+                modules.put(parentIdentifier.toString(), parent);
             }
 
             for (final DeploymentUnit sub : subDeployments) {
                 if (sub != deploymentUnit) {
                     final ModuleIdentifier identifier = sub.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE_IDENTIFIER);
                     if (identifier != null) {
-                        modules.put(identifier, sub);
+                        modules.put(identifier.toString(), sub);
                     }
                 }
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleAliasChecker.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleAliasChecker.java
@@ -66,7 +66,7 @@ public class ModuleAliasChecker {
      */
     public static void checkModuleAliasesForDependencies(List<ModuleDependency> dependencies, MessageContext context, String deploymentName) {
         for (ModuleDependency dependency : dependencies) {
-            String identifier = dependency.getIdentifier().toString();
+            String identifier = dependency.getDependencyModule();
             checkModuleAlias(context, deploymentName, identifier, false);
         }
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleIdentifierProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleIdentifierProcessor.java
@@ -29,6 +29,7 @@ public class ModuleIdentifierProcessor implements DeploymentUnitProcessor {
         final VirtualFile toplevelRoot = topLevelDeployment.getAttachment(Attachments.DEPLOYMENT_ROOT).getRoot();
         final ModuleIdentifier moduleIdentifier = createModuleIdentifier(deploymentUnit.getName(), deploymentRoot, topLevelDeployment, toplevelRoot, deploymentUnit.getParent() == null);
         deploymentUnit.putAttachment(Attachments.MODULE_IDENTIFIER, moduleIdentifier);
+        deploymentUnit.putAttachment(Attachments.MODULE_NAME, moduleIdentifier.toString());
     }
 
     public static ModuleIdentifier createModuleIdentifier(final String deploymentUnitName, final ResourceRoot deploymentRoot, final DeploymentUnit topLevelDeployment, final VirtualFile toplevelRoot, final boolean topLevel) {

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -30,6 +30,7 @@ import org.jboss.as.server.moduleservice.ModuleLoadService;
 import org.jboss.as.server.moduleservice.ModuleResolvePhaseService;
 import org.jboss.as.server.moduleservice.ServiceModuleLoader;
 import org.jboss.modules.DependencySpec;
+import org.jboss.modules.ModuleDependencySpecBuilder;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.ModuleSpec;
@@ -151,7 +152,7 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
         module.addSystemDependencies(moduleSpecification.getSystemDependenciesSet());
         module.addLocalDependencies(moduleSpecification.getLocalDependenciesSet());
         for(ModuleDependency dep : moduleSpecification.getUserDependenciesSet()) {
-            if(!dep.getIdentifier().equals(module.getModuleIdentifier())) {
+            if(!dep.getDependencyModule().equals(module.getModuleIdentifier().toString())) {
                 module.addUserDependency(dep);
             }
         }
@@ -337,8 +338,13 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
                     }
                     exportFilter = exportBuilder.create();
                 }
-                final DependencySpec depSpec = DependencySpec.createModuleDependencySpec(importFilter, exportFilter, dependency
-                        .getModuleLoader(), dependency.getIdentifier(), dependency.isOptional());
+                final DependencySpec depSpec = new ModuleDependencySpecBuilder()
+                        .setModuleLoader(dependency.getModuleLoader())
+                        .setName(dependency.getDependencyModule())
+                        .setOptional(dependency.isOptional())
+                        .setImportFilter(importFilter)
+                        .setExportFilter(exportFilter)
+                        .build();
                 specBuilder.addDependency(depSpec);
                 logger.debugf("Adding dependency %s to module %s", dependency, specBuilder.getIdentifier());
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
@@ -130,12 +130,12 @@ public class ModuleSpecification extends SimpleAttachable {
     private final List<PermissionFactory> permissionFactories = new ArrayList<>();
 
     public void addSystemDependency(final ModuleDependency dependency) {
-        if (!exclusions.contains(dependency.getIdentifier().toString())) {
+        if (!exclusions.contains(dependency.getDependencyModule())) {
             if (systemDependenciesSet.add(dependency)) {
                 resetDependencyLists();
             }
         } else {
-            excludedDependencies.add(dependency.getIdentifier().toString());
+            excludedDependencies.add(dependency.getDependencyModule());
         }
     }
 
@@ -180,12 +180,12 @@ public class ModuleSpecification extends SimpleAttachable {
     }
 
     public void addLocalDependency(final ModuleDependency dependency) {
-        if (!exclusions.contains(dependency.getIdentifier().toString())) {
+        if (!exclusions.contains(dependency.getDependencyModule())) {
             if (this.localDependenciesSet.add(dependency)) {
                 resetDependencyLists();
             }
         } else {
-            excludedDependencies.add(dependency.getIdentifier().toString());
+            excludedDependencies.add(dependency.getDependencyModule());
         }
     }
 
@@ -234,7 +234,7 @@ public class ModuleSpecification extends SimpleAttachable {
         Iterator<ModuleDependency> it = systemDependenciesSet.iterator();
         while (it.hasNext()) {
             final ModuleDependency dep = it.next();
-            if (dep.getIdentifier().toString().equals(exclusion)) {
+            if (dep.getDependencyModule().equals(exclusion)) {
                 it.remove();
                 resetDependencyLists();
             }
@@ -242,7 +242,7 @@ public class ModuleSpecification extends SimpleAttachable {
         it = localDependenciesSet.iterator();
         while (it.hasNext()) {
             final ModuleDependency dep = it.next();
-            if (dep.getIdentifier().toString().equals(exclusion)) {
+            if (dep.getDependencyModule().equals(exclusion)) {
                 it.remove();
                 resetDependencyLists();
             }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/SubDeploymentDependencyProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/SubDeploymentDependencyProcessor.java
@@ -33,7 +33,7 @@ public class SubDeploymentDependencyProcessor implements DeploymentUnitProcessor
 
         final ModuleSpecification moduleSpec = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER);
-        final ModuleIdentifier moduleIdentifier = deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER);
+        final String moduleIdentifier = deploymentUnit.getAttachment(Attachments.MODULE_IDENTIFIER).toString();
 
         if (deploymentUnit.getParent() != null) {
             final ModuleIdentifier parentModule = parent.getAttachment(Attachments.MODULE_IDENTIFIER);
@@ -55,14 +55,14 @@ public class SubDeploymentDependencyProcessor implements DeploymentUnitProcessor
         for (DeploymentUnit subDeployment : subDeployments) {
             final ModuleSpecification subModule = subDeployment.getAttachment(Attachments.MODULE_SPECIFICATION);
             if (!subModule.isPrivateModule() && (!parentModuleSpec.isSubDeploymentModulesIsolated() || subModule.isPublicModule())) {
-                ModuleIdentifier identifier = subDeployment.getAttachment(Attachments.MODULE_IDENTIFIER);
+                String identifier = subDeployment.getAttachment(Attachments.MODULE_IDENTIFIER).toString();
                 ModuleDependency dependency = new ModuleDependency(moduleLoader, identifier, false, false, true, false);
                 dependency.addImportFilter(PathFilters.acceptAll(), true);
                 accessibleModules.add(dependency);
             }
         }
         for (ModuleDependency dependency : accessibleModules) {
-            if (!dependency.getIdentifier().equals(moduleIdentifier)) {
+            if (!dependency.getDependencyModule().equals(moduleIdentifier)) {
                 moduleSpec.addLocalDependency(dependency);
             }
         }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/DeploymentStructureDescriptorParser.java
@@ -244,7 +244,7 @@ public class DeploymentStructureDescriptorParser implements DeploymentUnitProces
         }
         // No more nested loop
         for (ModuleDependency dependency : moduleDependencies) {
-            String identifier = dependency.getIdentifier().toString();
+            String identifier = dependency.getDependencyModule();
             if (index.containsKey(identifier)) {
                 aliasDependencies.add(new ModuleDependency(dependency.getModuleLoader(), index.get(identifier).getModuleIdentifier(), dependency.isOptional(), dependency.isExport(), dependency.isImportServices(), dependency.isUserSpecified()));
             }

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -193,11 +193,11 @@ public interface ServerLogger extends BasicLogger {
 
     @LogMessage(level = WARN)
     @Message(id = 18, value = "Deployment \"%s\" is using a private module (\"%s\") which may be changed or removed in future versions without notice.")
-    void privateApiUsed(String deployment, ModuleIdentifier dependency);
+    void privateApiUsed(String deployment, String dependency);
 
     @LogMessage(level = WARN)
     @Message(id = 19, value = "Deployment \"%s\" is using an unsupported module (\"%s\") which may be changed or removed in future versions without notice.")
-    void unsupportedApiUsed(String deployment, ModuleIdentifier dependency);
+    void unsupportedApiUsed(String deployment, String dependency);
 
     @LogMessage(level = WARN)
     @Message(id = 20, value = "Exception occurred removing deployment content %s")
@@ -1153,7 +1153,7 @@ public interface ServerLogger extends BasicLogger {
 
     @LogMessage(level = WARN)
     @Message(id = 221, value = "Deployment \"%s\" is using a deprecated module (\"%s\") which may be removed in future versions without notice.")
-    void deprecatedApiUsed(String name, ModuleIdentifier id);
+    void deprecatedApiUsed(String name, String id);
 
     @Message(id = 222, value="Illegal permission name '%s'")
     IllegalArgumentException illegalPermissionName(String name);

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ModuleDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ModuleDefinition.java
@@ -25,14 +25,29 @@ public class ModuleDefinition {
     private final Set<ModuleDependency> dependencies;
     private final ModuleSpec moduleSpec;
 
+
+    /** @deprecated use {@link #ModuleDefinition(String, Set, ModuleSpec)} */
+    @Deprecated(forRemoval = true)
     public ModuleDefinition(final ModuleIdentifier moduleIdentifier, final Set<ModuleDependency> dependencies, final ModuleSpec moduleSpec) {
         this.moduleIdentifier = moduleIdentifier;
         this.dependencies = dependencies;
         this.moduleSpec = moduleSpec;
     }
 
+    public ModuleDefinition(final String moduleIdentifier, final Set<ModuleDependency> dependencies, final ModuleSpec moduleSpec) {
+        this.moduleIdentifier = ModuleIdentifier.fromString(moduleIdentifier);  // inefficient but this is unused. When we switch the use to this we'll store the string.
+        this.dependencies = dependencies;
+        this.moduleSpec = moduleSpec;
+    }
+
+    /** @deprecated use {@link #getModuleName()}  */
+    @Deprecated(forRemoval = true)
     public ModuleIdentifier getModuleIdentifier() {
         return moduleIdentifier;
+    }
+
+    public String getModuleName() {
+        return moduleIdentifier.toString(); // inefficient but this is unused. When we switch the use to this we'll store the string.
     }
 
     public ModuleSpec getModuleSpec() {

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ModuleLoadService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ModuleLoadService.java
@@ -78,7 +78,7 @@ public class ModuleLoadService implements Service<Module> {
             moduleLoader.relinkModule(module);
             for (ModuleDependency dependency : allDependencies) {
                 if (dependency.isUserSpecified()) {
-                    final ModuleIdentifier id = dependency.getIdentifier();
+                    final String id = dependency.getDependencyModule();
                     try {
                         String val = moduleLoader.loadModule(id).getProperty("jboss.api");
                         if (val != null) {
@@ -112,8 +112,8 @@ public class ModuleLoadService implements Service<Module> {
         return module;
     }
 
-    private static ServiceName install(final ServiceTarget target, final ModuleIdentifier identifier, ModuleLoadService service) {
-        final ServiceName serviceName = ServiceModuleLoader.moduleServiceName(identifier.toString());
+    private static ServiceName install(final ServiceTarget target, final String identifier, ModuleLoadService service) {
+        final ServiceName serviceName = ServiceModuleLoader.moduleServiceName(identifier);
         final ServiceBuilder<Module> builder = target.addService(serviceName, service);
 
         builder.addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ServiceModuleLoader.class, service.getServiceModuleLoader());
@@ -127,12 +127,12 @@ public class ModuleLoadService implements Service<Module> {
 
     public static ServiceName install(final ServiceTarget target, final ModuleIdentifier identifier){
         final ModuleLoadService service = new ModuleLoadService();
-        return install(target, identifier, service);
+        return install(target, identifier.toString(), service);
     }
 
     public static ServiceName install(final ServiceTarget target, final ModuleIdentifier identifier, final Collection<ModuleDependency> systemDependencies, final Collection<ModuleDependency> localDependencies, final Collection<ModuleDependency> userDependencies) {
         final ModuleLoadService service = new ModuleLoadService(systemDependencies, localDependencies, userDependencies);
-        return install(target, identifier, service);
+        return install(target, identifier.toString(), service);
     }
 
     public static ServiceName installAliases(final ServiceTarget target, final ModuleIdentifier identifier, final List<ModuleIdentifier> aliases) {
@@ -141,7 +141,7 @@ public class ModuleLoadService implements Service<Module> {
             dependencies.add(new ModuleDependency(null, i, false, false, false, false));
         }
         final ModuleLoadService service = new ModuleLoadService(dependencies);
-        return install(target, identifier, service);
+        return install(target, identifier.toString(), service);
     }
 
     public InjectedValue<ServiceModuleLoader> getServiceModuleLoader() {

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ServiceModuleLoader.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ServiceModuleLoader.java
@@ -247,7 +247,7 @@ public class ServiceModuleLoader extends ModuleLoader implements Service<Service
 
     /**
      * Returns the corresponding module resolved service name for the given module.
-     *
+     * <p/>
      * The module resolved service is basically a latch that prevents the module from being loaded
      * until all the transitive dependencies that it depends upon have have their module spec services
      * come up.

--- a/server/src/test/java/org/jboss/as/server/deployment/module/ModuleDependencyUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/deployment/module/ModuleDependencyUnitTestCase.java
@@ -22,7 +22,7 @@ public class ModuleDependencyUnitTestCase {
     public void testBasicBuilder() {
         ModuleDependency dep = ModuleDependency.Builder.of(TEST_LOADER, MODULE_NAME).build();
         assertEquals(TEST_LOADER, dep.getModuleLoader());
-        assertEquals(MODULE_NAME, dep.getIdentifier().getName());
+        assertEquals(MODULE_NAME, dep.getDependencyModule());
         assertFalse(dep.isExport());
         assertFalse(dep.isImportServices());
         assertFalse(dep.isOptional());
@@ -43,7 +43,7 @@ public class ModuleDependencyUnitTestCase {
                 .build();
 
         assertEquals(TEST_LOADER, dep.getModuleLoader());
-        assertEquals(MODULE_NAME, dep.getIdentifier().getName());
+        assertEquals(MODULE_NAME, dep.getDependencyModule());
         assertTrue(dep.isExport());
         assertTrue(dep.isImportServices());
         assertTrue(dep.isOptional());

--- a/server/src/test/java/org/jboss/as/server/deployment/module/ModuleSpecificationTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/deployment/module/ModuleSpecificationTestCase.java
@@ -61,11 +61,11 @@ public class ModuleSpecificationTestCase {
         );
 
         // Removal consistency
-        ms.removeUserDependencies(md -> md.getIdentifier().toString().equals("a"));
+        ms.removeUserDependencies(md -> md.getDependencyModule().equals("a"));
         Set<ModuleDependency> userDepSet = ms.getUserDependenciesSet();
         assertEquals(INITIAL_DEPS.size() /* the initials, minus 'a', plus 'd'*/, userDepSet.size());
         for (ModuleDependency md : ALL_DEPS) {
-            boolean shouldFind = !md.getIdentifier().toString().equals("a");
+            boolean shouldFind = !md.getDependencyModule().equals("a");
             assertEquals(shouldFind, userDepSet.contains(md));
         }
         assertTrue(userDepSet.contains(DEP_D));
@@ -95,12 +95,12 @@ public class ModuleSpecificationTestCase {
     public void testModuleAliases() {
         ModuleSpecification ms = new ModuleSpecification();
         for (ModuleDependency dependency : ALL_DEPS) {
-            ms.addModuleAlias(dependency.getIdentifier().toString());
+            ms.addModuleAlias(dependency.getDependencyModule());
         }
         Set<String> aliases = ms.getModuleAliases();
         assertEquals(ALL_DEPS.size() - 1, aliases.size());
         for (ModuleDependency dep : INITIAL_DEPS) {
-            assertTrue(dep + " missing", aliases.contains(dep.getIdentifier().toString()));
+            assertTrue(dep + " missing", aliases.contains(dep.getDependencyModule()));
         }
     }
 
@@ -174,7 +174,7 @@ public class ModuleSpecificationTestCase {
         }
 
         // Test exclusions are treated as expected
-        ms.addModuleExclusion(DEP_D.getIdentifier().toString());
+        ms.addModuleExclusion(DEP_D.getDependencyModule());
         addConsumer.accept(ms, DEP_D);
         depSet = readFunction.apply(ms);
         assertEquals(ALL_DEPS.size() + (exclusionsSupported ? 0 : 1), depSet.size());
@@ -184,9 +184,9 @@ public class ModuleSpecificationTestCase {
         }
 
         // Check fictitious exclusion tracking
-        ms.addModuleExclusion(DEP_E.getIdentifier().toString());
+        ms.addModuleExclusion(DEP_E.getDependencyModule());
         Set<String> fictitious = ms.getFictitiousExcludedDependencies();
-        Set<String> expected = exclusionsSupported ? Set.of(DEP_E.getIdentifier().toString()) : Set.of(DEP_D.getIdentifier().toString(), DEP_E.getIdentifier().toString());
+        Set<String> expected = exclusionsSupported ? Set.of(DEP_E.getDependencyModule()) : Set.of(DEP_D.getDependencyModule(), DEP_E.getDependencyModule());
         assertEquals(expected, fictitious);
 
         return ms;


### PR DESCRIPTION
This is an aggregate of:

#6282 
#6293
#6298 
#6299 
#6300 
#6302

In total this deals with what I think are all the places where WF Core exposes ModuleIdentifier in API that full WildFly or an external extension might use. It deprecates all such places and provides an alternative for all but two things that I don't think external modules will use.[1]

I realize this is a lot to deal with at the last minute for WF Core 27, and **if it's too much that's ok**. Doing this though will give us more freedom to change things right away in Core 28 / WF 36, and gets the deprecation out of the way for downstream. (These APIs are not supported for external use downstream, but we'd likely want to deprecate them anyway before removing them in some future release.)

#6282 is the most substantive. #6293 is already approved. The others are new but pretty simple.

[1] Those two things deprecated without alternatives provided in this PR are:
Attachments.CLASS_PATH_ENTRIES which we should just break (by changing its list element type) with no migration path. It's not used outside the kernel and shouldn't be.
Attachments.ADDITIONAL_ANNOTATION_INDEXES for which we will need to do a simple migration dance in a couple core Betas to let the one 'ee' subsystem use migrate.

@yersan @ropalka @dmlloy FYI.
