### PR TITLE
WFCORE-7197 IO subsystem requires a worker or a buffer pool.  For purpose of test, use request-controller subsystem instead.

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/IgnoredResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/IgnoredResourcesTestCase.java
@@ -150,7 +150,7 @@ public class IgnoredResourcesTestCase {
         }
 
         // Modify the ignored profile
-        ModelNode mod = createOpNode("profile=ignored/subsystem=io", "add");
+        ModelNode mod = createOpNode("profile=ignored/subsystem=request-controller", "add");
         executeOperation(mod, domainPrimaryLifecycleUtil.getDomainClient());
 
         // Resource still should not exist on secondary


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7197

Extracted from https://github.com/wildfly/wildfly-core/pull/6261