### PR TITLE
WFCORE-7665 fix for HostControllerBootOperationsTestCase intermitent …

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostControllerBootOperationsTestCase.java
@@ -116,6 +116,10 @@ public class HostControllerBootOperationsTestCase {
         op.get("jvm-option").set("-Djava.security.policy==" + System.getProperty("java.io.tmpdir") + "/test-classes/byteman-scripts/byteman.policy");
         DomainTestUtils.executeForResult(op, primaryClient);
 
+        op = Util.createEmptyOperation("add-jvm-option", SECONDARY_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN));
+        op.get("jvm-option").set("-Dtest.byteman.delay=" + TimeoutUtil.adjust(Duration.ofSeconds(45)).toMillis());
+        DomainTestUtils.executeForResult(op, primaryClient);
+
         String bytemanJavaAgent = System.getProperty("jboss.test.host.server.byteman.javaagent")+"DelayServerRegistrationAndRunningState.btm";
         op = Util.getWriteAttributeOperation(SECONDARY_ADDR.append(SERVER_CONFIG_MAIN_THREE).append(JVM_BYTEMAN), "java-agent", bytemanJavaAgent);
         DomainTestUtils.executeForResult(op, primaryClient);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SecondaryRegistrationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SecondaryRegistrationTestCase.java
@@ -12,6 +12,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 
+import java.time.Duration;
+
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
@@ -19,6 +21,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -71,6 +74,10 @@ public class SecondaryRegistrationTestCase {
 
         op = Util.createEmptyOperation("add-jvm-option", PRIMARY_ADDR.append(SERVER_CONFIG_MAIN_TWO).append(JVM_DEFAULT));
         op.get("jvm-option").set("-Djboss.modules.system.pkgs=org.jboss.byteman");
+        DomainTestUtils.executeForResult(op, primaryClient);
+
+        op = Util.createEmptyOperation("add-jvm-option", PRIMARY_ADDR.append(SERVER_CONFIG_MAIN_TWO).append(JVM_DEFAULT));
+        op.get("jvm-option").set("-Dtest.byteman.delay=" + TimeoutUtil.adjust(Duration.ofSeconds(15)).toMillis());
         DomainTestUtils.executeForResult(op, primaryClient);
 
         String bytemanJavaAgent = System.getProperty("jboss.test.host.server.byteman.javaagent")+"DelayServerRegistration.btm";

--- a/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistration.btm
+++ b/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistration.btm
@@ -3,5 +3,5 @@ CLASS org.jboss.as.server.mgmt.domain.HostControllerConnection$ServerRegisterReq
 METHOD sendRequest
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 15*1000)
+DO waitFor($this, Long.parseLong(System.getProperty("test.byteman.delay", "15000")))
 ENDRULE

--- a/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
+++ b/testsuite/domain/src/test/resources/byteman-scripts/DelayServerRegistrationAndRunningState.btm
@@ -3,7 +3,7 @@ CLASS org.jboss.as.server.mgmt.domain.HostControllerConnection$ServerRegisterReq
 METHOD sendRequest
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 45*1000)
+DO waitFor($this, Long.parseLong(System.getProperty("test.byteman.delay", "45000")))
 ENDRULE
 
 RULE Delay Server finish boot
@@ -11,5 +11,5 @@ CLASS org.jboss.as.server.ServerService
 METHOD finishBoot
 AT ENTRY
 IF NOT waiting($this)
-DO waitFor($this, 45*1000)
+DO waitFor($this, Long.parseLong(System.getProperty("test.byteman.delay", "45000")))
 ENDRULE


### PR DESCRIPTION
Jira issue: https://redhat.atlassian.net/browse/WFCORE-7665

- tie byteman rules wait to `TimeoutUtil.adjust()` so they scale with `ts.timeout.factor`