### PR TITLE
Fix for WFCORE-7284, Potential mismatch between provisioning of HAL bits and config enablement of the console

### DIFF
--- a/core-feature-pack/galleon-common/src/main/resources/feature_groups/default-management-console.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/feature_groups/default-management-console.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<feature-group-spec name="default-management-console" xmlns="urn:jboss:galleon:feature-group:1.0">
+  <feature spec="core-service.management.management-interface.http-interface">
+    <unset param="console-enabled"/>
+  </feature>
+</feature-group-spec>

--- a/core-feature-pack/galleon-common/src/main/resources/layers/standalone/management/layer-spec.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/layers/standalone/management/layer-spec.xml
@@ -12,11 +12,12 @@
     <feature-group name="unsecured-management"/>
 
     <feature spec="core-service.management.management-interface.http-interface">
+        <param name="console-enabled" value="false"/>
         <param name="socket-binding" value="management-http"/>
         <param name="http-authentication-factory" value="management-http-authentication"/>
         <feature spec="core-service.management.management-interface.http-interface.http-upgrade">
             <param name="sasl-authentication-factory" value="management-sasl-authentication"/>
         </feature>
     </feature>
-    
+
 </layer-spec>

--- a/core-feature-pack/galleon-feature-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/core-feature-pack/galleon-feature-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -17,6 +17,7 @@
         <include name="discovery"/>
         <include name="core-tools"/>
     </layers>
+    <feature-group name="default-management-console"/>
     <!-- package included in case configuration is provisioned without inheriting all modules -->
     <packages>
         <package name="org.jboss.as.patching.cli"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-7284

* management layer now disables the console
* introduce a feature-group to disable the console-enabled attribute (that will be used by WildFly to update default configs that need it).
* default standalone config, reset console-enabled attribute

A successful run of WildFly with the fix for WFLY-20748 based on this PR: https://ci.wildfly.org/buildConfiguration/WF_WildFlyCoreIntegrationExperiments/509259
