### PR TITLE
WFCORE-7633 Standardize installation directory variable naming to JBO…

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/systemd/README
+++ b/core-feature-pack/common/src/main/resources/content/bin/systemd/README
@@ -9,11 +9,11 @@ using this server installation as the WildFly home.
 
 If you want to install WildFly as a systemd service from scratch as a systemd service, follow the steps below.
 
-== Install WildFly and initialize the WILDFLY_HOME variable
+== Install WildFly and initialize the JBOSS_HOME variable
 
     # unzip -d /opt wildfly-34.0.0.Final.zip
     # ln -s /opt/wildfly-34.0.0.Final /opt/wildfly
-    # WILDFLY_HOME=/opt/wildfly
+    # JBOSS_HOME=/opt/wildfly
 
 == Standalone or Domain mode ?
 
@@ -22,21 +22,21 @@ If you want to install WildFly as a systemd service from scratch as a systemd se
 == Create a wildfly user and group
 
     # groupadd -r wildfly
-    # useradd -r -g wildfly -d "${WILDFLY_HOME}" -s /sbin/nologin wildfly
+    # useradd -r -g wildfly -d "${JBOSS_HOME}" -s /sbin/nologin wildfly
 
 == Configure systemd
 
-    # cd "${WILDFLY_HOME}/bin/systemd"
+    # cd "${JBOSS_HOME}/bin/systemd"
     # cp "wildfly-${MODE}.conf" /etc/sysconfig/
     # cp "wildfly-${MODE}.service" $(pkg-config systemd --variable=systemdsystemunitdir)
-    # chown -R wildfly:wildfly "${WILDFLY_HOME}"/
-    # chmod +x "${WILDFLY_HOME}/bin/systemd/launch.sh"
+    # chown -R wildfly:wildfly "${JBOSS_HOME}"/
+    # chmod +x "${JBOSS_HOME}/bin/systemd/launch.sh"
     # systemctl daemon-reload
 
 === If SELinux is enabled, you need to set the appropriate context for the launch.sh script:
 
-    # sudo chcon -R -t bin_t "${WILDFLY_HOME}/"
-    # sudo semanage fcontext -a -t systemd_unit_file_t '${WILDFLY_HOME}(/.*)?'
+    # sudo chcon -R -t bin_t "${JBOSS_HOME}/"
+    # sudo semanage fcontext -a -t systemd_unit_file_t '${JBOSS_HOME}(/.*)?'
 
 == Start and enable WildFly
 
@@ -62,7 +62,7 @@ If you want to install WildFly as a systemd service from scratch as a systemd se
 
 == If you are using SELinux, remove the custom context added
 
-    sudo semanage fcontext -d '${WILDFLY_HOME}(/.*)?'
+    sudo semanage fcontext -d '${JBOSS_HOME}(/.*)?'
 
 == Remove WildFly systemd service
 
@@ -72,8 +72,8 @@ If you want to install WildFly as a systemd service from scratch as a systemd se
 
 == Remove WildFly installation
 
-    # rm -rf $(readlink "${WILDFLY_HOME}")
-    # rm -rf "${WILDFLY_HOME}"
+    # rm -rf $(readlink "${JBOSS_HOME}")
+    # rm -rf "${JBOSS_HOME}"
 
 == Remove WildFly user and group
 

--- a/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/systemd/README
+++ b/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/systemd/README
@@ -1,7 +1,7 @@
 = How to configure WildFly as a systemd service
 
-Note: The systemd scripts provided here have been deprecated in favor of $WFLY_HOME/bin/systemd
-See $WFLY_HOME/bin/systemd/README to get more information.
+Note: The systemd scripts provided here have been deprecated in favor of $JBOSS_HOME/bin/systemd
+See $JBOSS_HOME/bin/systemd/README to get more information.
 
 == Create a wildfly user
 

--- a/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/systemd/launch.sh
+++ b/core-feature-pack/common/src/main/resources/content/docs/contrib/scripts/systemd/launch.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ "x$WILDFLY_HOME" = "x" ]; then
-    WILDFLY_HOME="/opt/wildfly"
+if [ "x$JBOSS_HOME" = "x" ]; then
+    JBOSS_HOME="/opt/wildfly"
 fi
 
 if [[ "$1" == "domain" ]]; then
-    $WILDFLY_HOME/bin/domain.sh -c $2 -b $3
+    $JBOSS_HOME/bin/domain.sh -c $2 -b $3
 else
-    $WILDFLY_HOME/bin/standalone.sh -c $2 -b $3
+    $JBOSS_HOME/bin/standalone.sh -c $2 -b $3
 fi


### PR DESCRIPTION
…SS_HOME

Replace WILDFLY_HOME and WFLY_HOME with JBOSS_HOME in systemd documentation and the deprecated systemd launch script to align with the env var that standalone.sh/domain.sh actually parse.

Unchanged:
- WILDFLY_* systemd service configuration variables (WILDFLY_SH, WILDFLY_SERVER_CONFIG, WILDFLY_BIND, WILDFLY_CONSOLE_LOG, WILDFLY_SUSPEND_TIMEOUT, WILDFLY_OPTS, WILDFLY_HOST_CONFIG, WILDFLY_SYSTEMD_DEBUG) as those are systemd service parameters and not references to the installation directory.
- Java code variable names (jbossHome) and system properties (jboss.home) as those are already consistently using jboss naming.

https://redhat.atlassian.net/browse/WFCORE-7633