### PR TITLE
[WFCORE-7303]: GitRepository.clearExistingFiles removes file in the 'ignored' set

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
@@ -82,7 +82,7 @@ public class AbstractGitRepositoryTestCase {
         if (emptyRemoteRepository != null) {
             emptyRemoteRepository.close();
         }
-        FileUtils.delete(emptyRemoteRoot.getParent().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+        FileUtils.delete(emptyRemoteRoot.getParent().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
     }
 
     protected Repository createRepository() throws IOException {
@@ -100,10 +100,10 @@ public class AbstractGitRepositoryTestCase {
             repository.close();
         }
         if (Files.exists(getDotGitDir())) {
-            FileUtils.delete(getDotGitDir().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+            FileUtils.delete(getDotGitDir().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
         }
         if(Files.exists(getDotGitIgnore())) {
-            FileUtils.delete(getDotGitIgnore().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+            FileUtils.delete(getDotGitIgnore().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
         }
     }
 
@@ -155,7 +155,7 @@ public class AbstractGitRepositoryTestCase {
                     treeWalk.setRecursive(true);
                     List<DiffEntry> diff = DiffEntry.scan(treeWalk, false, null);
                     for (DiffEntry diffEntry : diff) {
-                        if(diffEntry.getChangeType() == DiffEntry.ChangeType.DELETE) {
+                        if (diffEntry.getChangeType() == DiffEntry.ChangeType.DELETE) {
                             result.add("-" + diffEntry.getOldPath());
                         } else {
                             result.add(diffEntry.getNewPath());

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
@@ -47,6 +47,10 @@ public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         if(Files.exists(properties)) {
             Files.delete(properties);
         }
+        Path standaloneHistory = repoConfigDir.resolve("standalone_xml_history");
+        if (Files.exists(standaloneHistory)) {
+            PathUtil.deleteRecursively(standaloneHistory);
+        }
         File gitDir = new File(baseDir, Constants.DOT_GIT);
         if (!gitDir.exists()) {
             try (Git git = Git.init().setDirectory(baseDir).setInitialBranch(Constants.MASTER).call()) {
@@ -74,13 +78,14 @@ public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         closeRepository();
         closeEmptyRemoteRepository();
         closeRemoteRepository();
+        Files.deleteIfExists(getJbossServerBaseDir().resolve("log").resolve("ignored.log"));
     }
 
     private void closeRemoteRepository() throws Exception{
         if (remoteRepository != null) {
             remoteRepository.close();
         }
-        FileUtils.delete(remoteRoot.getParent().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+        FileUtils.delete(remoteRoot.getParent().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
     }
 
     /**
@@ -88,6 +93,7 @@ public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
      */
     @Test
     public void startGitRepoRemoteTest() throws Exception {
+        Files.createFile(getJbossServerBaseDir().resolve("log").resolve("ignored.log"));
         // start with remote repository containing configuration (--git-repo=file:///my_repo/test/.git)
         container.startGitBackedConfiguration("file://" + remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString(), Constants.MASTER, null);
         Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteHttpGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteHttpGitRepositoryTestCase.java
@@ -51,6 +51,10 @@ public class RemoteHttpGitRepositoryTestCase extends AbstractGitRepositoryTestCa
         if (Files.exists(properties)) {
             Files.delete(properties);
         }
+        Path standaloneHistory = repoConfigDir.resolve("standalone_xml_history");
+        if (Files.exists(standaloneHistory)) {
+            PathUtil.deleteRecursively(standaloneHistory);
+        }
         File gitDir = new File(baseDir, Constants.DOT_GIT);
         if (!gitDir.exists()) {
             try (Git git = Git.init().setDirectory(baseDir).setInitialBranch(Constants.MASTER).call()) {
@@ -85,7 +89,7 @@ public class RemoteHttpGitRepositoryTestCase extends AbstractGitRepositoryTestCa
         if (remoteRepository != null) {
             remoteRepository.close();
         }
-        FileUtils.delete(remoteRoot.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+        FileUtils.delete(remoteRoot.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
     }
 
     @Test


### PR DESCRIPTION

* Using gitignore rules to define which file/directory to clean

Issue: https://issues.redhat.com/browse/WFCORE-7303