### PR TITLE
WFCORE-7297 ModelTestControllerVersion#getMavenGav produces invalid coordinates for core artifacts + WFCORE-7298 Replace legacy ModelTestControllerVersion#getMavenGav with proper methods to format Maven coordinates

### DIFF
--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -18,7 +18,7 @@ import org.wildfly.legacy.version.LegacyVersions;
  */
 public enum ModelTestControllerVersion {
     // Release version under test
-    MASTER (CurrentVersion.VERSION, false, null, "master" ),
+    MASTER(CurrentVersion.VERSION, false, null, "master"),
 
     //EAP releases
     EAP_7_4_0("7.4.0.GA-redhat-00005", true, "23.0.0", "15.0.2.Final-redhat-00001", "7.4.0"),
@@ -48,16 +48,18 @@ public enum ModelTestControllerVersion {
     ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String realVersionName) {
         this(mavenGavVersion, eap, testControllerVersion, null, realVersionName);
     }
+
     ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String coreVersion, String realVersionName) {
         this(mavenGavVersion, eap, testControllerVersion, coreVersion, realVersionName, false);
     }
+
     ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, String coreVersion, String realVersionName, boolean ignored) {
         this.mavenGavVersion = mavenGavVersion;
         this.testControllerVersion = testControllerVersion;
         this.eap = eap;
         this.stability = eap ? Stability.DEFAULT : Stability.COMMUNITY;
         this.validLegacyController = testControllerVersion != null;
-        this.coreVersion = coreVersion == null? mavenGavVersion : coreVersion; //full == core
+        this.coreVersion = coreVersion == null ? mavenGavVersion : coreVersion; //full == core
         this.realVersionName = realVersionName;
         this.ignored = ignored;
         if (eap) {
@@ -124,7 +126,12 @@ public enum ModelTestControllerVersion {
         return realVersionName;
     }
 
-    public String getArtifactIdPrefix(){
+    /**
+     * @deprecated The artifact prefix has not been relevant since WildFly 8. Remove usages of this method and replace with
+     * {@link ModelTestControllerVersion#createGAV(String)} and {@link ModelTestControllerVersion#createCoreGAV(String)} as appropriate.
+     */
+    @Deprecated(forRemoval = true)
+    public String getArtifactIdPrefix() {
         return artifactIdPrefix;
     }
 
@@ -151,19 +158,46 @@ public enum ModelTestControllerVersion {
         }
     }
 
-    public ModelVersion getSubsystemModelVersion(String subsystemName){
+    public ModelVersion getSubsystemModelVersion(String subsystemName) {
         return getSubsystemModelVersions().get(subsystemName);
     }
 
-    public Map<String,ModelVersion> getSubsystemModelVersions(){
-        if (subsystemModelVersions.isEmpty()){
-            synchronized (subsystemModelVersions){
+    public Map<String, ModelVersion> getSubsystemModelVersions() {
+        if (subsystemModelVersions.isEmpty()) {
+            synchronized (subsystemModelVersions) {
                 subsystemModelVersions.putAll(LegacyVersions.getModelVersions(realVersionName));
             }
         }
         return this.subsystemModelVersions;
     }
 
+    /**
+     * Creates a Maven GAV (groupId:artifactId:version) string for the specified artifact
+     * for this test controller version.
+     *
+     * @param artifactId the artifactId to include in the GAV string
+     * @return the Maven coordinates of the artifact for this test controller version.
+     */
+    public String createGAV(String artifactId) {
+        return String.format("%s:%s:%s", getMavenGroupId(), artifactId, getMavenGavVersion());
+    }
+
+    /**
+     * Creates a Maven GAV (groupId:artifactId:version) string for the specified wildfly-core artifact
+     * for this test controller version.
+     *
+     * @param artifactId the artifactId from wildfly-core to include in the GAV string
+     * @return the Maven coordinates of the wildfly-core artifact for this test controller version.
+     */
+    public String createCoreGAV(String artifactId) {
+        return String.format("%s:%s:%s", getCoreMavenGroupId(), artifactId, getCoreVersion());
+    }
+
+    /**
+     * @deprecated Use {@link ModelTestControllerVersion#createGAV(String)} and
+     * {@link ModelTestControllerVersion#createCoreGAV(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public String getMavenGav(String artifactIdPart, boolean coreArtifact) {
         return String.format("%s:%s%s:%s",
                 coreArtifact ? getCoreMavenGroupId() : getMavenGroupId(),

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -168,8 +168,7 @@ public enum ModelTestControllerVersion {
         return String.format("%s:%s%s:%s",
                 coreArtifact ? getCoreMavenGroupId() : getMavenGroupId(),
                 getArtifactIdPrefix(), artifactIdPart,
-                getMavenGavVersion());
-
+                coreArtifact ? getCoreVersion() : getMavenGavVersion());
     }
 
     public Stability getStability() {

--- a/model-test/src/test/java/org/jboss/as/model/test/ModelTestControllerVersionTest.java
+++ b/model-test/src/test/java/org/jboss/as/model/test/ModelTestControllerVersionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.model.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Trivial tests for {@link ModelTestControllerVersion} to prevent accidental breaking of the method contract.
+ *
+ * @author Radoslav Husar
+ */
+public class ModelTestControllerVersionTest {
+
+    @Test
+    public void testCreateGAV() {
+        // Test a released EAP version
+        String eapGav = ModelTestControllerVersion.EAP_8_0_0.createGAV("wildfly-artifact");
+        assertEquals("org.jboss.eap:wildfly-artifact:8.0.0.GA-redhat-00011", eapGav);
+
+        // Test a WildFly version
+        String wildflyGav = ModelTestControllerVersion.WILDFLY_31_0_0.createGAV("wildfly-artifact");
+        assertEquals("org.wildfly:wildfly-artifact:31.0.0.Final", wildflyGav);
+    }
+
+    @Test
+    public void testCreateCoreGAV() {
+        // Test a released EAP version
+        String eapCoreGav = ModelTestControllerVersion.EAP_8_0_0.createCoreGAV("wildfly-artifact");
+        assertEquals("org.wildfly.core:wildfly-artifact:21.0.5.Final-redhat-00001", eapCoreGav);
+
+        // Test a WildFly version
+        String wildflyCoreGav = ModelTestControllerVersion.WILDFLY_31_0_0.createCoreGAV("wildfly-artifact");
+        assertEquals("org.wildfly.core:wildfly-artifact:23.0.1.Final", wildflyCoreGav);
+    }
+
+}


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFCORE-7297
https://issues.redhat.com/browse/WFCORE-7298

The method org.jboss.as.model.test.ModelTestControllerVersion#getMavenGav incorrectly uses version of the main artifact even when specified as core artifact resulting in unusable maven coordinates.
The issue was never uncovered as this is not used, but it is required for EAP 8.1 clustering transformers.
The org.jboss.as.model.test.ModelTestControllerVersion#getMavenGav is legacy and problematic.
First of all, the method is incorrectly named - it's not a getter of any sorts.
Using both 'maven' and 'gav' in the same method is redundant, GAV is a maven concept.
Moreover, GAV should be all caps as it's already an abbreviation.
It makes use of irrelevant org.jboss.as.model.test.ModelTestControllerVersion#getArtifactIdPrefix which was last used in EAP 6.

Also... runs formatter on this horrible mess.
