### PR TITLE
[WFCORE-7619] verbosegclog java opt is missing from JAVA_OPTS echo output on standalone bat script on Semeru JDKs

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/standalone.bat
@@ -274,6 +274,7 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
                 set TMP_PARAM=-Xverbosegclog:"!JBOSS_LOG_DIR!\gc.log"
                 "!JAVA!" !TMP_PARAM! -version > nul 2>&1
                 if not errorlevel == 1 (
+                   rem Combination of Semeru JDK with a space in the path needs keeping GC_OPTS separate and passing it directly to the Java command
                    set "GC_OPTS=!TMP_PARAM!"
                 ) else (
                    set "GC_OPTS="
@@ -335,7 +336,7 @@ echo   JBOSS_HOME: "%JBOSS_HOME%"
 echo.
 echo   JAVA: "%JAVA%"
 echo.
-echo   JAVA_OPTS: "%JAVA_OPTS%"
+echo   JAVA_OPTS: "%JAVA_OPTS% %GC_OPTS%"
 echo.
 echo ===============================================================================
 echo.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFCORE-7619

Related to: https://github.com/wildfly/wildfly-core/pull/6726