### PR TITLE
WFCORE-7234 ParallelBootOperationContext.getResourceRegistration() can throw OperationFailedRuntimeException during operation rollback

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -144,14 +144,14 @@ class ParallelBootOperationContext extends AbstractOperationContext {
 
     @Override
     public ImmutableManagementResourceRegistration getResourceRegistration() {
-        ImmutableManagementResourceRegistration parent = primaryContext.getResourceRegistration();
+        ImmutableManagementResourceRegistration parent = primaryContext.getRootResourceRegistration();
         return  parent.getSubModel(activeStep.address);
     }
 
     @Override
     public ManagementResourceRegistration getResourceRegistrationForUpdate() {
         acquireControllerLock();
-        ManagementResourceRegistration parent = primaryContext.getResourceRegistrationForUpdate();
+        ManagementResourceRegistration parent = primaryContext.getRootResourceRegistrationForUpdate();
         return  parent.getSubModel(activeStep.address);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7234