### PR TITLE
[WFCORE-7134] Remove ModuleIdentifier use in the elytron subsystem

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ClassLoadingAttributeDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ClassLoadingAttributeDefinitions.java
@@ -4,12 +4,12 @@
  */
 package org.wildfly.extension.elytron;
 
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 
 /**
@@ -43,8 +43,7 @@ class ClassLoadingAttributeDefinitions {
     static ClassLoader resolveClassLoader(String module) throws ModuleLoadException {
         Module current = Module.getCallerModule();
         if (module != null && current != null) {
-            ModuleIdentifier mi = ModuleIdentifier.fromString(module);
-            current = current.getModule(mi);
+            current = current.getModule(ModuleIdentifierUtil.canonicalModuleIdentifier(module));
         }
 
         return current != null ? current.getClassLoader() : ClassLoadingAttributeDefinitions.class.getClassLoader();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -21,6 +21,7 @@ import javax.net.ssl.SSLContext;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -40,7 +41,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
@@ -160,9 +160,8 @@ class DirContextDefinition extends SimpleResourceDefinition {
         if(moduleName != null && !"".equals(moduleName)){
             try {
                 Module cm = Module.getCallerModule();
-                ModuleIdentifier mi = ModuleIdentifier.create(moduleName);
                 //module = Module.getCallerModule().getModule(ModuleIdentifier.create(moduleName));
-                module = cm.getModule(mi);
+                module = cm.getModule(ModuleIdentifierUtil.canonicalModuleIdentifier(moduleName));
             } catch (ModuleLoadException e) {
                 throw ElytronSubsystemMessages.ROOT_LOGGER.unableToLoadModule(moduleName, e);
             }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.AttributeMarshallers;
 import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.AttributeParsers;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -41,7 +42,6 @@ import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -404,9 +404,8 @@ class PermissionMapperDefinitions {
     private static java.security.Permission createPermission(Permission permission) throws StartException {
         Module currentModule = Module.getCallerModule();
         if (permission.getModule() != null && currentModule != null) {
-            ModuleIdentifier mi = ModuleIdentifier.fromString(permission.getModule());
             try {
-                currentModule = currentModule.getModule(mi);
+                currentModule = currentModule.getModule(permission.getModule());
             } catch (ModuleLoadException e) {
                 // If we cannot load it, it can never be checked.
                 throw ElytronSubsystemMessages.ROOT_LOGGER.invalidPermissionModule(permission.getModule(), e);
@@ -432,7 +431,7 @@ class PermissionMapperDefinitions {
 
         Permission(final String className, final String module, final String targetName, final String action) {
             this.className = className;
-            this.module = module;
+            this.module = module != null ? ModuleIdentifierUtil.canonicalModuleIdentifier(module) : module;
             this.targetName = targetName;
             this.action = action;
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-7134 

[WFCORE-7134] Remove `ModuleIdentifier` use in the elytron subsystem