### PR TITLE
[WFCORE-7586] Upgrade WildFly Elytron to 2.9.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <version.org.wildfly.legacy.test>10.0.2.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.3.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.security.elytron>2.9.0.CR2</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.9.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.2.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFCORE-7586

This version does not bring any changes but I needed to be sure CR2 would pass CI before tagging Final.