### PR TITLE
[ELY-7573] Remove debug System.out.println calls from Elytron tests

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java
@@ -150,7 +150,6 @@ public class CredentialStoreTestCase extends AbstractSubsystemTest {
         readAliases.get(ClientConstants.OP).set("read-aliases");
 
         ModelNode aliases = assertSuccess(services.executeOperation(readAliases)).get("result");
-        System.out.println(aliases.toString());
         List<ModelNode> aliasValues = aliases.asList();
         assertEquals("Expected alias count", expectedAlias != null ? 1 : 0, aliasValues.size());
         if (expectedAlias != null) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
@@ -592,7 +592,6 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron");
         operation.get(ClientConstants.OP).set("read-resource");
-        System.out.println(services.executeOperation(operation).get(ClientConstants.RESULT).asString());
         operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add(ElytronDescriptionConstants.KEY_STORE,"AutomaticKeystore");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIASES);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
@@ -288,7 +288,6 @@ public class LdapTestCase extends AbstractSubsystemTest {
             dns.add(it.next().getAuthorizationIdentity().getAttributes().getFirst("userDn"));
         }
         ((AutoCloseable) it).close();
-        System.out.println(dns);
         Assert.assertTrue(dns.contains("uid=plainUser,dc=users,dc=elytron,dc=wildfly,dc=org"));
         Assert.assertTrue(dns.contains("uid=refUser,dc=referredUsers,dc=elytron,dc=wildfly,dc=org"));
     }


### PR DESCRIPTION
## PR Description

## Summary

This PR removes three leftover `System.out.println` debug statements from Elytron test classes.

## Problem

A few tests contained direct console print statements that appear to have been used for debugging during development. These prints add unnecessary noise to test output and are not needed for assertions or test behavior.

## Issue

https://redhat.atlassian.net/browse/WFCORE-7573

## Files Updated

Removed one debug print from each of the following:

* `elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java`
* `elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java`
* `elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java`

## Removed Statements

Examples included:

```java
System.out.println(aliases.toString());
System.out.println(dns);
System.out.println(...asString());
```

## Result

* Cleaner test output
* Less noise during local and CI test runs
* No change to test logic or assertions

## Testing

* Verified no remaining `System.out.println` calls in the updated files
* No functional changes made

## Scope

Test cleanup only. No production code changes.
