### PR TITLE
[WFCORE-7325] Upgrade smallrye-common to 2.13.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <version.commons-io>2.16.1</version.commons-io>
         <version.io.netty>4.1.123.Final</version.io.netty>
         <version.io.smallrye.jandex>3.4.0</version.io.smallrye.jandex>
-        <version.io.smallrye.smallrye-common>2.12.2</version.io.smallrye.smallrye-common>
+        <version.io.smallrye.smallrye-common>2.13.8</version.io.smallrye.smallrye-common>
         <version.io.undertow>2.3.18.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7325

