### PR TITLE
[28.x] [WFCORE-7218] / [WFCORE-7219] Upgrade WildFly Elytron to 2.6.3.Final and Elytron Web to 4.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>2.6.3.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>4.1.2.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.1.4.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>
         <version.org.yaml.snakeyaml>2.4</version.org.yaml.snakeyaml>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.6.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.6.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.1.4.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7218
https://github.com/wildfly-security/wildfly-elytron/compare/2.6.2.Final...2.6.3.Final

https://issues.redhat.com/browse/WFCORE-7219
https://github.com/wildfly-security/elytron-web/compare/4.1.0.Final...4.1.2.Final

https://issues.redhat.com/browse/WFCORE-7210 can also be resolved with this one.

Upstream PR: https://github.com/wildfly/wildfly-core/pull/6393