### PR TITLE
Fix for WFCORE-7635, Upgrade to aesh-readline 2.6.3

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -186,7 +186,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.fusesource.jansi</groupId>
+            <groupId>org.jline</groupId>
             <artifactId>jansi</artifactId>
             <exclusions>
                 <exclusion>

--- a/core-feature-pack/common/pom.xml
+++ b/core-feature-pack/common/pom.xml
@@ -264,7 +264,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.fusesource.jansi</groupId>
+            <groupId>org.jline</groupId>
             <artifactId>jansi</artifactId>
         </dependency>
 

--- a/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
+++ b/core-feature-pack/common/src/main/resources/license/core-feature-pack-common-licenses.xml
@@ -7,7 +7,7 @@
 <licenseSummary>
   <dependencies>
     <dependency>
-      <groupId>org.fusesource.jansi</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jansi</artifactId>
       <licenses>
         <license>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
@@ -19,6 +19,6 @@
     <dependencies>
         <module name="jdk.unsupported"/>
         <module name="java.logging"/>
-        <module name="org.fusesource.jansi" />
+        <module name="org.jline.jansi" />
     </dependencies>
 </module>

--- a/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jline/jansi/main/module.xml
+++ b/core-feature-pack/common/src/main/resources/modules/system/layers/base/org/jline/jansi/main/module.xml
@@ -5,13 +5,13 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<module xmlns="urn:jboss:module:1.9" name="org.fusesource.jansi">
+<module xmlns="urn:jboss:module:1.9" name="org.jline.jansi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.fusesource.jansi:jansi}"/>
+        <artifact name="${org.jline:jansi}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <version.nxrm3.plugin>1.0.7</version.nxrm3.plugin>
         <version.org.aesh>2.8.4</version.org.aesh>
         <version.org.aesh-extensions>1.8</version.org.aesh-extensions>
-        <version.org.aesh-readline>2.6</version.org.aesh-readline>
+        <version.org.aesh-readline>2.6.3</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0.AM27</version.org.apache.ds>
         <version.org.apache.directory.api>2.1.7</version.org.apache.directory.api>
         <version.org.apache.kerby>2.0.3</version.org.apache.kerby>
@@ -266,7 +266,7 @@
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>7.6.0.202603022253-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.9</version.org.eclipse.parsson>
-        <version.org.fusesource.jansi>2.4.3</version.org.fusesource.jansi>
+        <version.org.jline.jansi>4.2.1</version.org.jline.jansi>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.jboss.byteman>4.0.27</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.3.1.Final</version.org.jboss.classfilewriter>
@@ -996,9 +996,9 @@
             </dependency>
             <!-- This dependency needs to be managed due to the dependency convergence enforcer rule -->
             <dependency>
-                <groupId>org.fusesource.jansi</groupId>
+                <groupId>org.jline</groupId>
                 <artifactId>jansi</artifactId>
-                <version>${version.org.fusesource.jansi}</version>
+                <version>${version.org.jline.jansi}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFCORE-7635

NOTE: This bump implies a change of dependency. org.fusesource.jansi is no more maintained and org.jline.jansi is the replacement. There are no changes in term of API. 
The major impact is at the JBoss Modules level. The module org.fusesource.jansi is removed and the org.jline:jansi module is introduced.