### PR TITLE
[WFCORE-7595] Upgrade Undertow to 2.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <version.io.netty>4.1.133.Final</version.io.netty>
         <version.io.smallrye.jandex>3.5.3</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-common>2.17.1</version.io.smallrye.smallrye-common>
-        <version.io.undertow>2.4.0.Final</version.io.undertow>
+        <version.io.undertow>2.4.1.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptor-api>2.1.0</version.jakarta.interceptor.jakarta-interceptor-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/WFCORE-7595

32.x PR: #6768 