### PR TITLE
[WFCORE-7573]: Remove leftover System.out.println calls from CredentialStoreTestCase, LdapTestCase and KeyStoresTestCase

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/CredentialStoreTestCase.java
@@ -150,7 +150,6 @@ public class CredentialStoreTestCase extends AbstractSubsystemTest {
         readAliases.get(ClientConstants.OP).set("read-aliases");
 
         ModelNode aliases = assertSuccess(services.executeOperation(readAliases)).get("result");
-        System.out.println(aliases.toString());
         List<ModelNode> aliasValues = aliases.asList();
         assertEquals("Expected alias count", expectedAlias != null ? 1 : 0, aliasValues.size());
         if (expectedAlias != null) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
@@ -592,7 +592,6 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
         ModelNode operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron");
         operation.get(ClientConstants.OP).set("read-resource");
-        System.out.println(services.executeOperation(operation).get(ClientConstants.RESULT).asString());
         operation = new ModelNode();
         operation.get(ClientConstants.OP_ADDR).add("subsystem","elytron").add(ElytronDescriptionConstants.KEY_STORE,"AutomaticKeystore");
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.READ_ALIASES);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/LdapTestCase.java
@@ -288,7 +288,6 @@ public class LdapTestCase extends AbstractSubsystemTest {
             dns.add(it.next().getAuthorizationIdentity().getAttributes().getFirst("userDn"));
         }
         ((AutoCloseable) it).close();
-        System.out.println(dns);
         Assert.assertTrue(dns.contains("uid=plainUser,dc=users,dc=elytron,dc=wildfly,dc=org"));
         Assert.assertTrue(dns.contains("uid=refUser,dc=referredUsers,dc=elytron,dc=wildfly,dc=org"));
     }


### PR DESCRIPTION
issue:https://redhat.atlassian.net/browse/WFCORE-7573


