### PR TITLE
[WFCORE-7228] Bump the kernel management API version to 31.0.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -84,7 +84,8 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY33("WildFly33.0", KernelAPIVersion.VERSION_26_0),
         WILDFLY34("WildFly34.0", KernelAPIVersion.VERSION_27_0),
         WILDFLY35("WildFly35.0", KernelAPIVersion.VERSION_28_0),
-        WILDFLY36("WildFly36.0", KernelAPIVersion.VERSION_29_0);
+        WILDFLY36("WildFly36.0", KernelAPIVersion.VERSION_29_0),
+        WILDFLY37("WildFly37.0", KernelAPIVersion.VERSION_30_0);
 
         private static final Map<String, KnownRelease> map = new HashMap<>();
         static {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -87,6 +87,8 @@ public enum KernelAPIVersion {
     VERSION_28_0(28, 0, 0),
     // WildFly 36.0.0
     VERSION_29_0(29, 0, 0),
+    // WildFly 37.0.0
+    VERSION_30_0(30, 0, 0),
 
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);

--- a/version/src/main/java/org/jboss/as/version/Version.java
+++ b/version/src/main/java/org/jboss/as/version/Version.java
@@ -18,7 +18,7 @@ public class Version {
     public static final String UNKNOWN_CODENAME = "";
     public static final String AS_VERSION;
     public static final String AS_RELEASE_CODENAME;
-    public static final int MANAGEMENT_MAJOR_VERSION = 30;
+    public static final int MANAGEMENT_MAJOR_VERSION = 31;
     public static final int MANAGEMENT_MINOR_VERSION = 0;
     public static final int MANAGEMENT_MICRO_VERSION = 0;
 


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7228

