### PR TITLE
[WFCORE-7596] Upgrade Elytron EE to 3.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.security.elytron>2.9.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.2.1.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.2.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>
         <version.org.yaml.snakeyaml>2.6</version.org.yaml.snakeyaml>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <version.org.wildfly.openssl>2.3.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.security.elytron>2.9.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>4.2.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>4.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>
         <version.org.yaml.snakeyaml>2.6</version.org.yaml.snakeyaml>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <version.org.wildfly.legacy.test>10.0.2.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.3.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
-        <version.org.wildfly.security.elytron>2.9.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.9.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>4.2.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.2.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.unstable.api.annotation>1.0.2.Final</version.org.wildfly.unstable.api.annotation>


### PR DESCRIPTION
This PR also contains https://github.com/wildfly/wildfly-core/pull/6765 as the changes are closely related in the pom.

https://redhat.atlassian.net/browse/WFCORE-7596

https://github.com/wildfly-security/wildfly-elytron-ee/compare/3.2.0.Final...3.2.1.Final