### PR TITLE
[WFCORE-7356] Upgrade io.smallrye:jandex from 3.4.0 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version.commons-lang3>3.18.0</version.commons-lang3>
         <version.commons-io>2.16.1</version.commons-io>
         <version.io.netty>4.1.127.Final</version.io.netty>
-        <version.io.smallrye.jandex>3.4.0</version.io.smallrye.jandex>
+        <version.io.smallrye.jandex>3.5.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-common>2.13.8</version.io.smallrye.smallrye-common>
         <version.io.undertow>2.3.19.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-7356

