### PR TITLE
[WFCORE-7135] Remove ModuleIdentifier use in the testsuite

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/byteman/ServerReloadHelper.java
+++ b/testsuite/shared/src/main/java/org/jboss/byteman/ServerReloadHelper.java
@@ -11,7 +11,6 @@ import org.jboss.byteman.rule.Rule;
 import org.jboss.byteman.rule.helper.Helper;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleClassLoader;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 /**
@@ -64,7 +63,7 @@ public class ServerReloadHelper extends Helper {
         Field instance = defaultBootModuleLoaderHolder.getDeclaredField("INSTANCE");
         instance.setAccessible(true);
         ModuleLoader loader = (ModuleLoader) instance.get(null);
-        Module module = loader.loadModule(ModuleIdentifier.fromString("org.jboss.as.deployment-scanner"));
+        Module module = loader.loadModule("org.jboss.as.deployment-scanner");
         traceln("ServerLoaderhelper", "Module " + module.toString() + " loaded.");
         ModuleClassLoader cl = module.getClassLoader();
         Class modelNodeClass = cl.loadClassLocal("org.jboss.dmr.ModelNode");

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ModuleInfoTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ModuleInfoTestCase.java
@@ -5,6 +5,7 @@
 
 package org.wildfly.core.test.standalone.mgmt.api.core;
 
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
@@ -13,7 +14,6 @@ import org.jboss.modules.DependencySpec;
 import org.jboss.modules.LocalModuleLoader;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleDependencySpec;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -101,7 +101,7 @@ public class ModuleInfoTestCase extends ContainerResourceMgmtTestBase {
         }*/
 
         // load module.xml
-        ModuleIdentifier identifier = ModuleIdentifier.fromString(TARGET_MODULE_NAME + ":main");
+        String identifier = ModuleIdentifierUtil.canonicalModuleIdentifier(TARGET_MODULE_NAME + ":main");
         Module module = loadModule(identifier);
 
         // run module-info operation
@@ -147,7 +147,7 @@ public class ModuleInfoTestCase extends ContainerResourceMgmtTestBase {
         Assert.assertTrue(module.getClassLoader().getLocalPaths().containsAll(paths));
     }
 
-    private Module loadModule(ModuleIdentifier identifier) throws IOException, ModuleLoadException {
+    private Module loadModule(String identifier) throws IOException, ModuleLoadException {
         File[] roots = new File[]{new File(LAYERS_BASE)};
         LocalModuleLoader moduleLoader = new LocalModuleLoader(roots);
         return moduleLoader.loadModule(identifier);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-7135

[WFCORE-7135] Remove `ModuleIdentifier` use in the testsuite