### PR TITLE
[WFCORE-7616] Add missing restore protection to stop lifecycle method.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/PolicyDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PolicyDefinitions.java
@@ -197,7 +197,9 @@ class PolicyDefinitions {
 
                     @Override
                     public void stop(StopContext context) {
-                        setPolicy(original);
+                        if (restorePolicy) {
+                            setPolicy(original);
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
This contains a check missing in the original PR:

https://redhat.atlassian.net/browse/WFCORE-7616

Upstream PR - https://github.com/wildfly/wildfly-core/pull/6810