### PR TITLE
[WFCORE-7359] Revert "[WFCORE-7352] Bump version.io.undertow from 2.3.18.Final to 2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <version.io.netty>4.1.127.Final</version.io.netty>
         <version.io.smallrye.jandex>3.5.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-common>2.13.8</version.io.smallrye.smallrye-common>
-        <version.io.undertow>2.3.19.Final</version.io.undertow>
+        <version.io.undertow>2.3.18.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
….3.19.Final"

This reverts commit cca7228f0f49528df4168b35f902d7b94491ff93.

Jira issue: https://issues.redhat.com/browse/WFCORE-7359