### PR TITLE
[WFCORE-7663] Update the ParameterCorrector javadoc

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ParameterCorrector.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParameterCorrector.java
@@ -7,15 +7,28 @@ package org.jboss.as.controller;
 import org.jboss.dmr.ModelNode;
 
 /**
- * An implementation of this interface will be invoked before
- * a new attribute value is set, so it has a chance to adjust the new value,
- * if and as necessary, e.g. propagate properties from the current value
- * in case the new value is missing them.
- * The implementation of this interface will be invoked before
- * the new value is validated by the attribute's parameter validator.
- * Which means after the value has been corrected by an instance of
- * this interface, the corrected value will be passed to the
- * attribute's parameter validator for validation.
+ * Allows ease-of-use adjustment of operation parameter values to conform to operation handler expectations.
+ * A corrector will be invoked in {@link OperationContext.Stage Stage.MODEL} before the parameter value is
+ * {@link org.jboss.as.controller.operations.validation.ParameterValidator#validateParameter(String, ModelNode) validated},
+ * so it has a chance to adjust the value if necessary. The corrected value will be what is passed to the validator.
+ * <p/>
+ * Some example uses:
+ * <ul>
+ *     <li>Simple formatting corrections to canonical formats, e.g. case correction</li>
+ *     <li>Compatibility migrations, where a previously legal value is 'corrected' to
+ *         a currently legal value with the same semantic</li>
+ * </ul>
+ * <p/>
+ * Implementations should ensure the given {@code parameterValue} meets expectations (e.g. is of the
+ * expected {@code ModelType}) before performing any correction. If it does not, the {@code parameterValue}
+ * should simply be returned unmodified. A {@code ParameterCorrector} should not attempt to reject unexpected values;
+ * that is the task of a {@link org.jboss.as.controller.operations.validation.ParameterValidator ParameterValidator}.
+ * <p/>
+ * <strong>Note:</strong> If an original operation parameter value contained nodes of {@code ModelType.STRING}
+ * where the string included expression syntax, a replacement node of {@code ModelType.EXPRESSION} will be
+ * passed to the parameter corrector, allowing the corrector to easily differentiate expressions from ordinary
+ * strings. The given {@code parameterValue} will not be the value of the resolved expression.
+ * Generally, a corrector should return expression nodes unmodified.
  *
  * @author Alexey Loubyansky
  */
@@ -23,11 +36,14 @@ import org.jboss.dmr.ModelNode;
 public interface ParameterCorrector {
 
     /**
-     * Adjusts the value to be set on the attribute.
+     * Adjusts a parameter value before use.
      *
-     * @param newValue  the new value to be set
-     * @param currentValue  the current value of the attribute
-     * @return  the value that actually should be set
+     * @param parameterValue  the operation parameter value. Will not be {@code null}
+     * @param currentValue  the current value of an attribute or complex attribute field or element
+     *                      whose value would be changed by the operation to {@code parameterValue}.
+     *                      May be {@code null} or an undefined node if a 'current value' is not
+     *                      relevant to the operation.
+     * @return  the value that actually should be used. Cannot be {@code null}
      */
-    ModelNode correct(ModelNode newValue, ModelNode currentValue);
+    ModelNode correct(ModelNode parameterValue, ModelNode currentValue);
 }


### PR DESCRIPTION
General cleanup to reflect that the primary relevant concept is operation parameter values, and not the attributes where such values often end up being stored.

Add a discussion of how expression values are handled.

Add example use cases

Add discussion of the need to confirm nodes meet expectations before correcting and how to handle any that don't

https://redhat.atlassian.net/browse/WFCORE-7663
