### PR TITLE
[WFCORE-7248] Upgrade WildFly Elytron to 2.6.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>2.6.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.6.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.1.2.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.1.4.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7248

https://github.com/wildfly-security/wildfly-elytron/compare/2.6.3.Final...2.6.4.Final
