### PR TITLE
Fix for WFLY-21956, Stale datasource reference left in 'ee' subsystem after removing the configured datasource via CLI

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -105,8 +105,10 @@ public class Util {
     public static final String CREDENTIAL_REFERENCE = "credential-reference";
     public static final String CIPHER_SUITE_FILTER = "cipher-suite-filter";
     public static final String CIPHER_SUITE_NAMES = "cipher-suite-names";
+    public static final String DATASOURCE = "datasource";
     public static final String DATASOURCES = "datasources";
     public static final String DEFAULT = "default";
+    public static final String DEFAULT_BINDINGS = "default-bindings";
     public static final String DEFAULT_PERMISSION_MAPPER = "default-permission-mapper";
     public static final String DEPLOY = "deploy";
     public static final String DEPLOYMENT = "deployment";
@@ -121,6 +123,7 @@ public class Util {
     public static final String DOMAIN_RESULTS = "domain-results";
     public static final String DRIVER_MODULE_NAME = "driver-module-name";
     public static final String DRIVER_NAME = "driver-name";
+    public static final String EE = "ee";
     public static final String ELYTRON = "elytron";
     public static final String ENABLED = "enabled";
     public static final String EXECUTE = "execute";
@@ -163,6 +166,7 @@ public class Util {
     public static final String INPUT_STREAM_INDEX = "input-stream-index";
     public static final String INSTALLED_DRIVERS_LIST = "installed-drivers-list";
     public static final String JBOSS_SERVER_CONFIG_DIR = "jboss.server.config.dir";
+    public static final String JNDI_NAME = "jndi-name";
     public static final String KEY_MANAGER = "key-manager";
     public static final String KEY_SIZE = "key-size";
     public static final String KEY_STORE = "key-store";
@@ -260,6 +264,7 @@ public class Util {
     public static final String SECURITY_REALM = "security-realm";
     public static final String SERVER = "server";
     public static final String SERVER_GROUP = "server-group";
+    public static final String SERVICE = "service";
     public static final String SERVER_SSL_CONTEXT = "server-ssl-context";
     public static final String SHUTDOWN = "shutdown";
     public static final String SIMPLE_ROLE_DECODER = "simple-role-decoder";

--- a/cli/src/main/java/org/jboss/as/cli/handlers/jca/DataSourceAddCompositeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/jca/DataSourceAddCompositeHandler.java
@@ -17,6 +17,7 @@ import org.jboss.as.cli.Util;
 import org.jboss.as.cli.handlers.OperationCommandWithDescription;
 import org.jboss.as.cli.handlers.ResourceCompositeOperationHandler;
 import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -29,18 +30,22 @@ import org.jboss.dmr.Property;
 public class DataSourceAddCompositeHandler extends ResourceCompositeOperationHandler implements OperationCommandWithDescription {
 
     private static final String CONNECTION_PROPERTIES = "connection-properties";
+    private static final String SET_DEFAULT_DATASOURCE = "set-default-datasource";
 
     private ArgumentWithValue conProps;
+    private final ArgumentWithoutValue setDefaultDatasource;
 
     public DataSourceAddCompositeHandler(CommandContext ctx, String nodeType) {
         super(ctx, "data-source-add", nodeType, null, Util.ADD);
         conProps = new ArgumentWithValue(this, null, ArgumentValueConverter.PROPERTIES, "--" + CONNECTION_PROPERTIES);
+        setDefaultDatasource = new ArgumentWithoutValue(this, "--" + SET_DEFAULT_DATASOURCE);
     }
 
     @Override
     protected Map<String, CommandArgument> loadArguments(CommandContext ctx) {
         final Map<String, CommandArgument> args = super.loadArguments(ctx);
         args.put(conProps.getFullName(), conProps);
+        args.put(setDefaultDatasource.getFullName(), setDefaultDatasource);
         return args;
     }
 
@@ -61,7 +66,39 @@ public class DataSourceAddCompositeHandler extends ResourceCompositeOperationHan
                 steps.add(addProp);
             }
         }
+
+        if (setDefaultDatasource.isPresent(ctx.getParsedCommandLine())) {
+            final String jndiName = ctx.getParsedCommandLine().getPropertyValue("--" + Util.JNDI_NAME);
+            if (jndiName == null) {
+                throw new CommandFormatException("--jndi-name is required when --set-default-datasource is set.");
+            }
+            final ModelNode writeStep = new ModelNode();
+            writeStep.get(Util.ADDRESS).set(buildEeDefaultBindingsAddress(ctx));
+            writeStep.get(Util.OPERATION).set(Util.WRITE_ATTRIBUTE);
+            writeStep.get(Util.NAME).set(Util.DATASOURCE);
+            writeStep.get(Util.VALUE).set(jndiName);
+            steps.add(writeStep);
+        }
+
         return req;
+    }
+
+    /**
+     * Builds the address for {@code /subsystem=ee/service=default-bindings}, prepending
+     * {@code /profile=<name>} when running in domain mode.
+     */
+    private ModelNode buildEeDefaultBindingsAddress(CommandContext ctx) throws CommandFormatException {
+        final ModelNode address = new ModelNode();
+        if (isDependsOnProfile() && ctx.isDomainMode()) {
+            final String profileName = profile.getValue(ctx.getParsedCommandLine());
+            if (profileName == null) {
+                throw new CommandFormatException("Required argument --profile is missing.");
+            }
+            address.add(Util.PROFILE, profileName);
+        }
+        address.add(Util.SUBSYSTEM, Util.EE);
+        address.add(Util.SERVICE, Util.DEFAULT_BINDINGS);
+        return address;
     }
 
     @Override
@@ -86,7 +123,7 @@ public class DataSourceAddCompositeHandler extends ResourceCompositeOperationHan
         final ModelNode opDescr = result.get(Util.DESCRIPTION);
         final StringBuilder buf = new StringBuilder();
         buf.append(opDescr.asString());
-        buf.append(" (unlike the add operation, this command accepts xa-datasource-properties).");
+        buf.append(" (unlike the add operation, this command accepts connection-properties).");
         opDescr.set(buf.toString());
 
         final ModelNode allProps = result.get(Util.REQUEST_PROPERTIES);
@@ -96,6 +133,15 @@ public class DataSourceAddCompositeHandler extends ResourceCompositeOperationHan
         conProps.get(Util.TYPE).set(ModelType.LIST);
         conProps.get(Util.REQUIRED).set(false);
         conProps.get(Util.NILLABLE).set(false);
+
+        final ModelNode setDefaultProp = allProps.get(SET_DEFAULT_DATASOURCE);
+        setDefaultProp.get(Util.DESCRIPTION).set(
+                "If present, sets this datasource as the default datasource in the EE subsystem " +
+                "(/subsystem=ee/service=default-bindings) using the datasource's jndi-name. " +
+                "Any existing default datasource is overridden.");
+        setDefaultProp.get(Util.TYPE).set(ModelType.BOOLEAN);
+        setDefaultProp.get(Util.REQUIRED).set(false);
+        setDefaultProp.get(Util.NILLABLE).set(true);
 
         return result;
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/jca/DataSourceRemoveCompositeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/jca/DataSourceRemoveCompositeHandler.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.cli.handlers.jca;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.jboss.as.cli.CommandArgument;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.handlers.OperationCommandWithDescription;
+import org.jboss.as.cli.handlers.ResourceCompositeOperationHandler;
+import org.jboss.as.cli.impl.ArgumentWithoutValue;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Command handler for the {@code remove} operation on a datasource. When the
+ * {@code --update-default-datasource} flag is set and the datasource being
+ * removed is currently referenced as the default datasource in the EE subsystem
+ * ({@code /subsystem=ee/service=default-bindings}), the handler prepends an
+ * {@code undefine-attribute} step to clear that reference before performing
+ * the removal, all within a single composite operation.
+ *
+ * @author WildFly Authors
+ */
+public class DataSourceRemoveCompositeHandler extends ResourceCompositeOperationHandler implements OperationCommandWithDescription {
+
+    private static final String UNSET_IF_DEFAULT_DATASOURCE = "unset-if-default-datasource";
+
+    private final ArgumentWithoutValue unsetIfDefaultDatasource;
+
+    public DataSourceRemoveCompositeHandler(CommandContext ctx, String nodeType) {
+        super(ctx, "data-source-remove", nodeType, null, Util.REMOVE);
+        unsetIfDefaultDatasource = new ArgumentWithoutValue(this, "--" + UNSET_IF_DEFAULT_DATASOURCE);
+    }
+
+    @Override
+    protected Map<String, CommandArgument> loadArguments(CommandContext ctx) {
+        final Map<String, CommandArgument> args = super.loadArguments(ctx);
+        args.put(unsetIfDefaultDatasource.getFullName(), unsetIfDefaultDatasource);
+        return args;
+    }
+
+    @Override
+    protected ModelNode buildRequestWithoutHeaders(CommandContext ctx) throws CommandFormatException {
+        final ModelNode req = super.buildRequestWithoutHeaders(ctx);
+
+        try {
+            if (!unsetIfDefaultDatasource.isPresent(ctx.getParsedCommandLine())) {
+                return req;
+            }
+        } catch (CommandFormatException e) {
+            throw e;
+        }
+
+        // Read the current default-datasource attribute from /subsystem=ee/service=default-bindings
+        final String currentDefault = readEeDefaultDatasource(ctx);
+        if (currentDefault == null) {
+            // No default configured, or ee subsystem absent — nothing to do
+            return req;
+        }
+
+        // Determine the JNDI name of the datasource being removed so we can compare
+        final String dsJndiName = buildDatasourceJndiName(ctx);
+        if (dsJndiName == null || !dsJndiName.equals(currentDefault)) {
+            // This datasource is not the current EE default — nothing to do
+            return req;
+        }
+
+        // Prepend an undefine-attribute step for /subsystem=ee/service=default-bindings:datasource
+        final ModelNode undefineStep = new ModelNode();
+        final ModelNode eeAddress = buildEeDefaultBindingsAddress(ctx);
+        undefineStep.get(Util.ADDRESS).set(eeAddress);
+        undefineStep.get(Util.OPERATION).set(Util.UNDEFINE_ATTRIBUTE);
+        undefineStep.get(Util.NAME).set(Util.DATASOURCE);
+
+        // Insert the undefine step before the remove step
+        final ModelNode steps = req.get(Util.STEPS);
+        final ModelNode existingSteps = steps.clone();
+        steps.setEmptyList();
+        steps.add(undefineStep);
+        for (ModelNode step : existingSteps.asList()) {
+            steps.add(step);
+        }
+
+        return req;
+    }
+
+    /**
+     * Builds the address for {@code /subsystem=ee/service=default-bindings}, prepending
+     * {@code /profile=<name>} when running in domain mode.
+     */
+    private ModelNode buildEeDefaultBindingsAddress(CommandContext ctx) throws CommandFormatException {
+        final ModelNode address = new ModelNode();
+        if (isDependsOnProfile() && ctx.isDomainMode()) {
+            final String profileName = profile.getValue(ctx.getParsedCommandLine());
+            if (profileName == null) {
+                throw new CommandFormatException("Required argument --profile is missing.");
+            }
+            address.add(Util.PROFILE, profileName);
+        }
+        address.add(Util.SUBSYSTEM, Util.EE);
+        address.add(Util.SERVICE, Util.DEFAULT_BINDINGS);
+        return address;
+    }
+
+    /**
+     * Reads the {@code datasource} attribute from {@code /subsystem=ee/service=default-bindings}.
+     * Returns {@code null} if the resource does not exist or the attribute is undefined.
+     */
+    private String readEeDefaultDatasource(CommandContext ctx) throws CommandFormatException {
+        final ModelNode request = new ModelNode();
+        final ModelNode address = buildEeDefaultBindingsAddress(ctx);
+        request.get(Util.ADDRESS).set(address);
+        request.get(Util.OPERATION).set(Util.READ_ATTRIBUTE);
+        request.get(Util.NAME).set(Util.DATASOURCE);
+        try {
+            final ModelNode response = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(response) && response.hasDefined(Util.RESULT)) {
+                final ModelNode result = response.get(Util.RESULT);
+                if (result.isDefined()) {
+                    return result.asString();
+                }
+            }
+        } catch (IOException e) {
+            throw new CommandFormatException("Failed to read EE default datasource attribute.", e);
+        }
+        return null;
+    }
+
+    /**
+     * Reads the {@code jndi-name} attribute from the datasource resource being removed.
+     * Returns {@code null} if unavailable.
+     */
+    private String buildDatasourceJndiName(CommandContext ctx) throws CommandFormatException {
+        final ModelNode address = buildOperationAddress(ctx);
+        final ModelNode request = new ModelNode();
+        request.get(Util.ADDRESS).set(address);
+        request.get(Util.OPERATION).set(Util.READ_ATTRIBUTE);
+        request.get(Util.NAME).set(Util.JNDI_NAME);
+        try {
+            final ModelNode response = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(response) && response.hasDefined(Util.RESULT)) {
+                final ModelNode result = response.get(Util.RESULT);
+                if (result.isDefined()) {
+                    return result.asString();
+                }
+            }
+        } catch (IOException e) {
+            throw new CommandFormatException("Failed to read datasource jndi-name attribute.", e);
+        }
+        return null;
+    }
+
+    @Override
+    public ModelNode getOperationDescription(CommandContext ctx) throws CommandLineException {
+        ModelNode request = initRequest(ctx);
+        if (request == null) {
+            return null;
+        }
+        request.get(Util.OPERATION).set(Util.READ_OPERATION_DESCRIPTION);
+        request.get(Util.NAME).set(Util.REMOVE);
+        final ModelNode response;
+        try {
+            response = ctx.getModelControllerClient().execute(request);
+        } catch (IOException e) {
+            throw new CommandFormatException("Failed to execute read-operation-description.", e);
+        }
+        if (!response.hasDefined(Util.RESULT)) {
+            return null;
+        }
+        final ModelNode result = response.get(Util.RESULT);
+
+        final ModelNode allProps = result.get(Util.REQUEST_PROPERTIES);
+        final ModelNode unsetDefaultProp = allProps.get(UNSET_IF_DEFAULT_DATASOURCE);
+        unsetDefaultProp.get(Util.DESCRIPTION).set(
+                "If present, and this datasource is currently set as the default datasource " +
+                "in the EE subsystem (/subsystem=ee/service=default-bindings), unsets it " +
+                "before removing the datasource. Has no effect if no default datasource is " +
+                "configured or if the configured default datasource is a different datasource.");
+        unsetDefaultProp.get(Util.TYPE).set(org.jboss.dmr.ModelType.BOOLEAN);
+        unsetDefaultProp.get(Util.REQUIRED).set(false);
+        unsetDefaultProp.get(Util.NILLABLE).set(true);
+
+        return result;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/handlers/jca/XADataSourceAddCompositeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/jca/XADataSourceAddCompositeHandler.java
@@ -17,6 +17,7 @@ import org.jboss.as.cli.Util;
 import org.jboss.as.cli.handlers.OperationCommandWithDescription;
 import org.jboss.as.cli.handlers.ResourceCompositeOperationHandler;
 import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -29,19 +30,23 @@ import org.jboss.dmr.Property;
 public class XADataSourceAddCompositeHandler extends ResourceCompositeOperationHandler implements OperationCommandWithDescription {
 
     private static final String XA_DATASOURCE_PROPERTIES = "xa-datasource-properties";
+    private static final String SET_DEFAULT_DATASOURCE = "set-default-datasource";
 
     private ArgumentWithValue xaProps;
+    private final ArgumentWithoutValue setDefaultDatasource;
 
     public XADataSourceAddCompositeHandler(CommandContext ctx, String nodeType) {
         super(ctx, "xa-data-source-add", nodeType, null, Util.ADD);
 
         xaProps = new ArgumentWithValue(this, null, ArgumentValueConverter.PROPERTIES, "--" + XA_DATASOURCE_PROPERTIES);
+        setDefaultDatasource = new ArgumentWithoutValue(this, "--" + SET_DEFAULT_DATASOURCE);
     }
 
     @Override
     protected Map<String, CommandArgument> loadArguments(CommandContext ctx) {
         final Map<String, CommandArgument> args = super.loadArguments(ctx);
         args.put(xaProps.getFullName(), xaProps);
+        args.put(setDefaultDatasource.getFullName(), setDefaultDatasource);
         return args;
     }
 
@@ -65,7 +70,38 @@ public class XADataSourceAddCompositeHandler extends ResourceCompositeOperationH
                 steps.add(addProp);
             }
         }
+        if (setDefaultDatasource.isPresent(ctx.getParsedCommandLine())) {
+            final String jndiName = ctx.getParsedCommandLine().getPropertyValue("--" + Util.JNDI_NAME);
+            if (jndiName == null) {
+                throw new CommandFormatException("--jndi-name is required when --set-default-datasource is set.");
+            }
+            final ModelNode writeStep = new ModelNode();
+            writeStep.get(Util.ADDRESS).set(buildEeDefaultBindingsAddress(ctx));
+            writeStep.get(Util.OPERATION).set(Util.WRITE_ATTRIBUTE);
+            writeStep.get(Util.NAME).set(Util.DATASOURCE);
+            writeStep.get(Util.VALUE).set(jndiName);
+            steps.add(writeStep);
+        }
+
         return req;
+    }
+
+    /**
+     * Builds the address for {@code /subsystem=ee/service=default-bindings}, prepending
+     * {@code /profile=<name>} when running in domain mode.
+     */
+    private ModelNode buildEeDefaultBindingsAddress(CommandContext ctx) throws CommandFormatException {
+        final ModelNode address = new ModelNode();
+        if (isDependsOnProfile() && ctx.isDomainMode()) {
+            final String profileName = profile.getValue(ctx.getParsedCommandLine());
+            if (profileName == null) {
+                throw new CommandFormatException("Required argument --profile is missing.");
+            }
+            address.add(Util.PROFILE, profileName);
+        }
+        address.add(Util.SUBSYSTEM, Util.EE);
+        address.add(Util.SERVICE, Util.DEFAULT_BINDINGS);
+        return address;
     }
 
     @Override
@@ -100,6 +136,15 @@ public class XADataSourceAddCompositeHandler extends ResourceCompositeOperationH
         xaProps.get(Util.TYPE).set(ModelType.LIST);
         xaProps.get(Util.REQUIRED).set(false);
         xaProps.get(Util.NILLABLE).set(false);
+
+        final ModelNode setDefaultProp = allProps.get(SET_DEFAULT_DATASOURCE);
+        setDefaultProp.get(Util.DESCRIPTION).set(
+                "If present, sets this datasource as the default datasource in the EE subsystem " +
+                "(/subsystem=ee/service=default-bindings) using the datasource's jndi-name. " +
+                "Any existing default datasource is overridden.");
+        setDefaultProp.get(Util.TYPE).set(ModelType.BOOLEAN);
+        setDefaultProp.get(Util.REQUIRED).set(false);
+        setDefaultProp.get(Util.NILLABLE).set(true);
 
         return result;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -136,6 +136,7 @@ import org.jboss.as.cli.handlers.ifelse.ElseHandler;
 import org.jboss.as.cli.handlers.ifelse.EndIfHandler;
 import org.jboss.as.cli.handlers.ifelse.IfHandler;
 import org.jboss.as.cli.handlers.jca.DataSourceAddCompositeHandler;
+import org.jboss.as.cli.handlers.jca.DataSourceRemoveCompositeHandler;
 import org.jboss.as.cli.handlers.jca.JDBCDriverInfoHandler;
 import org.jboss.as.cli.handlers.jca.JDBCDriverNameProvider;
 import org.jboss.as.cli.handlers.jca.XADataSourceAddCompositeHandler;
@@ -639,6 +640,9 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
         final DataSourceAddCompositeHandler dsAddHandler = new DataSourceAddCompositeHandler(this, "/subsystem=datasources/data-source");
         dsAddHandler.addValueCompleter(Util.DRIVER_NAME, driverNameCompleter);
         dsHandler.addHandler(Util.ADD, dsAddHandler);
+        // override the remove operation with the handler that can clean up the EE default datasource reference
+        final DataSourceRemoveCompositeHandler dsRemoveHandler = new DataSourceRemoveCompositeHandler(this, "/subsystem=datasources/data-source");
+        dsHandler.addHandler(Util.REMOVE, dsRemoveHandler);
         cmdRegistry.registerHandler(dsHandler, dsHandler.getCommandName());
         final GenericTypeOperationHandler xaDsHandler = new GenericTypeOperationHandler(this, "/subsystem=datasources/xa-data-source", null);
         xaDsHandler.addValueCompleter(Util.DRIVER_NAME, driverNameCompleter);
@@ -646,6 +650,9 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
         final XADataSourceAddCompositeHandler xaDsAddHandler = new XADataSourceAddCompositeHandler(this, "/subsystem=datasources/xa-data-source");
         xaDsAddHandler.addValueCompleter(Util.DRIVER_NAME, driverNameCompleter);
         xaDsHandler.addHandler(Util.ADD, xaDsAddHandler);
+        // override the xa remove operation with the handler that can clean up the EE default datasource reference
+        final DataSourceRemoveCompositeHandler xaDsRemoveHandler = new DataSourceRemoveCompositeHandler(this, "/subsystem=datasources/xa-data-source");
+        xaDsHandler.addHandler(Util.REMOVE, xaDsRemoveHandler);
         cmdRegistry.registerHandler(xaDsHandler, xaDsHandler.getCommandName());
         cmdRegistry.registerHandler(new JDBCDriverInfoHandler(this), "jdbc-driver-info");
 


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFLY-21956
Proposal: https://github.com/wildfly/wildfly-proposals/pull/850

Tests and community documentation will be added in the WildFly repository.  Here are the tests and doc changes: https://github.com/wildfly/wildfly/compare/main...jfdenise:wildfly:default_ds_handling?expand=1

Custom integration job execution: https://ci.wildfly.org/buildConfiguration/WF_WildFlyCoreIntegrationExperiments/574528

