### PR TITLE
[WFCORE-7659] Add model Controller versions based on WF41

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -48,6 +48,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
         data.add(new TransformersTestParameter(ModelVersion.create(22, 0, 0), ModelTestControllerVersion.EAP_8_0_0));
         data.add(new TransformersTestParameter(ModelVersion.create(24, 0, 0), ModelTestControllerVersion.WILDFLY_31_0_0));
         data.add(new TransformersTestParameter(ModelVersion.create(28, 0, 0), ModelTestControllerVersion.EAP_8_1_0));
+        data.add(new TransformersTestParameter(ModelVersion.create(34, 0, 0), ModelTestControllerVersion.WILDFLY_41_0_0));
         return data;
     }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -10,6 +10,7 @@ import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_4_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_8_0_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_8_1_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.WILDFLY_31_0_0;
+import static org.jboss.as.model.test.ModelTestControllerVersion.WILDFLY_41_0_0;
 import static org.junit.Assert.assertTrue;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.TRUST_MANAGER;
 
@@ -123,6 +124,11 @@ public class SubsystemTransformerTestCase extends AbstractElytronSubsystemBaseTe
     @Test
     public void testTransformerWFLY31() throws Exception {
         testTransformation(WILDFLY_31_0_0);
+    }
+
+    @Test
+    public void testTransformerWFLY41() throws Exception {
+        testTransformation(WILDFLY_41_0_0);
     }
 
     private KernelServices buildKernelServices(String xml, ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {

--- a/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTransformerTestCase.java
+++ b/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTransformerTestCase.java
@@ -32,7 +32,7 @@ public class IOSubsystemTransformerTestCase extends AbstractSubsystemTest {
 
     @Parameters
     public static Iterable<ModelTestControllerVersion> parameters() {
-        return EnumSet.of(ModelTestControllerVersion.EAP_7_4_0, ModelTestControllerVersion.EAP_8_0_0, ModelTestControllerVersion.EAP_8_1_0);
+        return EnumSet.of(ModelTestControllerVersion.EAP_7_4_0, ModelTestControllerVersion.EAP_8_0_0, ModelTestControllerVersion.EAP_8_1_0, ModelTestControllerVersion.WILDFLY_41_0_0);
     }
 
     private final ModelTestControllerVersion controller;
@@ -60,6 +60,7 @@ public class IOSubsystemTransformerTestCase extends AbstractSubsystemTest {
             case EAP_8_0_0:
                 return IOSubsystemModel.VERSION_5_0_0;
             case EAP_8_1_0:
+            case WILDFLY_41_0_0:
                 return IOSubsystemModel.VERSION_6_0_0;
             default:
                 throw new IllegalArgumentException();
@@ -70,11 +71,12 @@ public class IOSubsystemTransformerTestCase extends AbstractSubsystemTest {
         switch (this.controller) {
             case EAP_7_4_0:
             case EAP_8_0_0:
-                return new String[] {
+                return new String[]{
                         formatSubsystemArtifact(),
                 };
             case EAP_8_1_0:
-                return new String[] {
+            case WILDFLY_41_0_0:
+                return new String[]{
                         formatArtifact("org.wildfly.core:wildfly-io:%s"),
                         formatArtifact("org.wildfly.core:wildfly-subsystem:%s"),
                 };

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -28,7 +28,8 @@ public enum ModelTestControllerVersion {
     EAP_XP_5("5.0.0.GA-redhat-00005", true, "29.0.0", "21.0.5.Final-redhat-00001", "xp5"),
 
     //WildFly releases
-    WILDFLY_31_0_0("31.0.0.Final", false, "31.0.0", "23.0.1.Final", "wf31");
+    WILDFLY_31_0_0("31.0.0.Final", false, "31.0.0", "23.0.1.Final", "wf31"),
+    WILDFLY_41_0_0("41.0.0.Final", false, "41.0.0", "33.0.0.Final", "wf41");
 
     private final String mavenGavVersion;
     private final String testControllerVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <version.org.wildfly.discovery>1.3.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.installation-manager.installation-manager-api>1.2.1.Final</version.org.wildfly.installation-manager.installation-manager-api>
         <version.org.wildfly.launcher>1.0.3.Final</version.org.wildfly.launcher>
-        <version.org.wildfly.legacy.test>10.0.2.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>11.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>2.3.0.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>2.3.0.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.security.elytron>2.9.2.Final</version.org.wildfly.security.elytron>

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformerTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformerTestCase.java
@@ -7,6 +7,7 @@ package org.jboss.as.remoting;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_4_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_8_0_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_8_1_0;
+import static org.jboss.as.model.test.ModelTestControllerVersion.WILDFLY_41_0_0;
 import static org.jboss.as.remoting.RemotingSubsystemTestUtil.DEFAULT_ADDITIONAL_INITIALIZATION;
 import static org.junit.Assert.assertTrue;
 
@@ -38,7 +39,7 @@ public class RemotingSubsystemTransformerTestCase extends AbstractSubsystemTest 
 
     @Parameters
     public static Iterable<ModelTestControllerVersion> parameters() {
-        return EnumSet.of(EAP_8_1_0, EAP_8_0_0, EAP_7_4_0);
+        return EnumSet.of(EAP_8_1_0, EAP_8_0_0, EAP_7_4_0, WILDFLY_41_0_0);
     }
 
     private final ModelTestControllerVersion controller;
@@ -67,6 +68,8 @@ public class RemotingSubsystemTransformerTestCase extends AbstractSubsystemTest 
                 return EAP_8_0_0.getSubsystemModelVersion(getMainSubsystemName());
             case EAP_8_1_0:
                 return EAP_8_1_0.getSubsystemModelVersion(getMainSubsystemName());
+            case WILDFLY_41_0_0:
+                return WILDFLY_41_0_0.getSubsystemModelVersion(getMainSubsystemName());
             default:
                 throw new IllegalArgumentException();
         }
@@ -77,6 +80,7 @@ public class RemotingSubsystemTransformerTestCase extends AbstractSubsystemTest 
             case EAP_7_4_0:
             case EAP_8_0_0:
             case EAP_8_1_0:
+            case WILDFLY_41_0_0:
                 return new String[]{
                         formatSubsystemArtifact(),
                 };
@@ -134,14 +138,20 @@ public class RemotingSubsystemTransformerTestCase extends AbstractSubsystemTest 
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
         List<ModelNode> ops = builder.parseXmlResource("remoting-transform-rejects.xml");
+        ModelTestUtils.checkFailedTransformedBootOperations(services, modelVersion, ops, createFailedOperationTransformationConfig());
+    }
+
+    private FailedOperationTransformationConfig createFailedOperationTransformationConfig() {
+        FailedOperationTransformationConfig config = new FailedOperationTransformationConfig();
         PathAddress subsystemAddress = PathAddress.pathAddress("subsystem", RemotingExtension.SUBSYSTEM_NAME);
 
-        ModelTestUtils.checkFailedTransformedBootOperations(services, modelVersion, ops, new FailedOperationTransformationConfig()
-                .addFailedAttribute(subsystemAddress.append(ConnectorResource.PATH),
-                        new FailedOperationTransformationConfig
-                                .NewAttributesConfig(ConnectorResource.PROTOCOL)
-                )
-        );
+        if (RemotingSubsystemModel.VERSION_8_0_0.requiresTransformation(this.version)) {
+            config.addFailedAttribute(subsystemAddress.append(ConnectorResource.PATH),
+                    new FailedOperationTransformationConfig
+                            .NewAttributesConfig(ConnectorResource.PROTOCOL)
+            );
+        }
 
+        return config;
     }
 }

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-transform-8.0.0.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-transform-8.0.0.xml
@@ -1,0 +1,73 @@
+<subsystem xmlns="urn:jboss:domain:remoting:8.0">
+    <endpoint
+        worker="default-remoting"
+        send-buffer-size="8191"
+        receive-buffer-size="8191"
+        buffer-region-size="10240"
+        transmit-window-size="131071"
+        receive-window-size="131071"
+        max-outbound-channels="41"
+        max-inbound-channels="41"
+        authorize-id="foo"
+        auth-realm="ApplicationRealm"
+        authentication-retries="4"
+        max-outbound-messages="65534"
+        max-inbound-messages="79"
+        heartbeat-interval="20000"
+        max-inbound-message-size="1000000"
+        max-outbound-message-size="1000000"
+        server-name="test"
+        sasl-protocol="bar"
+    />
+    <connector name="remoting-connector"
+               socket-binding="remoting"
+               sasl-protocol="myProto"
+               server-name="myServer"
+               authentication-provider="blah"
+               protocol="remote+tls">
+        <properties>
+           <property name="TCP_NODELAY" value="true"/>
+           <property name="KEEP_ALIVE" value="true"/>
+        </properties>
+        <sasl include-mechanisms="one two three" qop="auth auth-int" strength="low high" server-auth="true" reuse-session="true">
+            <policy forward-secrecy="true" no-active="true" no-anonymous="true" no-dictionary="true" no-plain-text="true" pass-credentials="true"/>
+            <properties>
+               <property name="SASL_SERVER_AUTH" value="true"/>
+               <property name="SASL_POLICY_NOACTIVE" value="false"/>
+            </properties>
+        </sasl>
+    </connector>
+    <http-connector name="http-connector" connector-ref="http" sasl-protocol="myProto" server-name="myServer" authentication-provider="blah">
+        <properties>
+            <property name="TCP_NODELAY" value="true"/>
+            <property name="REUSE_ADDRESSES" value="true"/>
+        </properties>
+        <sasl include-mechanisms="one two three" qop="auth auth-int" strength="low high" server-auth="true" reuse-session="true">
+            <policy forward-secrecy="true" no-active="true" no-anonymous="true" no-dictionary="true" no-plain-text="true" pass-credentials="true"/>
+            <properties>
+               <property name="SASL_SERVER_AUTH" value="true"/>
+               <property name="SASL_POLICY_NOACTIVE" value="false"/>
+            </properties>
+        </sasl>
+    </http-connector>
+    <outbound-connections>
+        <local-outbound-connection name="local" outbound-socket-binding-ref="dummy-outbound-socket">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </local-outbound-connection>
+        <remote-outbound-connection name="remote" outbound-socket-binding-ref="other-outbound-socket" protocol="remote+http">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </remote-outbound-connection>
+        <outbound-connection name="generic" uri="local://-">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </outbound-connection>
+    </outbound-connections>
+</subsystem>


### PR DESCRIPTION
- Adds model controller versions for WF 41
- Use the expected wildfly-legacy-test that kicks them off
- Adds IO, remoting and Elytron transformers 


Jira issue: https://redhat.atlassian.net/browse/WFCORE-7659