### PR TITLE
[WFCORE-7630] Upgrade smallrye-common to 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <version.commons-io>2.21.0</version.commons-io>
         <version.io.netty>4.1.135.Final</version.io.netty>
         <version.io.smallrye.jandex>3.5.3</version.io.smallrye.jandex>
-        <version.io.smallrye.smallrye-common>2.17.1</version.io.smallrye.smallrye-common>
+        <version.io.smallrye.smallrye-common>2.19.0</version.io.smallrye.smallrye-common>
         <version.io.undertow>2.4.1.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.3</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptor-api>2.1.0</version.jakarta.interceptor.jakarta-interceptor-api>


### PR DESCRIPTION
Supersedes #6776

Jira issue: https://redhat.atlassian.net/browse/WFCORE-7630
