### PR TITLE
[WFCORE-6846] Upgrade commons-daemon to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.9.0</version.commons-cli>
         <version.commons-collections>3.2.2</version.commons-collections>
-        <version.commons-daemon>1.3.4</version.commons-daemon>
+        <version.commons-daemon>1.4.0</version.commons-daemon>
         <version.commons-lang3>3.17.0</version.commons-lang3>
         <version.commons-io>2.10.0</version.commons-io>
         <version.io.netty>4.1.117.Final</version.io.netty>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6846

Verified that WildFly standalone / WildFly domain can be installed as a Windows Service and started/stopped successfully with commons-daemon updated to 1.4.0
