### PR TITLE
[WFCORE-7061] Bump the kernel management API version to 29.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -82,7 +82,8 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY31("WildFly31.0", KernelAPIVersion.VERSION_24_0),
         WILDFLY32("WildFly32.0", KernelAPIVersion.VERSION_25_0),
         WILDFLY33("WildFly33.0", KernelAPIVersion.VERSION_26_0),
-        WILDFLY34("WildFly34.0", KernelAPIVersion.VERSION_27_0);
+        WILDFLY34("WildFly34.0", KernelAPIVersion.VERSION_27_0),
+        WILDFLY35("WildFly35.0", KernelAPIVersion.VERSION_28_0);
 
         private static final Map<String, KnownRelease> map = new HashMap<>();
         static {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -83,6 +83,8 @@ public enum KernelAPIVersion {
     VERSION_26_0(26, 0, 0),
     // WildFly 34.0.0
     VERSION_27_0(27, 0, 0),
+    // WildFly 35.0.0
+    VERSION_28_0(28, 0, 0),
 
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -18,7 +18,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 28;
+    public static final int MANAGEMENT_MAJOR_VERSION = 29;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7061
