### PR TITLE
[WFCORE-7563] Upgrade Elytron EE to 3.2.1.CR3

### DIFF
--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authorization/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authorization/main/module.xml
@@ -20,6 +20,12 @@
         <module name="jdk.security.auth"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager"/>
+        <!-- The WebPCFResolver needs metadata, but it is fine to be optional     -->
+        <!-- As it only becomes an issue if the API is called and that would need -->
+        <!-- these two modules anyway. -->
+        <module name="org.jboss.metadata.common" optional="true" />
+        <module name="org.jboss.metadata.web" optional="true" />
+
         <module name="jakarta.security.jacc.api" optional="true"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-base"/>

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.security.elytron>2.8.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.2.0.CR1</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.2.1.CR2</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.2.1.CR3</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>
         <version.org.yaml.snakeyaml>2.6</version.org.yaml.snakeyaml>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.security.elytron>2.8.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.2.0.CR1</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.2.1.CR2</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>
         <version.org.yaml.snakeyaml>2.6</version.org.yaml.snakeyaml>
     </properties>


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFCORE-7563

https://github.com/wildfly-security/wildfly-elytron-ee/compare/3.2.0.Final...3.2.1.CR3

This change also adds some optional module.xml dependencies. These are able to be optional as we know if these methods are called the caller had access to this module.