### PR TITLE
Bump jackson-databind and jackson-core from 2.21.2 to 2.21.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,9 +226,9 @@
         <version.com.google.code.findbugs>3.0.2</version.com.google.code.findbugs>
         <version.com.google.guava>31.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.3</version.com.google.guava.failureaccess>
-        <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.21.3</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.annotations>2.21</version.com.fasterxml.jackson.annotations>
-        <version.com.fasterxml.jackson.databind>2.21.2</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.11.0</version.commons-cli>
         <version.commons-collections>3.2.2</version.commons-collections>


### PR DESCRIPTION
- This is a test only dependency
- Supersedes #6739 and #6737

