### PR TITLE
Ignore ProvisioningConsistencyTestCase on s390x

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/provisioning/ProvisioningConsistencyTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/provisioning/ProvisioningConsistencyTestCase.java
@@ -25,6 +25,8 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.logging.Logger;
+import org.junit.AssumptionViolatedException;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -54,6 +56,13 @@ public class ProvisioningConsistencyTestCase {
             return new File(System.getenv("JBOSS_HOME")).getCanonicalFile().toPath();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeClass
+    public static void assumeNotS390() {
+        if ("s390x".equalsIgnoreCase(System.getProperty("os.arch"))) {
+            throw new AssumptionViolatedException("WFCORE-7269");
         }
     }
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/WFLY-20620 where we've agreed to disable this test and the main WF analogue on s390x.