### PR TITLE
[WFCORE-7130] Enhancing CLI tests to don't fail on JDK24+ when JDK warning is being printed

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
@@ -132,6 +132,13 @@ public class CliArgumentsTestCase {
         String output = cli.getOutput();
         try (BufferedReader reader = new BufferedReader(new StringReader(output))) {
             String line = reader.readLine();
+            // WFCORE-7130 workaround
+            if (Runtime.version().feature() >= 24) {
+                // Ignore JDK warnings about sun.misc.Unsafe deprecated method usages on JDK24+
+                while (line.contains("WARNING: ")) {
+                    line = reader.readLine();
+                }
+            }
             while (line.contains("Picked up JDK_JAVA_OPTIONS:") || line.contains("Picked up JAVA_TOOL_OPTIONS:")) {
                 line = reader.readLine();
             }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ColorOutputTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ColorOutputTestCase.java
@@ -124,6 +124,13 @@ public class ColorOutputTestCase {
         String printableChars = Parser.stripAwayAnsiCodes(cli.getOutput());
         try (BufferedReader reader = new BufferedReader(new StringReader(printableChars))) {
             String line = reader.readLine();
+            // WFCORE-7130 workaround
+            if (Runtime.version().feature() >= 24) {
+                // Ignore JDK warnings about sun.misc.Unsafe deprecated method usages on JDK24+
+                while (line.contains("WARNING: ")) {
+                    line = reader.readLine();
+                }
+            }
             while (line.contains("Picked up JDK_JAVA_OPTIONS:") || line.contains("Picked up JAVA_TOOL_OPTIONS:")) {
                 line = reader.readLine();
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7130