### PR TITLE
[WFCORE-7593] Upgrade Elytron Web to 4.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <version.org.wildfly.openssl>2.3.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.security.elytron>2.9.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>4.2.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>4.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>
         <version.org.yaml.snakeyaml>2.6</version.org.yaml.snakeyaml>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <version.org.wildfly.legacy.test>10.0.2.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.3.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.security.elytron>2.9.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.9.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.2.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFCORE-7593

https://github.com/wildfly-security/elytron-web/compare/4.2.0.Final...4.2.1.Final

This PR follows up on https://github.com/wildfly/wildfly-core/pull/6763, as they are closely related they would trigger a merge conflict.

