### PR TITLE
[WFCORE-7294] embed-server can delete the same tmp/vfs directory for running server

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/StandaloneSystemPropertyContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/StandaloneSystemPropertyContext.java
@@ -41,6 +41,6 @@ final class StandaloneSystemPropertyContext extends SystemPropertyContext {
         addPropertyIfAbsent(SERVER_CONTENT_DIR, resolvePath(dataDir, "content"));
         addPropertyIfAbsent(SERVER_DEPLOY_DIR, resolvePath(dataDir, "content"));
         addPropertyIfAbsent(SERVER_LOG_DIR, resolvePath(baseDir, "log"));
-        addPropertyIfAbsent(SERVER_TEMP_DIR, resolvePath(baseDir, "tmp"));
+        addPropertyIfAbsent(SERVER_TEMP_DIR, resolvePath(baseDir, "tmp/embedded-server"));
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/SystemPropertyResetTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/SystemPropertyResetTestCase.java
@@ -38,7 +38,7 @@ public class SystemPropertyResetTestCase extends AbstractTestCase {
         expectedProperties.put("jboss.server.config.dir", resolvePath(baseDir, "configuration"));
         expectedProperties.put("jboss.server.content.dir", resolvePath(baseDir, "data", "content"));
         expectedProperties.put("jboss.server.data.dir", resolvePath(baseDir, "data"));
-        expectedProperties.put("jboss.server.temp.dir", resolvePath(baseDir, "tmp"));
+        expectedProperties.put("jboss.server.temp.dir", resolvePath(baseDir, "tmp/embedded-server"));
 
         final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.createConfigBuilder().build());
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7294