### PR TITLE
[29.x][WFCORE-7319] Maven warning: found duplicate declaration of plugin or…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,11 +365,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>${version.gpg.plugin}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.wildfly</groupId>
                     <artifactId>wildfly-maven-gpg-plugin</artifactId>
                     <version>${version.org.wildfly.wildfly-maven-gpg-plugin}</version>


### PR DESCRIPTION
…g.apache.maven.plugins:maven-gpg-plugin

upstream: #6474
Jira issue: https://issues.redhat.com/browse/WFCORE-7319



