### PR TITLE
[29.x] [CVE-2025-48924] [WFCORE-7306] Upgrade commons-lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.commons-cli>1.9.0</version.commons-cli>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-daemon>1.4.1</version.commons-daemon>
-        <version.commons-lang3>3.17.0</version.commons-lang3>
+        <version.commons-lang3>3.18.0</version.commons-lang3>
         <version.commons-io>2.16.1</version.commons-io>
         <version.io.netty>4.1.123.Final</version.io.netty>
         <version.io.smallrye.jandex>3.3.2</version.io.smallrye.jandex>


### PR DESCRIPTION
Upstream PR: https://github.com/wildfly/wildfly-core/pull/6463
https://issues.redhat.com/browse/WFCORE-7306