### PR TITLE
[WFCORE-5718] Remoting: add an ability to configure protocol used by …

### DIFF
--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -37,8 +37,8 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
-import org.jboss.as.network.SocketBindingManager;
 import org.jboss.as.remoting.EndpointService;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ServerEnvironmentResourceDescription;
@@ -657,7 +657,7 @@ public class JMXSubsystemTestCase extends AbstractSubsystemBaseTest {
 
             RemotingServices.installConnectorServicesForSocketBinding(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                     "remote", SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("remote"), OptionMap.EMPTY,
-                    null, null, ServiceName.parse(SocketBindingManager.SERVICE_DESCRIPTOR.getName()));
+                    null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"), Protocol.REMOTE.toString());
         }
     }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -72,8 +72,8 @@ import org.jboss.as.controller.operations.common.ResolveExpressionHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.jmx.model.ModelControllerMBeanHelper;
-import org.jboss.as.network.SocketBindingManager;
 import org.jboss.as.remoting.EndpointService;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
@@ -1666,7 +1666,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
 
             RemotingServices.installConnectorServicesForSocketBinding(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                     "server", SOCKET_BINDING_CAPABILITY.getCapabilityServiceName("server"), OptionMap.EMPTY,
-                    null, null, ServiceName.parse(SocketBindingManager.SERVICE_DESCRIPTOR.getName()));
+                    null, null, ServiceName.parse("org.wildfly.management.socket-binding-manager"), Protocol.REMOTE.toString());
         }
 
         @Override

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/AbstractStreamServerService.java
@@ -48,6 +48,8 @@ abstract class AbstractStreamServerService implements Service {
     private final Supplier<SocketBindingManager> socketBindingManagerSupplier;
     private final OptionMap connectorPropertiesOptionMap;
 
+    private final String protocol;
+
     private volatile AcceptingChannel<StreamConnection> streamServer;
     private volatile ManagedBinding managedBinding;
 
@@ -57,19 +59,21 @@ abstract class AbstractStreamServerService implements Service {
             final Supplier<SaslAuthenticationFactory> saslAuthenticationFactorySupplier,
             final Supplier<SSLContext> sslContextSupplier,
             final Supplier<SocketBindingManager> socketBindingManagerSupplier,
-            final OptionMap connectorPropertiesOptionMap) {
+            final OptionMap connectorPropertiesOptionMap,
+            final String protocol) {
         this.streamServerConsumer = streamServerConsumer;
         this.endpointSupplier = endpointSupplier;
         this.saslAuthenticationFactorySupplier = saslAuthenticationFactorySupplier;
         this.sslContextSupplier = sslContextSupplier;
         this.socketBindingManagerSupplier = socketBindingManagerSupplier;
         this.connectorPropertiesOptionMap = connectorPropertiesOptionMap;
+        this.protocol = protocol;
     }
 
     @Override
     public void start(final StartContext context) throws StartException {
         try {
-            NetworkServerProvider networkServerProvider = endpointSupplier.get().getConnectionProviderInterface("remoting", NetworkServerProvider.class);
+            NetworkServerProvider networkServerProvider = endpointSupplier.get().getConnectionProviderInterface(protocol, NetworkServerProvider.class);
 
             SSLContext sslContext = sslContextSupplier != null ? sslContextSupplier.get() : null;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
@@ -21,7 +21,6 @@ import org.jboss.as.network.SocketBindingManager;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.remoting3.Endpoint;
 import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.xnio.OptionMap;
 
@@ -66,7 +65,9 @@ public class ConnectorAdd extends AbstractAddStepHandler {
 
         final ServiceName sbmName = context.getCapabilityServiceName(SocketBindingManager.SERVICE_DESCRIPTOR);
 
-        RemotingServices.installConnectorServicesForSocketBinding(target, context.getCapabilityServiceName(RemotingSubsystemRootResource.REMOTING_ENDPOINT_CAPABILITY.getName(), Endpoint.class), connectorName,
-                socketBindingName, optionMap, saslAuthenticationFactoryName, sslContextName, sbmName);
+        final String protocol = ConnectorResource.PROTOCOL.resolveModelAttribute(context, fullModel).asString();
+
+        RemotingServices.installConnectorServicesForSocketBinding(target, RemotingServices.SUBSYSTEM_ENDPOINT, connectorName,
+                socketBindingName, optionMap, saslAuthenticationFactoryName, sslContextName, sbmName, protocol);
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorResource.java
@@ -21,10 +21,12 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.network.ProtocolSocketBinding;
 import org.jboss.as.network.SocketBinding;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -79,8 +81,15 @@ public class ConnectorResource extends SimpleResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(CommonAttributes.PROTOCOL, ModelType.STRING)
+            .setDefaultValue(new ModelNode(Protocol.REMOTE.toString()))
+            .setValidator(EnumValidator.create(Protocol.class))
+            .setRequired(false)
+            .setRestartAllServices()
+            .build();
+
     static final Collection<AttributeDefinition> ATTRIBUTES  = List.of(AUTHENTICATION_PROVIDER, SOCKET_BINDING, SECURITY_REALM,
-            SERVER_NAME, SASL_PROTOCOL, SASL_AUTHENTICATION_FACTORY, SSL_CONTEXT);
+            SERVER_NAME, SASL_PROTOCOL, SASL_AUTHENTICATION_FACTORY, SSL_CONTEXT, PROTOCOL);
 
     ConnectorResource() {
         super(new Parameters(PATH, RemotingExtension.getResourceDescriptionResolver(CONNECTOR))

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedNetworkBindingStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedNetworkBindingStreamServerService.java
@@ -38,9 +38,10 @@ final class InjectedNetworkBindingStreamServerService extends AbstractStreamServ
             final Supplier<SSLContext> sslContextSupplier,
             final Supplier<SocketBindingManager> socketBindingManagerSupplier,
             final Supplier<NetworkInterfaceBinding> interfaceBindingSupplier,
-            final OptionMap connectorPropertiesOptionMap, int port) {
+            final OptionMap connectorPropertiesOptionMap, int port,
+            final String protocol) {
         super(streamServerConsumer, endpointSupplier, saslAuthenticationFactorySupplier,
-                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap);
+                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap, protocol);
         this.interfaceBindingSupplier = interfaceBindingSupplier;
         this.port = port;
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedSocketBindingStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedSocketBindingStreamServerService.java
@@ -33,6 +33,7 @@ final class InjectedSocketBindingStreamServerService extends AbstractStreamServe
 
     private final Supplier<SocketBinding> socketBindingSupplier;
     private final String remotingConnectorName;
+    private final Protocol protocol;
 
     InjectedSocketBindingStreamServerService(
             final Consumer<AcceptingChannel<StreamConnection>> streamServerConsumer,
@@ -42,17 +43,19 @@ final class InjectedSocketBindingStreamServerService extends AbstractStreamServe
             final Supplier<SocketBindingManager> socketBindingManagerSupplier,
             final Supplier<SocketBinding> socketBindingSupplier,
             final OptionMap connectorPropertiesOptionMap,
-            final String remotingConnectorName) {
+            final String remotingConnectorName,
+            final String protocol) {
         super(streamServerConsumer, endpointSupplier, saslAuthenticationFactorySupplier,
-                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap);
+                sslContextSupplier, socketBindingManagerSupplier, connectorPropertiesOptionMap, protocol);
         this.socketBindingSupplier = socketBindingSupplier;
         this.remotingConnectorName = remotingConnectorName;
+        this.protocol = Protocol.forName(protocol);
     }
 
     @Override
     public void start(final StartContext context) throws StartException {
         super.start(context);
-        RemotingConnectorBindingInfoService.install(context.getChildTarget(), remotingConnectorName, getSocketBinding(), Protocol.REMOTE);
+        RemotingConnectorBindingInfoService.install(context.getChildTarget(), remotingConnectorName, getSocketBinding(), protocol);
     }
 
     @Override

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Protocol.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Protocol.java
@@ -19,6 +19,7 @@ import org.jboss.dmr.ModelNode;
 public enum Protocol {
 
     REMOTE("remote"),
+    REMOTE_TLS("remote+tls"),
     REMOTE_HTTP("remote+http"),
     HTTP_REMOTING("http-remoting"),
     HTTPS_REMOTING("https-remoting"),

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -108,6 +108,7 @@ public class RemotingServices {
                                                                           final String connectorName,
                                                                           final ServiceName networkInterfaceBindingName,
                                                                           final int port,
+                                                                          final String protocol,
                                                                           final OptionMap connectorPropertiesOptionMap,
                                                                           final ServiceName saslAuthenticationFactory,
                                                                           final ServiceName sslContext,
@@ -121,7 +122,7 @@ public class RemotingServices {
         final Supplier<SocketBindingManager> sbmSupplier = socketBindingManager != null ? builder.requires(socketBindingManager) : null;
         final Supplier<NetworkInterfaceBinding> ibSupplier = builder.requires(networkInterfaceBindingName);
         builder.setInstance(new InjectedNetworkBindingStreamServerService(streamServerConsumer,
-                eSupplier, safSupplier, scSupplier, sbmSupplier, ibSupplier, connectorPropertiesOptionMap, port));
+                eSupplier, safSupplier, scSupplier, sbmSupplier, ibSupplier, connectorPropertiesOptionMap, port, protocol));
         builder.install();
     }
 
@@ -132,7 +133,8 @@ public class RemotingServices {
                                                                 final OptionMap connectorPropertiesOptionMap,
                                                                 final ServiceName saslAuthenticationFactory,
                                                                 final ServiceName sslContext,
-                                                                final ServiceName socketBindingManager) {
+                                                                final ServiceName socketBindingManager,
+                                                                final String protocol) {
         final ServiceName serviceName = serverServiceName(connectorName);
         final ServiceBuilder<?> builder = serviceTarget.addService(serviceName);
         final Consumer<AcceptingChannel<StreamConnection>> streamServerConsumer = builder.provides(serviceName);
@@ -142,7 +144,7 @@ public class RemotingServices {
         final Supplier<SocketBindingManager> sbmSupplier = builder.requires(socketBindingManager);
         final Supplier<SocketBinding> sbSupplier = builder.requires(socketBindingName);
         builder.setInstance(new InjectedSocketBindingStreamServerService(streamServerConsumer,
-                eSupplier, safSupplier, scSupplier, sbmSupplier, sbSupplier, connectorPropertiesOptionMap, connectorName));
+                eSupplier, safSupplier, scSupplier, sbmSupplier, sbSupplier, connectorPropertiesOptionMap, connectorName, protocol));
         builder.install();
     }
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemModel.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemModel.java
@@ -14,9 +14,10 @@ public enum RemotingSubsystemModel implements SubsystemModel {
     VERSION_4_0_0(4, 0, 0), // WildFly 11, EAP 7.1
     VERSION_5_0_0(5, 0, 0), // WildFly 12 - 26, EAP 7.2 - 7.4
     VERSION_6_0_0(6, 0, 0), // WildFly 27 - present, EAP 8.0
-    VERSION_7_0_0(6, 0, 0), // WildFly 30
+    VERSION_7_0_0(7, 0, 0), // WildFly 30 - 35
+    VERSION_8_0_0(8,0,0) // WildFly 36 - present
     ;
-    static final RemotingSubsystemModel CURRENT = VERSION_7_0_0;
+    static final RemotingSubsystemModel CURRENT = VERSION_8_0_0;
 
     private final ModelVersion version;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemTransformationDescriptionFactory.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemTransformationDescriptionFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.remoting;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescription;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
+
+import java.util.function.Function;
+
+public enum RemotingSubsystemTransformationDescriptionFactory implements Function<ModelVersion, TransformationDescription> {
+    INSTANCE;
+
+    @Override
+    public TransformationDescription apply(ModelVersion version) {
+        ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+        if (RemotingSubsystemModel.VERSION_8_0_0.requiresTransformation(version)) {
+            builder.addChildResource(ConnectorResource.PATH)
+                    .getAttributeBuilder()
+                    .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode("remote")),ConnectorResource.PROTOCOL)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED,ConnectorResource.PROTOCOL)
+                    .end();
+        }
+        return builder.build();
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingTransformerRegistration.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingTransformerRegistration.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.remoting;
+
+import org.jboss.as.controller.transform.SubsystemExtensionTransformerRegistration;
+
+public class RemotingTransformerRegistration extends SubsystemExtensionTransformerRegistration {
+    public RemotingTransformerRegistration() {
+        super(RemotingExtension.SUBSYSTEM_NAME, RemotingSubsystemModel.CURRENT, RemotingSubsystemTransformationDescriptionFactory.INSTANCE);
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFacto
 import org.jboss.as.controller.remote.ModelControllerOperationHandlerFactory;
 import org.jboss.as.network.SocketBindingManager;
 import org.jboss.as.protocol.mgmt.support.ManagementChannelInitialization;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.logging.RemotingLogger;
 import org.jboss.dmr.ModelNode;
@@ -84,7 +85,7 @@ public final class ManagementRemotingServices extends RemotingServices {
         ServiceName sbmName = context.hasOptionalCapability(SocketBindingManager.SERVICE_DESCRIPTOR, NATIVE_MANAGEMENT_RUNTIME_CAPABILITY, null)
                 ? context.getCapabilityServiceName(SocketBindingManager.SERVICE_DESCRIPTOR) : null;
         installConnectorServicesForNetworkInterfaceBinding(serviceTarget, endpointName, MANAGEMENT_CONNECTOR,
-                networkInterfaceBinding, port, options, saslAuthenticationFactory, sslContext, sbmName);
+                networkInterfaceBinding, port, Protocol.REMOTE.toString(), options, saslAuthenticationFactory, sslContext, sbmName);
     }
 
     /**

--- a/remoting/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/remoting/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,1 @@
+org.jboss.as.remoting.RemotingTransformerRegistration

--- a/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -79,6 +79,7 @@ connector.sasl-protocol=The protocol to pass into the SASL mechanisms used for a
 connector.ssl-context=Reference to the SSLContext to use for this connector.
 connector.security=Configuration of security for this connector.
 connector.property=Properties to further configure the connector.
+connector.protocol=Protocol used in the connection.
 
 remoting.http-connector=The remoting HTTP Upgrade connectors.
 http-connector=The configuration of a HTTP Upgrade based Remoting connector.

--- a/remoting/subsystem/src/main/resources/schema/wildfly-remoting_8_0.xsd
+++ b/remoting/subsystem/src/main/resources/schema/wildfly-remoting_8_0.xsd
@@ -1,0 +1,447 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:remoting:8.0"
+            xmlns="urn:jboss:domain:remoting:8.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="8.0">
+
+    <!-- The remoting subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration of the Remoting subsystem.
+
+                The 'worker-thread-pool' element configures the worker thread pool.
+                The nested "connector" element(s) define connectors for this subsystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="endpoint" type="endpointType"/>
+            <xs:element name="connector" type="connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="http-connector" type="http-connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="outbound-connections" minOccurs="0" type="outbound-connectionsType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="endpointType">
+        <xs:annotation>
+            <xs:documentation>
+                Configures the remoting endpoint.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="worker" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+	                The name of the IO subsystem worker the endpoint should use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="authorize-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified and the selected SASL mechanism demands a user name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="auth-realm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The authentication realm to use if no authentication CallbackHandler is specified.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote+http">
+            <xs:annotation>
+                <xs:documentation>
+                    Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buffer-region-size" type="xs:positiveInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    The size of allocated buffer regions.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    The size of the largest buffer that this endpoint will accept over a connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-retries" type="xs:positiveInteger" default="3">
+            <xs:annotation>
+                <xs:documentation>
+                    Specify the number of times a client is allowed to retry authentication before closing the connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="transmit-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum window size of the transmit direction for connection channels, in bytes.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-messages" type="xs:positiveInteger" default="65535">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of concurrent outbound messages on a channel.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="send-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    The size of the largest buffer that this endpoint will transmit over a connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-messages" type="xs:positiveInteger" default="80">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of concurrent inbound messages on a channel.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum window size of the receive direction for connection channels, in bytes.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="heartbeat-interval" type="xs:positiveInteger" default="2147483647">
+            <xs:annotation>
+                <xs:documentation>
+                    The interval to use for connection heartbeat, in milliseconds.
+                    If the connection is idle in the outbound direction for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum inbound message size to be allowed.
+                    Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of outbound channels to support for a connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of inbound channels to support for a connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="server-name">
+            <xs:annotation>
+                <xs:documentation>
+                    The server side of the connection passes it's name to the client in the initial greeting, by default the name is automatically discovered from the local address of the connection or it can be overridden using this.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="abstractConnector" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                The base configuration of a Remoting connector.
+
+                The "name" attribute specifies the unique name of this connector.
+
+                The optional nested "sasl" element contains the SASL authentication configuration for this connector.
+
+                The optional nested "authentication-provider" element contains the name of the authentication provider to
+                use for incoming connections.
+
+                The optional server-name attribute specifies the server name that should be used in the initial exchange with
+                the client and within the SASL mechanisms used for authentication.
+
+                The optional sasl-protocol attribute specifies the protocol that should be used within the SASL mechanisms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="sasl" type="sasl" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="authentication-provider" type="xs:string"/>
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Deprecated: Security configuration for connectors should be specified using a sasl-authentication-factory and/or
+                    ssl-context reference instead of using a security-realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="server-name" type="xs:string" use="optional" />
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote" />
+        <xs:attribute name="sasl-authentication-factory" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the SASL authentication factory to use for authenticating requests to this connector.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="connector">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration of a Remoting connector.
+
+                The "socket-binding" attribute specifies the name of the socket binding to attach to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="socket-binding" type="xs:string" use="required"/>
+                <xs:attribute name="ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SSLContext to use for this connector.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="protocol" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-connector">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration of a Remoting HTTP upgrade based connector.
+
+                The "connector-ref" specifies the name of the Undertow http connector to use.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="connector-ref" type="name-list" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sasl">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration of the SASL authentication layer for this server.
+
+                The optional nested "include-mechanisms" element contains a whitelist of allowed SASL mechanism names.
+                No mechanisms will be allowed which are not present in this list.
+
+                The optional nested "qop" element contains a list of quality-of-protection values, in decreasing order
+                of preference.
+
+                The optional nested "strength" element contains a list of cipher strength values, in decreasing order
+                of preference.
+
+                The optional nested "reuse-session" boolean element specifies whether or not the server should attempt
+                to reuse previously authenticated session information.  The mechanism may or may not support such reuse,
+                and other factors may also prevent it.
+
+                The optional nested "server-auth" boolean element specifies whether the server should authenticate to the
+                client.  Not all mechanisms may support this setting.
+
+                The optional nested "policy" boolean element specifies a policy to use to narrow down the available set
+                of mechanisms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="policy" type="policy" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="include-mechanisms" type="name-list"/>
+        <xs:attribute name="qop" type="qop-list"/>
+        <xs:attribute name="strength" type="strength-list"/>
+        <xs:attribute name="reuse-session" type="xs:boolean" default="false"/>
+        <xs:attribute name="server-auth" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="policy">
+        <xs:annotation>
+            <xs:documentation>
+                Policy criteria items to use in order to choose a SASL mechanism.
+
+                The optional nested "forward-secrecy" element contains a boolean value which specifies whether mechanisms
+                that implement forward secrecy between sessions are required. Forward secrecy means that breaking into
+                one session will not automatically provide information for breaking into future sessions.
+
+                The optional nested "no-active" element contains a boolean value which specifies whether mechanisms
+                susceptible to active (non-dictionary) attacks are not permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-anonymous" element contains a boolean value which specifies whether mechanisms
+                that accept anonymous login are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-dictionary" element contains a boolean value which specifies whether mechanisms
+                susceptible to passive dictionary attacks are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-plain-text" element contains a boolean value which specifies whether mechanisms
+                susceptible to simple plain passive attacks (e.g., "PLAIN") are not permitted.    "false" to permit, "true" to deny.
+
+                The optional nested "pass-credentials" element contains a boolean value which specifies whether
+                mechanisms that pass client credentials are required.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="forward-secrecy" type="xs:boolean" default="true"/>
+        <xs:attribute name="no-active" type="xs:boolean" default="true"/>
+        <xs:attribute name="no-anonymous" type="xs:boolean" default="true"/>
+        <xs:attribute name="no-dictionary" type="xs:boolean" default="true"/>
+        <xs:attribute name="no-plain-text" type="xs:boolean" default="true"/>
+        <xs:attribute name="pass-credentials" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="name-listType">
+        <xs:annotation>
+            <xs:documentation>
+                An element specifying a string list.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="name-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="name-list">
+        <xs:annotation>
+            <xs:documentation>
+                A set of string items.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="qop-list">
+        <xs:annotation>
+            <xs:documentation>
+                The SASL quality-of-protection value list.
+                See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#QOP for more information.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="auth"/>
+                    <xs:enumeration value="auth-int"/>
+                    <xs:enumeration value="auth-conf"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:simpleType name="strength-list">
+        <xs:annotation>
+            <xs:documentation>
+                The SASL strength value list.
+                See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#STRENGTH for more information.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="low"/>
+                    <xs:enumeration value="medium"/>
+                    <xs:enumeration value="high"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="properties">
+        <xs:annotation>
+            <xs:documentation>
+                A set of free-form properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="property">
+        <xs:annotation>
+            <xs:documentation>
+                A free-form property.  The name is required; the value is optional.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionsType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="local-outbound-connection" type="local-outbound-connectionType" />
+            <xs:element name="remote-outbound-connection" type="remote-outbound-connectionType" />
+            <xs:element name="outbound-connection" type="outbound-connectionType" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="base-outbound-connectionType">
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="local-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="remote-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+                <xs:attribute name="username" type="xs:string" use="optional"/>
+                <xs:attribute name="security-realm" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Deprecated: Outbound connection definitions should migrate to use an authentication-context
+                            instead of the security-realm reference.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="protocol" type="xs:string" use="optional"/>
+                <xs:attribute name="authentication-context" type="xs:string" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-8.0.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-8.0.xml
@@ -1,0 +1,68 @@
+<subsystem xmlns="urn:jboss:domain:remoting:8.0">
+    <endpoint
+        worker="default-remoting"
+        send-buffer-size="8191"
+        receive-buffer-size="8191"
+        buffer-region-size="10240"
+        transmit-window-size="131071"
+        receive-window-size="131071"
+        max-outbound-channels="41"
+        max-inbound-channels="41"
+        authorize-id="foo"
+        auth-realm="ApplicationRealm"
+        authentication-retries="4"
+        max-outbound-messages="65534"
+        max-inbound-messages="79"
+        heartbeat-interval="20000"
+        max-inbound-message-size="1000000"
+        max-outbound-message-size="1000000"
+        server-name="test"
+        sasl-protocol="bar"
+    />
+    <connector name="remoting-connector" socket-binding="remoting" sasl-protocol="myProto" protocol="remote" server-name="myServer" authentication-provider="blah">
+        <properties>
+           <property name="TCP_NODELAY" value="true"/>
+           <property name="KEEP_ALIVE" value="true"/>
+        </properties>
+        <sasl include-mechanisms="one two three" qop="auth auth-int" strength="low high" server-auth="true" reuse-session="true">
+            <policy forward-secrecy="true" no-active="true" no-anonymous="true" no-dictionary="true" no-plain-text="true" pass-credentials="true"/>
+            <properties>
+               <property name="SASL_SERVER_AUTH" value="true"/>
+               <property name="SASL_POLICY_NOACTIVE" value="false"/>
+            </properties>
+        </sasl>
+    </connector>
+    <http-connector name="http-connector" connector-ref="http" sasl-protocol="myProto" server-name="myServer" authentication-provider="blah">
+        <properties>
+            <property name="TCP_NODELAY" value="true"/>
+            <property name="REUSE_ADDRESSES" value="true"/>
+        </properties>
+        <sasl include-mechanisms="one two three" qop="auth auth-int" strength="low high" server-auth="true" reuse-session="true">
+            <policy forward-secrecy="true" no-active="true" no-anonymous="true" no-dictionary="true" no-plain-text="true" pass-credentials="true"/>
+            <properties>
+               <property name="SASL_SERVER_AUTH" value="true"/>
+               <property name="SASL_POLICY_NOACTIVE" value="false"/>
+            </properties>
+        </sasl>
+    </http-connector>
+    <outbound-connections>
+        <local-outbound-connection name="local" outbound-socket-binding-ref="dummy-outbound-socket">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </local-outbound-connection>
+        <remote-outbound-connection name="remote" outbound-socket-binding-ref="other-outbound-socket" protocol="remote+http">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </remote-outbound-connection>
+        <outbound-connection name="generic" uri="local://-">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </outbound-connection>
+    </outbound-connections>
+</subsystem>

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.management.BaseNativeInterfaceAddStepHandler;
 import org.jboss.as.controller.management.NativeInterfaceCommonPolicy;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.network.SocketBindingManager;
+import org.jboss.as.remoting.Protocol;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.logging.ServerLogger;
@@ -84,7 +85,7 @@ public class NativeManagementAddHandler extends BaseNativeInterfaceAddStepHandle
         ManagementRemotingServices.installConnectorServicesForSocketBinding(serviceTarget, endpointName,
                     ManagementRemotingServices.MANAGEMENT_CONNECTOR,
                     socketBindingServiceName, commonPolicy.getConnectorOptions(),
-                    saslAuthenticationFactoryName, sslContextName, sbmName);
+                    saslAuthenticationFactoryName, sslContextName, sbmName, Protocol.REMOTE.toString());
         return Arrays.asList(REMOTING_BASE.append("server", MANAGEMENT_CONNECTOR), socketBindingServiceName);
     }
 


### PR DESCRIPTION
…the remoting connector

https://issues.redhat.com/browse/WFCORE-5718
https://issues.redhat.com/browse/WFLY-13828

This is a configuration fix that allows for easy configuration of feature required by EAP7-1672, which is using "remote+tls" protocol from ejb client. The protocol is supported by jboss-remoting but simply adding it to the configuration doesn't work out of the box. I have noticed that no matter what the connector configuration is on the server side, the connector is hardcoded to use
a connection provider associated with "remoting" protocol. This provider is configured differently than "remote+tls" one and this lead to inability to establish a connection. With this change customer has an ability to configure "remote+tls" on both client and the server and establish a connection using "always SSL" protocol.