### PR TITLE
[29.x][WFCORE-7342] Upgrade wildfly-bom-builder-plugin to 2.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <!-- wildfly-maven-plugin-->
         <version.wildfly.plugin>5.1.3.Final</version.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
-        <version.org.wildfly.bom-builder-plugin>2.0.9.Final</version.org.wildfly.bom-builder-plugin>
+        <version.org.wildfly.bom-builder-plugin>2.0.10.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.wildfly-maven-gpg-plugin>3.2.8.SP1</version.org.wildfly.wildfly-maven-gpg-plugin>
         <version.org.wildfly.licenses.plugin>2.4.2.Final</version.org.wildfly.licenses.plugin>
         <version.versions.plugin>2.5</version.versions.plugin>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7342
