### PR TITLE
WFCORE-7205 Add proper xs:attribute support to generic XMLElement.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/NamedResourceRegistrationXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/NamedResourceRegistrationXMLElement.java
@@ -109,7 +109,7 @@ public interface NamedResourceRegistrationXMLElement extends ResourceRegistratio
             XMLContent<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> content = this.getContent();
 
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> resourceReader = new ResourceXMLContainerReader(new ResourceAttributesXMLContentReader(attributes, configuration), content);
-            XMLContentWriter<Property> resourceWriter = new ResourceXMLContainerWriter<>(name, new ResourcePropertyAttributesXMLContentWriter(resourceAttributeName, attributes, configuration), Property::getValue, content);
+            XMLContentWriter<Property> resourceWriter = new DefaultXMLElementWriter<>(name, new ResourcePropertyAttributesXMLContentWriter(resourceAttributeName, attributes, configuration), Property::getValue, content);
 
             BiConsumer<Map<PathAddress, ModelNode>, PathAddress> operationTransformation = this.getOperationTransformation();
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> elementReader = new XMLElementReader<>() {

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceRegistrationXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceRegistrationXMLElement.java
@@ -224,7 +224,7 @@ public interface ResourceRegistrationXMLElement extends ResourceXMLElement, Reso
         }
     }
 
-    class DefaultResourceRegistrationXMLElement extends DefaultXMLElement<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> implements ResourceRegistrationXMLElement {
+    class DefaultResourceRegistrationXMLElement extends DefaultResourceXMLElement implements ResourceRegistrationXMLElement {
         private final PathElement path;
 
         DefaultResourceRegistrationXMLElement(ResourceRegistration registration, QName name, XMLCardinality cardinality, XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> reader, XMLContentWriter<ModelNode> writer) {

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceXMLContainer.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceXMLContainer.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -230,43 +229,6 @@ public interface ResourceXMLContainer extends XMLContainer<Map.Entry<PathAddress
             this.attributesReader.readElement(reader, operation);
 
             this.content.readContent(reader, context);
-        }
-    }
-
-    class ResourceXMLContainerWriter<C> implements XMLContentWriter<C> {
-        private final QName name;
-        private final XMLContentWriter<C> attributesWriter;
-        private final Function<C, ModelNode> model;
-        private final XMLContent<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> childContent;
-
-        ResourceXMLContainerWriter(QName name, XMLContentWriter<C> attributesWriter, Function<C, ModelNode> model, XMLContent<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> childContent) {
-            this.name = name;
-            this.attributesWriter = attributesWriter;
-            this.model = model;
-            this.childContent = childContent;
-        }
-
-        @Override
-        public void writeContent(XMLExtendedStreamWriter writer, C content) throws XMLStreamException {
-            String namespaceURI = this.name.getNamespaceURI();
-            writer.writeStartElement(namespaceURI, this.name.getLocalPart());
-
-            // If namespace is not yet bound to any prefix, bind it
-            if (writer.getNamespaceContext().getPrefix(namespaceURI) == null) {
-                writer.setPrefix(this.name.getPrefix(), namespaceURI);
-                writer.writeNamespace(this.name.getPrefix(), namespaceURI);
-            }
-
-            this.attributesWriter.writeContent(writer, content);
-
-            this.childContent.writeContent(writer, this.model.apply(content));
-
-            writer.writeEndElement();
-        }
-
-        @Override
-        public boolean isEmpty(C content) {
-            return this.attributesWriter.isEmpty(content) && this.childContent.isEmpty(this.model.apply(content));
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceXMLElement.java
@@ -100,7 +100,7 @@ public interface ResourceXMLElement extends ResourceXMLContainer, XMLElement<Map
     class DefaultResourceXMLElement extends DefaultXMLElement<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> implements ResourceXMLElement {
 
         DefaultResourceXMLElement(QName name, XMLCardinality cardinality, XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> reader, XMLContentWriter<ModelNode> writer, Stability stability) {
-            super(name, cardinality, reader, writer, stability);
+            super(name, cardinality, XMLElementReader.validate(name, reader), writer, stability);
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/ResourceXMLElement.java
@@ -83,7 +83,7 @@ public interface ResourceXMLElement extends ResourceXMLContainer, XMLElement<Map
             XMLContent<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> content = this.getContent();
 
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> reader = new ResourceXMLContainerReader(new ResourceAttributesXMLContentReader(attributes, configuration), content);
-            XMLContentWriter<ModelNode> writer = new ResourceXMLContainerWriter<>(this.name, new ResourceAttributesXMLContentWriter(attributes, configuration), Function.identity(), content) {
+            XMLContentWriter<ModelNode> writer = new DefaultXMLElementWriter<>(this.name, new ResourceAttributesXMLContentWriter(attributes, configuration), Function.identity(), content) {
                 @Override
                 public void writeContent(XMLExtendedStreamWriter writer, ModelNode content) throws XMLStreamException {
                     // Skip if empty

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/SingletonResourceRegistrationXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/SingletonResourceRegistrationXMLElement.java
@@ -82,7 +82,7 @@ public interface SingletonResourceRegistrationXMLElement extends ResourceRegistr
             XMLContent<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> content = this.getContent();
 
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> resourceReader = new ResourceXMLContainerReader(attributesReader, content);
-            XMLContentWriter<ModelNode> resourceWriter = new ResourceXMLContainerWriter<>(name, attributesWriter, Function.identity(), content);
+            XMLContentWriter<ModelNode> resourceWriter = new DefaultXMLElementWriter<>(name, attributesWriter, Function.identity(), content);
 
             BiConsumer<Map<PathAddress, ModelNode>, PathAddress> operationTransformation = this.getOperationTransformation();
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> elementReader = new XMLElementReader<>() {

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/SingletonResourceRegistrationXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/SingletonResourceRegistrationXMLElement.java
@@ -94,7 +94,7 @@ public interface SingletonResourceRegistrationXMLElement extends ResourceRegistr
                 }
 
                 @Override
-                public void handleAbsentElement(Map.Entry<PathAddress, Map<PathAddress, ModelNode>> context) {
+                public void whenAbsent(Map.Entry<PathAddress, Map<PathAddress, ModelNode>> context) {
                     if (implied) {
                         // Create add operation for implied resource if element is absent
                         this.createOperationEntry(context);

--- a/controller/src/main/java/org/jboss/as/controller/persistence/xml/SubsystemResourceRegistrationXMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/xml/SubsystemResourceRegistrationXMLElement.java
@@ -65,7 +65,7 @@ public interface SubsystemResourceRegistrationXMLElement extends ResourceRegistr
             XMLContent<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>, ModelNode> content = this.getContent();
 
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> resourceReader = new ResourceXMLContainerReader(attributesReader, content);
-            XMLContentWriter<ModelNode> resourceWriter = new ResourceXMLContainerWriter<>(name, attributesWriter, Function.identity(), content);
+            XMLContentWriter<ModelNode> resourceWriter = new DefaultXMLElementWriter<>(name, attributesWriter, Function.identity(), content);
 
             BiConsumer<Map<PathAddress, ModelNode>, PathAddress> operationTransformation = this.getOperationTransformation();
             XMLElementReader<Map.Entry<PathAddress, Map<PathAddress, ModelNode>>> elementReader = new XMLElementReader<>() {

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLAll.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLAll.java
@@ -112,15 +112,15 @@ public interface XMLAll<RC, WC> extends XMLElementGroup<RC, WC> {
                             throw ParseUtils.minOccursNotReached(reader, required, XMLCardinality.Single.REQUIRED);
                         }
                         for (XMLElement<RC, WC> remainingElement : remaining.values()) {
-                            remainingElement.getReader().handleAbsentElement(context);
+                            remainingElement.getReader().whenAbsent(context);
                         }
                     }
                 }
 
                 @Override
-                public void handleAbsentElement(RC context) {
+                public void whenAbsent(RC context) {
                     for (XMLElement<RC, WC> element : orderedElements) {
-                        element.getReader().handleAbsentElement(context);
+                        element.getReader().whenAbsent(context);
                     }
                 }
             });

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLAttribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLAttribute.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.version.Stability;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+import org.wildfly.common.Assert;
+import org.wildfly.common.function.Functions;
+
+/**
+ * Encapsulates an attribute of an XML element.
+ */
+public interface XMLAttribute<RC, WC> extends XMLComponent<RC, WC> {
+
+    /**
+     * Returns the qualified name of this attribute.
+     * @return the qualified name of this attribute.
+     */
+    QName getName();
+
+    @Override
+    XMLAttributeReader<RC> getReader();
+
+    /**
+     * Returns the usage of this XML attribute.
+     * @return the usage of this XML attribute.
+     */
+    XMLUsage getUsage();
+
+    /**
+     * Enumerates permissible xs:attribute usage.
+     */
+    enum Use implements XMLUsage {
+        OPTIONAL(false, true),
+        PROHIBITED(false, false),
+        REQUIRED(true, true),
+        ;
+        private final boolean required;
+        private final boolean enabled;
+
+        Use(boolean required, boolean enabled) {
+            this.required = required;
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean isRequired() {
+            return this.required;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return this.enabled;
+        }
+    }
+
+    interface Builder<RC, WC> {
+        /**
+         * Overrides the usage of this attribute
+         * @param usage the attribute usage
+         * @return a reference to this builder
+         */
+        Builder<RC, WC> withUsage(XMLUsage usage);
+
+        /**
+         * Specifies a default value for this attribute, applied if the attribute is absent from the input.
+         * @param defaultValue the default value of this attribute
+         * @return a reference to this builder
+         */
+        Builder<RC, WC> withDefaultValue(String defaultValue);
+
+        /**
+         * Specifies a fixed value of this attribute, applied if the attribute is absent from the input.
+         * However, if this attribute is present in the input, it must specify this fixed value.
+         * @param defaultValue the fixed value of this attribute
+         * @return a reference to this builder
+         */
+        Builder<RC, WC> withFixedValue(String fixedValue);
+
+        /**
+         * Specifies a consumer used to apply an attribute value to the read context.
+         * @param consumer consumes the attribute value into the read context
+         * @return a reference to this builder
+         */
+        Builder<RC, WC> withConsumer(BiConsumer<RC, String> consumer);
+
+        /**
+         * Specifies a function used to format content as an attribute value.
+         * @param formatter a function returning the attribute value of the content to be written.
+         * @return a reference to this builder
+         */
+        Builder<RC, WC> withFormatter(Function<WC, String> formatter);
+
+        /**
+         * Builds this attribute
+         * @return an XML attribute
+         */
+        XMLAttribute<RC, WC> build();
+    }
+
+    static class DefaultBuilder<RC, WC> implements Builder<RC, WC> {
+        private final QName name;
+        private final Stability stability;
+        private volatile BiConsumer<RC, String> consumer = Functions.discardingBiConsumer();
+        private volatile Function<WC, String> formatter = Object::toString;
+        private volatile XMLUsage usage = Use.OPTIONAL;
+        private volatile String defaultValue = null;
+        private volatile boolean fixed = false;
+
+        DefaultBuilder(QName name, Stability stability) {
+            this.name = name;
+            this.stability = stability;
+        }
+
+        @Override
+        public Builder<RC, WC> withConsumer(BiConsumer<RC, String> consumer) {
+            this.consumer = consumer;
+            return this;
+        }
+
+        @Override
+        public Builder<RC, WC> withFormatter(Function<WC, String> formatter) {
+            this.formatter = formatter;
+            return this;
+        }
+
+        @Override
+        public Builder<RC, WC> withUsage(XMLUsage usage) {
+            this.usage = usage;
+            return this;
+        }
+
+        @Override
+        public Builder<RC, WC> withDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+            this.fixed = false;
+            return this;
+        }
+
+        @Override
+        public Builder<RC, WC> withFixedValue(String fixedValue) {
+            Assert.assertNotNull(fixedValue);
+            this.withDefaultValue(fixedValue);
+            this.fixed = true;
+            return this;
+        }
+
+        @Override
+        public XMLAttribute<RC, WC> build() {
+            QName name = this.name;
+            XMLUsage usage = this.usage;
+            BiConsumer<RC, String> consumer = this.consumer;
+            Function<WC, String> formatter = this.formatter;
+            String defaultValue = this.defaultValue;
+            boolean fixed = this.fixed;
+            XMLAttributeReader<RC> reader = new XMLAttributeReader<>() {
+                @Override
+                public void readAttribute(XMLStreamReader reader, int index, RC context) throws XMLStreamException {
+                    String value = reader.getAttributeValue(index);
+                    // Detect invalid fixed value
+                    if (fixed && !value.equals(defaultValue)) {
+                        throw ControllerLogger.ROOT_LOGGER.invalidAttributeValue(value, reader.getAttributeName(index), reader.getLocation());
+                    }
+                    consumer.accept(context, reader.getAttributeValue(index));
+                }
+
+                @Override
+                public void whenAbsent(RC context) {
+                    if (defaultValue != null) {
+                        // Apply default value, if attribute was absent from input
+                        consumer.accept(context, defaultValue);
+                    }
+                }
+            };
+            XMLContentWriter<WC> writer = new XMLContentWriter<>() {
+                @Override
+                public void writeContent(XMLExtendedStreamWriter writer, WC content) throws XMLStreamException {
+                    String value = formatter.apply(content);
+                    if ((value != null) && (usage.isRequired() || !value.equals(defaultValue))) {
+                        writer.writeAttribute(name.getLocalPart(), value);
+                    }
+                }
+
+                @Override
+                public boolean isEmpty(WC content) {
+                    return formatter.apply(content) == null;
+                }
+            };
+            return new DefaultXMLAttribute<>(this.name, this.usage, reader, writer, this.stability);
+        }
+    }
+
+    static class DefaultXMLAttribute<RC, WC> implements XMLAttribute<RC, WC> {
+        private final QName name;
+        private final XMLUsage usage;
+        private final XMLAttributeReader<RC> reader;
+        private final XMLContentWriter<WC> writer;
+        private final Stability stability;
+
+        DefaultXMLAttribute(QName name, XMLUsage usage, XMLAttributeReader<RC> reader, XMLContentWriter<WC> writer, Stability stability) {
+            this.name = name;
+            this.usage = usage;
+            this.reader = reader;
+            this.writer = writer;
+            this.stability = stability;
+        }
+
+        @Override
+        public QName getName() {
+            return this.name;
+        }
+
+        @Override
+        public XMLAttributeReader<RC> getReader() {
+            return this.reader;
+        }
+
+        @Override
+        public XMLContentWriter<WC> getWriter() {
+            return this.writer;
+        }
+
+        @Override
+        public XMLUsage getUsage() {
+            return this.usage;
+        }
+
+        @Override
+        public Stability getStability() {
+            return this.stability;
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLAttributeReader.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLAttributeReader.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+/**
+ * Adds absentee attribute handling to an {link org.jboss.staxmapper.XMLAttributeReader}.
+ * @author Paul Ferraro
+ * @param <C> the reader context type
+ */
+public interface XMLAttributeReader<C> extends org.jboss.staxmapper.XMLAttributeReader<C>, XMLComponentReader<C> {
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLCardinality.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLCardinality.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * Defines the cardinality of an XML particle.
  */
-public interface XMLCardinality {
+public interface XMLCardinality extends XMLUsage {
 
     /**
      * Returns the minimum number of occurrences of this particle.
@@ -30,6 +30,7 @@ public interface XMLCardinality {
      * Indicates whether or not the associated particle must occur, i.e. minOccurs &gt; 0
      * @return true, if the associated particle is required, false otherwise
      */
+    @Override
     default boolean isRequired() {
         return this.getMinOccurs() > 0;
     }
@@ -46,6 +47,7 @@ public interface XMLCardinality {
      * Indicates whether or not the associated particle may occur at all, i.e. maxOccurs &gt; 0
      * @return true, if the associated particle is enabled, false otherwise
      */
+    @Override
     default boolean isEnabled() {
         return this.getMaxOccurs().orElse(Integer.MAX_VALUE) > 0;
     }

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLChoice.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLChoice.java
@@ -100,14 +100,14 @@ public interface XMLChoice<RC, WC> extends XMLParticleGroup<RC, WC> {
                     } else if (cardinality.isRequired()) {
                         throw ParseUtils.unexpectedElement(reader, choices.keySet());
                     } else {
-                        this.handleAbsentElement(context);
+                        this.whenAbsent(context);
                     }
                 }
 
                 @Override
-                public void handleAbsentElement(RC context) {
-                    for (XMLParticleGroup<RC, WC> choice : groups) {
-                        choice.getReader().handleAbsentElement(context);
+                public void whenAbsent(RC context) {
+                    for (XMLParticleGroup<RC, WC> group : groups) {
+                        group.getReader().whenAbsent(context);
                     }
                 }
             });
@@ -127,7 +127,7 @@ public interface XMLChoice<RC, WC> extends XMLParticleGroup<RC, WC> {
 
         // Singleton choice
         DefaultXMLElementChoice(XMLElement<RC, WC> element) {
-            this(Map.of(element.getName(), element), element.getCardinality(), element.getReader()::handleAbsentElement, List.of(element), element.getStability());
+            this(Map.of(element.getName(), element), element.getCardinality(), element.getReader()::whenAbsent, List.of(element), element.getStability());
         }
 
         protected DefaultXMLElementChoice(Collection<? extends XMLElement<RC, WC>> elements, XMLCardinality cardinality, Consumer<RC> absenteeHandler, Stability stability) {
@@ -167,12 +167,12 @@ public interface XMLChoice<RC, WC> extends XMLParticleGroup<RC, WC> {
                     } else if (cardinality.isRequired()) {
                         throw ParseUtils.unexpectedElement(reader, names);
                     } else {
-                        this.handleAbsentElement(context);
+                        this.whenAbsent(context);
                     }
                 }
 
                 @Override
-                public void handleAbsentElement(RC context) {
+                public void whenAbsent(RC context) {
                     absenteeHandler.accept(context);
                 }
             }, writer, stability);

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLComponent.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLComponent.java
@@ -10,13 +10,13 @@ import org.jboss.as.controller.Feature;
 /**
  * Encapsulates an XML component, e.g. particle/attribute.
  */
-public interface XMLComponent<R, WC> extends Feature {
+public interface XMLComponent<RC, WC> extends Feature {
 
     /**
      * Returns the reader of this XML component.
      * @return the reader of this XML component.
      */
-    R getReader();
+    XMLComponentReader<RC> getReader();
 
     /**
      * Returns the writer of this XML component.

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLComponent.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+import org.jboss.as.controller.Feature;
+
+/**
+ * Encapsulates an XML component, e.g. particle/attribute.
+ */
+public interface XMLComponent<R, WC> extends Feature {
+
+    /**
+     * Returns the reader of this XML component.
+     * @return the reader of this XML component.
+     */
+    R getReader();
+
+    /**
+     * Returns the writer of this XML component.
+     * @return the writer of this XML component.
+     */
+    XMLContentWriter<WC> getWriter();
+}

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLComponentReader.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLComponentReader.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+/**
+ * Super-interface for XML component readers with absentee handling.
+ * @author Paul Ferraro
+ * @param <C> the reader context type
+ */
+public interface XMLComponentReader<C> {
+    /**
+     * Triggered when the associated XML content is absent from the XML input.
+     * @param context a reader context
+     */
+    void whenAbsent(C context);
+}

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLContent.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLContent.java
@@ -95,7 +95,7 @@ public interface XMLContent<RC, WC> extends XMLContentWriter<WC> {
                     this.group.getReader().readElement(reader, context);
                 } while (reader.getEventType() != XMLStreamConstants.END_ELEMENT);
             } else {
-                this.group.getReader().handleAbsentElement(context);
+                this.group.getReader().whenAbsent(context);
             }
             // Validate minOccurs
             if (occurrences < this.group.getCardinality().getMinOccurs()) {

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLContentWriter.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLContentWriter.java
@@ -82,19 +82,19 @@ public interface XMLContentWriter<C> extends XMLElementWriter<C> {
         };
     }
 
-    static <RC, WC> XMLContentWriter<WC> composite(Collection<? extends XMLParticle<RC, WC>> particles) {
+    static <RC, WC> XMLContentWriter<WC> composite(Collection<? extends XMLComponent<RC, WC>> components) {
         return new XMLContentWriter<>() {
             @Override
             public void writeContent(XMLExtendedStreamWriter writer, WC content) throws XMLStreamException {
-                for (XMLParticle<RC, WC> particle : particles) {
-                    particle.getWriter().writeContent(writer, content);
+                for (XMLComponent<RC, WC> component : components) {
+                    component.getWriter().writeContent(writer, content);
                 }
             }
 
             @Override
             public boolean isEmpty(WC content) {
-                for (XMLParticle<RC, WC> particle : particles) {
-                    XMLContentWriter<WC> contentWriter = particle.getWriter();
+                for (XMLComponent<RC, WC> component : components) {
+                    XMLContentWriter<WC> contentWriter = component.getWriter();
                     if (!contentWriter.isEmpty(content)) return false;
                 }
                 return true;

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLContentWriter.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLContentWriter.java
@@ -5,6 +5,7 @@
 package org.jboss.as.controller.xml;
 
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -22,6 +23,26 @@ public interface XMLContentWriter<C> extends XMLElementWriter<C> {
      * Indicates whether the specified content is empty.
      */
     boolean isEmpty(C content);
+
+    /**
+     * Returns a new writer whose content is mapped from the specified function.
+     * @param mapper a content mapping function
+     * @param <T> the mapped content type
+     * @return a new writer whose content is mapped from the specified function.
+     */
+    default <T> XMLContentWriter<T> map(Function<T, C> mapper) {
+        return new XMLContentWriter<>() {
+            @Override
+            public void writeContent(XMLExtendedStreamWriter writer, T content) throws XMLStreamException {
+                XMLContentWriter.this.writeContent(writer, mapper.apply(content));
+            }
+
+            @Override
+            public boolean isEmpty(T content) {
+                return XMLContentWriter.this.isEmpty(mapper.apply(content));
+            }
+        };
+    }
 
     /**
      * Returns a new writer that invokes {@link #writeContent(XMLExtendedStreamWriter, Object)} on the specified writer <em>after</em> invoking {@link #writeContent(XMLExtendedStreamWriter, Object)} on this writer.

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLElement.java
@@ -10,7 +10,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
@@ -36,6 +38,14 @@ public interface XMLElement<RC, WC> extends XMLContainer<RC, WC> {
      * @return a qualified name
      */
     QName getName();
+
+    default <R, W> XMLElement<R, W> map(Function<R, RC> readContextMapper, Function<W, WC> writeContentMapper) {
+        return new DefaultXMLElement<>(this.getName(), this.getCardinality(), this.getReader().map(readContextMapper), this.getWriter().map(writeContentMapper), this.getStability());
+    }
+
+    default <R, W> XMLElement<R, W> withContext(Supplier<RC> readContextFactory, BiConsumer<R, RC> readContextConsumer, Function<W, WC> writeContentMapper) {
+        return new DefaultXMLElement<>(this.getName(), this.getCardinality(), this.getReader().withContext(readContextFactory, readContextConsumer), this.getWriter().map(writeContentMapper), this.getStability());
+    }
 
     /**
      * Builder of an XML element.

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLElementReader.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLElementReader.java
@@ -5,6 +5,15 @@
 
 package org.jboss.as.controller.xml;
 
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.wildfly.common.Assert;
+
 /**
  * Adds absentee element handling to an {link org.jboss.staxmapper.XMLElementReader}.
  * @author Paul Ferraro
@@ -15,5 +24,38 @@ public interface XMLElementReader<C> extends org.jboss.staxmapper.XMLElementRead
     @Override
     default void whenAbsent(C context) {
         // Do nothing
+    }
+
+    /**
+     * Decorates an {@link XMLElementReader} with entry/exit criteria validation.
+     * @param <C> the read context
+     * @param name the name of the expected element
+     * @param elementReader the reader of an element
+     * @return a validating reader
+     */
+    static <C> XMLElementReader<C> validate(QName expected, XMLElementReader<C> elementReader) {
+        return new XMLElementReader<>() {
+            @Override
+            public void readElement(XMLExtendedStreamReader reader, C value) throws XMLStreamException {
+                // Validate entry criteria
+                Assert.assertTrue(reader.isStartElement());
+                if (!reader.getName().equals(expected)) {
+                    throw ParseUtils.unexpectedElement(reader, Set.of(expected));
+                }
+                elementReader.readElement(reader, value);
+                // Validate exit criteria
+                if (!reader.isEndElement()) {
+                    throw ParseUtils.unexpectedElement(reader);
+                }
+                if (!reader.getName().equals(expected)) {
+                    throw ParseUtils.unexpectedEndElement(reader);
+                }
+            }
+
+            @Override
+            public void whenAbsent(C context) {
+                elementReader.whenAbsent(context);
+            }
+        };
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLElementReader.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLElementReader.java
@@ -7,14 +7,13 @@ package org.jboss.as.controller.xml;
 
 /**
  * Adds absentee element handling to an {link org.jboss.staxmapper.XMLElementReader}.
+ * @author Paul Ferraro
+ * @param <C> the reader context type
  */
-public interface XMLElementReader<C> extends org.jboss.staxmapper.XMLElementReader<C> {
-    /**
-     * Handles the case where the associated element is not present in the XML input.
-     * By default, no action is taken.
-     * @param context a reader context
-     */
-    default void handleAbsentElement(C context) {
+public interface XMLElementReader<C> extends org.jboss.staxmapper.XMLElementReader<C>, XMLComponentReader<C> {
+
+    @Override
+    default void whenAbsent(C context) {
         // Do nothing
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLParticle.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLParticle.java
@@ -5,7 +5,6 @@
 
 package org.jboss.as.controller.xml;
 
-import org.jboss.as.controller.Feature;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.version.Stability;
 
@@ -15,25 +14,13 @@ import org.jboss.as.version.Stability;
  * @param <RC> the reader context
  * @param <WC> the writer content
  */
-public interface XMLParticle<RC, WC> extends Feature {
+public interface XMLParticle<RC, WC> extends XMLComponent<XMLElementReader<RC>, WC> {
 
     /**
      * Returns the cardinality of this XML particle.
      * @return the cardinality of this XML particle.
      */
     XMLCardinality getCardinality();
-
-    /**
-     * Returns the reader of this XML particle.
-     * @return the reader of this XML particle.
-     */
-    XMLElementReader<RC> getReader();
-
-    /**
-     * Returns the writer of this XML particle.
-     * @return the writer of this XML particle.
-     */
-    XMLContentWriter<WC> getWriter();
 
     interface Builder<RC, WC, T extends XMLParticle<RC, WC>, B extends Builder<RC, WC, T, B>> {
         /**

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLParticle.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLParticle.java
@@ -14,7 +14,10 @@ import org.jboss.as.version.Stability;
  * @param <RC> the reader context
  * @param <WC> the writer content
  */
-public interface XMLParticle<RC, WC> extends XMLComponent<XMLElementReader<RC>, WC> {
+public interface XMLParticle<RC, WC> extends XMLComponent<RC, WC> {
+
+    @Override
+    XMLElementReader<RC> getReader();
 
     /**
      * Returns the cardinality of this XML particle.

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLSequence.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLSequence.java
@@ -105,14 +105,14 @@ public interface XMLSequence<RC, WC> extends XMLParticleGroup<RC, WC> {
                         if (group.getCardinality().isRequired()) {
                             throw ParseUtils.minOccursNotReached(reader, group.getNames(), group.getCardinality());
                         }
-                        group.getReader().handleAbsentElement(context);
+                        group.getReader().whenAbsent(context);
                     }
                 }
 
                 @Override
-                public void handleAbsentElement(RC context) {
+                public void whenAbsent(RC context) {
                     for (XMLParticleGroup<RC, WC> group : groups) {
-                        group.getReader().handleAbsentElement(context);
+                        group.getReader().whenAbsent(context);
                     }
                 }
 
@@ -126,7 +126,7 @@ public interface XMLSequence<RC, WC> extends XMLParticleGroup<RC, WC> {
                         if (group.getCardinality().isRequired()) {
                             throw ParseUtils.minOccursNotReached(reader, group.getNames(), group.getCardinality());
                         }
-                        group.getReader().handleAbsentElement(context);
+                        group.getReader().whenAbsent(context);
                     }
                     return null;
                 }

--- a/controller/src/main/java/org/jboss/as/controller/xml/XMLUsage.java
+++ b/controller/src/main/java/org/jboss/as/controller/xml/XMLUsage.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+/**
+ * Defines the usage of a an XML component.
+ * @author Paul Ferraro
+ */
+public interface XMLUsage {
+
+    /**
+     * Indicates whether or not the associated XML component is required.
+     * @return true, if the associated XML component is required, false otherwise.
+     */
+    boolean isRequired();
+
+    /**
+     * Indicates whether or not the associated XML component is enabled.
+     * @return true, if the associated XML component is enabled, false otherwise.
+     */
+    boolean isEnabled();
+}

--- a/controller/src/test/java/org/jboss/as/controller/xml/XMLAllTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/xml/XMLAllTestCase.java
@@ -20,12 +20,17 @@ import org.junit.Test;
 /**
  * Unit test validating read semantics of {@link XMLAll}.
  */
-public class XMLAllTestCase implements FeatureRegistry {
-    private final XMLParticleFactory<Void, Void> factory = XMLParticleFactory.newInstance(this);
+public class XMLAllTestCase implements FeatureRegistry, QNameResolver {
+    private final XMLComponentFactory<Void, Void> factory = XMLComponentFactory.newInstance(this, this);
 
     @Override
     public Stability getStability() {
         return Stability.COMMUNITY;
+    }
+
+    @Override
+    public QName resolve(String localName) {
+        return new QName(localName);
     }
 
     @Test
@@ -43,7 +48,7 @@ public class XMLAllTestCase implements FeatureRegistry {
             if (this.factory.getStability().enables(stability)) {
                 expectedSize += 1;
             }
-            builder.addElement(this.factory.element(new QName(stability.toString()), stability).build());
+            builder.addElement(this.factory.element(this.resolve(stability.toString()), stability).build());
         }
         XMLAll<Void, Void> all = builder.build();
         Assert.assertSame(expected, all.getStability());
@@ -55,13 +60,13 @@ public class XMLAllTestCase implements FeatureRegistry {
     public void testRequiredAll() throws XMLStreamException {
         // Validate xs:all with minOccurs = 1, maxOccurs = 1
         XMLAll<Void, Void> all = this.factory.all()
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(all).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(all).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -105,13 +110,13 @@ public class XMLAllTestCase implements FeatureRegistry {
     public void testOptionalAll() throws XMLStreamException {
         // Validate xs:all with minOccurs = 0, maxOccurs = 1
         XMLAll<Void, Void> all = this.factory.all().withCardinality(XMLCardinality.Single.OPTIONAL)
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(all).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(all).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -155,9 +160,9 @@ public class XMLAllTestCase implements FeatureRegistry {
     public void testDisabledAll() throws XMLStreamException {
         // Validate xs:all with minOccurs = 0, maxOccurs = 0
         XMLAll<Void, Void> all = this.factory.all().withCardinality(XMLCardinality.DISABLED)
-                .addElement(this.factory.element(new QName("required")).build())
+                .addElement(this.factory.element(this.resolve("required")).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(all).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(all).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -177,10 +182,10 @@ public class XMLAllTestCase implements FeatureRegistry {
         XMLAll.Builder<Void, Void> builder = this.factory.all();
 
         // xs:all does not allow repeated elements
-        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(new QName("unbounded")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(new QName("unbounded")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(new QName("unbounded")).withCardinality(XMLCardinality.of(0, OptionalInt.of(2))).build()));
-        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(new QName("unbounded")).withCardinality(XMLCardinality.of(1, OptionalInt.of(2))).build()));
+        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(this.resolve("unbounded")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build()));
+        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(this.resolve("unbounded")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build()));
+        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(this.resolve("unbounded")).withCardinality(XMLCardinality.of(0, OptionalInt.of(2))).build()));
+        Assert.assertThrows(IllegalArgumentException.class, () -> builder.addElement(this.factory.element(this.resolve("unbounded")).withCardinality(XMLCardinality.of(1, OptionalInt.of(2))).build()));
         // xs:all is not repeatable
         Assert.assertThrows(IllegalArgumentException.class, () -> builder.withCardinality(XMLCardinality.Unbounded.OPTIONAL));
         Assert.assertThrows(IllegalArgumentException.class, () -> builder.withCardinality(XMLCardinality.Unbounded.REQUIRED));

--- a/controller/src/test/java/org/jboss/as/controller/xml/XMLChoiceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/xml/XMLChoiceTestCase.java
@@ -19,12 +19,17 @@ import org.junit.Test;
 /**
  * Unit test validating read semantics of {@link XMLChoice}.
  */
-public class XMLChoiceTestCase implements FeatureRegistry {
-    private final XMLParticleFactory<Void, Void> factory = XMLParticleFactory.newInstance(this);
+public class XMLChoiceTestCase implements FeatureRegistry, QNameResolver {
+    private final XMLComponentFactory<Void, Void> factory = XMLComponentFactory.newInstance(this, this);
 
     @Override
     public Stability getStability() {
         return Stability.COMMUNITY;
+    }
+
+    @Override
+    public QName resolve(String localName) {
+        return new QName(localName);
     }
 
     @Test
@@ -42,7 +47,7 @@ public class XMLChoiceTestCase implements FeatureRegistry {
             if (this.factory.getStability().enables(stability)) {
                 expectedSize += 1;
             }
-            builder.addElement(this.factory.element(new QName(stability.toString()), stability).build());
+            builder.addElement(this.factory.element(this.resolve(stability.toString()), stability).build());
         }
         XMLChoice<Void, Void> all = builder.build();
         Assert.assertSame(expected, all.getStability());
@@ -54,15 +59,15 @@ public class XMLChoiceTestCase implements FeatureRegistry {
     public void testRequiredChoice() throws XMLStreamException {
         // Validate xs:choice with minOccurs = 1, maxOccurs = 1
         XMLChoice<Void, Void> choice = this.factory.choice()
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(choice).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(choice).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -108,15 +113,15 @@ public class XMLChoiceTestCase implements FeatureRegistry {
     public void testOptionalChoice() throws XMLStreamException {
         // Validate xs:choice with minOccurs = 0, maxOccurs = 1
         XMLChoice<Void, Void> choice = this.factory.choice().withCardinality(XMLCardinality.Single.OPTIONAL)
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(choice).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(choice).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -162,15 +167,15 @@ public class XMLChoiceTestCase implements FeatureRegistry {
     public void testRepeatableChoice() throws XMLStreamException {
         // Validate xs:choice with minOccurs = 0, maxOccurs = unbounded
         XMLChoice<Void, Void> choice = this.factory.choice().withCardinality(XMLCardinality.Unbounded.OPTIONAL)
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(choice).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(choice).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -215,15 +220,15 @@ public class XMLChoiceTestCase implements FeatureRegistry {
     public void testRepeatedChoice() throws XMLStreamException {
         // Validate xs:choice with minOccurs = 0, maxOccurs = unbounded
         XMLChoice<Void, Void> choice = this.factory.choice().withCardinality(XMLCardinality.Unbounded.REQUIRED)
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(choice).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(choice).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -268,9 +273,9 @@ public class XMLChoiceTestCase implements FeatureRegistry {
     public void testDisabledChoice() throws XMLStreamException {
         // Validate xs:all with minOccurs = 0, maxOccurs = 0
         XMLChoice<Void, Void> choice = this.factory.choice().withCardinality(XMLCardinality.DISABLED)
-                .addElement(this.factory.element(new QName("required")).build())
+                .addElement(this.factory.element(this.resolve("required")).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(choice).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(choice).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests

--- a/controller/src/test/java/org/jboss/as/controller/xml/XMLElementTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/xml/XMLElementTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.controller.xml;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.FeatureRegistry;
+import org.jboss.as.version.Stability;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test validating read/write semantics of an {@link XMLElement} containing attributes and text content.
+ */
+public class XMLElementTestCase implements FeatureRegistry, QNameResolver {
+    private static final String NAMESPACE_URI = "wildfly:test:1.0";
+    private final XMLComponentFactory<Map<Attribute, String>, Map<Attribute, String>> factory = XMLComponentFactory.newInstance(this, this);
+
+    @Override
+    public QName resolve(String localName) {
+        return new QName(NAMESPACE_URI, localName);
+    }
+
+    @Override
+    public Stability getStability() {
+        return Stability.COMMUNITY;
+    }
+
+    enum Attribute implements BiConsumer<Map<Attribute, String>, String>, Function<Map<Attribute, String>, String> {
+        REQUIRED(null),
+        OPTIONAL(null),
+        DEFAULT("default-value"),
+        OPTIONAL_FIXED("optional-fixed-value"),
+        REQUIRED_FIXED("required-fixed-value"),
+        PROHIBITED(null),
+        EXPERIMENTAL(null),
+        CONTENT(null)
+        ;
+        private final String defaultValue;
+
+        Attribute(String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        String getDefaultValue() {
+            return this.defaultValue;
+        }
+
+        @Override
+        public String apply(Map<Attribute, String> map) {
+            return map.get(this);
+        }
+
+        @Override
+        public void accept(Map<Attribute, String> map, String value) {
+            map.put(this, value);
+        }
+    }
+
+    @Test
+    public void testAttributes() throws XMLStreamException {
+        XMLElement<Map<Attribute, String>, Map<Attribute, String>> containerElement = this.factory.element(this.resolve("element"))
+                .addAttribute(this.factory.attribute(this.resolve("required")).withUsage(XMLAttribute.Use.REQUIRED).withConsumer(Attribute.REQUIRED).withFormatter(Attribute.REQUIRED).build())
+                .addAttribute(this.factory.attribute(this.resolve("optional")).withConsumer(Attribute.OPTIONAL).withFormatter(Attribute.OPTIONAL).build())
+                .addAttribute(this.factory.attribute(this.resolve("default")).withConsumer(Attribute.DEFAULT).withDefaultValue(Attribute.DEFAULT.getDefaultValue()).withFormatter(Attribute.DEFAULT).build())
+                .addAttribute(this.factory.attribute(this.resolve("optional-fixed")).withConsumer(Attribute.OPTIONAL_FIXED).withFixedValue(Attribute.OPTIONAL_FIXED.getDefaultValue()).withFormatter(Attribute.OPTIONAL_FIXED).build())
+                .addAttribute(this.factory.attribute(this.resolve("required-fixed")).withUsage(XMLAttribute.Use.REQUIRED).withConsumer(Attribute.REQUIRED_FIXED).withFixedValue(Attribute.REQUIRED_FIXED.getDefaultValue()).withFormatter(Attribute.REQUIRED_FIXED).build())
+                .addAttribute(this.factory.attribute(this.resolve("prohibited")).withUsage(XMLAttribute.Use.PROHIBITED).withConsumer(Attribute.PROHIBITED).withFormatter(Attribute.PROHIBITED).build())
+                .addAttribute(this.factory.attribute(this.resolve("experimental"), Stability.EXPERIMENTAL).withConsumer(Attribute.EXPERIMENTAL).withFormatter(Attribute.EXPERIMENTAL).build())
+                .withContent(XMLContent.of(Attribute.CONTENT, Attribute.CONTENT))
+                .build();
+
+        try (XMLElementTester<Map<Attribute, String>, Map<Attribute, String>> tester = XMLElementTester.of(containerElement, () -> new EnumMap<>(Attribute.class))) {
+            // Positive tests
+
+            // Verify minimal attributes present
+            String xml = String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><element xmlns=\"%s\" required=\"foo\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue());
+            Map<Attribute, String> result = tester.readElement(xml);
+
+            Assert.assertEquals(result.toString(), 5, result.size());
+            Assert.assertEquals(result.toString(), "foo", result.get(Attribute.REQUIRED));
+            Assert.assertEquals(result.toString(), Attribute.DEFAULT.getDefaultValue(), result.get(Attribute.DEFAULT));
+            Assert.assertEquals(result.toString(), Attribute.OPTIONAL_FIXED.getDefaultValue(), result.get(Attribute.OPTIONAL_FIXED));
+            Assert.assertEquals(result.toString(), Attribute.REQUIRED_FIXED.getDefaultValue(), result.get(Attribute.REQUIRED_FIXED));
+            Assert.assertEquals(result.toString(), "", result.get(Attribute.CONTENT));
+
+            assertXMLEquals(xml, tester.writeElement(result));
+
+            // Verify maximal attributes present, overriding any default values
+            xml = String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><element xmlns=\"%s\" default=\"baz\" optional=\"bar\" optional-fixed=\"%s\" required=\"foo\" required-fixed=\"%s\">qux</element>", NAMESPACE_URI, Attribute.OPTIONAL_FIXED.getDefaultValue(), Attribute.REQUIRED_FIXED.getDefaultValue());
+            result = tester.readElement(xml);
+
+            Assert.assertEquals(result.toString(), 6, result.size());
+            Assert.assertEquals(result.toString(), "foo", result.get(Attribute.REQUIRED));
+            Assert.assertEquals(result.toString(), "bar", result.get(Attribute.OPTIONAL));
+            Assert.assertEquals(result.toString(), "baz", result.get(Attribute.DEFAULT));
+            Assert.assertEquals(result.toString(), "optional-fixed-value", result.get(Attribute.OPTIONAL_FIXED));
+            Assert.assertEquals(result.toString(), "required-fixed-value", result.get(Attribute.REQUIRED_FIXED));
+            Assert.assertEquals(result.toString(), "qux", result.get(Attribute.CONTENT));
+
+            // Optional fixed values will not appear in output
+            assertXMLEquals(String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><element xmlns=\"%s\" default=\"baz\" optional=\"bar\" required=\"foo\" required-fixed=\"%s\">qux</element>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue()), tester.writeElement(result));
+
+            // Negative tests
+
+            // Missing required attribute
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\"/>", NAMESPACE_URI)));
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" required=\"foo\"/>", NAMESPACE_URI)));
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue())));
+
+            // Duplicate attribute
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" optional=\"bar\" optional=\"baz\" required=\"foo\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue())));
+
+            // Unexpected attribute
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" required=\"foo\" unexpected=\"foo\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue())));
+
+            // Impermissible fixed attribute
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" required=\"foo\" required-fixed=\"bar\"/>", NAMESPACE_URI)));
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" optional-fixed=\"bar\" required=\"foo\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue())));
+
+            // Prohibited attribute
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<element xmlns=\"%s\" prohibited=\"bar\" required=\"foo\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue())));
+
+            // Experimental attribute
+            Assert.assertThrows(XMLStreamException.class, () -> tester.readElement(String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><element xmlns=\"%s\" experimental=\"bar\" required=\"foo\" required-fixed=\"%s\"/>", NAMESPACE_URI, Attribute.REQUIRED_FIXED.getDefaultValue())));
+        }
+    }
+
+    private static void assertXMLEquals(String expected, String actual) {
+        Assert.assertEquals(actual, trim(expected), trim(actual));
+    }
+
+    private static String trim(String xml) {
+        // Trim whitespace between elements
+        return xml.replaceAll(Pattern.quote(">") + "\\s*(\\S*)\\s*" + Pattern.quote("<"), ">$1<");
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/xml/XMLSequenceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/xml/XMLSequenceTestCase.java
@@ -19,12 +19,17 @@ import org.junit.Test;
 /**
  * Unit test validating read semantics of {@link XMLSequence}.
  */
-public class XMLSequenceTestCase implements FeatureRegistry {
-    private final XMLParticleFactory<Void, Void> factory = XMLParticleFactory.newInstance(this);
+public class XMLSequenceTestCase implements FeatureRegistry, QNameResolver {
+    private final XMLComponentFactory<Void, Void> factory = XMLComponentFactory.newInstance(this, this);
 
     @Override
     public Stability getStability() {
         return Stability.COMMUNITY;
+    }
+
+    @Override
+    public QName resolve(String localName) {
+        return new QName(localName);
     }
 
     @Test
@@ -42,7 +47,7 @@ public class XMLSequenceTestCase implements FeatureRegistry {
             if (this.factory.getStability().enables(stability)) {
                 expectedSize += 1;
             }
-            builder.addElement(this.factory.element(new QName(stability.toString()), stability).build());
+            builder.addElement(this.factory.element(this.resolve(stability.toString()), stability).build());
         }
         XMLSequence<Void, Void> all = builder.build();
         Assert.assertSame(expected, all.getStability());
@@ -55,15 +60,15 @@ public class XMLSequenceTestCase implements FeatureRegistry {
     public void testRequiredSequence() throws XMLStreamException {
         // Validate xs:sequence with minOccurs = 1, maxOccurs = 1
         XMLSequence<Void, Void> sequence = this.factory.sequence()
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(sequence).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(sequence).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -115,15 +120,15 @@ public class XMLSequenceTestCase implements FeatureRegistry {
     public void testOptionalSequence() throws XMLStreamException {
         // Validate xs:sequence with minOccurs = 0, maxOccurs = 1
         XMLSequence<Void, Void> sequence = this.factory.sequence().withCardinality(XMLCardinality.Single.OPTIONAL)
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(sequence).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(sequence).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -175,15 +180,15 @@ public class XMLSequenceTestCase implements FeatureRegistry {
     public void testRepeatableSequence() throws XMLStreamException {
         // Validate xs:sequence with minOccurs = 0, maxOccurs = unbounded
         XMLSequence<Void, Void> sequence = this.factory.sequence().withCardinality(XMLCardinality.Unbounded.OPTIONAL)
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(sequence).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(sequence).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -247,15 +252,15 @@ public class XMLSequenceTestCase implements FeatureRegistry {
     public void testRepeatedSequence() throws XMLStreamException {
         // Validate xs:sequence with minOccurs = 1, maxOccurs = unbounded
         XMLSequence<Void, Void> sequence = this.factory.sequence().withCardinality(XMLCardinality.Unbounded.REQUIRED)
-                .addElement(this.factory.element(new QName("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("required"), Stability.COMMUNITY).build())
-                .addElement(this.factory.element(new QName("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
-                .addElement(this.factory.element(new QName("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
-                .addElement(this.factory.element(new QName("preview"), Stability.PREVIEW).build())
-                .addElement(this.factory.element(new QName("experimental"), Stability.EXPERIMENTAL).build())
-                .addElement(this.factory.element(new QName("disabled")).withCardinality(XMLCardinality.DISABLED).build())
+                .addElement(this.factory.element(this.resolve("optional")).withCardinality(XMLCardinality.Single.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("required"), Stability.COMMUNITY).build())
+                .addElement(this.factory.element(this.resolve("repeatable")).withCardinality(XMLCardinality.Unbounded.OPTIONAL).build())
+                .addElement(this.factory.element(this.resolve("repeated")).withCardinality(XMLCardinality.Unbounded.REQUIRED).build())
+                .addElement(this.factory.element(this.resolve("preview"), Stability.PREVIEW).build())
+                .addElement(this.factory.element(this.resolve("experimental"), Stability.EXPERIMENTAL).build())
+                .addElement(this.factory.element(this.resolve("disabled")).withCardinality(XMLCardinality.DISABLED).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(sequence).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(sequence).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests
@@ -319,9 +324,9 @@ public class XMLSequenceTestCase implements FeatureRegistry {
     public void testDisabledSequence() throws XMLStreamException {
         // Validate xs:sequence with minOccurs = 0, maxOccurs = 0
         XMLSequence<Void, Void> sequence = this.factory.sequence().withCardinality(XMLCardinality.DISABLED)
-                .addElement(this.factory.element(new QName("required")).build())
+                .addElement(this.factory.element(this.resolve("required")).build())
                 .build();
-        XMLElement<Void, Void> containerElement = this.factory.element(new QName("container")).withContent(sequence).build();
+        XMLElement<Void, Void> containerElement = this.factory.element(this.resolve("container")).withContent(sequence).build();
 
         try (XMLElementTester<Void, Void> tester = XMLElementTester.of(containerElement)) {
             // Positive tests


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7205

Enhances interfaces introduced by WFCORE-6779 adding proper xs:attribute support to a generic XMLElement (for use with creating deployment descriptor schemas, etc.)
This proposal modifies several interfaces introduced in https://github.com/wildfly/wildfly-core/pull/6261 and thus is intended for inclusion in 28.0.0.Final.
