### PR TITLE
[WFCORE-7629] Upgrade io.smallrye:jandex from 3.5.3 to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <version.commons-lang3>3.20.0</version.commons-lang3>
         <version.commons-io>2.21.0</version.commons-io>
         <version.io.netty>4.1.135.Final</version.io.netty>
-        <version.io.smallrye.jandex>3.5.3</version.io.smallrye.jandex>
+        <version.io.smallrye.jandex>3.6.0</version.io.smallrye.jandex>
         <version.io.smallrye.smallrye-common>2.19.0</version.io.smallrye.smallrye-common>
         <version.io.undertow>2.4.1.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFCORE-7629
