### PR TITLE
[WFCORE-7616] Deprecate the /subsystem=elytron/policy=* resource.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/PolicyDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PolicyDefinitions.java
@@ -174,10 +174,18 @@ class PolicyDefinitions {
             private Service<Policy> createPolicyService(Consumer<Consumer<Policy>> policyProvider) {
                 return new Service<Policy>() {
                     volatile Policy original;
+                    volatile boolean restorePolicy;
 
                     @Override
                     public void start(StartContext context) throws StartException {
-                        original = getPolicy();
+                        try {
+                            original = getPolicy();
+                            restorePolicy = true;
+                        } catch (UnsupportedOperationException e) {
+                            restorePolicy = false;
+                            ElytronSubsystemMessages.ROOT_LOGGER.settingPolicyNotSupported();
+                        }
+
 
                         try {
                             policyProvider.accept(this::setPolicy);
@@ -269,6 +277,7 @@ class PolicyDefinitions {
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
                 .setCapabilities(POLICY_RUNTIME_CAPABILITY)
+                .setDeprecatedSince(ElytronExtension.ELYTRON_19_0_0)
                 .setMaxOccurs(1)) {
             @Override
             public void registerAttributes(ManagementResourceRegistration resourceRegistration) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -671,6 +671,10 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @LogMessage(level = WARN)
     void noAllowedJkuValuesSpecifiedForTokenRealm(String realmName, String systemPropertyName);
 
+    @Message(id = 1091, value = "From Jakarta EE 11 setting a Policy is no longer required, the /subsystem=elytron/policy=* resource(s) can be removed.")
+    @LogMessage(level = WARN)
+    void settingPolicyNotSupported();
+
     /*
      * Expression Resolver Section
      */

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -671,7 +671,7 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @LogMessage(level = WARN)
     void noAllowedJkuValuesSpecifiedForTokenRealm(String realmName, String systemPropertyName);
 
-    @Message(id = 1091, value = "From Jakarta EE 11 setting a Policy is no longer required, the /subsystem=elytron/policy=* resource(s) can be removed.")
+    @Message(id = 1091, value = "In an EE 11 or later environment setting a Policy is no longer required; the /subsystem=elytron/policy=* resource(s) can be removed.")
     @LogMessage(level = WARN)
     void settingPolicyNotSupported();
 

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1663,6 +1663,7 @@ elytron.dir-context.properties=The additional connection properties for the DirC
 #######################
 
 elytron.policy=A definition that sets up a policy provider.
+elytron.policy.deprecated=Support for security Policy implementations has been removed from Java 25, setting a JACC Policy will no longer be required from Jakarta EE 11.
 # Operations
 elytron.policy.add=Add operation for adding a policy provider.
 elytron.policy.remove=Remove operation for removing a policy provider.

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1663,7 +1663,7 @@ elytron.dir-context.properties=The additional connection properties for the DirC
 #######################
 
 elytron.policy=A definition that sets up a policy provider.
-elytron.policy.deprecated=Support for security Policy implementations has been removed from Java 25, setting a JACC Policy will no longer be required from Jakarta EE 11.
+elytron.policy.deprecated=Support for security Policy implementations has been removed from Java 25, and setting a JACC Policy is no longer required in an EE 11 or later environment.
 # Operations
 elytron.policy.add=Add operation for adding a policy provider.
 elytron.policy.remove=Remove operation for removing a policy provider.


### PR DESCRIPTION
This resource will be removed at a later date once no longer supported.

Additionally for Jakarta EE 11 don't fail the service start up, instead log a WARN.

https://redhat.atlassian.net/browse/WFCORE-7616
