### PR TITLE
[WFCORE-7208] Fix intermittent failures on DeploymentOperationsTestCa…

### DIFF
--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
@@ -94,7 +94,7 @@ public class DeploymentOperationsTestCase {
     @Inject
     private ManagementClient managementClient;
 
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    private static final int TIMEOUT = TimeoutUtil.adjust(40000);
     private static final String TEST_DEPLOYMENT_NAME = "test-deployment.jar";
     private static final String PROPERTIES_RESOURCE = "service-activator-deployment.properties";
 


### PR DESCRIPTION
…se by increasing the operation timeout

This test is occasionally failing when executing a management operation to add additional content to an existing deployment, this seems to be failing in a slower environment, so doubling the timeout here to make it more resilient

Jira issue: https://issues.redhat.com/browse/WFCORE-7208

