### PR TITLE
[ELY-7571] Add missing @Test annotation for JASPI parsing test

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -118,6 +118,7 @@ public class SubsystemParsingTestCase extends AbstractElytronSubsystemBaseTest {
         standardSubsystemTest("credential-stores.xml");
     }
 
+    @Test
     public void testParseAndMarshalModel_JASPI() throws Exception {
         standardSubsystemTest("jaspi.xml");
     }


### PR DESCRIPTION
## PR Description

## Summary

This PR fixes a missing JUnit annotation in `SubsystemParsingTestCase` that prevented one test from being executed.

## Problem

The method:

```java
testParseAndMarshalModel_JASPI()
```

was missing the `@Test` annotation in:

```text
elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
```

As a result, JUnit did not discover or run the test.

While reviewing the class, all other test methods were correctly annotated, making this one an obvious omission.

## Issue

https://redhat.atlassian.net/browse/WFCORE-7571

## Fix

Added the missing `@Test` annotation:

```java
@Test
public void testParseAndMarshalModel_JASPI() throws Exception {
    standardSubsystemTest("jaspi.xml");
}
```

## Result

The JASPI parsing / marshal model test is now included in normal test execution and will run with the rest of the Elytron subsystem tests.

## Additional Note

During local verification, a separate runtime issue was observed from a corrupted cached Maven dependency (`wildfly-controller` JAR compiled with an ECJ unresolved-compilation stub). That is a local environment artifact and unrelated to this fix.

## Testing

* Verified source change
* Confirmed method is now discoverable as a JUnit test
* No production code changes involved

## Scope

Test-only change. No functional/runtime behavior changes outside test execution.
