### PR TITLE
[WFCORE-7153] Don't test reload-enhanced if it's not an available operation

### DIFF
--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/StandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/StandardRolesBasicTestCase.java
@@ -19,14 +19,17 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_XML_FILE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_XML_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_ENHANCED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESUME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USERNAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
@@ -45,6 +48,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.interfaces.ManagementInterface;
 import org.jboss.as.test.integration.management.rbac.Outcome;
@@ -73,12 +77,12 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
     protected static final String EXAMPLE_DS = "subsystem=rbac/rbac-constrained=default";
     private static final String TEST_PATH = "path=rbac.test";
 
-    private static final ModelNode WFLY_1916_OP;
+    private static final ModelNode UPLOAD_DEPLOYMENT_BYTES;
 
     static {
-        WFLY_1916_OP = Util.createEmptyOperation(UPLOAD_DEPLOYMENT_BYTES, PathAddress.EMPTY_ADDRESS);
-        WFLY_1916_OP.get(BYTES).set(new byte[64]);
-        WFLY_1916_OP.protect();
+        UPLOAD_DEPLOYMENT_BYTES = Util.createEmptyOperation(ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES, PathAddress.EMPTY_ADDRESS);
+        UPLOAD_DEPLOYMENT_BYTES.get(BYTES).set(new byte[64]);
+        UPLOAD_DEPLOYMENT_BYTES.protect();
     }
 
     protected static void deployDeployment1(ManagementClient client) throws IOException {
@@ -141,10 +145,15 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.UNAUTHORIZED);
         addPath(client, Outcome.UNAUTHORIZED);
 
-        testWFLY1916(client, Outcome.UNAUTHORIZED);
+        uploadDeploymentBytes(client, Outcome.UNAUTHORIZED);
 
-        // Monitor can't shutdown
-        testWCORE1067(client);
+        suspend(client, Outcome.UNAUTHORIZED);
+        resume(client, Outcome.UNAUTHORIZED);
+
+        // Monitor can't shut down or reload
+        shutdownUnauthorized(client);
+        reloadUnauthorized(client);
+        reloadEnhancedUnauthorized(client);
     }
 
     @Test
@@ -164,7 +173,10 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.UNAUTHORIZED);
         addPath(client, Outcome.UNAUTHORIZED);
 
-        testWFLY1916(client, Outcome.SUCCESS);
+        uploadDeploymentBytes(client, Outcome.SUCCESS);
+
+        suspend(client, Outcome.SUCCESS);
+        resume(client, Outcome.SUCCESS);
     }
 
     @Test
@@ -184,7 +196,10 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.SUCCESS);
         addPath(client, Outcome.SUCCESS);
 
-        testWFLY1916(client, Outcome.SUCCESS);
+        uploadDeploymentBytes(client, Outcome.SUCCESS);
+
+        suspend(client, Outcome.SUCCESS);
+        resume(client, Outcome.SUCCESS);
     }
 
     @Test
@@ -204,10 +219,15 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.SUCCESS);
         addPath(client, Outcome.UNAUTHORIZED);
 
-        testWFLY1916(client, Outcome.SUCCESS);
+        uploadDeploymentBytes(client, Outcome.SUCCESS);
 
-        // Deployer can't shutdown
-        testWCORE1067(client);
+        suspend(client, Outcome.UNAUTHORIZED);
+        resume(client, Outcome.UNAUTHORIZED);
+
+        // Deployer can't shut down or reload
+        shutdownUnauthorized(client);
+        reloadUnauthorized(client);
+        reloadEnhancedUnauthorized(client);
     }
 
     @Test
@@ -229,7 +249,10 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.SUCCESS);
         addPath(client, Outcome.SUCCESS);
 
-        testWFLY1916(client, Outcome.SUCCESS);
+        uploadDeploymentBytes(client, Outcome.SUCCESS);
+
+        suspend(client, Outcome.SUCCESS);
+        resume(client, Outcome.SUCCESS);
     }
 
     @Test
@@ -250,10 +273,15 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.UNAUTHORIZED);
         addPath(client, Outcome.UNAUTHORIZED);
 
-        testWFLY1916(client, Outcome.UNAUTHORIZED);
+        uploadDeploymentBytes(client, Outcome.UNAUTHORIZED);
 
-        // Auditor can't shutdown
-        testWCORE1067(client);
+        suspend(client, Outcome.UNAUTHORIZED);
+        resume(client, Outcome.UNAUTHORIZED);
+
+        // Auditor can't shut down or reload
+        shutdownUnauthorized(client);
+        reloadUnauthorized(client);
+        reloadEnhancedUnauthorized(client);
     }
 
     @Test
@@ -274,7 +302,7 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         addDeployment2(client, Outcome.SUCCESS);
         addPath(client, Outcome.SUCCESS);
 
-        testWFLY1916(client, Outcome.SUCCESS);
+        uploadDeploymentBytes(client, Outcome.SUCCESS);
     }
 
     private static void whoami(ManagementInterface client, String expectedUsername) throws IOException {
@@ -438,13 +466,33 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
         }
     }
 
-    private void testWFLY1916(ManagementInterface client, Outcome expected) throws IOException {
-        ModelNode op = WFLY_1916_OP.clone();
+    private static void uploadDeploymentBytes(ManagementInterface client, Outcome expected) throws IOException {
+        ModelNode op = UPLOAD_DEPLOYMENT_BYTES.clone();
         RbacUtil.executeOperation(client, op, expected);
     }
 
-    private void testWCORE1067(ManagementInterface client) throws IOException {
+    private static void suspend(ManagementInterface client, Outcome expected) throws IOException {
+        ModelNode op = Util.createEmptyOperation(SUSPEND, PathAddress.EMPTY_ADDRESS);
+        RbacUtil.executeOperation(client, op, expected);
+    }
+
+    private static void resume(ManagementInterface client, Outcome expected) throws IOException {
+        ModelNode op = Util.createEmptyOperation(RESUME, PathAddress.EMPTY_ADDRESS);
+        RbacUtil.executeOperation(client, op, expected);
+    }
+
+    private static void shutdownUnauthorized(ManagementInterface client) throws IOException {
         ModelNode op = Util.createEmptyOperation(SHUTDOWN, PathAddress.EMPTY_ADDRESS);
+        RbacUtil.executeOperation(client, op, Outcome.UNAUTHORIZED);
+    }
+
+    private static void reloadUnauthorized(ManagementInterface client) throws IOException {
+        ModelNode op = Util.createEmptyOperation(RELOAD, PathAddress.EMPTY_ADDRESS);
+        RbacUtil.executeOperation(client, op, Outcome.UNAUTHORIZED);
+    }
+
+    private static void reloadEnhancedUnauthorized(ManagementInterface client) throws IOException {
+        ModelNode op = Util.createEmptyOperation(RELOAD_ENHANCED, PathAddress.EMPTY_ADDRESS);
         RbacUtil.executeOperation(client, op, Outcome.UNAUTHORIZED);
     }
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/StandardRolesBasicTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/StandardRolesBasicTestCase.java
@@ -18,6 +18,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_XML_FILE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_XML_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_ENHANCED;
@@ -46,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -363,7 +365,7 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
     }
 
     private static ModelNode readAttribute(ManagementInterface client, String address, String attributeName,
-            Outcome expectedOutcome) throws IOException {
+                                           Outcome expectedOutcome) throws IOException {
         ModelNode op = createOpNode(address, READ_ATTRIBUTE_OPERATION);
         op.get(NAME).set(attributeName);
 
@@ -492,8 +494,13 @@ public abstract class StandardRolesBasicTestCase extends AbstractManagementInter
     }
 
     private static void reloadEnhancedUnauthorized(ManagementInterface client) throws IOException {
-        ModelNode op = Util.createEmptyOperation(RELOAD_ENHANCED, PathAddress.EMPTY_ADDRESS);
-        RbacUtil.executeOperation(client, op, Outcome.UNAUTHORIZED);
+        ModelNode opNames = Util.createEmptyOperation(READ_OPERATION_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        List<ModelNode> ops  = RbacUtil.executeOperation(client, opNames, Outcome.SUCCESS)
+                .get(RESULT).asList();
+        if (ops.contains(new ModelNode(RELOAD_ENHANCED))) {
+            ModelNode op = Util.createEmptyOperation(RELOAD_ENHANCED, PathAddress.EMPTY_ADDRESS);
+            RbacUtil.executeOperation(client, op, Outcome.UNAUTHORIZED);
+        }
     }
 
 }


### PR DESCRIPTION
This builds on #6329, adding a commit to allow the tests to work downstream.

https://issues.redhat.com/browse/WFCORE-7153