### PR TITLE
[33.x][WFCORE-7641] Bump version.org.apache.logging.log4j from 2.25.4 to 2.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <version.org.apache.kerby>2.0.3</version.org.apache.kerby>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
-        <version.org.apache.logging.log4j>2.25.4</version.org.apache.logging.log4j>
+        <version.org.apache.logging.log4j>2.25.5</version.org.apache.logging.log4j>
         <version.org.apache.maven.provider>3.5.4</version.org.apache.maven.provider>
         <version.org.apache.maven.resolver>1.1.1</version.org.apache.maven.resolver>
         <version.org.apache.sshd>2.18.0</version.org.apache.sshd>


### PR DESCRIPTION
…25.5

Jira issue: https://redhat.atlassian.net/browse/WFCORE-7641
Upsream PR: https://github.com/wildfly/wildfly-core/pull/6838


Bumps `version.org.apache.logging.log4j` from 2.25.4 to 2.25.5.

Updates `org.apache.logging.log4j:log4j-api` from 2.25.4 to 2.25.5

Updates `org.apache.logging.log4j:log4j-core` from 2.25.4 to 2.25.5

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api dependency-version: 2.25.5 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.logging.log4j:log4j-core dependency-version: 2.25.5 dependency-type: direct:production update-type: version-update:semver-patch ...

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

Remember to use the Jira issue ID in the PR title, and any commits.
