### PR TITLE
WFCORE-7625 Deprecate TimeoutUtil.adjust(int) and add Duration-based variant of the method

### DIFF
--- a/testsuite/bootable-configurator/tests/src/test/java/org/wildfly/core/test/bootable/configurator/BootableConfiguratorTestCase.java
+++ b/testsuite/bootable-configurator/tests/src/test/java/org/wildfly/core/test/bootable/configurator/BootableConfiguratorTestCase.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Properties;
 
 import jakarta.inject.Inject;
@@ -36,7 +37,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 
 @RunWith(WildFlyRunner.class)
 public class BootableConfiguratorTestCase {
-    private static final long RELOAD_WAITING_TIME = TimeoutUtil.adjust(10000);
+    private static final Duration RELOAD_WAITING_TIME = TimeoutUtil.adjust(Duration.ofSeconds(10));
     @Inject
     private ManagementClient managementClient;
 
@@ -58,7 +59,7 @@ public class BootableConfiguratorTestCase {
             assertTrue(Files.exists(modulePath));
         }
         // Wait for the server to be in ready state
-        long timeout = RELOAD_WAITING_TIME;
+        long timeout = RELOAD_WAITING_TIME.toMillis();
         int freq = 500;
         while(timeout > 0) {
             if (managementClient.isServerInNormalMode() && managementClient.isServerInRunningState()) {

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/ClientAgainstOldServerTestCase.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/ClientAgainstOldServerTestCase.java
@@ -11,6 +11,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_VERSION;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -45,7 +46,7 @@ import org.wildfly.core.testrunner.ManagementClient;
 public class ClientAgainstOldServerTestCase {
 
     // Max time to wait for some action to complete, in s
-    private static final int TIMEOUT = TimeoutUtil.adjust(240);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofMinutes(4));
 
     private final Version.AsVersion version;
 
@@ -103,7 +104,7 @@ public class ClientAgainstOldServerTestCase {
 
     private void awaitDeploymentExecution(Future<?> future) {
         try {
-            future.get(TIMEOUT, TimeUnit.SECONDS);
+            future.get(TIMEOUT.toNanos(), TimeUnit.NANOSECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,7 +54,7 @@ public class AdminOnlyPolicyTestCase {
     private static final long initTime = System.currentTimeMillis();
     private static int secondaryCount;
 
-    private static int exitCodeTimeout = TimeoutUtil.adjust(30);
+    private static int exitCodeTimeout = (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds();
 
     @BeforeClass
     public static void setupDomain() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainGracefulShutdownTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainGracefulShutdownTestCase.java
@@ -23,6 +23,7 @@ import java.lang.reflect.ReflectPermission;
 import java.net.HttpURLConnection;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -233,11 +234,11 @@ public class DomainGracefulShutdownTestCase {
             Future<Object> result = executorService.submit(new Callable<Object>() {
                 @Override
                 public Object call() throws Exception {
-                    return HttpRequest.get(address, TimeoutUtil.adjust(60), TimeUnit.SECONDS);
+                    return HttpRequest.get(address, TimeoutUtil.adjust(Duration.ofMinutes(1)).toSeconds(), TimeUnit.SECONDS);
                 }
             });
             appLocked = true;
-            TimeUnit.SECONDS.sleep(TimeoutUtil.adjust(1));
+            TimeUnit.NANOSECONDS.sleep(TimeoutUtil.adjust(Duration.ofSeconds(1)).toNanos());
 
             shutdownResult = executorService.submit(new Callable<ModelNode>() {
                 @Override
@@ -245,7 +246,7 @@ public class DomainGracefulShutdownTestCase {
                     ModelNode op = new ModelNode();
                     op.get(OP).set("shutdown");
                     op.get(OP_ADDR).set(PRIMARY_ADDR.toModelNode());
-                    op.get(ModelDescriptionConstants.SUSPEND_TIMEOUT).set(TimeoutUtil.adjust(60));
+                    op.get(ModelDescriptionConstants.SUSPEND_TIMEOUT).set((int) TimeoutUtil.adjust(Duration.ofMinutes(1)).toSeconds());
                     op.get(ModelDescriptionConstants.RESTART).set(false);
                     return domainPrimaryLifecycleUtil.executeAwaitConnectionClosed(op);
                 }
@@ -264,23 +265,23 @@ public class DomainGracefulShutdownTestCase {
             }
 
             //make sure the server is still up, and trigger the actual shutdown
-            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
             appLocked = false;
 
             //make sure our initial request completed
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
 
-            ModelNode shutdownOpResult = shutdownResult.get(TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+            ModelNode shutdownOpResult = shutdownResult.get(TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
             Assert.assertTrue("There was a failure executing the shutdown operation", SUCCESS.equals(shutdownOpResult.get(OUTCOME).asString()));
 
         } finally {
             if (appLocked) {
-                HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+                HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
             }
 
             if (shutdownResult != null) {
                 try {
-                    shutdownResult.get(TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+                    shutdownResult.get(TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
                 } catch (Exception e) {
                     domainPrimaryLifecycleUtil.stop();
                     domainPrimaryLifecycleUtil.start();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
@@ -23,6 +23,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -314,7 +315,7 @@ public class HostControllerBootOperationsTestCase {
     }
 
     private static void waitUntilServerRegisteredButStarting(final ModelControllerClient client, final PathAddress serverAddress) throws IOException, MgmtOperationException {
-        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(TimeoutUtil.adjust(60));
+        final long deadline = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofMinutes(1)).toMillis();
         for(;;) {
             final long remaining = deadline - System.currentTimeMillis();
             if(remaining <= 0) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/JVMServerPropertiesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/JVMServerPropertiesTestCase.java
@@ -14,6 +14,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 
 import org.jboss.as.controller.PathAddress;
@@ -64,7 +65,7 @@ public class JVMServerPropertiesTestCase {
         testSupport = DomainTestSupport.create(configuration);
         primaryLifecycleUtil = testSupport.getDomainPrimaryLifecycleUtil();
         testSupport.start();
-        primaryLifecycleUtil.awaitServers(TimeoutUtil.adjust(30 * 1000));
+        primaryLifecycleUtil.awaitServers(TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -98,8 +99,8 @@ public class OperationTimeoutTestCase {
     private static final String TIMEOUT_CONFIG = "-Djboss.as.management.blocking.timeout=1";
     private static final String TIMEOUT_ADDER_CONFIG = "-Dorg.wildfly.unsupported.test.domain-timeout-adder=1000";
 
-    private static final long SAFE_TIMEOUT = TimeoutUtil.adjust(20);
-    private static final long GET_TIMEOUT = TimeoutUtil.adjust(10000);
+    private static final Duration SAFE_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
+    private static final Duration GET_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(10));
 
     private static DomainTestSupport testSupport;
     private static DomainClient primaryClient;
@@ -175,7 +176,7 @@ public class OperationTimeoutTestCase {
 
     /** Applies a more normal blocking-timeout to an op so it does not get tripped up by the low timeouts on the domain processes */
     private static ModelNode safeTimeout(ModelNode op) {
-        op.get(OPERATION_HEADERS, BLOCKING_TIMEOUT).set(SAFE_TIMEOUT);
+        op.get(OPERATION_HEADERS, BLOCKING_TIMEOUT).set(SAFE_TIMEOUT.toSeconds());
         return op;
     }
 
@@ -215,7 +216,7 @@ public class OperationTimeoutTestCase {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         System.out.println(response);
         assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYDC0080"));
@@ -227,7 +228,7 @@ public class OperationTimeoutTestCase {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("main-three"));
         assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0409"));
@@ -239,7 +240,7 @@ public class OperationTimeoutTestCase {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("main-one"));
         assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0409"));
@@ -251,7 +252,7 @@ public class OperationTimeoutTestCase {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // cancelling on the secondary during Stage.DONE should not result in a prepare-phase failure sent to primary,
         // so result should always be SUCCESS
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -263,7 +264,7 @@ public class OperationTimeoutTestCase {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to primary,
         // so result should always be SUCCESS
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -275,7 +276,7 @@ public class OperationTimeoutTestCase {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.COMPLETING, start);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to primary,
         // so result should always be SUCCESS
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -335,7 +336,7 @@ public class OperationTimeoutTestCase {
     private String findActiveOperation(DomainClient client, PathAddress address, String opName, OperationContext.ExecutionStatus targetStatus, long executionStart, boolean serverOpOnly) throws Exception {
         ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
         op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
-        long maxTime = TimeoutUtil.adjust(5000);
+        long maxTime = TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis();
         long timeout = executionStart + maxTime;
         List<String> activeOps = new ArrayList<String>();
         String opToCancel = null;
@@ -390,7 +391,7 @@ public class OperationTimeoutTestCase {
 
         // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
         // something strange is happening on the machine is overloaded
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis();
         MgmtOperationException failure;
         do {
             String id = findActiveOperation(client, baseAddress, "block");
@@ -421,7 +422,7 @@ public class OperationTimeoutTestCase {
 
         // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
         // something strange is happening on the machine is overloaded
-        long timeout = patient ? System.currentTimeMillis() + TimeoutUtil.adjust(5000) : 0;
+        long timeout = patient ? System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis() : 0;
         MgmtOperationException failure;
         do {
             try {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/autoignore/AutoIgnoredResourcesDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/autoignore/AutoIgnoredResourcesDomainTestCase.java
@@ -32,6 +32,7 @@ import static org.jboss.as.test.integration.domain.management.util.DomainTestSup
 
 import java.io.File;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -744,7 +745,7 @@ public class AutoIgnoredResourcesDomainTestCase {
     }
 
     private void restartDomainAndReloadReadOnlyConfig(boolean secondaryIsBackupDC, boolean secondaryIsCachedDC) throws Exception {
-        DomainTestSupport.stopHosts(TimeoutUtil.adjust(30000), domainSecondaryLifecycleUtil, domainPrimaryLifecycleUtil);
+        DomainTestSupport.stopHosts(TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), domainSecondaryLifecycleUtil, domainPrimaryLifecycleUtil);
         testSupport.close();
 
         //Totally reinitialize the domain client

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/cacheddc/CachedDcDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/cacheddc/CachedDcDomainTestCase.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
@@ -55,10 +56,10 @@ import org.junit.Test;
  */
 public class CachedDcDomainTestCase {
 
-    private static Logger log = Logger.getLogger(CachedDcDomainTestCase.class);
+    private static final Logger log = Logger.getLogger(CachedDcDomainTestCase.class);
 
-    private static final long TIMEOUT_S = TimeoutUtil.adjust(30);
-    private static final long NOT_STARTED_TIMEOUT_S = TimeoutUtil.adjust(7);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(30));
+    private static final Duration NOT_STARTED_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(7));
     private static final int TIMEOUT_SLEEP_MILLIS = 50;
 
     private static final String TEST_LOGGER_NAME = "org.jboss.test";
@@ -112,7 +113,7 @@ public class CachedDcDomainTestCase {
     /**
      * DC is up, HC successfully starts if parameter --backup, both HC and DC is put down
      * and when HC is subsequently started with --cached-dc it uses cached file created during start-up
-     * with --backup param and HC is succesfully started
+     * with --backup param and HC is successfully started
      */
     @Test
     public void hcStartsWhenCachedConfigAvailable_BackupDCParamIsSet() throws Exception {
@@ -138,7 +139,7 @@ public class CachedDcDomainTestCase {
 
         // expecting that HC is not started
         try (final DomainClient client = getDomainClient(domainConfig.getSecondaryConfiguration())) {
-            waitForHostControllerBeingStarted(NOT_STARTED_TIMEOUT_S, client);
+            waitForHostControllerBeingStarted(NOT_STARTED_TIMEOUT.toSeconds(), client);
             Assert.fail("DC not started, domain.cached-remote.xml does not exist but "
                 + "secondary host controller was started ");
         } catch (IllegalStateException ise) {
@@ -211,7 +212,7 @@ public class CachedDcDomainTestCase {
 
         // timeout waits to get changes from DC propagated to HC
         // by WFCORE-2331 the host controller log file should advert need of configuration change
-        runWithTimeout(TIMEOUT_S, () -> checkHostControllerLogFile(domainConfig.getSecondaryConfiguration(), "WFLYHC0202"));
+        runWithTimeout(TIMEOUT.toSeconds(), () -> checkHostControllerLogFile(domainConfig.getSecondaryConfiguration(), "WFLYHC0202"));
     }
 
     /**
@@ -283,20 +284,20 @@ public class CachedDcDomainTestCase {
         // starting DC where domain config contains a configuration change
         domainManager.getDomainPrimaryLifecycleUtil().start();
 
-        runWithTimeout(TIMEOUT_S, () -> {
+        runWithTimeout(TIMEOUT.toSeconds(), () -> {
             ModelNode hostRead = readLoggingApiDependenciesAtServerOtherTwo(domainManager.getDomainSecondaryLifecycleUtil().getDomainClient());
             assertEquals("Read operation should suceed", SUCCESS, hostRead.get(OUTCOME).asString());
             assertEquals("Expecting change of attribute 'add-logging-api-dependencies' requests a reload: " + hostRead,
                 "reload-required", hostRead.get("response-headers").get("process-state").asString());
         });
         reloadServers(domainManager.getDomainPrimaryLifecycleUtil().getDomainClient());
-        runWithTimeout(TIMEOUT_S, () -> {
+        runWithTimeout(TIMEOUT.toSeconds(), () -> {
             ModelNode hostRead = readLoggingApiDependenciesAtServerOtherTwo(domainManager.getDomainPrimaryLifecycleUtil().getDomainClient());
             assertEquals("Expecting value of attribute 'add-logging-api-dependencies' changed: " + hostRead,
                     isAddLoggingApiDependencies, hostRead.get("result").asBoolean());
         });
         // by WFCORE-2331 the host controller log file should advert need of configuration change
-        runWithTimeout(TIMEOUT_S, () -> checkHostControllerLogFile(domainConfig.getSecondaryConfiguration(), "WFLYHC0202"));
+        runWithTimeout(TIMEOUT.toSeconds(), () -> checkHostControllerLogFile(domainConfig.getSecondaryConfiguration(), "WFLYHC0202"));
     }
 
     private void test_hcStartsWhenCachedConfigAvailable(DomainTestSupport.Configuration domainConfig) throws Exception {
@@ -323,7 +324,7 @@ public class CachedDcDomainTestCase {
 
         try (final DomainClient client = getDomainClient(domainConfig.getSecondaryConfiguration())) {
             // getting statuses of servers from secondary HC as waiting for HC being ready
-            runWithTimeout(TimeoutUtil.adjust(5), () -> client.getServerStatuses());
+            runWithTimeout(TimeoutUtil.adjust(Duration.ofSeconds(5)).toSeconds(), () -> client.getServerStatuses());
             Assert.fail("DC started with no param, it's waiting for DC but it's not possible to connect to it");
         } catch (IllegalStateException ise) {
             // as HC should not be started IllegalStateException is expected
@@ -331,8 +332,8 @@ public class CachedDcDomainTestCase {
 
         // after starting DC, HC is ready to use with all its servers
         domainManager.getDomainPrimaryLifecycleUtil().start();
-        waitForHostControllerBeingStarted(TIMEOUT_S, domainManager.getDomainSecondaryLifecycleUtil().getDomainClient());
-        waitForServersBeingStarted(TIMEOUT_S, domainManager.getDomainSecondaryLifecycleUtil().getDomainClient());
+        waitForHostControllerBeingStarted(TIMEOUT.toSeconds(), domainManager.getDomainSecondaryLifecycleUtil().getDomainClient());
+        waitForServersBeingStarted(TIMEOUT.toSeconds(), domainManager.getDomainSecondaryLifecycleUtil().getDomainClient());
     }
 
     private DomainClient getDomainClient(WildFlyManagedConfiguration config) throws UnknownHostException {
@@ -511,7 +512,7 @@ public class CachedDcDomainTestCase {
     /**
      * @param hostname the hostname to query
      * @param requiredState the {@link ControlledProcessState.State} expected, or null for any state}
-     * @return true if the host is present in the queried hosts's model (in the requiredState, if present), false otherwise.
+     * @return true if the host is present in the queried hosts' model (in the requiredState, if present), false otherwise.
      */
     private boolean isHostPresentInModel(final String hostname, final ControlledProcessState.State requiredState) throws IOException {
         final ModelNode operation = new ModelNode();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
@@ -11,6 +11,7 @@ import static org.wildfly.test.jmx.ControlledStateNotificationListener.RUNTIME_C
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -181,7 +182,7 @@ public class JmxControlledStateNotificationsTestCase {
     private void checkFacadeJmxNotifications(List<Pair<String, String>> configurationStateTransitions,
                                              List<Pair<String, String>> runningStateTransitions)
             throws IOException, InterruptedException {
-        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(20)).toMillis();
         while (true) {
             try {
                 readAndCheckFile(JMX_FACADE_RUNTIME, list -> {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/secondaryreconnect/SecondaryReconnectTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/secondaryreconnect/SecondaryReconnectTestCase.java
@@ -22,6 +22,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.time.Duration;
 import java.util.List;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -59,7 +60,7 @@ public class SecondaryReconnectTestCase {
     private static DomainLifecycleUtil domainPrimaryLifecycleUtil;
     private static DomainLifecycleUtil domainSecondaryLifecycleUtil;
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
     private static final String RIGHT_PASSWORD = DomainLifecycleUtil.SECONDARY_HOST_PASSWORD;
 
 
@@ -151,18 +152,18 @@ public class SecondaryReconnectTestCase {
             primaryClient = domainPrimaryLifecycleUtil.createDomainClient();
 
             //Wait for the secondary to reconnect, look for the secondary in the list of hosts
-            long end = System.currentTimeMillis() + 20 * ADJUSTED_SECOND;
+            long end = System.currentTimeMillis() + ADJUSTED_SECOND.multipliedBy(20).toMillis();
             boolean secondaryReconnected = false;
             do {
-                Thread.sleep(1 * ADJUSTED_SECOND);
+                Thread.sleep(ADJUSTED_SECOND.toMillis());
                 secondaryReconnected = checkSecondaryReconnected(primaryClient);
             } while (!secondaryReconnected && System.currentTimeMillis() < end);
 
             //Wait for primary servers to come up
-            end = System.currentTimeMillis() + 60 * ADJUSTED_SECOND;
+            end = System.currentTimeMillis() + ADJUSTED_SECOND.multipliedBy(60).toMillis();
             boolean serversUp = false;
             do {
-                Thread.sleep(1 * ADJUSTED_SECOND);
+                Thread.sleep(ADJUSTED_SECOND.toMillis());
                 serversUp = checkHostServersStarted(primaryClient, "primary");
             } while (!serversUp && System.currentTimeMillis() < end);
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/AuditLogTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/AuditLogTestCase.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -70,7 +71,7 @@ public class AuditLogTestCase {
 
     private static final int SYSLOG_PORT = 10514;
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
 
     private PathAddress primaryAuditAddress = PathAddress.pathAddress(
@@ -407,7 +408,7 @@ public class AuditLogTestCase {
     }
 
     private ModelNode expectSyslogData(PathAddress pathAddress, ModelNode op, boolean primaryOnlyOp) throws Exception {
-        byte[] data = server.receiveData(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        byte[] data = server.receiveData((int) ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull(data);
         String msg = new String(data, StandardCharsets.UTF_8);
         msg = msg.substring(msg.indexOf('{')).replace("#012", "\n");
@@ -437,7 +438,7 @@ public class AuditLogTestCase {
     }
 
     private void expectNoSyslogData() throws InterruptedException {
-        byte[] data = server.receiveData(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        byte[] data = server.receiveData((int) ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull(data);
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CompositeOperationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CompositeOperationTestCase.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.PropertyPermission;
@@ -585,7 +586,7 @@ public class CompositeOperationTestCase {
             List<ModelNode> steps;
 
             // it could ensure we have acquired the lock by the deployment operation executed before
-            TimeUnit.SECONDS.sleep(TimeoutUtil.adjust(1));
+            TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofSeconds(1)).toMillis());
 
             steps = prepareReadCompositeOperations(PathAddress.pathAddress(HOST_SECONDARY), secondaryChildrenTypes);
             op = createComposite(steps);
@@ -603,7 +604,7 @@ public class CompositeOperationTestCase {
             Assert.assertEquals("It is expected deployment operation is still in progress", false, deploymentFuture.isDone());
 
             // keep the timeout in sync with SlowServiceActivator timeout
-            deploymentFuture.get(TimeoutUtil.adjust(60), TimeUnit.SECONDS);
+            deploymentFuture.get(TimeoutUtil.adjust(Duration.ofMinutes(1)).toMillis(), TimeUnit.MILLISECONDS);
 
         } finally {
             try {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -66,7 +67,7 @@ import org.junit.Test;
  */
 public class DeploymentOverlayTestCase {
 
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
     private static final String DEPLOYMENT_NAME = "deployment.jar";
     private static final String MAIN_RUNTIME_NAME = "main-deployment.jar";
     private static final String OTHER_RUNTIME_NAME = "other-deployment.jar";
@@ -324,7 +325,7 @@ public class DeploymentOverlayTestCase {
 
     private ModelNode awaitSimpleOperationExecution(Future<ModelNode> future) {
         try {
-            return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            return future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainSuspendResumeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainSuspendResumeTestCase.java
@@ -10,6 +10,7 @@ import java.lang.reflect.ReflectPermission;
 import java.net.HttpURLConnection;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -51,7 +52,7 @@ public class DomainSuspendResumeTestCase {
     private static DomainTestSupport testSupport;
     private static DomainLifecycleUtil domainPrimaryLifecycleUtil;
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
     @BeforeClass
     public static void setupDomain() throws Exception {
@@ -88,7 +89,7 @@ public class DomainSuspendResumeTestCase {
                 }
             });
 
-            Thread.sleep(ADJUSTED_SECOND); //nasty, but we need to make sure the HTTP request has started
+            Thread.sleep(ADJUSTED_SECOND.toMillis()); //nasty, but we need to make sure the HTTP request has started
 
             ModelNode op = new ModelNode();
             op.get(ModelDescriptionConstants.OP).set("suspend-servers");

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ExplodedDeploymentTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ExplodedDeploymentTestCase.java
@@ -53,6 +53,7 @@ import java.util.Properties;
 import java.util.PropertyPermission;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jboss.as.controller.HashUtil;
@@ -87,7 +88,7 @@ import org.junit.Test;
  */
 public class ExplodedDeploymentTestCase {
 
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
     private static final String DEPLOYMENT_NAME = "deployment.jar";
     private static final String MSG = "main-server-group";
     private static final PathElement DEPLOYMENT_PATH = PathElement.pathElement(DEPLOYMENT, DEPLOYMENT_NAME);
@@ -417,7 +418,7 @@ public class ExplodedDeploymentTestCase {
 
     private ModelNode awaitSimpleOperationExecution(Future<ModelNode> future) {
         try {
-            return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            return future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -430,7 +431,7 @@ public class ExplodedDeploymentTestCase {
 
     private OperationResponse awaitReadContentExecution(Future<OperationResponse> future) {
         try {
-            return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            return future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/HcExtensionAndSubsystemManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/HcExtensionAndSubsystemManagementTestCase.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.HashMap;
@@ -91,7 +92,7 @@ public class HcExtensionAndSubsystemManagementTestCase {
     private static final PathAddress SECONDARY_SOCKET_BINDING_ADDRESS =
             PathAddress.pathAddress(SECONDARY_SOCKET_BINDING_GROUP_ADDRESS).append(SOCKET_BINDING, SOCKET_BINDING_NAME);
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
     private static DomainTestSupport testSupport;
     private static DomainLifecycleUtil domainPrimaryLifecycleUtil;
@@ -481,10 +482,10 @@ public class HcExtensionAndSubsystemManagementTestCase {
         reloaded = reloaded || reloadHostsIfReloadRequired(domainSecondaryLifecycleUtil, PathAddress.pathAddress(SECONDARY_HOST_ELEMENT));
         if (reloaded) {
             //Wait for the secondary to reconnect, look for the secondary in the list of hosts
-            long end = System.currentTimeMillis() + 20 * ADJUSTED_SECOND;
+            long end = System.currentTimeMillis() + ADJUSTED_SECOND.multipliedBy(20).toMillis();
             boolean secondaryReconnected;
             do {
-                Thread.sleep(ADJUSTED_SECOND);
+                Thread.sleep(ADJUSTED_SECOND.toMillis());
                 secondaryReconnected = checkSecondaryReconnected(domainPrimaryLifecycleUtil.getDomainClient());
             } while (!secondaryReconnected && System.currentTimeMillis() < end);
 
@@ -509,7 +510,7 @@ public class HcExtensionAndSubsystemManagementTestCase {
 
         Set<String> required = serversByHost.get(util);
         Set<String> unstarted;
-        long timeout = TimeoutUtil.adjust(120 * 1000);
+        long timeout = TimeoutUtil.adjust(Duration.ofMinutes(2)).toMillis();
         long deadline = System.currentTimeMillis() + timeout;
         do {
             unstarted = new HashSet<>(required);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/HostSuspendResumeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/HostSuspendResumeTestCase.java
@@ -10,6 +10,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOS
 
 import java.lang.reflect.ReflectPermission;
 import java.net.SocketPermission;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -126,11 +127,11 @@ public class HostSuspendResumeTestCase {
             Future<Object> result = executorService.submit(new Callable<Object>() {
                 @Override
                 public Object call() throws Exception {
-                    return HttpRequest.get(appUrl, TimeoutUtil.adjust(30), TimeUnit.SECONDS);
+                    return HttpRequest.get(appUrl, TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds(), TimeUnit.SECONDS);
                 }
             });
 
-            TimeUnit.SECONDS.sleep(TimeoutUtil.adjust(1)); //nasty, but we need to make sure the HTTP request has started
+            TimeUnit.NANOSECONDS.sleep(TimeoutUtil.adjust(Duration.ofSeconds(1)).toNanos()); //nasty, but we need to make sure the HTTP request has started
 
             final DomainClient primaryClient = domainPrimaryLifecycleUtil.getDomainClient();
             final DomainClient secondaryClient = domainSecondaryLifecycleUtil.getDomainClient();
@@ -139,7 +140,7 @@ public class HostSuspendResumeTestCase {
                 @Override
                 public String call() throws Exception {
                     ModelNode op = Util.createOperation(SUSPEND_SERVERS, PRIMARY_ADDR);
-                    op.get(ModelDescriptionConstants.SUSPEND_TIMEOUT).set(TimeoutUtil.adjust(30));
+                    op.get(ModelDescriptionConstants.SUSPEND_TIMEOUT).set((int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds());
                     return DomainTestUtils.executeForResult(op, domainPrimaryLifecycleUtil.createDomainClient()).asString();
                 }
             });
@@ -149,7 +150,7 @@ public class HostSuspendResumeTestCase {
             ModelNode op = Util.getReadAttributeOperation(SECONDARY_ADDR.append(SERVER_MAIN_THREE), SUSPEND_STATE);
             Assert.assertEquals(RUNNING, DomainTestUtils.executeForResult(op, secondaryClient).asString());
 
-            HttpRequest.get(appUrl + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(30), TimeUnit.SECONDS);
+            HttpRequest.get(appUrl + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds(), TimeUnit.SECONDS);
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
 
             op = Util.getReadAttributeOperation(PRIMARY_ADDR.append(SERVER_MAIN_ONE), SUSPEND_STATE);
@@ -165,7 +166,7 @@ public class HostSuspendResumeTestCase {
             Assert.assertEquals(RUNNING, DomainTestUtils.executeForResult(op, secondaryClient).asString());
 
         } finally {
-            HttpRequest.get(appUrl + "?" + TestUndertowService.SKIP_GRACEFUL, TimeoutUtil.adjust(30), TimeUnit.SECONDS);
+            HttpRequest.get(appUrl + "?" + TestUndertowService.SKIP_GRACEFUL, TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds(), TimeUnit.SECONDS);
             executorService.shutdown();
         }
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -93,7 +94,7 @@ public class OperationCancellationTestCase {
 
     private static final Set<BlockerExtension.BlockPoint> RUNTIME_POINTS =
             EnumSet.of(BlockerExtension.BlockPoint.RUNTIME, BlockerExtension.BlockPoint.SERVICE_START, BlockerExtension.BlockPoint.SERVICE_STOP);
-    private static final long GET_TIMEOUT = TimeoutUtil.adjust(10000);
+    private static final Duration GET_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(10));
 
     private static DomainTestSupport testSupport;
     private static DomainClient primaryClient;
@@ -174,7 +175,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", null, BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.EXECUTING, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.EXECUTING, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertFailedOrCancelled(response);
         validateNoActiveOperation(primaryClient, "primary", null, id, false);
     }
@@ -185,7 +186,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", null, BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.EXECUTING, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.EXECUTING, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertFailedOrCancelled(response);
         validateNoActiveOperation(primaryClient, "primary", null, id, false);
     }
@@ -197,7 +198,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", null, BlockerExtension.BlockPoint.SERVICE_START);
         String id = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", null, id, false);
     }
@@ -210,7 +211,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         blockFuture.cancel(true);
         try {
-            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             fail("not cancelled: " + response);
         } catch (CancellationException good) {
             // good
@@ -224,7 +225,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", null, BlockerExtension.BlockPoint.VERIFY);
         String id = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.EXECUTING, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.EXECUTING, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertFailedOrCancelled(response);
         validateNoActiveOperation(primaryClient, "primary", null, id, false);
     }
@@ -235,7 +236,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", null, BlockerExtension.BlockPoint.COMMIT);
         String blockId = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", null, blockId, false);
     }
@@ -246,7 +247,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", null, BlockerExtension.BlockPoint.ROLLBACK);
         String blockId = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // primary has already failed when we cancel, so it reports as failed
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", null, blockId, false);
@@ -259,7 +260,7 @@ public class OperationCancellationTestCase {
         String blockId = findActiveOperation(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
         Future<ModelNode> writeFuture = primaryClient.executeAsync(WRITE_FOO_OP, OperationMessageHandler.DISCARD);
         cancel(primaryClient, "primary", null, "write-attribute", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, start, false);
-        ModelNode response = writeFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = writeFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         blockFuture.cancel(true);
         validateNoActiveOperation(primaryClient, "primary", null, blockId, true);
@@ -273,7 +274,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> writeFuture = primaryClient.executeAsync(WRITE_FOO_OP, OperationMessageHandler.DISCARD);
         findActiveOperation(primaryClient, "primary", null, "write-attribute", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, start);
         cancel(primaryClient, "primary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start, false);
-        ModelNode response = writeFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = writeFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", null, blockId, true);
     }
@@ -284,7 +285,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, id, true);
     }
@@ -295,7 +296,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, id, true);
     }
@@ -307,7 +308,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.SERVICE_START);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, id, true);
     }
@@ -320,7 +321,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         blockFuture.cancel(true);
         try {
-            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             fail("not cancelled: " + response);
         } catch (CancellationException good) {
             // good
@@ -334,7 +335,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.VERIFY);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, id, true);
     }
@@ -345,7 +346,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // The primary may or may not be done with DomainSecondaryHandler.execute and DomainRolloutStepHandler.execute
         // when cancelled. If yes, result is SUCCESS, if not result is CANCELLED
         assertSuccessOrCancelled(response);
@@ -358,7 +359,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.ROLLBACK);
         String id = findActiveOperation(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // Secondary fails before Stage.DONE so no normal prepared message in DONE with the failure. The block in
         // rollback prevents the failure coming via the final response. So the primary doesn't know about
         // the failure and just detects the local cancellation. So, CANCELLED
@@ -373,7 +374,7 @@ public class OperationCancellationTestCase {
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         Future<ModelNode> writeFuture = primaryClient.executeAsync(WRITE_FOO_OP, OperationMessageHandler.DISCARD);
         cancel(primaryClient, "primary", null, "write-attribute", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, start, false);
-        ModelNode response = writeFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = writeFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         blockFuture.cancel(true);
         validateNoActiveOperation(primaryClient, "secondary", null, blockId, true);
@@ -385,7 +386,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.MODEL);
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "secondary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, blockId, false);
     }
@@ -396,7 +397,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.RUNTIME);
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "secondary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, blockId, false);
     }
@@ -408,7 +409,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.SERVICE_START);
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, blockId, false);
     }
@@ -419,7 +420,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.VERIFY);
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "secondary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, blockId, false);
     }
@@ -430,7 +431,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.COMMIT);
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
         cancel(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.COMPLETING , start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // cancellation any time in Stage.DONE on secondary will not result in a prepare-phase failed response to
         // primary, so this should always be success
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -443,7 +444,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", null, BlockerExtension.BlockPoint.ROLLBACK);
         String blockId = findActiveOperation(primaryClient, "secondary", null, "block", null, start);
         cancel(primaryClient, "secondary", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // Cancelling the rollback does not prevent the primary learning that the secondary failed.
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", null, blockId, true);
@@ -455,7 +456,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, true);
     }
@@ -466,7 +467,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, true);
     }
@@ -478,7 +479,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.SERVICE_START);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, true);
     }
@@ -491,7 +492,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         blockFuture.cancel(true);
         try {
-            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             fail("not cancelled: " + response);
         } catch (CancellationException good) {
             // good
@@ -505,7 +506,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.VERIFY);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, true);
     }
@@ -516,7 +517,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.COMPLETING, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // The result may be success or cancelled depending on whether the cancelled executed while
         // DomainRolloutStepHandler.execute was running (CANCELLED) or afterwards (SUCCESS)
         assertSuccessOrCancelled(response);
@@ -529,7 +530,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.ROLLBACK);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // The server op does not reach the prepare stage, so the primary doesn't either and reports as cancelled
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, true);
@@ -541,7 +542,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", "main-one", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, false);
     }
@@ -552,7 +553,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", "main-one", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, false);
     }
@@ -564,7 +565,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.SERVICE_START);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, false);
     }
@@ -575,7 +576,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.VERIFY);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", null, start);
         cancel(primaryClient, "primary", "main-one", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "primary", "main-one", id, false);
     }
@@ -586,7 +587,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.COMPLETING, start);
         cancel(primaryClient, "primary", "main-one", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to primary,
         // so result should always be SUCCESS
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -599,7 +600,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("primary", "main-one", BlockerExtension.BlockPoint.ROLLBACK);
         String id = findActiveOperation(primaryClient, "primary", "main-one", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         cancel(primaryClient, "primary", "main-one", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // Server never reaches Stage.DONE before blocking, so primary is waiting for initial response.
         // Cancelling the rollback on server doesn't change that response from FAILED. So primary sees and reports failure.
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
@@ -612,7 +613,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id , true);
     }
@@ -623,7 +624,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -635,7 +636,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.SERVICE_START);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -648,7 +649,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         blockFuture.cancel(true);
         try {
-            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             fail("not cancelled: " + response);
         } catch (CancellationException good) {
             // good
@@ -662,7 +663,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.VERIFY);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -673,7 +674,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // The result may be success or cancelled depending on whether the cancelled executed while
         // DomainRolloutStepHandler.execute was running (CANCELLED) or afterwards (SUCCESS)
         assertSuccessOrCancelled(response);
@@ -686,7 +687,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         cancel(primaryClient, "primary", null, "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // Server doesn't get to DONE so doesn't report there, so primary is waiting for initial report, which is blocking
         // on server. So primary detects local cancellation and reports it
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
@@ -708,7 +709,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
         cancel(primaryClient, "secondary", null, "block", null, start, true);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -720,7 +721,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
         cancel(primaryClient, "secondary", null, "block", null, start, true);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -733,7 +734,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
         // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
         cancel(primaryClient, "secondary", null, "block", null, start, true);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -745,7 +746,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
         cancel(primaryClient, "secondary", null, "block", null, start, true);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
     }
@@ -757,7 +758,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start);
         // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
         cancel(primaryClient, "secondary", null, "block", null, start, true);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // The secondary will already have sent its prepare phase response to primary before the secondary op even gets started.
         // So the subsequent cancellation will not affect the overall result, so it's SUCCESS
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -771,7 +772,7 @@ public class OperationCancellationTestCase {
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
         cancel(primaryClient, "secondary", null, "block", null, start, true);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // Server can't report it's failure as a prepared message in DONE because it doesn't get there. So primary is
         // waiting for the initial report. The secondary then cancelling releases the initial report but doesn't change
         // its outcome from FAILED. So primary sees failure
@@ -785,7 +786,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "secondary", "main-three", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, false);
     }
@@ -796,7 +797,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.RUNTIME);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "secondary", "main-three", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, false);
     }
@@ -808,7 +809,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.SERVICE_START);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, false);
     }
@@ -819,7 +820,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.VERIFY);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "secondary", "main-three", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, false);
     }
@@ -830,7 +831,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.COMMIT);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", null, start);
         cancel(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to primary,
         // so result should always be SUCCESS
         assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
@@ -843,7 +844,7 @@ public class OperationCancellationTestCase {
         Future<ModelNode> blockFuture = block("secondary", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
         String id = findActiveOperation(primaryClient, "secondary", "main-three", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
         cancel(primaryClient, "secondary", "main-three", "block", null, start, false);
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         // Cancelling in rollback doesn't change the server's FAILED outcome, so primary sees it and reports it.
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
         validateNoActiveOperation(primaryClient, "secondary", "main-three", id, false);
@@ -861,7 +862,7 @@ public class OperationCancellationTestCase {
         op.get("timeout").set(0);
         ModelNode result = executeForResult(op, primaryClient);
         assertEquals(result.toString(), id, result.asString());
-        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        ModelNode response = blockFuture.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
         // Bogus as "id" is not the id on secondary/main-three
 //        validateNoActiveOperation(primaryClient, "secondary", "main-three", id, true);
@@ -968,7 +969,7 @@ public class OperationCancellationTestCase {
     private String findActiveOperation(DomainClient client, PathAddress address, String opName, OperationContext.ExecutionStatus targetStatus, long executionStart, boolean serverOpOnly) throws Exception {
         ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
         op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
-        long maxTime = TimeoutUtil.adjust(5000);
+        long maxTime = TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis();
         long timeout = executionStart + maxTime;
         List<String> activeOps = new ArrayList<String>();
         String opToCancel = null;
@@ -1030,7 +1031,7 @@ public class OperationCancellationTestCase {
 
         // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
         // something strange is happening on the machine is overloaded
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis();
         MgmtOperationException failure;
         do {
             String id = findActiveOperation(client, baseAddress, "block");
@@ -1061,7 +1062,7 @@ public class OperationCancellationTestCase {
 
         // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
         // something strange is happening on the machine is overloaded
-        long timeout = patient ? System.currentTimeMillis() + TimeoutUtil.adjust(5000) : 0;
+        long timeout = patient ? System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis() : 0;
         MgmtOperationException failure;
         do {
             try {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationErrorTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationErrorTestCase.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -93,7 +94,7 @@ public class OperationErrorTestCase {
     private static final EnumSet<ErrorExtension.ErrorPoint> RUNTIME_POINTS =
             EnumSet.of(ErrorExtension.ErrorPoint.RUNTIME, ErrorExtension.ErrorPoint.SERVICE_START, ErrorExtension.ErrorPoint.SERVICE_STOP);
 
-    private static final long GET_TIMEOUT = TimeoutUtil.adjust(10000);
+    private static final Duration GET_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(10));
 
     private static final ModelNode ROLLOUT_HEADER;
 
@@ -457,7 +458,7 @@ public class OperationErrorTestCase {
 
         // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
         // something strange is happening on the machine is overloaded
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis();
         MgmtOperationException failure;
         String id;
         do {
@@ -505,7 +506,7 @@ public class OperationErrorTestCase {
     private static ModelNode execute(final ModelNode op, final ModelControllerClient modelControllerClient) throws Exception {
         Future<ModelNode> future =  modelControllerClient.executeAsync(op, OperationMessageHandler.DISCARD);
         try {
-            return future.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            return future.get(GET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             future.cancel(true);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/SlowServiceActivator.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/SlowServiceActivator.java
@@ -5,6 +5,7 @@
 
 package org.jboss.as.test.integration.domain.suites;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.test.shared.TimeoutUtil;
@@ -21,7 +22,7 @@ public class SlowServiceActivator implements ServiceActivator {
     @Override
     public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
         try {
-            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(60)*1000;
+            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofMinutes(1)).toMillis();
             while (System.currentTimeMillis() - timeout < 0) {
                 TimeUnit.SECONDS.sleep(1);
             }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
@@ -26,6 +26,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivilegedAction;
 import java.security.Security;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -104,7 +105,7 @@ public abstract class AbstractKerberosMgmtSaslTestBase {
 
     protected static Logger LOGGER = Logger.getLogger(AbstractKerberosMgmtSaslTestBase.class);
 
-    protected static final int CONNECTION_TIMEOUT_IN_MS = TimeoutUtil.adjust(6 * 1000);
+    protected static final Duration CONNECTION_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(6));
 
     protected static final int PORT_NATIVE = 10567;
 
@@ -345,7 +346,7 @@ public abstract class AbstractKerberosMgmtSaslTestBase {
             fail(message);
         } catch (IOException | GeneralSecurityException e) {
             assertTrue("Connection reached its timeout (hang).",
-                    startTime + CONNECTION_TIMEOUT_IN_MS > System.currentTimeMillis());
+                    startTime + CONNECTION_TIMEOUT.toMillis() > System.currentTimeMillis());
             Throwable cause = e.getCause();
             assertThat("ConnectionException was expected as a cause when authentication fails", cause,
                     is(instanceOf(ConnectException.class)));

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.security.Provider;
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,7 +78,7 @@ public abstract class AbstractMgmtSaslTestBase {
     protected static final String DIGEST_ALGORITHM_SHA384 = "digest-sha-384";
     protected static final String DIGEST_ALGORITHM_SHA512 = "digest-sha-512";
 
-    protected static final int CONNECTION_TIMEOUT_IN_MS = TimeoutUtil.adjust(6 * 1000);
+    protected static final Duration CONNECTION_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(6));
 
     protected static final Provider PROVIDER_ELYTRON = new WildFlyElytronProvider();
 
@@ -195,7 +196,7 @@ public abstract class AbstractMgmtSaslTestBase {
             fail(message);
         } catch (IOException e) {
             assertTrue("Connection reached its timeout (hang).",
-                    startTime + CONNECTION_TIMEOUT_IN_MS > System.currentTimeMillis());
+                    startTime + CONNECTION_TIMEOUT.toMillis() > System.currentTimeMillis());
             Throwable cause = e.getCause();
             assertThat("ConnectionException was expected as a cause when SASL authentication fails", cause,
                     is(instanceOf(ConnectException.class)));
@@ -214,7 +215,7 @@ public abstract class AbstractMgmtSaslTestBase {
     protected static ModelNode executeWhoAmI(String clientBindAddress) throws IOException {
         try (ModelControllerClient client = ModelControllerClient.Factory
                 .create(new ModelControllerClientConfiguration.Builder().setHostName(TestSuiteEnvironment.getServerAddress())
-                        .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS).setClientBindAddress(clientBindAddress).build())) {
+                        .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout((int) CONNECTION_TIMEOUT.toMillis()).setClientBindAddress(clientBindAddress).build())) {
 
             ModelNode operation = new ModelNode();
             operation.get("operation").set("whoami");

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ExternalMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ExternalMgmtSaslTestCase.java
@@ -12,7 +12,7 @@ import static org.jboss.as.test.integration.security.common.SecurityTestConstant
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.CONNECTION_TIMEOUT_IN_MS;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.CONNECTION_TIMEOUT;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.PORT_NATIVE;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertAuthenticationFails;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertWhoAmI;
@@ -199,7 +199,7 @@ public class ExternalMgmtSaslTestCase {
             fail(message);
         } catch (IOException e) {
             assertTrue("Connection reached its timeout (hang).",
-                    startTime + CONNECTION_TIMEOUT_IN_MS > System.currentTimeMillis());
+                    startTime + CONNECTION_TIMEOUT.toMillis() > System.currentTimeMillis());
             Throwable cause = e.getCause();
             assertThat("ConnectionException was expected as a cause when certificate authentication fails", cause,
                     is(instanceOf(ConnectException.class)));

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
@@ -65,7 +65,7 @@ public class KerberosHttpMgmtSaslTestCase extends AbstractKerberosMgmtSaslTestBa
 
     private static final ModelControllerClient client = ModelControllerClient.Factory
             .create(new ModelControllerClientConfiguration.Builder().setHostName(CoreUtils.getDefaultHost(false))
-                    .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS).build());
+                    .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout((int) CONNECTION_TIMEOUT.toMillis()).build());
 
     /**
      * Configures test sasl-server-factory to use given mechanism. It also enables/disables SSL based on provided flag.
@@ -111,7 +111,7 @@ public class KerberosHttpMgmtSaslTestCase extends AbstractKerberosMgmtSaslTestBa
     protected ModelNode executeWhoAmI(boolean withTls) throws IOException, GeneralSecurityException {
         ModelControllerClientConfiguration.Builder clientConfigBuilder = new ModelControllerClientConfiguration.Builder()
                 .setHostName(CoreUtils.getDefaultHost(false)).setPort(withTls ? 9993 : 9990)
-                .setProtocol(withTls ? "https-remoting" : "http-remoting").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS);
+                .setProtocol(withTls ? "https-remoting" : "http-remoting").setConnectionTimeout((int) CONNECTION_TIMEOUT.toMillis());
         if (withTls) {
             clientConfigBuilder.setSslContext(sslFactory.create());
         }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
@@ -86,7 +86,7 @@ public class KerberosNativeMgmtSaslTestCase extends AbstractKerberosMgmtSaslTest
     protected ModelNode executeWhoAmI(boolean withTls) throws IOException, GeneralSecurityException {
         ModelControllerClientConfiguration.Builder clientConfigBuilder = new ModelControllerClientConfiguration.Builder()
                 .setHostName(CoreUtils.getDefaultHost(false)).setPort(PORT_NATIVE)
-                .setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS);
+                .setProtocol("remote").setConnectionTimeout((int) CONNECTION_TIMEOUT.toMillis());
         if (withTls) {
             clientConfigBuilder.setSslContext(sslFactory.create());
         }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramPlusMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ScramPlusMgmtSaslTestCase.java
@@ -13,7 +13,7 @@ import static org.jboss.as.test.integration.security.common.SecurityTestConstant
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.CONNECTION_TIMEOUT_IN_MS;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.CONNECTION_TIMEOUT;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.PORT_NATIVE;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertAuthenticationFails;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertWhoAmI;
@@ -222,7 +222,7 @@ public class ScramPlusMgmtSaslTestCase {
             fail("Client authentication failure is expected.");
         } catch (IOException e) {
             assertTrue("Connection reached its timeout (hang).",
-                    startTime + CONNECTION_TIMEOUT_IN_MS > System.currentTimeMillis());
+                    startTime + CONNECTION_TIMEOUT.toMillis() > System.currentTimeMillis());
             Throwable cause = e.getCause();
             assertThat("ConnectionException was expected as a cause when SASL authentication fails", cause,
                     is(instanceOf(ConnectException.class)));

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
@@ -60,7 +60,7 @@ public class AbstractTestCase {
         final Callable<Boolean> callable = new Callable<Boolean>() {
             @Override
             public Boolean call() throws InterruptedException {
-                long timeout = Environment.TIMEOUT * 1000;
+                long timeout = Environment.TIMEOUT.toMillis();
                 final long sleep = 100L;
                 while (timeout > 0) {
                     long before = System.currentTimeMillis();
@@ -77,7 +77,7 @@ public class AbstractTestCase {
         try {
             final Future<Boolean> future = service.submit(callable);
             if (!future.get()) {
-                throw new TimeoutException(String.format("The embedded server did not start within %s seconds.", Environment.TIMEOUT));
+                throw new TimeoutException(String.format("The embedded server did not start within %s seconds.", Environment.TIMEOUT.toSeconds()));
             }
         } catch (ExecutionException e) {
             throw new RuntimeException("Failed to determine if the embedded server is running.", e);

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
@@ -7,6 +7,7 @@ package org.wildfly.core.test.embedded;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.wildfly.core.embedded.Configuration;
@@ -19,7 +20,7 @@ public class Environment {
     public static final Path JBOSS_HOME;
     public static final Path MODULE_PATH;
     public static final Path LOG_DIR;
-    public static final int TIMEOUT;
+    public static final Duration TIMEOUT;
 
     static {
         String jbossHome = System.getProperty("jboss.home");
@@ -42,7 +43,7 @@ public class Environment {
 
         LOG_DIR = Paths.get(System.getProperty("jboss.test.log.dir"));
         final String timeoutString = System.getProperty("jboss.test.start.timeout", "20");
-        TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
+        TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(Integer.parseInt(timeoutString)));
     }
 
     public static Configuration.Builder createConfigBuilder() {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTestCase.java
@@ -9,6 +9,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TRU
 import static org.jboss.as.test.manualmode.auditlog.AbstractLogFieldsOfLogTestCase.executeForSuccess;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -128,7 +129,7 @@ public class AuditLogBootingSyslogTestCase {
     private void waitForExpectedOperations(int expectedOperations, BlockingQueue<SyslogServerEventIF> queue) throws InterruptedException {
         int operations = 0;
         int openClose = 0;
-        long endTime = System.currentTimeMillis() + TimeoutUtil.adjust(READ_MESSAGES_TIMEOUT_MILLISECONDS);
+        long endTime = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofMillis(READ_MESSAGES_TIMEOUT_MILLISECONDS)).toMillis();
         StringBuilder sb = new StringBuilder();
         do {
             if (queue.isEmpty()) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
@@ -7,6 +7,7 @@ package org.jboss.as.test.manualmode.auditlog;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -52,7 +53,7 @@ import org.xnio.IoUtils;
 public class AuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCase {
 
     private final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
     private static final AuditLogToUDPSyslogSetup SYSLOG_SETUP = new AuditLogToUDPSyslogSetup();
     private final PathAddress auditLogConfigAddress = PathAddress.pathAddress(CoreManagementResourceDefinition.PATH_ELEMENT,
             AccessAuditResourceDefinition.PATH_ELEMENT, AuditLogLoggerResourceDefinition.PATH_ELEMENT);
@@ -121,7 +122,7 @@ public class AuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCase 
         SyslogServerEventIF syslogEvent = null;
 
         Assert.assertTrue(makeOneLog());
-        syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("Event wasn't logged into the syslog", syslogEvent);
 
         Rfc5424SyslogEvent event = (Rfc5424SyslogEvent) syslogEvent;

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/cli/boot/ops/CliBootOperationsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/cli/boot/ops/CliBootOperationsTestCase.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.nio.file.Files;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
@@ -211,7 +212,7 @@ public class CliBootOperationsTestCase {
 
     void waitForMarkerFile(String expected) throws Exception {
         File file = getMarkerFile();
-        long end = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis();
         String contents = null;
         while (System.currentTimeMillis() < end) {
             Thread.sleep(100);
@@ -256,7 +257,7 @@ public class CliBootOperationsTestCase {
     private void waitForRunningMode(String runningMode) throws Exception {
         // Following a reload to normal mode, we might read the running mode too early and hit the admin-only server
         // Cycle around a bit to make sure we get the server reloaded into normal mode
-        long end = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+        long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
         while (true) {
             try {
                 Thread.sleep(100);

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerNotificationUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerNotificationUnitTestCase.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
@@ -56,7 +57,7 @@ public class DeploymentScannerNotificationUnitTestCase extends AbstractDeploymen
                 addDeploymentScanner(client, 1000, false, true);
                 try {
                     // Wait until deployed ...
-                    long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(30000);
+                    long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis();
                     while (!exists(client, DEPLOYMENT_ONE) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(100);
                     }
@@ -65,7 +66,7 @@ public class DeploymentScannerNotificationUnitTestCase extends AbstractDeploymen
                     final Path oneDeployed = getDeployDirPath().resolve("deployment-one.jar.deployed");
                     final Path oneUndeployed = getDeployDirPath().resolve("deployment-one.jar.undeployed");
                     Assert.assertTrue(Files.deleteIfExists(oneDeployed));
-                    timeout = System.currentTimeMillis() + TimeoutUtil.adjust(30000);
+                    timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis();
                     while (!Files.exists(oneUndeployed) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(10);
                     }
@@ -81,7 +82,7 @@ public class DeploymentScannerNotificationUnitTestCase extends AbstractDeploymen
                     deploy(client, deploymentOne);
                     Assert.assertTrue(exists(client, DEPLOYMENT_ONE));
                     Assert.assertEquals("OK", deploymentState(client, DEPLOYMENT_ONE));
-                    timeout = System.currentTimeMillis() + TimeoutUtil.adjust(30000);
+                    timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis();
                     while (!Files.exists(oneDeployed) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(10);
                     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationRollbackTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationRollbackTestCase.java
@@ -15,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 import org.jboss.as.controller.PathAddress;
@@ -41,7 +42,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @RunWith(WildFlyRunner.class)
 @ServerControl(manual = true)
 public class DeploymentScannerOperationRollbackTestCase extends AbstractDeploymentScannerBasedTestCase {
-    private static final int FAILING_TIMEOUT = 3000;
+    private static final Duration FAILING_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(3));
     @Inject
     private ServerController container;
 
@@ -58,7 +59,7 @@ public class DeploymentScannerOperationRollbackTestCase extends AbstractDeployme
                     assertThat(exists(client, DEPLOYMENT_ONE), is(false));
                     runFailingScan(client);
                     // Wait until deployed ...
-                    long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(FAILING_TIMEOUT);
+                    long timeout = System.currentTimeMillis() + FAILING_TIMEOUT.toMillis();
                     while (!exists(client, DEPLOYMENT_ONE) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(DELAY);
                     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationTestCase.java
@@ -11,6 +11,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.time.Duration;
 
 
 import jakarta.inject.Inject;
@@ -36,7 +37,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @ServerControl(manual = true)
 public class DeploymentScannerOperationTestCase extends AbstractDeploymentScannerBasedTestCase {
 
-    private static final int TIMEOUT = 30000;
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(30));
 
     @Inject
     private ServerController container;
@@ -55,7 +56,7 @@ public class DeploymentScannerOperationTestCase extends AbstractDeploymentScanne
                     Assert.assertFalse(exists(client, DEPLOYMENT_ONE));
                     runScan(client);
                     // Wait until deployed ...
-                    long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(TIMEOUT);
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while (!exists(client, DEPLOYMENT_ONE) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(DELAY);
                     }
@@ -70,7 +71,7 @@ public class DeploymentScannerOperationTestCase extends AbstractDeploymentScanne
                     Assert.assertEquals("OK", deploymentState(client, DEPLOYMENT_ONE));
                     runScan(client);
                     // Wait until undeployed ...
-                    timeout = System.currentTimeMillis() + TimeoutUtil.adjust(TIMEOUT);
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while (exists(client, DEPLOYMENT_ONE) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(DELAY);
                     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerRedeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerRedeploymentTestCase.java
@@ -8,6 +8,7 @@ package org.jboss.as.test.manualmode.deployment;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 
 import java.io.File;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
@@ -26,7 +27,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @ServerControl(manual = true)
 public class DeploymentScannerRedeploymentTestCase extends AbstractDeploymentScannerBasedTestCase {
     private static final int DELAY = 100;
-    private static final int TIMEOUT = 30000;
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(30));
     private static final PathAddress DEPLOYMENT_TEST = PathAddress.pathAddress(DEPLOYMENT, "deployment-test.jar");
 
     @Inject
@@ -47,7 +48,7 @@ public class DeploymentScannerRedeploymentTestCase extends AbstractDeploymentSca
                 addDeploymentScanner(client, 0, false, true);
                 try {
                     // Wait until deployed ...
-                    long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(TIMEOUT);
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while (!exists(client, DEPLOYMENT_TEST) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(DELAY);
                     }
@@ -64,7 +65,7 @@ public class DeploymentScannerRedeploymentTestCase extends AbstractDeploymentSca
 
                     startContainer(client);
 
-                    timeout = System.currentTimeMillis() + TimeoutUtil.adjust(TIMEOUT);
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while (exists(client, DEPLOYMENT_TEST) && System.currentTimeMillis() < timeout) {
                         Thread.sleep(200);
                     }
@@ -97,7 +98,7 @@ public class DeploymentScannerRedeploymentTestCase extends AbstractDeploymentSca
         container.start();
 
         // Wait until started ...
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(TIMEOUT);
+        long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
         while (!isRunning(client) && System.currentTimeMillis() < timeout) {
             Thread.sleep(200);
         }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerShutdownTestCase.java
@@ -14,6 +14,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.time.Duration;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -65,7 +66,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 public class DeploymentScannerShutdownTestCase {
 
     // Max time to wait for some action to complete, in ms
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
     // Pause time between checks whether some action has completed, in ms
     private static final int BACKOFF = 10;
     private static final String DEPLOYMENT_SCANNER_EXTENSION = "org.jboss.as.deployment-scanner";
@@ -145,7 +146,7 @@ public class DeploymentScannerShutdownTestCase {
         final File file = new File(dir, DEPLOYMENT_NAME);
         archive.as(ZipExporter.class).exportTo(file, true);
         deploy(file, target, deployed);
-        container.reload(TIMEOUT);
+        container.reload((int) TIMEOUT.toMillis());
         Assert.assertTrue("We should have the deployed marker", deployed.exists());
         Assert.assertTrue(container.isStarted());
         Path serverLog = getAbsoluteLogFilePath("jboss.server.log.dir", "server.log");
@@ -174,7 +175,7 @@ public class DeploymentScannerShutdownTestCase {
         deploy(file, target, deployed);
         deployRules();
         undeploy(target, undeployed);
-        container.reload(TIMEOUT);
+        container.reload((int) TIMEOUT.toMillis());
         Assert.assertTrue("We should have the undeployed marker", undeployed.exists());
         Assert.assertTrue(container.isStarted());
         Path serverLog = getAbsoluteLogFilePath("jboss.server.log.dir", "server.log");
@@ -226,7 +227,7 @@ public class DeploymentScannerShutdownTestCase {
     }
 
     private void waitForMarkerFile(File marker) {
-        for (int i = 0; i < TIMEOUT / BACKOFF; i++) {
+        for (int i = 0; i < TIMEOUT.toMillis() / BACKOFF; i++) {
             if (marker.exists()) {
                 break;
             }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerUnitTestCase.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +61,7 @@ public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBase
     private static final String JAR_TWO = "deployment-startup-two.jar";
     private static final PathAddress DEPLOYMENT_ONE = PathAddress.pathAddress(DEPLOYMENT, JAR_ONE);
     private static final PathAddress DEPLOYMENT_TWO = PathAddress.pathAddress(DEPLOYMENT, JAR_TWO);
-    private static final int TIMEOUT = TimeoutUtil.adjust(30000);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(30));
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss,SSS");
 
     @SuppressWarnings("unused")
@@ -86,9 +87,9 @@ public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBase
                 addDeploymentScanner(client, 0, false, true);
                 try {
                     // Wait until deployed ...
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while (!(exists(client, DEPLOYMENT_ONE) && exists(client, DEPLOYMENT_TWO)) && System.currentTimeMillis() < timeout) {
-                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(300));
+                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofMillis(300)).toMillis());
                     }
                     Assert.assertTrue(exists(client, DEPLOYMENT_ONE));
                     Assert.assertEquals("OK", deploymentState(client, DEPLOYMENT_ONE));
@@ -108,9 +109,9 @@ public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBase
                     client = TestSuiteEnvironment.getModelControllerClient();
 
                     // Wait until started ...
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while (!isRunning(client) && System.currentTimeMillis() < timeout) {
-                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(300));
+                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofMillis(300)).toMillis());
                     }
 
                     Assert.assertTrue(Files.exists(oneDeployed));
@@ -119,9 +120,9 @@ public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBase
                     Assert.assertTrue(exists(client, DEPLOYMENT_ONE));
                     Assert.assertEquals("OK", deploymentState(client, DEPLOYMENT_ONE));
 
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     do {
-                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(300));
+                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofMillis(300)).toMillis());
                     } while (exists(client, DEPLOYMENT_TWO) && System.currentTimeMillis() < timeout);
                     Assert.assertFalse("Deployment two should not exist at " + TIME_FORMATTER.format(LocalDateTime.now()), exists(client, DEPLOYMENT_TWO));
                     ModelNode disableScanner = Util.getWriteAttributeOperation(PathAddress.parseCLIStyleAddress("/subsystem=deployment-scanner/scanner=testScanner"), "scan-interval", 300000);
@@ -134,10 +135,10 @@ public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBase
                     Assert.assertTrue(exists(client, DEPLOYMENT_ONE));
                     Assert.assertEquals("STOPPED", deploymentState(client, DEPLOYMENT_ONE));
 
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
 
                     while (Files.exists(oneDeployed) && System.currentTimeMillis() < timeout) {
-                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(300));
+                        TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofMillis(300)).toMillis());
                     }
                     Assert.assertFalse(Files.exists(oneDeployed));
                 } finally {
@@ -352,9 +353,9 @@ public class DeploymentScannerUnitTestCase extends AbstractDeploymentScannerBase
 
 
     private void waitFor(String message, ExceptionWrappingSupplier<Boolean> condition) throws Exception {
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(TIMEOUT);
+        long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
         do {
-            TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(300));
+            TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofMillis(300)).toMillis());
         } while (!condition.get() && System.currentTimeMillis() < timeout);
 
         Assert.assertTrue(message, condition.get());

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractSyslogReconnectionTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractSyslogReconnectionTestCase.java
@@ -4,6 +4,8 @@
  */
 package org.jboss.as.test.manualmode.logging;
 
+import java.time.Duration;
+
 import org.apache.http.HttpStatus;
 import org.jboss.as.controller.PathAddress;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
@@ -32,7 +34,7 @@ public abstract class AbstractSyslogReconnectionTestCase extends AbstractLogging
     protected static final String SYSLOG_UDP_HANDLER_NAME = "SYSLOG_UDP_HANDLER";
     protected static final String SYSLOG_TCP_HANDLER_NAME = "SYSLOG_TCP_HANDLER";
 
-    protected static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    protected static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
     protected static SyslogServerIF udpServer;
     protected static SyslogServerIF tcpServer;
@@ -126,7 +128,7 @@ public abstract class AbstractSyslogReconnectionTestCase extends AbstractLogging
                 SYSLOG_TCP_PORT,
                 SyslogConstants.TCP);
         // reconnection timeout is 5sec for TCP syslog handler
-        Thread.sleep(6 * ADJUSTED_SECOND);
+        Thread.sleep(ADJUSTED_SECOND.multipliedBy(6).toMillis());
     }
 
     protected static void stopSyslogServers() throws InterruptedException {
@@ -140,7 +142,7 @@ public abstract class AbstractSyslogReconnectionTestCase extends AbstractLogging
             tcpServer.getConfig().removeAllEventHandlers();
         }
         // wait for 1 second to stop syslog server instances properly
-        Thread.sleep(1 * ADJUSTED_SECOND);
+        Thread.sleep(ADJUSTED_SECOND.toMillis());
     }
 
     protected void makeLog() throws Exception {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
@@ -64,43 +64,43 @@ public class ReconnectSyslogServerTestCase extends AbstractSyslogReconnectionTes
 
         // logging before syslog restart
         makeLog();
-        SyslogServerEventIF udpSyslogEvent = udpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        SyslogServerEventIF udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the UDP syslog", udpSyslogEvent);
-        SyslogServerEventIF tcpSyslogEvent = tcpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        SyslogServerEventIF tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the TCP syslog", tcpSyslogEvent);
 
         stopSyslogServers();
 
         makeLog_syslogIsOffline();
-        udpSyslogEvent = udpQueue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Message was logged into the UDP syslog even if syslog server should be stopped", udpSyslogEvent);
-        tcpSyslogEvent = tcpQueue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Message was logged into the TCP syslog even if syslog server should be stopped", tcpSyslogEvent);
 
         startSyslogServers(host);
 
         // logging after first syslog restart
         makeLog();
-        udpSyslogEvent = udpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the UDP syslog after first syslog server restart", udpSyslogEvent);
-        tcpSyslogEvent = tcpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the TCP syslog after first syslog server restart", tcpSyslogEvent);
 
         stopSyslogServers();
 
         makeLog_syslogIsOffline();
-        udpSyslogEvent = udpQueue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Message was logged into the UDP syslog even if syslog server should be stopped", udpSyslogEvent);
-        tcpSyslogEvent = tcpQueue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Message was logged into the TCP syslog even if syslog server should be stopped", tcpSyslogEvent);
 
         startSyslogServers(host);
 
         // logging after second syslog restart
         makeLog();
-        udpSyslogEvent = udpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the UDP syslog after second syslog server restart", udpSyslogEvent);
-        tcpSyslogEvent = tcpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the TCP syslog after second syslog server restart", tcpSyslogEvent);
 
     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
@@ -68,18 +68,18 @@ public class SyslogIsNotAvailableDuringServerBootTestCase extends AbstractSyslog
 
         // do log when syslog is not running
         makeLog_syslogIsOffline();
-        SyslogServerEventIF udpSyslogEvent = udpQueue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        SyslogServerEventIF udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Message was logged into the UDP syslog even if syslog server should be stopped", udpSyslogEvent);
-        SyslogServerEventIF tcpSyslogEvent = tcpQueue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        SyslogServerEventIF tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("Message was logged into the TCP syslog even if syslog server should be stopped", tcpSyslogEvent);
 
         startSyslogServers(host);
 
         // do log when syslog is running
         makeLog();
-        udpSyslogEvent = udpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        udpSyslogEvent = udpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the UDP syslog", udpSyslogEvent);
-        tcpSyslogEvent = tcpQueue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        tcpSyslogEvent = tcpQueue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("No message was logged into the TCP syslog", tcpSyslogEvent);
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.util.List;
 
 import org.codehaus.plexus.util.FileUtils;
@@ -190,7 +191,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
         } else {
             checkNoLogging("WFLYSRV0025");
         }
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
 
         // The app embedding the server should still be able to log
         checkClientSideLogging();
@@ -237,12 +238,12 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
         assertState("running", 0);
         // embedded-hc requires admin-only
         cli.sendLine("/host=primary:reload(admin-only=true");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
         cli.sendLine("/extension=org.wildfly.extension.io:remove");
         assertState("running", 0);
         // High level
         cli.sendLine("reload --host=primary --admin-only=true");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
     }
 
     /** Confirms that the low and high level shutdown commands are not available */
@@ -422,7 +423,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
         cli.sendLine("/core-service=management/access=authorization:write-attribute(name=provider,value=rbac");
         assertState("reload-required", 0);
         cli.sendLine("reload --host=primary --admin-only=true");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
     }
 
     @Test
@@ -550,7 +551,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
         configureManagementInterface("foo");
         cli.sendLine("/host=foo:write-attribute(name=name,value=renamed-foo)");
         cli.sendLine("/host=foo:reload(admin-only=true)");
-        assertState("running", TimeoutUtil.adjust(30000), "/host=renamed-foo:read-attribute(name=host-state)");
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), "/host=renamed-foo:read-attribute(name=host-state)");
 
         assertTrue(cli.isConnected());
 
@@ -606,7 +607,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
 
         cli.sendLine("/host=foo:write-attribute(name=name,value=renamed-foo)");
         cli.sendLine("/host=foo:reload(admin-only=true)");
-        assertState("running", TimeoutUtil.adjust(30000), "/host=renamed-foo:read-attribute(name=host-state)");
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), "/host=renamed-foo:read-attribute(name=host-state)");
 
         readManagementInterface("renamed-foo");
 
@@ -764,7 +765,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
     }
 
     private void checkLogging(String line) throws IOException {
-        long delay = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+        long delay = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
         boolean traceSeen = false;
         StringBuilder allOutput = new StringBuilder();
         do {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -222,11 +223,11 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         String line = "embed-server --admin-only=false --server-config=standalone-cli.xml " + stdoutParam + JBOSS_HOME;
         cli.sendLine(line);
         if (expectServerLogging) {
-            checkLogging("WFLYSRV0025", TimeoutUtil.adjust(30000));
+            checkLogging("WFLYSRV0025", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
         } else {
             checkNoLogging("WFLYSRV0025");
         }
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
 
         // The app embedding the server should still be able to log
         checkClientSideLogging();
@@ -273,12 +274,12 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         assertState("reload-required", 0);
         // Low level
         cli.sendLine(":reload");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
         cli.sendLine("/subsystem=request-controller:add");
         assertState("reload-required", 0);
         // High level
         cli.sendLine("reload");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
     }
 
     /** Confirms that the low and high level shutdown commands are not available */
@@ -413,7 +414,7 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         assertState("reload-required", 0);
 
         cli.sendLine("reload --admin-only=false");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
 
         // We could use the CLI to do this, but since the code using MCC already exists, re-use it
         ModelControllerClient mcc = cli.getCommandContext().getModelControllerClient();
@@ -663,7 +664,7 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         cli.sendLine("/core-service=management/access=authorization:write-attribute(name=provider,value=rbac");
         assertState("reload-required", 0);
         cli.sendLine("reload --admin-only=true");
-        assertState("running", TimeoutUtil.adjust(30000));
+        assertState("running", (int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis());
     }
 
     @Test

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CommandTimeoutHandlerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CommandTimeoutHandlerTestCase.java
@@ -6,6 +6,7 @@ package org.jboss.as.test.manualmode.management.cli;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -455,7 +456,7 @@ public class CommandTimeoutHandlerTestCase {
                 TimeoutCommandContext tc = (TimeoutCommandContext) context;
                 tc.setLastHandlerTask(null);
                 try {
-                    long sleep = TimeoutUtil.adjust(1000);
+                    long sleep = TimeoutUtil.adjust(Duration.ofSeconds(1)).toMillis();
                     Thread.sleep(sleep);
                     holder.add(null);
                 } catch (InterruptedException ex) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ShutdownRestartTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ShutdownRestartTestCase.java
@@ -4,6 +4,8 @@
  */
 package org.jboss.as.test.manualmode.management.cli;
 
+import java.time.Duration;
+
 import jakarta.inject.Inject;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
@@ -42,6 +44,6 @@ public class ShutdownRestartTestCase {
             }
         };
 
-        serverController.handleServerRestart(restartTrigger, TimeoutUtil.adjust(10000), false);
+        serverController.handleServerRestart(restartTrigger, TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis(), false);
     }
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/yaml/YamlExtensionTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/yaml/YamlExtensionTestCase.java
@@ -28,6 +28,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
@@ -316,7 +317,7 @@ public class YamlExtensionTestCase {
     public void testSimpleYamlWithReload() throws Exception {
         container.startYamlExtension(new Path[]{testYaml});
         Assert.assertEquals("Yaml changes to configuration were persisted to xml. This should never happen as it's in read-only mode.", expectedXml, readConfigAsXml());
-        container.reload(TimeoutUtil.adjust(5000));
+        container.reload((int) TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis());
         compareXML(expectedXml, readConfigAsXml());
     }
 
@@ -332,7 +333,7 @@ public class YamlExtensionTestCase {
         }
         WildFlySecurityManager.setPropertyPrivileged("jvm.args", sb.toString());
         container.start(null, null, Server.StartMode.ADMIN_ONLY, System.out, false, null, null, null, null, new Path[]{testYaml});
-        container.waitForLiveServerToReload(TimeoutUtil.adjust(5000));
+        container.waitForLiveServerToReload((int) TimeoutUtil.adjust(Duration.ofSeconds(5)).toMillis());
         waitForRunningMode("NORMAL");
         String xml = readConfigAsXml();
         compareXML(expectedBootCLiXml, xml);
@@ -674,7 +675,7 @@ public class YamlExtensionTestCase {
     private void waitForRunningMode(String runningMode) throws Exception {
         // Following a reload to normal mode, we might read the running mode too early and hit the admin-only server
         // Cycle around a bit to make sure we get the server reloaded into normal mode
-        long end = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+        long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
         while (true) {
             try {
                 Thread.sleep(100);

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/secman/PermissionsDeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/secman/PermissionsDeploymentTestCase.java
@@ -28,6 +28,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 
 import jakarta.inject.Inject;
 import java.io.File;
+import java.time.Duration;
 
 /**
  * Tests the processing of {@code permissions.xml} in deployments
@@ -144,7 +145,7 @@ public class PermissionsDeploymentTestCase extends AbstractDeploymentScannerBase
 
     private void waitForDeploymentToFinish(final PathAddress deploymentPathAddr) throws Exception {
         // Wait until deployed ...
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(30000);
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis();
         while (!exists(modelControllerClient, deploymentPathAddr) && System.currentTimeMillis() < timeout) {
             Thread.sleep(100);
         }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnShutdownTestCase.java
@@ -15,6 +15,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUS
 import java.net.HttpURLConnection;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -114,21 +115,21 @@ public class SuspendOnShutdownTestCase {
             final Future<String> result = executorService.submit(new Callable<String>() {
                 @Override
                 public String call() throws Exception {
-                    return HttpRequest.get(address, TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+                    return HttpRequest.get(address, TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
                 }
             });
 
             appLocked = true;
 
             //Try to ensure that the HTTP request arrives
-            TimeUnit.SECONDS.sleep(TimeoutUtil.adjust(1));
+            TimeUnit.NANOSECONDS.sleep(TimeoutUtil.adjust(Duration.ofSeconds(1)).toNanos());
 
             shutdownResult = executorService.submit(new Callable<ModelNode>() {
                 @Override
                 public ModelNode call() throws Exception {
                     ModelNode op = new ModelNode();
                     op.get(OP).set(SHUTDOWN);
-                    op.get(SUSPEND_TIMEOUT).set(TimeoutUtil.adjust(30));
+                    op.get(SUSPEND_TIMEOUT).set((int) TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds());
                     return serverController.getClient().executeForResult(op);
                 }
             });
@@ -146,7 +147,7 @@ public class SuspendOnShutdownTestCase {
 
             HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", 10, TimeUnit.SECONDS);
             appLocked = false;
-            Assert.assertEquals(SuspendResumeHandler.TEXT, result.get(TimeoutUtil.adjust(10), TimeUnit.SECONDS));
+            Assert.assertEquals(SuspendResumeHandler.TEXT, result.get(TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS));
 
             //check if it is in SUSPENDED or ignore if the server was already stopped
             waitForSuspendState(SUSPENDED, true);
@@ -155,12 +156,12 @@ public class SuspendOnShutdownTestCase {
             executorService.shutdown();
 
             if (appLocked) {
-                HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+                HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
             }
 
             if (shutdownResult != null) {
                 try {
-                    shutdownResult.get(TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+                    shutdownResult.get(TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
                     serverController.stop(true);
                     serverController.start();
                 } catch (Exception e) {
@@ -178,12 +179,12 @@ public class SuspendOnShutdownTestCase {
         op.get(NAME).set(SUSPEND_STATE);
 
         String suspendState;
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
         try {
             do {
                 suspendState = serverController.getClient().executeForResult(op).asString();
                 if (!state.equals(suspendState)) {
-                    TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(50));
+                    TimeUnit.MILLISECONDS.sleep(TimeoutUtil.adjust(Duration.ofMillis(50)).toMillis());
                 } else {
                     break;
                 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
@@ -17,6 +17,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -117,7 +118,7 @@ public class SuspendOnSoftKillTestCase {
 
     private void startContainer(int suspendTimeout) throws Exception {
 
-        suspendTimeout = suspendTimeout < 1 ? suspendTimeout : TimeoutUtil.adjust(suspendTimeout);
+        suspendTimeout = suspendTimeout < 1 ? suspendTimeout : (int) TimeoutUtil.adjust(Duration.ofSeconds(suspendTimeout)).toSeconds();
 
         jbossArgs = System.getProperty("jboss.args");
         String newArgs = jbossArgs == null ? "" : jbossArgs;
@@ -166,7 +167,7 @@ public class SuspendOnSoftKillTestCase {
                 }
             });
 
-            Thread.sleep(TimeoutUtil.adjust(1000)); //nasty, but we need to make sure the HTTP request has started
+            Thread.sleep(TimeoutUtil.adjust(Duration.ofSeconds(1)).toMillis()); //nasty, but we need to make sure the HTTP request has started
 
             softKillServer();
 
@@ -175,7 +176,7 @@ public class SuspendOnSoftKillTestCase {
             op.get(NAME).set(SUSPEND_STATE);
 
             String suspendState;
-            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
             do {
                 suspendState = serverController.getClient().executeForResult(op).asString();
                 if (!"SUSPENDING".equals(suspendState)) {
@@ -208,14 +209,14 @@ public class SuspendOnSoftKillTestCase {
             }
 
             // Send a request that will trigger the first request to complete
-            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(30), TimeUnit.SECONDS);
+            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds(), TimeUnit.SECONDS);
             // Confirm 1st request completed
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
 
             // Check server behaves like a suspended, suspending or stopped server; which it will be is unknown.
             // If we are still in suspending state, wait a bit longer until get suspended or the server is down.
             try {
-                timeout = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+                timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
                 do {
                     suspendState = serverController.getClient().executeForResult(op).asString();
                     if ("SUSPENDING".equals(suspendState)) {
@@ -245,7 +246,7 @@ public class SuspendOnSoftKillTestCase {
         // Server should be suspended already with no in-flight requests, so it should stop quickly.
         // But we're willing to be patient and wait to be sure it stops even on a slow system.
         // The point is just to make sure it eventually stops, not to check how fast
-        final long time = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        final long time = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(20)).toMillis();
         List<RunningProcess> runningProcesses;
         do {
             runningProcesses = processUtil.getRunningProcesses();

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/ManagementInterfaceResourcesTestCase.java
@@ -5,13 +5,13 @@
 
 package org.wildfly.core.test.standalone.mgmt;
 
-import static org.jboss.as.test.shared.TimeoutUtil.adjust;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.time.Duration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 
 import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionRunnable;
@@ -64,7 +65,7 @@ public class ManagementInterfaceResourcesTestCase {
 
     /**
      * Test that the management interface will not accept new connections when the number of active connections reaches the
-     * high water mark.  After the number of open connections has been reduced to the low watermark it will test that connections
+     * high watermark.  After the number of open connections has been reduced to the low watermark it will test that connections
      * are accepted again.
      */
     @Test
@@ -131,7 +132,7 @@ public class ManagementInterfaceResourcesTestCase {
             // Notice that the exception received when we tried to open a new socket could have been a timeout (SocketTimeoutException)
             // or a connection refused (IOException). It depends on the OS and the network configuration.
             // So, we could also have had 5000ms for each bad socket that triggered a SocketTimeoutException.
-            Thread.sleep(adjust(12000));
+            Thread.sleep(TimeoutUtil.adjust(Duration.ofSeconds(12)).toMillis());
 
             Socket goodSocket = new Socket();
             // This needs to be longer than 500ms to give the server time to respond to the closed connections.

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -8,6 +8,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.time.Duration;
+
 import jakarta.inject.Inject;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -40,9 +42,9 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 public class PreparedResponseTestCase {
 
     public static Logger LOGGER = Logger.getLogger(PreparedResponseTestCase.class);
-    private static final long FREQUENCY = TimeoutUtil.adjust(50);
-    private static final long SHUTDOWN_WAITING_TIME = TimeoutUtil.adjust(3000);
-    private static final long RESTART_WAITING_TIME = TimeoutUtil.adjust(20000);
+    private static final Duration FREQUENCY = TimeoutUtil.adjust(Duration.ofMillis(50));
+    private static final Duration SHUTDOWN_WAITING_TIME = TimeoutUtil.adjust(Duration.ofSeconds(3));
+    private static final Duration RESTART_WAITING_TIME = TimeoutUtil.adjust(Duration.ofSeconds(20));
 
     @Inject
     protected static ServerController controller;
@@ -69,7 +71,7 @@ public class PreparedResponseTestCase {
     private void block(ManagementClient client) throws UnsuccessfulOperationException {
         ModelNode blockOp = Operations.createOperation("block", PathAddress.pathAddress(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME).toModelNode());
         blockOp.get("block-point").set("SERVICE_STOP");
-        blockOp.get("block-time").set(SHUTDOWN_WAITING_TIME);
+        blockOp.get("block-time").set(SHUTDOWN_WAITING_TIME.toMillis());
         client.executeForResult(blockOp);
     }
 
@@ -77,10 +79,10 @@ public class PreparedResponseTestCase {
     public void reloadServer() throws Exception {
         try (ManagementClient managementClient = getManagementClient()) {
             block(managementClient);
-            long timeout = SHUTDOWN_WAITING_TIME + System.currentTimeMillis();
+            long timeout = SHUTDOWN_WAITING_TIME.toMillis() + System.currentTimeMillis();
             ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), false);
             while (System.currentTimeMillis() < timeout) {
-                Thread.sleep(FREQUENCY);
+                Thread.sleep(FREQUENCY.toMillis());
                 try {
                     managementClient.isServerInRunningState();
                 } catch (RuntimeException ex) {
@@ -88,9 +90,9 @@ public class PreparedResponseTestCase {
                 }
             }
             Assert.assertFalse(System.currentTimeMillis() < timeout);
-            timeout = RESTART_WAITING_TIME + System.currentTimeMillis();
+            timeout = RESTART_WAITING_TIME.toMillis() + System.currentTimeMillis();
             while (System.currentTimeMillis() < timeout) {
-                Thread.sleep(FREQUENCY);
+                Thread.sleep(FREQUENCY.toMillis());
                 try {
                     managementClient.isServerInRunningState();
                 } catch (RuntimeException ex) {
@@ -104,10 +106,10 @@ public class PreparedResponseTestCase {
     public void shutdownServer() throws Exception {
         try (ManagementClient managementClient = getManagementClient()) {
             block(managementClient);
-            long timeout = SHUTDOWN_WAITING_TIME + System.currentTimeMillis();
+            long timeout = SHUTDOWN_WAITING_TIME.toMillis() + System.currentTimeMillis();
             managementClient.executeForResult(Operations.createOperation(SHUTDOWN, new ModelNode().setEmptyList()));
             while (System.currentTimeMillis() < timeout) {
-                Thread.sleep(FREQUENCY);
+                Thread.sleep(FREQUENCY.toMillis());
                 try {
                     controller.getClient().isServerInRunningState();
                 } catch (RuntimeException ex) {

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsInStaticModuleTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsInStaticModuleTestCase.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -205,7 +206,7 @@ public class JmxControlledStateNotificationsInStaticModuleTestCase {
     private void checkFacadeJmxNotifications(List<Pair<String, String>> configurationStateTransitions,
                                              List<Pair<String, String>> runningStateTransitions)
             throws IOException, InterruptedException {
-        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(20)).toMillis();
         while (true) {
             try {
                 readAndCheckFile(JMX_FACADE_RUNTIME, list -> {

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/JmxControlledStateNotificationsTestCase.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -158,7 +159,7 @@ public class JmxControlledStateNotificationsTestCase {
     private void checkFacadeJmxNotifications(List<Pair<String, String>> configurationStateTransitions,
                                              List<Pair<String, String>> runningStateTransitions)
             throws IOException, InterruptedException {
-        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(20)).toMillis();
         while (true) {
             try {
                 readAndCheckFile(JMX_FACADE_RUNTIME, list -> {

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/ProcessStateListenerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/events/ProcessStateListenerTestCase.java
@@ -17,6 +17,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -81,7 +82,7 @@ public class ProcessStateListenerTestCase extends AbstractLoggingTestCase {
         // setup listener in server
         try {
             controller.startInAdminMode();
-            addListener(LISTENER_ADDRESS, TestListener.class.getPackage().getName(), null, TimeoutUtil.adjust(5));
+            addListener(LISTENER_ADDRESS, TestListener.class.getPackage().getName(), null, (int) TimeoutUtil.adjust(Duration.ofSeconds(5)).toSeconds());
         } finally {
             controller.stop();
         }
@@ -152,7 +153,7 @@ public class ProcessStateListenerTestCase extends AbstractLoggingTestCase {
 
             // try to add new listener with non-existing module
             try {
-                addListener(WRONG_MODULE_LISTENER_ADDRESS, "non.existing.module", null, TimeoutUtil.adjust(5));
+                addListener(WRONG_MODULE_LISTENER_ADDRESS, "non.existing.module", null, (int) TimeoutUtil.adjust(Duration.ofSeconds(5)).toSeconds());
                 fail("Command should fail");
             } catch (UnsuccessfulOperationException uoe) {
                 // expected

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerConfigurator.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerConfigurator.java
@@ -122,7 +122,7 @@ public class ServerConfigurator {
                 ServerHelper.shutdownStandalone(client);
             }
 
-            if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+            if (!process.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
                 Assert.fail(readStdout(stdout));
             }
 
@@ -206,7 +206,7 @@ public class ServerConfigurator {
                 ServerHelper.waitForManagedServer(client, "server-three", () -> readStdout(stdout));
                 ServerHelper.shutdownDomain(client);
             }
-            if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+            if (!process.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
                 Assert.fail(readStdout(stdout));
             }
 

--- a/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerHelper.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/common/test/ServerHelper.java
@@ -15,6 +15,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +47,7 @@ import org.junit.Assert;
  */
 public class ServerHelper {
     public static final ModelNode EMPTY_ADDRESS = new ModelNode().setEmptyList();
-    public static final int TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(System.getProperty("jboss.test.start.timeout", "15")));
+    public static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(Integer.parseInt(System.getProperty("jboss.test.start.timeout", "15"))));
     public static final Path JBOSS_HOME;
     public static final String[] DEFAULT_SERVER_JAVA_OPTS = {
             "-Djboss.management.http.port=" + TestSuiteEnvironment.getServerPort(),
@@ -297,7 +298,7 @@ public class ServerHelper {
     }
 
     private static void waitForStart(final Process process, final Supplier<String> failureDescription, final BooleanSupplier check) throws InterruptedException {
-        long timeout = ServerHelper.TIMEOUT * 1000;
+        long timeout = ServerHelper.TIMEOUT.toMillis();
         final long sleep = 100L;
         while (timeout > 0) {
             long before = System.currentTimeMillis();
@@ -314,7 +315,7 @@ public class ServerHelper {
             if (process != null) {
                 process.destroy();
             }
-            Assert.fail(String.format("The server did not start within %s seconds: %s", ServerHelper.TIMEOUT, failureDescription.get()));
+            Assert.fail(String.format("The server did not start within %s seconds: %s", ServerHelper.TIMEOUT.toSeconds(), failureDescription.get()));
         }
     }
 }

--- a/testsuite/scripts/src/test/java/org/wildfly/launcher/test/LauncherTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/launcher/test/LauncherTestCase.java
@@ -76,7 +76,7 @@ public class LauncherTestCase {
             try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
                 ServerHelper.shutdownStandalone(client);
             }
-            process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS);
+            process.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             if (process.exitValue() != 0) {
                 Assert.fail(readStdout());
             }
@@ -126,7 +126,7 @@ public class LauncherTestCase {
 
                 ServerHelper.shutdownDomain(client);
             }
-            process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS);
+            process.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             if (process.exitValue() != 0) {
                 Assert.fail(readStdout());
             }

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -114,14 +114,14 @@ public abstract class ScriptTestCase {
     }
 
     void validateProcess(final ScriptProcess script) throws InterruptedException {
-        if (script.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+        if (script.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
             // The script has exited, validate the exit code is valid
             final int exitValue = script.exitValue();
             if (exitValue != 0) {
                 Assert.fail(script.getErrorMessage(String.format("Expected an exit value 0f 0 got %d", exitValue)));
             }
         } else {
-            Assert.fail(script.getErrorMessage("The script process did not exit within " + ServerHelper.TIMEOUT + " seconds."));
+            Assert.fail(script.getErrorMessage("The script process did not exit within " + ServerHelper.TIMEOUT.toSeconds() + " seconds."));
         }
     }
 
@@ -135,7 +135,7 @@ public abstract class ScriptTestCase {
 
     private void executeTests(final Shell shell) throws InterruptedException, IOException, TimeoutException {
         for (Path path : ServerConfigurator.PATHS) {
-            try (ScriptProcess script = new ScriptProcess(path, scriptBaseName, shell, ServerHelper.TIMEOUT)) {
+            try (ScriptProcess script = new ScriptProcess(path, scriptBaseName, shell, ServerHelper.TIMEOUT.toSeconds())) {
                 testScript(script);
                 script.close();
                 testCommonConf(script, shell);
@@ -177,7 +177,7 @@ public abstract class ScriptTestCase {
         }
         try {
             script.start(env);
-            if (!script.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+            if (!script.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
                 Assert.fail(script.getErrorMessage("Failed to exit script from " + confFile));
             }
             // Batch scripts print the quotes around the text

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Shell.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Shell.java
@@ -75,7 +75,7 @@ public enum Shell {
             Process process = null;
             try {
                 process = builder.start();
-                if (!process.waitFor(ServerHelper.TIMEOUT, TimeUnit.SECONDS)) {
+                if (!process.waitFor(ServerHelper.TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
                     return false;
                 }
                 return process.exitValue() == 0;

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -70,7 +70,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         Assume.assumeTrue(TestSuiteEnvironment.isWindows());
         final String variableToEscape = "-Dhttp.nonProxyHosts=localhost|127.0.0.1|10.10.10.*";
         ServerConfigurator.appendJavaOpts(ServerHelper.JBOSS_HOME, "standalone", variableToEscape);
-        try (ScriptProcess script = new ScriptProcess(ServerHelper.JBOSS_HOME, STANDALONE_BASE_NAME, Shell.BATCH, ServerHelper.TIMEOUT)) {
+        try (ScriptProcess script = new ScriptProcess(ServerHelper.JBOSS_HOME, STANDALONE_BASE_NAME, Shell.BATCH, ServerHelper.TIMEOUT.toSeconds())) {
             testScript(script);
         }
         ServerConfigurator.removeJavaOpts(ServerHelper.JBOSS_HOME, "standalone", variableToEscape);
@@ -81,7 +81,7 @@ public class StandaloneScriptTestCase extends ScriptTestCase {
         Assume.assumeTrue(TestSuiteEnvironment.isWindows());
         final String escapedVariable = "-Dhttp.nonProxyHosts=localhost^|127.0.0.1^|10.10.10.*";
         ServerConfigurator.appendJavaOpts(ServerHelper.JBOSS_HOME, STANDALONE_BASE_NAME, escapedVariable);
-        try (ScriptProcess script = new ScriptProcess(ServerHelper.JBOSS_HOME, STANDALONE_BASE_NAME, Shell.BATCH, ServerHelper.TIMEOUT)) {
+        try (ScriptProcess script = new ScriptProcess(ServerHelper.JBOSS_HOME, STANDALONE_BASE_NAME, Shell.BATCH, ServerHelper.TIMEOUT.toSeconds())) {
             testScript(script);
         }
         ServerConfigurator.removeJavaOpts(ServerHelper.JBOSS_HOME, STANDALONE_BASE_NAME, escapedVariable);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestUtils.java
@@ -24,6 +24,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -43,8 +44,8 @@ import org.junit.Assert;
  */
 public class DomainTestUtils {
 
-    private static final int DEFAULT_TIMEOUT = TimeoutUtil.adjust(60);
-    private static final int SLEEP_TIME_MILLIS = TimeoutUtil.adjust(100);
+    private static final Duration DEFAULT_TIMEOUT = TimeoutUtil.adjust(Duration.ofMinutes(1));
+    private static final Duration SLEEP_TIME = TimeoutUtil.adjust(Duration.ofMillis(100));
 
     private DomainTestUtils() {
         //
@@ -231,7 +232,7 @@ public class DomainTestUtils {
      * @throws IOException if an I/O error occurs while executing the operation
      */
     public static void waitUntilState(final ModelControllerClient client, final PathAddress serverAddress, final String state) throws IOException {
-        waitUntilState(client, serverAddress, state, DEFAULT_TIMEOUT, TimeUnit.SECONDS, "status");
+        waitUntilState(client, serverAddress, state, DEFAULT_TIMEOUT.toSeconds(), TimeUnit.SECONDS, "status");
     }
 
     /**
@@ -242,7 +243,7 @@ public class DomainTestUtils {
      * @param state         the required state
      * @throws IOException if an I/O error occurs while executing the operation
      */
-    public static void waitUntilState(final ModelControllerClient client, final PathAddress serverAddress, final String state, int timeout, TimeUnit timeoutUnit) throws IOException {
+    public static void waitUntilState(final ModelControllerClient client, final PathAddress serverAddress, final String state, long timeout, TimeUnit timeoutUnit) throws IOException {
         waitUntilState(client, serverAddress, state, timeout, timeoutUnit, "status");
     }
 
@@ -255,7 +256,7 @@ public class DomainTestUtils {
      * @throws IOException if an I/O error occurs while executing the operation
      */
     public static void waitUntilSuspendState(final ModelControllerClient client, final PathAddress serverAddress, final String state) throws IOException {
-        waitUntilState(client, serverAddress, state, DEFAULT_TIMEOUT, TimeUnit.SECONDS, "suspend-state");
+        waitUntilState(client, serverAddress, state, DEFAULT_TIMEOUT.toSeconds(), TimeUnit.SECONDS, "suspend-state");
     }
 
     /**
@@ -366,7 +367,7 @@ public class DomainTestUtils {
                 return;
             }
             try {
-                TimeUnit.MILLISECONDS.sleep(SLEEP_TIME_MILLIS);
+                TimeUnit.MILLISECONDS.sleep(SLEEP_TIME.toMillis());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 break;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/WildFlyManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/WildFlyManagedConfiguration.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
 import javax.security.auth.callback.CallbackHandler;
 
 import org.jboss.as.test.shared.TimeoutUtil;
@@ -57,7 +58,7 @@ public class WildFlyManagedConfiguration {
 
     private String javaVmArguments = System.getProperty("server.jvm.args", "-Xmx512m");
 
-    private int startupTimeoutInSeconds = TimeoutUtil.adjust(120);
+    private int startupTimeoutInSeconds = (int) TimeoutUtil.adjust(Duration.ofMinutes(2)).toSeconds();
 
     private boolean outputToConsole = true;
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessWrapper.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import static org.junit.Assert.fail;
 
@@ -194,10 +195,10 @@ public class CliProcessWrapper extends CliProcessBuilder {
         }
     }
 
-    private int resultTimeout = TimeoutUtil.adjust(20000);
+    private Duration resultTimeout = TimeoutUtil.adjust(Duration.ofSeconds(20));
     private int resultInterval = 100;
 
-    public void setResultTimeout(int resultTimeout) {
+    public void setResultTimeout(Duration resultTimeout) {
         this.resultTimeout = resultTimeout;
     }
 
@@ -217,7 +218,7 @@ public class CliProcessWrapper extends CliProcessBuilder {
             waitingTime += resultInterval;
 
             // If the timeout is reached, return regardless.
-            if (waitingTime > resultTimeout) {
+            if (waitingTime > resultTimeout.toMillis()) {
                 wait = false;
             }
 
@@ -259,7 +260,7 @@ public class CliProcessWrapper extends CliProcessBuilder {
             }
 
             // If the timeout is reached, destroy the process and return false
-            if (waitingTime > resultTimeout) {
+            if (waitingTime > resultTimeout.toMillis()) {
                 cliProcess.destroyForcibly();
                 wait = false;
             }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,7 +53,7 @@ public class CustomCLIExecutor {
 
     private static Logger LOGGER = Logger.getLogger(CustomCLIExecutor.class);
 
-    private static final int CLI_PROC_TIMEOUT = TimeoutUtil.adjust(30000);
+    private static final Duration CLI_PROC_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(30));
 
     public static String execute(File cliConfigFile, String operation) {
 
@@ -104,7 +105,7 @@ public class CustomCLIExecutor {
             cliConfigPath = Paths.get(jbossDist, "bin", "jboss-cli.xml");
         }
         commandBuilder.addJavaOption("-Djboss.cli.config=" + cliConfigPath);
-        commandBuilder.addCliArgument("--timeout="+CLI_PROC_TIMEOUT);
+        commandBuilder.addCliArgument("--timeout="+CLI_PROC_TIMEOUT.toMillis());
         commandBuilder.addCliArgument("--error-on-interact"); // if server prompt for certificate to accept
         commandBuilder.addCliArgument("--no-color-output");
 
@@ -227,7 +228,7 @@ public class CustomCLIExecutor {
         CustomCLIExecutor.ConsoleConsumer.start(cliProc.getErrorStream(), err);
         int exitCode = Integer.MIN_VALUE;
         try {
-            boolean finished = cliProc.waitFor(CLI_PROC_TIMEOUT, TimeUnit.MILLISECONDS);
+            boolean finished = cliProc.waitFor(CLI_PROC_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             if (finished) {
                 exitCode = cliProc.exitValue();
             } else {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/layers/LayersTest.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/layers/LayersTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -348,7 +349,7 @@ public class LayersTest {
             }
         };
         try {
-            executor.submit(r).get(TimeoutUtil.adjust(1), TimeUnit.MINUTES);
+            executor.submit(r).get(TimeoutUtil.adjust(Duration.ofMinutes(1)).toNanos(), TimeUnit.NANOSECONDS);
         } catch (Exception ex) {
             throw new Exception("Exception checking " + installation.getFileName().toString()
                     + "\n Server log \n" + str, ex);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -31,8 +32,8 @@ import org.junit.Assert;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
  */
 public class ModelParserUtils {
-    // Timeout for the embedded Server / Host Controller to fully start, in seconds.
-    private static final long EMBEDDED_FULLY_STARTED_TIMEOUT = TimeoutUtil.adjust(5*60);
+    // Timeout for the embedded Server / Host Controller to fully start.
+    private static final Duration EMBEDDED_FULLY_STARTED_TIMEOUT = TimeoutUtil.adjust(Duration.ofMinutes(5));
 
     /**
      * Tests the ability to boot an admin-only server using the given config, persist the config,
@@ -53,14 +54,14 @@ public class ModelParserUtils {
         CLIWrapper cli = new CLIWrapper(false);
         try {
 
-            String line = "embed-server --admin-only=true --server-config=" + originalConfig.getName() + " --std-out=echo --jboss-home=" + jbossHome.getCanonicalPath() + " --timeout=" + EMBEDDED_FULLY_STARTED_TIMEOUT;
+            String line = "embed-server --admin-only=true --server-config=" + originalConfig.getName() + " --std-out=echo --jboss-home=" + jbossHome.getCanonicalPath() + " --timeout=" + EMBEDDED_FULLY_STARTED_TIMEOUT.toSeconds();
             cli.sendLine(line);
-            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(30000), false);
+            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), false);
             ModelNode firstResult = readResourceTree(cli);
             cli.sendLine("/system-property=model-parser-util:add(value=true)");
             cli.sendLine("/system-property=model-parser-util:remove");
             cli.sendLine("reload --admin-only=true");
-            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(30000), false);
+            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), false);
             ModelNode secondResult = readResourceTree(cli);
             compare(firstResult, secondResult);
             return secondResult;
@@ -97,15 +98,15 @@ public class ModelParserUtils {
         CLIWrapper cli = new CLIWrapper(false);
         try {
             String configType = hostXml ? "--host-config=" : "--domain-config=";
-            String line = "embed-host-controller " + configType + originalConfig.getName() + " --std-out=echo --jboss-home=" + target.getCanonicalPath()  + " --timeout=" + EMBEDDED_FULLY_STARTED_TIMEOUT;
+            String line = "embed-host-controller " + configType + originalConfig.getName() + " --std-out=echo --jboss-home=" + target.getCanonicalPath()  + " --timeout=" + EMBEDDED_FULLY_STARTED_TIMEOUT.toSeconds();
             cli.sendLine(line);
-            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(30000), true);
+            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), true);
             ModelNode firstResult = readResourceTree(cli);
             String hostName = firstResult.get(HOST).asProperty().getName();
             cli.sendLine("/system-property=model-parser-util:add(value=true)");
             cli.sendLine("/system-property=model-parser-util:remove");
             cli.sendLine("reload --host=" + hostName + " --admin-only=true");
-            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(30000), true);
+            assertProcessState(cli, ControlledProcessState.State.RUNNING.toString(), TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), true);
             ModelNode secondResult = readResourceTree(cli);
             compare(pruneDomainModel(firstResult, hostXml), pruneDomainModel(secondResult, hostXml));
             return secondResult;
@@ -148,7 +149,7 @@ public class ModelParserUtils {
         return hostControllerTest(originalConfig, jbossHome, false);
     }
 
-    private static void assertProcessState(CLIWrapper cli, String expected, int timeout, boolean forHost) throws InterruptedException {
+    private static void assertProcessState(CLIWrapper cli, String expected, long timeout, boolean forHost) throws InterruptedException {
         long done = timeout < 1 ? 0 : System.currentTimeMillis() + timeout;
         StringBuilder historyBuf = new StringBuilder();
         String state = null;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TimeoutUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TimeoutUtil.java
@@ -6,12 +6,12 @@ package org.jboss.as.test.shared;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Adjusts default timeouts according to the system property.
- *
  * All tests influenced by machine slowness should employ this util.
  *
  * @author Ondrej Zizka
@@ -21,7 +21,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 public class TimeoutUtil {
 
     public static final String FACTOR_SYS_PROP = "ts.timeout.factor";
-    private static int factor;
+    private static final int factor;
 
     static {
         factor = WildFlySecurityManager.isChecking() ? AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger(FACTOR_SYS_PROP, 100)) : Integer.getInteger(FACTOR_SYS_PROP, 100);
@@ -31,7 +31,9 @@ public class TimeoutUtil {
      * Adjusts timeout for operations.
      *
      * @return given timeout adjusted by ratio from system property "ts.timeout.factor"
+     * @deprecated Use {@link #adjust(Duration)} for more granular adjustment; simple integer-based adjustment loses precision.
      */
+    @Deprecated(forRemoval = true)
     public static int adjust(int amount) {
        if(amount<0){
           throw new IllegalArgumentException("amount must be non-negative");
@@ -51,12 +53,26 @@ public class TimeoutUtil {
     }
 
     /**
+     * Adjusts timeout for operations using {@link Duration} for more granular adjustment.
+     *
+     * @param duration the base duration to adjust
+     * @return given duration adjusted by ratio from system property "ts.timeout.factor"
+     */
+    public static Duration adjust(Duration duration) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("duration must be non-negative");
+        }
+        long adjustedNanos = (long) (duration.toNanos() * getFactor());
+        return Duration.ofNanos(adjustedNanos);
+    }
+
+    /**
      * Get timeout factor to multiply by.
      *
      * @return double factor value
      */
     public static double getFactor() {
-        return (double)factor / 100;
+        return (double) factor / 100;
     }
 
     /**

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/AuditLogToSyslogTestCase.java
@@ -11,6 +11,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -38,7 +39,7 @@ import org.wildfly.core.testrunner.ManagementClient;
  */
 public abstract class AuditLogToSyslogTestCase {
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
     @Inject
     protected ManagementClient managementClient;
@@ -66,70 +67,70 @@ public abstract class AuditLogToSyslogTestCase {
 
         SyslogServerEventIF syslogEvent = null;
         makeOneLog();
-        syslogEvent = queue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        syslogEvent = queue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("No message was expected in the syslog, because syslog is disabled", syslogEvent);
 
         try {
             setAuditlogEnabled(true);
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Enabling audit log wasn't logged into the syslog", syslogEvent);
             Assert.assertEquals(1, syslogEvent.getFacility());
             assertAppName(AuditLogToSyslogSetup.DEFAULT_APPNAME, syslogEvent);
 
             makeOneLog();
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Auditable event was't logged into the syslog (adding system property)", syslogEvent);
             Assert.assertEquals(1, syslogEvent.getFacility());
             assertAppName(AuditLogToSyslogSetup.DEFAULT_APPNAME, syslogEvent);
 
             // disable audit log - auditable event
             setAuditlogEnabled(false);
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Disabling audit log wasn't logged into the syslog", syslogEvent);
             Assert.assertEquals(1, syslogEvent.getFacility());
             assertAppName(AuditLogToSyslogSetup.DEFAULT_APPNAME, syslogEvent);
 
             //remove handler
             CoreUtils.applyUpdate(Util.createRemoveOperation(AuditLogToSyslogSetup.AUDIT_LOG_LOGGER_SYSLOG_HANDLER_ADDR), managementClient.getControllerClient());
-            syslogEvent = queue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNull("No message was expected in the syslog, because syslog is disabled", syslogEvent);
 
             //add other handler which has another appname and facility = LINE_PRINTER (6)
             CoreUtils.applyUpdate(Util.createAddOperation(AuditLogToSyslogSetup.AUDIT_LOG_LOGGER_SYSLOG_HANDLER_ADDR2), managementClient.getControllerClient());
-            syslogEvent = queue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNull("No message was expected in the syslog, because syslog is disabled", syslogEvent);
 
             // enable audit log again
             setAuditlogEnabled(true);
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Enabling audit log wasn't logged into the syslog", syslogEvent);
             Assert.assertEquals(6, syslogEvent.getFacility());
             assertAppName("TestApp", syslogEvent);
 
             //Change other handler app name
             CoreUtils.applyUpdate(Util.getWriteAttributeOperation(AuditLogToSyslogSetup.AUDIT_SYSLOG_HANDLER_ADDR2, APP_NAME, new ModelNode("Stuff")), managementClient.getControllerClient());
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Auditable event was't logged into the syslog (setting new app-name in audit-log)", syslogEvent);
             Assert.assertEquals(6, syslogEvent.getFacility());
             assertAppName("Stuff", syslogEvent);
 
             //Reset other handler app name
             CoreUtils.applyUpdate(Util.getWriteAttributeOperation(AuditLogToSyslogSetup.AUDIT_SYSLOG_HANDLER_ADDR2, APP_NAME, new ModelNode()), managementClient.getControllerClient());
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Auditable event was't logged into the syslog (setting new app-name in audit-log)", syslogEvent);
             Assert.assertEquals(6, syslogEvent.getFacility());
             assertAppName(AuditLogToSyslogSetup.DEFAULT_APPNAME, syslogEvent);
 
             //Change other handler facility = LOCAL_USE_0 (16)
             CoreUtils.applyUpdate(Util.getWriteAttributeOperation(AuditLogToSyslogSetup.AUDIT_SYSLOG_HANDLER_ADDR2, FACILITY, new ModelNode("LOCAL_USE_0")), managementClient.getControllerClient());
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Auditable event was't logged into the syslog (setting new facility in audit-log)", syslogEvent);
             Assert.assertEquals(16, syslogEvent.getFacility());
             assertAppName(AuditLogToSyslogSetup.DEFAULT_APPNAME, syslogEvent);
 
             //Reset other handler facility
             CoreUtils.applyUpdate(Util.getWriteAttributeOperation(AuditLogToSyslogSetup.AUDIT_SYSLOG_HANDLER_ADDR2, FACILITY, new ModelNode()), managementClient.getControllerClient());
-            syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("Auditable event was't logged into the syslog (setting new facility in audit-log)", syslogEvent);
             Assert.assertEquals(1, syslogEvent.getFacility());
             assertAppName(AuditLogToSyslogSetup.DEFAULT_APPNAME, syslogEvent);
@@ -137,10 +138,10 @@ public abstract class AuditLogToSyslogTestCase {
         } finally {
             setAuditlogEnabled(false);
         }
-        syslogEvent = queue.poll(5 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        syslogEvent = queue.poll(ADJUSTED_SECOND.multipliedBy(5).toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNotNull("Disabling audit log wasn't logged into the syslog", syslogEvent);
         makeOneLog();
-        syslogEvent = queue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        syslogEvent = queue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertNull("No message was expected in the syslog, because syslog is disabled", syslogEvent);
 
         for (Long property : properties) {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/TLSAuditLogToTCPSyslogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/TLSAuditLogToTCPSyslogTestCase.java
@@ -9,6 +9,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TLS;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -44,7 +45,7 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @ServerSetup(TLSAuditLogToTCPSyslogTestCase.AuditLogToTCPSyslogTestCaseSetup.class)
 public class TLSAuditLogToTCPSyslogTestCase {
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
     @Inject
     private ManagementClient managementClient;
@@ -62,7 +63,7 @@ public class TLSAuditLogToTCPSyslogTestCase {
         try {
             setAuditlogEnabled(true);
             // enabling audit-log is auditable event
-            syslogEvent = queue.poll(1 * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+            syslogEvent = queue.poll(ADJUSTED_SECOND.toMillis(), TimeUnit.MILLISECONDS);
             // but we don't expect a message in TCP syslog server
             Assert.assertNull("No message was expected in the syslog, because TCP syslog server is used", syslogEvent);
         } finally {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/JmxControlledStateNotificationsTestCase.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -100,7 +101,7 @@ public class JmxControlledStateNotificationsTestCase {
     private void checkFacadeJmxNotifications(List<Pair<String, String>> configurationStateTransitions,
                                              List<Pair<String, String>> runningStateTransitions)
             throws IOException, InterruptedException {
-        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        final long end = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(20)).toMillis();
         while (true) {
             try {
                 readAndCheckFile(JMX_FACADE_RUNTIME, list -> {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/JsonLogServer.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/JsonLogServer.java
@@ -18,6 +18,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.security.KeyStore;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -163,7 +164,7 @@ public abstract class JsonLogServer implements Runnable, AutoCloseable {
             stop();
         } finally {
             service.shutdown();
-            service.awaitTermination(TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+            service.awaitTermination(TimeoutUtil.adjust(Duration.ofSeconds(10)).toSeconds(), TimeUnit.SECONDS);
         }
     }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/SocketHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/SocketHandlerTestCase.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.time.Duration;
 import jakarta.json.JsonObject;
 import javax.security.auth.x500.X500Principal;
 
@@ -67,7 +68,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
     private static final String HOSTNAME = TestSuiteEnvironment.getServerAddress();
     private static final int PORT = 10514;
     private static final int ALT_PORT = 11514;
-    private static final int DFT_TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(System.getProperty("org.jboss.as.logging.timeout", "3")) * 1000);
+    private static final Duration DFT_TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(Integer.parseInt(System.getProperty("org.jboss.as.logging.timeout", "3"))));
     private static final String SOCKET_BINDING_NAME = "log-server";
     private static final String FORMATTER_NAME = "json";
     private static final ModelNode LOGGER_ADDRESS = SUBSYSTEM_ADDRESS.append("logger", LoggingServiceActivator.LOGGER.getName()).toModelNode();
@@ -123,7 +124,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
     public void testTcpSocket() throws Exception {
         // Create a TCP server and start it
         try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
 
             // Add the socket handler and test all levels
             final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", null, null);
@@ -139,7 +140,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
     public void testAsyncTcpSocket() throws Exception {
         // Create a TCP server and start it
         try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
 
             // Add the socket handler and test all levels
             final ModelNode socketHandlerAddress = addSocketHandler("test-async-log-server", null, null, null, true);
@@ -157,7 +158,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
         final Path serverCertFile = createTemporaryKeyStoreFile(serverKeyStore, "server-cert-store.jks");
         // Create a TCP server and start it
         try (JsonLogServer server = JsonLogServer.createTlsServer(PORT, serverCertFile, TEST_PASSWORD)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
 
             // Add the socket handler and test all levels
             final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", null, "SSL_TCP", clientTrustFile);
@@ -173,7 +174,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
     public void testUdpSocket() throws Exception {
         // Create a UDP server and start it
         try (JsonLogServer server = JsonLogServer.createUdpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
             final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", null, "UDP");
             checkLevelsLogged(server, EnumSet.allOf(Logger.Level.class), "Test UPD all levels.");
 
@@ -187,7 +188,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
     public void testLevelChange() throws Exception {
         // Create a TCP server and start it
         try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
 
             // Add the socket handler and test all levels
             final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", "WARN", null);
@@ -203,7 +204,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
     public void testWithFilter() throws Exception {
         // Create a TCP server and start it
         try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
 
             final ModelNode address = addSocketHandler("test-log-server", "INFO", "TCP");
             executeOperation(Operations.createWriteAttributeOperation(address, "filter-spec", "substituteAll(\"\\\\s\", \"_\")"));
@@ -224,7 +225,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
         final ModelNode address = addSocketHandler("test-log-server", "INFO", "TCP");
         // Create a TCP server and start it
         try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
             // We should end up with a single log INFO log message
             final JsonObject foundMessage = executeRequest("Test TCP message",
                     Collections.singletonMap(LoggingServiceActivator.LOG_LEVELS_KEY, "INFO"), server);
@@ -234,7 +235,7 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
 
         // Create a new UDP server
         try (JsonLogServer server = JsonLogServer.createUdpServer(PORT)) {
-            server.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
 
             // Change the protocol and ensure we can connect
             executeOperation(Operations.createWriteAttributeOperation(address, "protocol", "UDP"));
@@ -260,8 +261,8 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
         try (JsonLogServer server = JsonLogServer.createTcpServer(PORT);
              JsonLogServer altServer = JsonLogServer.createTcpServer(ALT_PORT)
         ) {
-            server.start(DFT_TIMEOUT);
-            altServer.start(DFT_TIMEOUT);
+            server.start(DFT_TIMEOUT.toMillis());
+            altServer.start(DFT_TIMEOUT.toMillis());
             final ModelNode altAddress = addSocketHandler("test-log-server-alt", null, null);
 
             // Log a single message to the current log server and validate
@@ -285,9 +286,9 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
         executeRequest(msg, Collections.singletonMap("includeLevel", "true"));
         final List<JsonObject> foundMessages = new ArrayList<>();
         for (int i = 0; i < expectedLevels.size(); i++) {
-            final JsonObject foundMessage = server.getLogMessage(DFT_TIMEOUT);
+            final JsonObject foundMessage = server.getLogMessage(DFT_TIMEOUT.toMillis());
             if (foundMessage == null) {
-                final String failureMessage = "A log messages was not received within " + DFT_TIMEOUT + " milliseconds." +
+                final String failureMessage = "A log messages was not received within " + DFT_TIMEOUT.toMillis() + " milliseconds." +
                         System.lineSeparator() +
                         "Found the following messages: " + foundMessages +
                         System.lineSeparator() +
@@ -407,9 +408,9 @@ public class SocketHandlerTestCase extends AbstractLoggingTestCase {
         executeRequest(msg, params);
         final List<JsonObject> messages = new ArrayList<>(expectedMessages);
         for (int i = 0; i < expectedMessages; i++) {
-            final JsonObject foundMessage = server.getLogMessage(DFT_TIMEOUT);
+            final JsonObject foundMessage = server.getLogMessage(DFT_TIMEOUT.toMillis());
             if (foundMessage == null) {
-                final String failureMessage = "A log messages was not received within " + DFT_TIMEOUT + " milliseconds." +
+                final String failureMessage = "A log messages was not received within " + DFT_TIMEOUT.toMillis() + " milliseconds." +
                         System.lineSeparator() +
                         "Found the following messages: " + messages;
                 Assert.fail(failureMessage);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -14,6 +14,7 @@ import static org.productivity.java.syslog4j.SyslogConstants.UDP;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -77,7 +78,7 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
      */
     private static final int PORT = 10514;
 
-    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+    private static final Duration ADJUSTED_SECOND = TimeoutUtil.adjust(Duration.ofSeconds(1));
 
     @BeforeClass
     public static void deploy() throws Exception {
@@ -147,7 +148,7 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
      * @throws Exception
      */
     private void testLog(final BlockingQueue<SyslogServerEventIF> queue, final Level expectedLevel) throws Exception {
-        SyslogServerEventIF log = queue.poll(15L * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        SyslogServerEventIF log = queue.poll(ADJUSTED_SECOND.multipliedBy(15).toMillis(), TimeUnit.MILLISECONDS);
         assertNotNull(log);
         String msg = log.getMessage();
         assertEquals("Message with unexpected Syslog event level received: " + msg, getSyslogLevel(expectedLevel), log.getLevel());
@@ -163,7 +164,7 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
      * @throws Exception
      */
     private void testJsonLog(final BlockingQueue<SyslogServerEventIF> queue, final Level expectedLevel) throws Exception {
-        final SyslogServerEventIF log = queue.poll(15L * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        final SyslogServerEventIF log = queue.poll(ADJUSTED_SECOND.multipliedBy(15).toMillis(), TimeUnit.MILLISECONDS);
         assertNotNull(log);
         final String msg = log.getMessage();
         assertNotNull(msg);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -65,7 +66,7 @@ public class JBossCliXmlConfigTestCase {
                     .launch();
             // Must flush otherwise process doesn't exit.
             flushInStream(cliProc.getInputStream());
-            cliProc.waitFor(TimeoutUtil.adjust(10000), TimeUnit.MILLISECONDS);
+            cliProc.waitFor(TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException | IOException e) {
             fail("Failed to start CLI process: " + e.getLocalizedMessage());
         }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/LongOutputTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/LongOutputTestCase.java
@@ -35,6 +35,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -399,7 +400,7 @@ public class LongOutputTestCase {
     private void testDisabledOutputPaging() throws Exception {
         consoleWriter.println("/subsystem=elytron:read-resource-description(recursive=true)");
         Assert.assertFalse(consoleWriter.checkError());
-        String window = queue.poll(TimeoutUtil.adjust(20), TimeUnit.SECONDS);
+        String window = queue.poll(TimeoutUtil.adjust(Duration.ofSeconds(20)).toSeconds(), TimeUnit.SECONDS);
 
         Assert.assertNotNull(window);
         checkWithRegex(window, promptPattern);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,7 @@ public class HttpGetMgmtOpsTestCase {
     private static final int MGMT_PORT = 9990;
     private static final String MGMT_CTX = "/management";
     private static Map<String, String> properties = new HashMap<>();
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
 
     @Inject
     protected ManagementClient managementClient;
@@ -194,7 +195,7 @@ public class HttpGetMgmtOpsTestCase {
     private void awaitDeploymentExecution(Future<?> future) {
         Object t = null;
         try {
-            t = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            t = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/deployment/InterdependentDeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/deployment/InterdependentDeploymentTestCase.java
@@ -7,6 +7,7 @@ package org.wildfly.core.test.standalone.deployment;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -116,7 +117,7 @@ public class InterdependentDeploymentTestCase {
 
             // USE A SYSTEM PROPERTY TO EXECUTE full-replace-deployment repeatedly
             int loops = Integer.parseInt(System.getProperty("InterdependentDeploymentTestCase.count", "100"));
-            int blockingTime = TimeoutUtil.adjust(30); // set this to fail faster if it fails
+            long blockingTime = TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds(); // set this to fail faster if it fails
             for (int i = 0; i < loops; i++) {
 
                 try {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentOverlayTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentOverlayTestCase.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -60,8 +61,8 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @RunWith(WildFlyRunner.class)
 public class DeploymentOverlayTestCase {
 
-    // Max time to wait for some action to complete, in ms
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    // Max time to wait for some action to complete
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
     private static final PathAddress OVERLAY_ADDR = PathAddress.pathAddress(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, "overlay");
     private static final ModelNode OVERLAY_CONTENT_ADDR = OVERLAY_ADDR.append(CONTENT, ServiceActivatorDeployment.PROPERTIES_RESOURCE).toModelNode();
     private static final ModelNode OVERLAY_DEPLOYMENT_ADDR = OVERLAY_ADDR.append(ModelDescriptionConstants.DEPLOYMENT, "test-deployment.jar").toModelNode();
@@ -166,7 +167,7 @@ public class DeploymentOverlayTestCase {
                         Operation.Factory.create(
                                 Operations.createReadAttributeOperation(OVERLAY_CONTENT_ADDR, "stream")), OperationMessageHandler.DISCARD);
                 try {
-                    OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    OperationResponse response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     Assert.assertTrue(Operations.isSuccessfulOutcome(response.getResponseNode()));
                     Assert.assertTrue(Operations.readResult(response.getResponseNode()).hasDefined(UUID));
                     List<OperationResponse.StreamEntry> streams = response.getInputStreams();
@@ -264,7 +265,7 @@ public class DeploymentOverlayTestCase {
     private void awaitDeploymentExecution(Future<?> future) {
         Object t = null;
         try {
-            t = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            t = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentTestCase.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -81,8 +82,8 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @ServerSetup({DeploymentScannerSetupTask.class})
 public class DeploymentTestCase {
 
-    // Max time to wait for some action to complete, in ms
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    // Max time to wait for some action to complete
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
     // Pause time between checks whether some action has completed, in ms
     private static final int BACKOFF = 10;
 
@@ -363,7 +364,7 @@ public class DeploymentTestCase {
                         out.write(deploymentName.getBytes());
                     }
                     Assert.assertTrue(dodeploy.exists());
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
@@ -388,7 +389,7 @@ public class DeploymentTestCase {
                     archive2.as(ZipExporter.class).exportTo(target, true);
                     dodeploy.createNewFile();
                     Assert.assertTrue(dodeploy.exists());
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
@@ -420,7 +421,7 @@ public class DeploymentTestCase {
                     final File dodeploy = new File(deployDir, deploymentName + ".dodeploy");
                     final File isdeploying = new File(deployDir, deploymentName +".isdeploying");
                     final File undeployed = new File(deployDir, deploymentName+ ".undeployed");
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
@@ -439,7 +440,7 @@ public class DeploymentTestCase {
 
                     // Delete file from deploy directory
                     deployed.delete();
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (undeployed.exists()) {
                             break;
@@ -491,7 +492,7 @@ public class DeploymentTestCase {
                     Files.copy(file.toPath(), target.toPath());
                     Assert.assertTrue(file.exists());
 
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!isdeploying.exists() && deployed.exists()) {
                             break;
@@ -522,7 +523,7 @@ public class DeploymentTestCase {
                             +  Files.getLastModifiedTime(target).toInstant(), Files.getLastModifiedTime(target).toInstant().isAfter(deploymentLastModified));
                     // Wait until filesystem action gets picked up by scanner
                     boolean wasUndeployed = false;
-                    long timeout = System.currentTimeMillis() + TIMEOUT + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if ((isdeploying.exists() && !deployed.exists()) || Files.getLastModifiedTime(deployed.toPath()).toMillis() > deployedlastModified.toMillis()) {
                             wasUndeployed = true;
@@ -537,7 +538,7 @@ public class DeploymentTestCase {
                     }
                     Assert.assertTrue("fullReplace step did not complete in a reasonably timely fashion " + Files.getLastModifiedTime(deployed.toPath()), wasUndeployed);
                     // Wait for redeploy to finish
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!isdeploying.exists() && deployed.exists()) {
                             break;
@@ -567,7 +568,7 @@ public class DeploymentTestCase {
                 public void undeploy() {
                     final File isdeploying = new File(deployDir, deploymentName + ".isdeploying");
                     final File undeployed = new File(deployDir, deploymentName + ".undeployed");
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!isdeploying.exists() && deployed.exists()) {
                             break;
@@ -586,7 +587,7 @@ public class DeploymentTestCase {
 
                     // Delete file from deploy directory
                     target.delete();
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (undeployed.exists()) {
                             break;
@@ -630,7 +631,7 @@ public class DeploymentTestCase {
         Assert.assertTrue(Files.exists(target));
         addDeploymentScanner(deployDir.toFile(), client, scannerName, true, -1);
         try {
-            long timeout = System.currentTimeMillis() + TIMEOUT;
+            long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
             while(System.currentTimeMillis() <= timeout) {
                 if (Files.exists(deployed)) {
                     break;
@@ -677,7 +678,7 @@ public class DeploymentTestCase {
                     final File isdeploying = new File(deployDir, "test-deployment.jar.isdeploying");
                     Files.write(dodeploy.toPath(), "test-deployment.jar".getBytes(StandardCharsets.UTF_8));
                     Assert.assertTrue(dodeploy.exists());
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
@@ -707,7 +708,7 @@ public class DeploymentTestCase {
                     }
                     dodeploy.createNewFile();
                     Assert.assertTrue(dodeploy.exists());
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
@@ -732,7 +733,7 @@ public class DeploymentTestCase {
                     op.get(ClientConstants.PATH).set(path);
                     Future<ModelNode> future = client.executeAsync(OperationBuilder.create(op, false).build(), null);
                     try {
-                        ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                        ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                         Assert.assertFalse("Operation browse-content should not be successful with unmanaged deployments.",
                                 Operations.isSuccessfulOutcome(response));
                         String failureDescription = Operations.getFailureDescription(response).toString();
@@ -759,7 +760,7 @@ public class DeploymentTestCase {
                     op.get(ClientConstants.OP_ADDR).add(DEPLOYMENT, "test-deployment.jar");
                     Future<ModelNode> future = client.executeAsync(OperationBuilder.create(op, false).build(), null);
                     try {
-                        ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                        ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                         Assert.assertFalse("Operation browse-content should not be successful with unmanaged deployments.",
                                 Operations.isSuccessfulOutcome(response));
                         String failureDescription = Operations.getFailureDescription(response).toString();
@@ -784,7 +785,7 @@ public class DeploymentTestCase {
                     final File dodeploy = new File(deployDir, "test-deployment.jar.dodeploy");
                     final File isdeploying = new File(deployDir, "test-deployment.jar.isdeploying");
                     final File undeployed = new File(deployDir, "test-deployment.jar.undeployed");
-                    long timeout = System.currentTimeMillis() + TIMEOUT;
+                    long timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
@@ -803,7 +804,7 @@ public class DeploymentTestCase {
 
                     // Delete file from deploy directory
                     deployed.delete();
-                    timeout = System.currentTimeMillis() + TIMEOUT;
+                    timeout = System.currentTimeMillis() + TIMEOUT.toMillis();
                     while(System.currentTimeMillis() <= timeout) {
                         if (undeployed.exists()) {
                             break;
@@ -953,7 +954,7 @@ public class DeploymentTestCase {
 
     private void awaitDeploymentExecution(Future<?> future) {
         try {
-            future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -987,7 +988,7 @@ public class DeploymentTestCase {
         Future<OperationResponse> future = client.executeOperationAsync(OperationBuilder.create(op, false).build(), null);
 
         try {
-            OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            OperationResponse response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             if (path.isEmpty()) {
                 Assert.assertFalse("Operation read-content should not be successful without defined path parameter on exploded deployments",
                         Operations.isSuccessfulOutcome(response.getResponseNode()));
@@ -1035,7 +1036,7 @@ public class DeploymentTestCase {
         }
         Future<ModelNode> future = client.executeAsync(OperationBuilder.create(op, false).build(), null);
         try {
-            ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             if (!Operations.isSuccessfulOutcome(response)) {
                 Assert.fail("Operation browse content should be successful, but failed: " +
                         Operations.getFailureDescription(response).toString());

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ExplodedDeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ExplodedDeploymentTestCase.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.PropertyPermission;
 import java.util.Set;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -70,8 +71,8 @@ import org.wildfly.core.testrunner.WildFlyRunner;
 @RunWith(WildFlyRunner.class)
 public class ExplodedDeploymentTestCase {
 
-    // Max time to wait for some action to complete, in ms
-    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    // Max time to wait for some action to complete
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(20));
 
     @Inject
     private ManagementClient managementClient;
@@ -175,7 +176,7 @@ public class ExplodedDeploymentTestCase {
                 Future<OperationResponse> future = client.executeOperationAsync(OperationBuilder.create(op, false).build(), null);
 
                 try {
-                    OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    OperationResponse response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     if (path.isEmpty()) {
                         Assert.assertFalse("Operation read-content should not be successful without defined path parameter on exploded deployments",
                                 Operations.isSuccessfulOutcome(response.getResponseNode()));
@@ -223,7 +224,7 @@ public class ExplodedDeploymentTestCase {
                 op.get(PATH).set(path);
                 Future<OperationResponse> future = client.executeOperationAsync(OperationBuilder.create(op, false).build(), null);
                 try {
-                    OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    OperationResponse response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     Assert.assertFalse(Operations.isSuccessfulOutcome(response.getResponseNode()));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -255,7 +256,7 @@ public class ExplodedDeploymentTestCase {
                 }
                 Future<ModelNode> future = client.executeAsync(OperationBuilder.create(op, false).build(), null);
                 try {
-                    ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     if (!Operations.isSuccessfulOutcome(response)) {
                         Assert.fail("Operation browse content should be successful, but failed: " +
                                 Operations.getFailureDescription(response).toString());
@@ -377,7 +378,7 @@ public class ExplodedDeploymentTestCase {
                 Future<OperationResponse> future = client.executeOperationAsync(OperationBuilder.create(op, false).build(), null);
 
                 try {
-                    OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    OperationResponse response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     if (path.isEmpty()) {
                         Assert.assertFalse("Operation read-content should not be successful without defined path parameter on exploded deployments",
                                 Operations.isSuccessfulOutcome(response.getResponseNode()));
@@ -427,7 +428,7 @@ public class ExplodedDeploymentTestCase {
                 op.get(PATH).set(path);
                 Future<OperationResponse> future = client.executeOperationAsync(OperationBuilder.create(op, false).build(), null);
                 try {
-                    OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    OperationResponse response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     Assert.assertFalse(Operations.isSuccessfulOutcome(response.getResponseNode()));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -459,7 +460,7 @@ public class ExplodedDeploymentTestCase {
                 }
                 Future<ModelNode> future = client.executeAsync(OperationBuilder.create(op, false).build(), null);
                 try {
-                    ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                    ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
                     Assert.assertTrue(Operations.isSuccessfulOutcome(response));
                     List<String> unexpectedContents = new ArrayList<String>();
                     if (expectedContents.isEmpty()) {
@@ -596,7 +597,7 @@ public class ExplodedDeploymentTestCase {
     private void awaitDeploymentExecution(Future<?> future) {
         Object t = null;
         try {
-            t = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            t = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.PropertyPermission;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -94,7 +95,7 @@ public class DeploymentOperationsTestCase {
     @Inject
     private ManagementClient managementClient;
 
-    private static final int TIMEOUT = TimeoutUtil.adjust(40000);
+    private static final Duration TIMEOUT = TimeoutUtil.adjust(Duration.ofSeconds(40));
     private static final String TEST_DEPLOYMENT_NAME = "test-deployment.jar";
     private static final String PROPERTIES_RESOURCE = "service-activator-deployment.properties";
 
@@ -276,7 +277,7 @@ public class DeploymentOperationsTestCase {
         op.get(NAME).set(MANAGED);
         Future<ModelNode> future = managementClient.getControllerClient().executeAsync(OperationBuilder.create(op, false).build(), null);
         try {
-            ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             return Operations.readResult(response).asBoolean();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -368,7 +369,7 @@ public class DeploymentOperationsTestCase {
             Future<ModelNode> future = client.executeAsync(Operation.Factory.create(addContentOp, attachments), null);
             ModelNode response;
             try {
-                response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+                response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
@@ -695,7 +696,7 @@ public class DeploymentOperationsTestCase {
     private void awaitOperationExecution(ModelNode op) {
         Future<ModelNode> future = managementClient.getControllerClient().executeAsync(OperationBuilder.create(op, false).build(), null);
         try {
-            ModelNode response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            ModelNode response = future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertTrue(Operations.isSuccessfulOutcome(response));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -714,7 +715,7 @@ public class DeploymentOperationsTestCase {
     private ModelNode awaitOperationExecutionAndReturnResult(ModelNode op) {
         Future<ModelNode> future = managementClient.getControllerClient().executeAsync(OperationBuilder.create(op, false).build(), null);
         try {
-            return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+            return future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -731,7 +732,7 @@ public class DeploymentOperationsTestCase {
 
     private ServerDeploymentPlanResult awaitDeploymentExecution(Future<ServerDeploymentPlanResult> future) {
         try {
-           return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+           return future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ResponseAttachmentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ResponseAttachmentTestCase.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -238,7 +239,7 @@ public class ResponseAttachmentTestCase extends ContainerResourceMgmtTestBase {
                     httpget.setHeader("org.wildfly.useStreamAsResponse", "0");
                     HttpClient client = getConcurrentHttpClient(url);
                     gate.countDown();
-                    gate.await(TimeoutUtil.adjust(30000), TimeUnit.MILLISECONDS);
+                    gate.await(TimeoutUtil.adjust(Duration.ofSeconds(30)).toMillis(), TimeUnit.MILLISECONDS);
                     readHttpResponse(client.execute(httpget), 200);
                     //System.out.println(idx + " succeeded");
                     return null;
@@ -251,7 +252,7 @@ public class ResponseAttachmentTestCase extends ContainerResourceMgmtTestBase {
 
         for (Future<Throwable> future : futures) {
             @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-            Throwable t = future.get(TimeoutUtil.adjust(1), TimeUnit.MINUTES);
+            Throwable t = future.get(TimeoutUtil.adjust(Duration.ofMinutes(1)).toNanos(), TimeUnit.NANOSECONDS);
             if (t != null) {
                 if (t instanceof Error) {
                     throw (Error) t;

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
@@ -7,6 +7,7 @@ package org.wildfly.core.test.standalone.suspend.web;
 import java.net.HttpURLConnection;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -94,10 +95,10 @@ public class SuspendResumeTestCase {
             op.get(NAME).set(SUSPEND_STATE);
             Assert.assertEquals("SUSPENDING", serverController.getClient().executeForResult(op).asString());
 
-            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(30), TimeUnit.SECONDS);
+            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(Duration.ofSeconds(30)).toSeconds(), TimeUnit.SECONDS);
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
             String suspendState;
-            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(10000);
+            long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(Duration.ofSeconds(10)).toMillis();
             do {
                 suspendState = serverController.getClient().executeForResult(op).asString();
                 if ("SUSPENDING".equals(suspendState)) {


### PR DESCRIPTION
The integer-based adjust method loses precision very quickly; deprecate it in favor of a new adjust(Duration) overload that operates at sufficient, nanosecond, granularity.

Migrate all callers from TimeoutUtil.adjust(int) to adjust(Duration) and make all timeouts proper Durations

Replace all usages of the deprecated adjust(int) with the new Duration-based one.
Timeout fields are stored as Duration for clarity and flexibility.

Note that this is 95% mechanical with no intention to fix pre-existing issues.

Resolves
https://redhat.atlassian.net/browse/WFCORE-7625