### PR TITLE
[WFCORE-7607] Upgrade commons-daemon to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <version.com.jcraft.jsch>0.1.55</version.com.jcraft.jsch>
         <version.commons-cli>1.11.0</version.commons-cli>
         <version.commons-collections>3.2.2</version.commons-collections>
-        <version.commons-daemon>1.5.1</version.commons-daemon>
+        <version.commons-daemon>1.6.0</version.commons-daemon>
         <version.commons-lang3>3.20.0</version.commons-lang3>
         <version.commons-io>2.21.0</version.commons-io>
         <version.io.netty>4.1.134.Final</version.io.netty>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFCORE-7607

Verified that WildFly standalone / WildFly domain can be installed as a Windows Service and started/stopped successfully with commons-daemon upgraded to 1.6.0