### PR TITLE
[WFCORE-7370] StandaloneRootResourceTestCase also needs to call getCanonicalHostName

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/standalone/root/StandaloneRootResourceTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/standalone/root/StandaloneRootResourceTestCase.java
@@ -253,7 +253,7 @@ public class StandaloneRootResourceTestCase extends AbstractCoreModelTest {
     }
 
     private String getDefaultServerName() throws Exception {
-        String hostName = NetworkUtils.canonize(InetAddress.getLocalHost().getHostName().toLowerCase(Locale.ENGLISH));
+        String hostName = NetworkUtils.canonize(InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.ENGLISH));
         int index = hostName.indexOf('.');
         return index == -1 ? hostName : hostName.substring(0, index);
     }


### PR DESCRIPTION

https://issues.redhat.com/browse/WFCORE-7370