### PR TITLE
WFCORE-7361 Suspend/resume operation handlers can throw IllegalArgumentException if failed future has no cause

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/ServerResumeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerResumeHandler.java
@@ -11,6 +11,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -73,7 +74,7 @@ public class ServerResumeHandler implements OperationStepHandler {
                                 Thread.currentThread().interrupt();
                                 resume.toCompletableFuture().cancel(false);
                             } catch (ExecutionException e) {
-                                context.getFailureDescription().set(e.getCause().getLocalizedMessage());
+                                context.getFailureDescription().set(Optional.ofNullable(e.getCause()).orElse(e).toString());
                             }
                         }
                     }

--- a/server/src/main/java/org/jboss/as/server/operations/ServerSuspendHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerSuspendHandler.java
@@ -13,6 +13,7 @@ import static org.jboss.as.server.controller.resources.ServerRootResourceDefinit
 import static org.jboss.as.server.controller.resources.ServerRootResourceDefinition.renameTimeoutToSuspendTimeout;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -88,7 +89,7 @@ public class ServerSuspendHandler implements OperationStepHandler {
                     } catch (TimeoutException e) {
                         // Stop waiting, but do not rollback
                     } catch (ExecutionException e) {
-                        context.getFailureDescription().set(e.getCause().getLocalizedMessage());
+                        context.getFailureDescription().set(Optional.ofNullable(e.getCause()).orElse(e).toString());
                         context.setRollbackOnly();
                     }
                 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-7361
