### PR TITLE
[29.x][WFCORE-7330][WFCORE-7321] Use wildfly-bom-builder-plugin and upgrade it to 2.0.9

### DIFF
--- a/component-matrix-builder/pom.xml
+++ b/component-matrix-builder/pom.xml
@@ -36,18 +36,18 @@
                             <goal>build-bom</goal>
                         </goals>
                         <configuration>
-                            <parent>
+                            <bomParent>
                                 <groupId>org.jboss</groupId>
                                 <artifactId>jboss-parent</artifactId>
                                 <relativePath/>
-                            </parent>
+                            </bomParent>
                             <bomGroupId>${project.groupId}</bomGroupId>
                             <bomArtifactId>wildfly-core-component-matrix</bomArtifactId>
                             <bomVersion>${project.version}</bomVersion>
                             <bomName>WildFly Core: Component Matrix</bomName>
                             <bomDescription>WildFly Core: Component Matrix</bomDescription>
                             <inheritExclusions>ALL</inheritExclusions>
-                            <licenses>true</licenses>
+                            <generateLicenses>true</generateLicenses>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <!-- wildfly-maven-plugin-->
         <version.wildfly.plugin>5.1.3.Final</version.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
-        <version.org.wildfly.bom-builder-plugin>2.0.8.Final</version.org.wildfly.bom-builder-plugin>
+        <version.org.wildfly.bom-builder-plugin>2.0.9.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.wildfly-maven-gpg-plugin>3.2.8.SP1</version.org.wildfly.wildfly-maven-gpg-plugin>
         <version.org.wildfly.licenses.plugin>2.4.2.Final</version.org.wildfly.licenses.plugin>
         <version.versions.plugin>2.5</version.versions.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFCORE-7330
Upstream: https://github.com/wildfly/wildfly-core/pull/6487

Issue: https://issues.redhat.com/browse/WFCORE-7321
Upstream: https://github.com/wildfly/wildfly-core/pull/6478