### PR TITLE
[WFCORE-7307]: Upgrade jgit from 6.10.1.202505221210-r to 7.3.0.202506031305-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
         <version.org.bouncycastle>1.81</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
-        <version.org.eclipse.jgit>6.10.1.202505221210-r</version.org.eclipse.jgit>
+        <version.org.eclipse.jgit>7.3.0.202506031305-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.7</version.org.eclipse.parsson>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>


### PR DESCRIPTION
Since we are no longer limited to java 11 we can upgrade to the newest major version.

Jira: https://issues.redhat.com/browse/WFCORE-7307