### PR TITLE
[WFCORE-7114] Deprecate use of ModuleIdentifier in ModuleDefinition

### DIFF
--- a/server/src/main/java/org/jboss/as/server/moduleservice/ModuleDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ModuleDefinition.java
@@ -25,14 +25,29 @@ public class ModuleDefinition {
     private final Set<ModuleDependency> dependencies;
     private final ModuleSpec moduleSpec;
 
+
+    /** @deprecated use {@link #ModuleDefinition(String, Set, ModuleSpec)} */
+    @Deprecated(forRemoval = true)
     public ModuleDefinition(final ModuleIdentifier moduleIdentifier, final Set<ModuleDependency> dependencies, final ModuleSpec moduleSpec) {
         this.moduleIdentifier = moduleIdentifier;
         this.dependencies = dependencies;
         this.moduleSpec = moduleSpec;
     }
 
+    public ModuleDefinition(final String moduleIdentifier, final Set<ModuleDependency> dependencies, final ModuleSpec moduleSpec) {
+        this.moduleIdentifier = ModuleIdentifier.fromString(moduleIdentifier);  // inefficient but this is unused. When we switch the use to this we'll store the string.
+        this.dependencies = dependencies;
+        this.moduleSpec = moduleSpec;
+    }
+
+    /** @deprecated use {@link #getModuleName()}  */
+    @Deprecated(forRemoval = true)
     public ModuleIdentifier getModuleIdentifier() {
         return moduleIdentifier;
+    }
+
+    public String getModuleName() {
+        return moduleIdentifier.toString(); // inefficient but this is unused. When we switch the use to this we'll store the string.
     }
 
     public ModuleSpec getModuleSpec() {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7114