### PR TITLE
[WFCORE-7571] Add missing @Test annotation to SubsystemParsingTestCase#testParseAndMarshalModel_JASPI

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -118,6 +118,7 @@ public class SubsystemParsingTestCase extends AbstractElytronSubsystemBaseTest {
         standardSubsystemTest("credential-stores.xml");
     }
 
+    @Test
     public void testParseAndMarshalModel_JASPI() throws Exception {
         standardSubsystemTest("jaspi.xml");
     }


### PR DESCRIPTION
issue: https://redhat.atlassian.net/browse/WFCORE-7571

