### PR TITLE
WIP: [WFCORE-7335] Block deployments if the security manager subsyste…

### DIFF
--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerSubsystemAdd.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerSubsystemAdd.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -62,14 +63,21 @@ class SecurityManagerSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final ModelNode node = Resource.Tools.readModel(resource);
         // get the minimum set of deployment permissions.
         final ModelNode deploymentPermissionsModel = node.get(DEPLOYMENT_PERMISSIONS_PATH.getKeyValuePair());
-        final ModelNode minimumPermissionsNode = MINIMUM_PERMISSIONS.resolveModelAttribute(context, deploymentPermissionsModel);
-        final List<PermissionFactory> minimumSet = this.retrievePermissionSet(DeferredPermissionFactory.Type.MINIMUM_SET, context, minimumPermissionsNode);
-
-        // get the maximum set of deployment permissions.
-        ModelNode maximumPermissionsNode = MAXIMUM_PERMISSIONS.resolveModelAttribute(context, deploymentPermissionsModel);
+        ModelNode minimumPermissionsNode = null;
+        ModelNode maximumPermissionsNode = null;
+        try {
+            minimumPermissionsNode = MINIMUM_PERMISSIONS.resolveModelAttribute(context, deploymentPermissionsModel);
+            maximumPermissionsNode = MAXIMUM_PERMISSIONS.resolveModelAttribute(context, deploymentPermissionsModel);
+        } catch (ExpressionResolver.ExpressionResolutionUserException ex) {
+            // TODO: better exception choice ?
+            throw (System.getSecurityManager() != null) ? new RuntimeException(ex) : ex;
+        }
         if (!maximumPermissionsNode.isDefined())
             maximumPermissionsNode = DEFAULT_MAXIMUM_SET;
-        final List<PermissionFactory> maximumSet = this.retrievePermissionSet(DeferredPermissionFactory.Type.MAXIMUM_SET, context, maximumPermissionsNode);
+        final List<PermissionFactory> minimumSet = this
+                .retrievePermissionSet(DeferredPermissionFactory.Type.MINIMUM_SET, context, minimumPermissionsNode);
+        final List<PermissionFactory> maximumSet = this
+                .retrievePermissionSet(DeferredPermissionFactory.Type.MAXIMUM_SET, context, maximumPermissionsNode);
 
         // validate the configured permissions - the minimum set must be implied by the maximum set.
         final FactoryPermissionCollection maxPermissionCollection = new FactoryPermissionCollection(maximumSet.toArray(new PermissionFactory[maximumSet.size()]));


### PR DESCRIPTION
/cc @darranl 
issue: https://issues.redhat.com/browse/WFCORE-7335

This is only a draft PR to showcase a possible solution.

When `standalone.xml` security manager subsystem configuration is invalid, f.g: 
```xml
<subsystem xmlns="urn:jboss:domain:security-manager:1.0">
    <deployment-permissions>
        <maximum-set>
            <permission class="java.io.FilePermission" name="${badExpression}" actions="write,delete"/>
        </maximum-set>
    </deployment-permissions>
</subsystem>
```
Upon WF instance startup, the `ExpressionResolverImpl.java` will log and throw an exception of type `OperationClientException`
https://github.com/wildfly/wildfly-core/blob/70bb2a1953d7e8cd9d8f0dbbe542f3574741b6e5/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java#L282
> 
`OperationClientException` means that:
```java
This class implements {@link OperationClientException}, so if it is thrown during execution of an {@code OperationStepHandler}, the management kernel will adequately handle the exception as a user mistake, not a server fault.
````
This exception is then handled in the `AbstractOperationContext`:
https://github.com/wildfly/wildfly-core/blob/70bb2a1953d7e8cd9d8f0dbbe542f3574741b6e5/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java#L1074-L1084

So here is the fundamental problem.

### Possible Solution
I have come up with a solution by wrapping the `OperationClientException` of the expression resolver in the `SecurityManagerSubsystemAdd`, which, from my understanding, is only executed during the start-up of WildFly (boot). This wrapped exception is not handled in the `AbstractOperationContext`, making the WildFly startup fail due to the exception.

So, in the current implementation with invalid configuration:
 - using CLI => roll back the configuration (with or without `-secmgr`)
 - booting without `-secmgr` => logs the error, but the boot won't fail
 - booting with `-secmgr` => logs the error, but boot will fail
 - `--admin-only` mode =>  both CLI and booting (invalid `XML`) won't fail (with or without `-secmgr`)
 
> [!NOTE]
> - Is the `--admin-only` mode behavior valid in this case?
> - PR is missing the test, one because this is a Draft PR, so given that this solution might not be ideally implemented, I did not implement the tests yet, and secondly, I was not sure where to put these tests, if in `wildfly-core` repository or in the `wildfly` (repository) integration tests.
> - Due to this PR being a PoC, I only used `RuntimeException`, but maybe other exceptions would be suited better.