### PR TITLE
[33.x][WFCORE-7647] Upgrade BouncyCastle from 1.84 to 1.85

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.org.apache.sshd>2.18.0</version.org.apache.sshd>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
         <version.org.assertj>3.27.7</version.org.assertj>
-        <version.org.bouncycastle>1.84</version.org.bouncycastle>
+        <version.org.bouncycastle>1.85</version.org.bouncycastle>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jgit>7.6.0.202603022253-r</version.org.eclipse.jgit>
         <version.org.eclipse.parsson>1.1.9</version.org.eclipse.parsson>


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFCORE-7647
Upstream PR: https://github.com/wildfly/wildfly-core/pull/6857
