### PR TITLE
[WFCORE-7274] Upgrade BouncyCastle from 1.80 to 1.81

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.15.0</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
-        <version.org.bouncycastle>1.80</version.org.bouncycastle>
+        <version.org.bouncycastle>1.81</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>6.10.1.202505221210-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.7</version.org.eclipse.parsson>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7274
