### PR TITLE
[WFCORE-7372]: Feature-spec generation treats all host parameters as bound to domain mode.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
@@ -110,9 +110,12 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
             .setReplyValueType(ModelType.OBJECT)
             .build();
 
-    private static final String PROFILE_PREFIX = "$profile.";
+    private static final String PROFILE_ALIAS = "__profile";
+    private static final String HOST_ALIAS = "__host";
+    private static final String PROFILE_PREFIX = "$__profile.";
     private static final String DOMAIN_EXTENSION = "domain.extension";
     private static final String HOST_EXTENSION = "host.extension";
+    private static final String GLN_UNDEFINED = "GLN_UNDEFINED";
 
     //Placeholder for NoSuchResourceExceptions coming from proxies to remove the child in ReadFeatureHandler
     private static final ModelNode PROXY_NO_SUCH_RESOURCE;
@@ -370,6 +373,10 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
             }
             if (isProfile) {
                 capabilityName = PROFILE_PREFIX + capabilityName;
+            } else { //In case we are providing a profie capability
+                if(capabilityName.endsWith('$' + PROFILE)) {
+                    capabilityName = capabilityName.substring(0, capabilityName.lastIndexOf(PROFILE)) + PROFILE_ALIAS;
+                }
             }
             capabilities.add(capabilityName);
         }
@@ -587,15 +594,23 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
         ModelNode params = feature.get(PARAMS).setEmptyList();
         Set<String> paramNames = new HashSet<>();
         StringJoiner addressParams = new StringJoiner(",");
+        boolean aliasNeededProfile = address.toPathStyleString().startsWith("/" + PROFILE);
+        boolean aliasNeededHost = address.toPathStyleString().startsWith("/" + HOST);
         for (PathElement elt : address) {
-            String paramName = elt.getKey();
             ModelNode param = new ModelNode();
-            param.get(ModelDescriptionConstants.NAME).set(paramName);
-            if (PROFILE.equals(elt.getKey()) || HOST.equals(elt.getKey())) {
-                param.get(DEFAULT).set("GLN_UNDEFINED");
+            String paramName = elt.getKey();
+            if (aliasNeededProfile && PROFILE.equals(elt.getKey())) {
+                aliasNeededProfile = false;
+                paramName = PROFILE_ALIAS;
+                param.get(DEFAULT).set(GLN_UNDEFINED);
+            } else if (aliasNeededHost && HOST.equals(elt.getKey())) {
+                aliasNeededHost = false;
+                paramName = HOST_ALIAS;
+                param.get(DEFAULT).set(GLN_UNDEFINED);
             } else if (!elt.isWildcard()) {
                 param.get(DEFAULT).set(elt.getValue());
             }
+            param.get(ModelDescriptionConstants.NAME).set(paramName);
             param.get(FEATURE_ID).set(true);
             params.add(param);
             paramNames.add(paramName);
@@ -609,7 +624,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
 //            }
             ModelNode param = new ModelNode();
             String paramName;
-            if (paramNames.contains(att.getName()) || ((PROFILE.equals(att.getName()) || HOST.equals(att.getName())) && isSubsystem(address))) {
+            if (paramNames.contains(att.getName())) {
                 paramName = att.getName() + "-feature";
                 featureParamMappings.put(att.getName(), paramName);
             } else {
@@ -755,6 +770,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                         if (capabilityName.indexOf('$') > 0) {
                             baseName = capabilityName.substring(0, capabilityName.indexOf('$') - 1);
                         }
+                        processProfileCapabilityDependency(baseName, feature);
                         CapabilityRegistration<?> capReg = getCapability(new CapabilityId(baseName, scope));
                         if (att.getValue().hasDefined(FEATURE_REFERENCE) && att.getValue().require(FEATURE_REFERENCE).asBoolean()) {
                             if (capReg != null) {
@@ -800,6 +816,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                 } else {
                     baseRequirementName = requirement.getBaseRequirementName();
                 }
+                processProfileCapabilityDependency(baseRequirementName, feature);
                 ModelNode capability = new ModelNode();
                 if (dynamicElements == null) {
                     capability.get(NAME).set(baseRequirementName);
@@ -827,6 +844,21 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
         }
     }
 
+    /**
+     * Weneed to add a parameter called *__profile* if we are bound to the profile feature and no such parameter exists.
+     * @param baseRequirementName
+     * @param feature
+     */
+    private static void processProfileCapabilityDependency(String baseRequirementName, ModelNode feature) {
+        if ("org.wildfly.domain.profile".equals(baseRequirementName)) { //Check if equals is better
+            if (feature.get(PARAMS).asList().stream().filter(node -> (PROFILE_ALIAS).equals(node.get(NAME).asString())).findFirst().isEmpty()) {
+                ModelNode param = new ModelNode();
+                param.get(ModelDescriptionConstants.NAME).set(PROFILE_ALIAS);
+                param.get(DEFAULT).set(GLN_UNDEFINED);
+                feature.get(PARAMS).add(param);
+            }
+        }
+    }
     private ModelNode getRequiredCapabilityDefinition(ModelNode attrDescription, CapabilityScope scope, boolean isProfile, String attributeName) {
         ModelNode capability = new ModelNode();
         String capabilityName = attrDescription.get(CAPABILITY_REFERENCE).asString();
@@ -845,7 +877,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
             for (ModelNode elt : attrDescription.get(CAPABILITY_REFERENCE_PATTERN_ELEMENTS).asList()) {
                 elements.add("$" + elt.asString());
             }
-            capabilityName = RuntimeCapability.buildDynamicCapabilityName(baseName, elements.toArray(new String[elements.size()]));
+            capabilityName = RuntimeCapability.buildDynamicCapabilityName(baseName, elements.toArray(String[]::new));
         }
         capability.get(OPTIONAL).set(attrDescription.hasDefined(NILLABLE) && attrDescription.get(NILLABLE).asBoolean());
         if (isProfile) {

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
@@ -74,6 +74,7 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
     private static final String RESOURCE = "resource";
     private static final String MAIN_RESOURCE = "main-resource";
     private static final String SPECIAL_NAMES_RESOURCE = "special-names-resource";
+    private static final String SPECIAL_HOST_RESOURCE = "special-host-resource";
     private static final String REFERENCING_RESOURCE = "referencing-resource";
     private static final String RUNTIME_RESOURCE = "runtime-resource";
     private static final String NON_FEATURE_RESOURCE = "non-feature-resource";
@@ -353,8 +354,8 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
         assertFeatureIdParam(SUBSYSTEM, TEST_SUBSYSTEM, params);
         assertFeatureIdParam(TEST, SPECIAL_NAMES_RESOURCE, params); // note that parameter "test" is bound to address element
         Assert.assertTrue(params.containsKey(TEST + "-feature")); // while resource attribute "test" is renamed to "test-feature"
-        Assert.assertTrue(params.containsKey(HOST + "-feature")); // likewise "host" should be renamed to "host-feature"
-        Assert.assertTrue(params.containsKey(PROFILE + "-feature")); // and the same for "profile"
+        Assert.assertTrue(params.containsKey(HOST)); // likewise "host" should be renamed to "host-feature"
+        Assert.assertTrue(params.containsKey(PROFILE)); // and the same for "profile"
 
         // annotation
         ModelNode annotation = feature.require(ANNOTATION);
@@ -363,7 +364,44 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
         // the renamed "*-feature" parameters should be mapped to their original names
         assertSortedArrayEquals(new String[] {HOST, TEST, PROFILE},
                 annotation.require(OP_PARAMS_MAPPING).asString().split(","));
-        assertSortedArrayEquals(new String[] {HOST + "-feature", TEST + "-feature", PROFILE + "-feature"},
+        assertSortedArrayEquals(new String[] {HOST, TEST + "-feature", PROFILE },
+                annotation.require(OP_PARAMS).asString().split(","));
+    }
+    /**
+     * Reads resource that:
+     *
+     * - contains attributes with special names ('host', 'profile'),
+     * - contains an attribute that conflicts with resource path element (path '_test_/storage-resource', attribute 'test'),
+     * - doesn't have add handler.
+     *
+     * Expectations:
+     *
+     * - mentioned attributes need to be remapped to '*-feature'.
+     * - annotation will reference 'write-attribute' operation instead of 'add' operation.
+     */
+    @Test
+    public void testSpecialResourceNames() throws OperationFailedException {
+        PathAddress address = PathAddress.pathAddress(SUBSYSTEM, TEST_SUBSYSTEM).append(TEST, SPECIAL_HOST_RESOURCE).append(HOST, "myHost");
+        ModelNode result = readFeatureDescription(address);
+
+        ModelNode feature = result.require(FEATURE);
+        Assert.assertEquals(serializeAddress(address), feature.require(NAME).asString());
+        Map<String, ModelNode> params = extractParamsToMap(feature);
+        assertFeatureIdParam(SUBSYSTEM, TEST_SUBSYSTEM, params);
+        assertFeatureIdParam(TEST, SPECIAL_HOST_RESOURCE, params); // note that parameter "test" is bound to address element
+        assertFeatureIdParam(HOST, "myHost", params); // note that parameter "test" is bound to address element
+        Assert.assertTrue(params.containsKey(TEST + "-feature")); // while resource attribute "test" is renamed to "test-feature"
+        Assert.assertTrue(params.containsKey(HOST + "-feature")); // likewise "host" should be renamed to "host-feature"
+        Assert.assertTrue(params.containsKey(PROFILE)); // and the same for "profile"
+
+        // annotation
+        ModelNode annotation = feature.require(ANNOTATION);
+        Assert.assertArrayEquals(new String[] {SUBSYSTEM, TEST, HOST}, annotation.require(ADDR_PARAMS).asString().split(","));
+        Assert.assertEquals(WRITE_ATTRIBUTE_OPERATION, annotation.require(NAME).asString());
+        // the renamed "*-feature" parameters should be mapped to their original names
+        assertSortedArrayEquals(new String[] {HOST, TEST, PROFILE},
+                annotation.require(OP_PARAMS_MAPPING).asString().split(","));
+        assertSortedArrayEquals(new String[] {HOST + "-feature", TEST + "-feature", PROFILE},
                 annotation.require(OP_PARAMS).asString().split(","));
     }
 
@@ -440,9 +478,9 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
         params = extractParamsToMap(resource1);
         assertFeatureIdParam(SUBSYSTEM, TEST_SUBSYSTEM, params);
         assertFeatureIdParam(TEST, SPECIAL_NAMES_RESOURCE, params);
-        Assert.assertTrue(params.containsKey("host-feature"));
+        Assert.assertTrue(params.containsKey("host"));
         Assert.assertTrue(params.containsKey("test-feature"));
-        Assert.assertTrue(params.containsKey("profile-feature"));
+        Assert.assertTrue(params.containsKey("profile"));
 
         ModelNode resource2 = feature.require(CHILDREN).require("subsystem.testsubsystem.resource.main-resource");
         Assert.assertEquals("subsystem.testsubsystem.resource.main-resource", resource2.get(NAME).asString());
@@ -584,6 +622,10 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
         // register resource "test=storage-resource" with attribute "test", so that the "test" parameter will need to be
         // remapped to "test-feature"
         subsysRegistration.registerSubModel(new TestResourceDefinition(PathElement.pathElement(TEST, SPECIAL_NAMES_RESOURCE),
+                        NonResolvingResourceDescriptionResolver.INSTANCE));
+        subsysRegistration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement(TEST, SPECIAL_HOST_RESOURCE),
+                            NonResolvingResourceDescriptionResolver.INSTANCE))
+                .registerSubModel(new TestResourceDefinition(PathElement.pathElement(HOST, "myHost"),
                         NonResolvingResourceDescriptionResolver.INSTANCE));
 
         registration.registerAlias(PathElement.pathElement("alias", "alias-to-resource"), new AliasEntry(mainResourceRegistration) {

--- a/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-primary.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-primary.xml
@@ -6,7 +6,7 @@
 
 <feature-group-spec name="core-host-primary" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
         <param name="persist-name" value="true"/>
 
         <feature-group name="host-audit"/>

--- a/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-secondary.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-secondary.xml
@@ -6,7 +6,7 @@
 
 <feature-group-spec name="core-host-secondary" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="host">
-        <param name="host" value="secondary"/>
+        <param name="__host" value="secondary"/>
         <param name="persist-name" value="false"/>
 
         <feature-group name="host-audit"/>
@@ -16,8 +16,8 @@
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
                 <param name="protocol" value="${jboss.domain.primary.protocol:remote+http}"/>
-                <param name="host-feature" value="${jboss.domain.primary.address}"/>
-                <param name="host" value="secondary"/>
+                <param name="host" value="${jboss.domain.primary.address}"/>
+                <param name="__host" value="secondary"/>
                 <param name="port" value="${jboss.domain.primary.port:9990}"/>
             </feature>
         </feature>

--- a/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/feature_groups/core-host.xml
@@ -9,7 +9,7 @@
     <feature-group name="core-host-primary"/>
 
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
         <feature-group name="host-interfaces"/>
 
         <feature spec="host.server-config">

--- a/core-feature-pack/galleon-common/src/main/resources/feature_groups/domain-server-groups.xml
+++ b/core-feature-pack/galleon-common/src/main/resources/feature_groups/domain-server-groups.xml
@@ -16,6 +16,7 @@
         </feature>
     </feature>
     <feature spec="domain.server-group">
+        <param name="profile" value="default"/>
         <param name="socket-binding-group" value="standard-sockets" />
         <param name="server-group" value="other-server-group"/>
     </feature>

--- a/core-feature-pack/galleon-feature-pack/src/main/resources/feature_groups/domain.xml
+++ b/core-feature-pack/galleon-feature-pack/src/main/resources/feature_groups/domain.xml
@@ -22,7 +22,8 @@
     <feature-group name="domain-host-excludes"/>
 
     <feature spec="profile">
-        <param name="profile" value="default"/>
+        <param name="__profile" value="default"/>
         <feature-group name="domain-profile"/>
     </feature>
+        
 </feature-group-spec>


### PR DESCRIPTION
Renaming host and profile address parameters to __host and __profile when they are the 1st elements of the address to avoid confusion
Jira: https://issues.redhat.com/browse/WFCORE-7372

For integration use https://github.com/wildfly/wildfly/pull/19253
