### PR TITLE
[WFCORE-7453] Expose ordered child types in read-resource-description

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceDescriptionProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceDescriptionProvider.java
@@ -16,6 +16,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MOD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ORDERED_CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
 import static org.wildfly.common.Assert.checkNotNullParam;
@@ -194,6 +195,11 @@ public class DefaultResourceDescriptionProvider implements DescriptionProvider {
                 childNode.get(DESCRIPTION).set(descriptionResolver.getChildTypeDescription(key, locale, bundle));
                 childNode.get(MODEL_DESCRIPTION); // placeholder
             }
+        }
+
+        final ModelNode orderedChildren = result.get(ORDERED_CHILDREN).setEmptyList();
+        for (String orderedChildType : registration.getOrderedChildTypes()) {
+            orderedChildren.add(orderedChildType);
         }
 
         return result;

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -352,6 +352,7 @@ public class ModelDescriptionConstants {
     public static final String OPTIONAL = "optional";
     public static final String OPTIONS = "options";
     public static final String OPERATOR = "operator";
+    public static final String ORDERED_CHILDREN = "ordered-children";
     public static final String OUTBOUND_CONNECTION = "outbound-connection";
     /** Use this standard operation address field in the operation *description* ModelNode */
     public static final String OUTCOME = "outcome";

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -59,7 +61,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     // We assume at least 2 attrs, so just instantiate a hash map
     private final Map<String, AttributeAccess> attributes = new HashMap<>();
 
-    private Set <String> orderedChildTypes;
+    private SortedSet<String> orderedChildTypes;
 
     private final boolean runtimeOnly;
     private final boolean ordered;
@@ -173,7 +175,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             checkPermission();
             readLock.lock();
             try {
-                return orderedChildTypes == null ? Collections.emptySet() : new HashSet<>(orderedChildTypes);
+                return orderedChildTypes == null ? Collections.emptySortedSet() : new TreeSet<>(orderedChildTypes);
             } finally {
                 readLock.unlock();
             }
@@ -994,13 +996,9 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         writeLock.lock();
         try {
             if (orderedChildTypes == null) {
-                orderedChildTypes = Collections.singleton(type);
-            } else {
-                if (orderedChildTypes.size() == 1) {
-                    orderedChildTypes = new HashSet<>(orderedChildTypes);
-                }
-                orderedChildTypes.add(type);
+                orderedChildTypes = new TreeSet<>();
             }
+            orderedChildTypes.add(type);
         } finally {
             writeLock.unlock();
         }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
@@ -303,17 +303,17 @@ public interface ImmutableManagementResourceRegistration extends FeatureRegistry
 
 
     /**
-     * Return @code true} if a child resource registration was registered using
-     * {@link ManagementResourceRegistration#registerSubModel(ResourceDefinition)}, and {@code false} otherwise
+     * Returns {@code true} if a child resource registration was registered using
+     * {@link ManagementResourceRegistration#registerSubModel(ResourceDefinition)}, and {@code false} otherwise.
      *
      * @return whether this is an ordered child or not
      */
     boolean isOrderedChildResource();
 
     /**
-     * Return the names of the child types registered to be ordered.
+     * Return the names of the child types registered to be ordered, sorted by child type name.
      *
-     * @return the set of ordered child types, and and empty set if there are none
+     * @return the set of ordered child types, and an empty set if there are none
      */
     Set<String> getOrderedChildTypes();
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 
@@ -491,8 +492,8 @@ final class NodeSubregistry {
             if (result == null) {
                 result = wildCardChildren;
             } else if (wildCardChildren != null) {
-                // Merge
-                result = new HashSet<String>(result);
+                // Merge, keeping the child types sorted by name
+                result = new TreeSet<String>(result);
                 result.addAll(wildCardChildren);
             }
         }

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -470,7 +470,7 @@ public abstract class AbstractProxyControllerTest {
 
     private void checkHostSubModelDescription(ModelNode result, boolean operations, boolean notifications) {
 
-        assertEquals(result.toString(), 7, result.keys().size());
+        assertEquals(result.toString(), 8, result.keys().size());
         assertEquals("description", result.get(DESCRIPTION).asString());
         assertEquals("serverchild", result.get(CHILDREN, "serverchild", DESCRIPTION).asString());
         assertEquals(1, result.get(CHILDREN, "serverchild", MODEL_DESCRIPTION).keys().size());
@@ -505,7 +505,7 @@ public abstract class AbstractProxyControllerTest {
     }
 
     private void checkHostChildSubModelDescription(ModelNode result, boolean operations, boolean notifications) {
-        assertEquals(6, result.keys().size());
+        assertEquals(7, result.keys().size());
         assertEquals(1, result.get(ATTRIBUTES).keys().size());
         assertEquals(ModelType.STRING, result.get(ATTRIBUTES, "name", TYPE).asType());
         assertEquals("name", result.get(ATTRIBUTES, "name", DESCRIPTION).asString());
@@ -548,7 +548,7 @@ public abstract class AbstractProxyControllerTest {
     }
 
     private void checkHostChildChildSubModelDescription(ModelNode result, boolean operations, boolean notifications) {
-        assertEquals(6, result.keys().size());
+        assertEquals(7, result.keys().size());
         assertEquals(3, result.get(ATTRIBUTES).keys().size());
         assertEquals(ModelType.STRING, result.get(ATTRIBUTES, "name", TYPE).asType());
         assertEquals("name", result.get(ATTRIBUTES, "name", DESCRIPTION).asString());

--- a/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
@@ -11,11 +11,14 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ORDERED_CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
+
+import java.util.Collections;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ManagementModel;
@@ -44,6 +47,7 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
 
     private static final PathElement PARENT_MAIN = PathElement.pathElement("parent", "main");
     private static final PathElement CHILD = PathElement.pathElement("child");
+    private static final PathElement NON_ORDERED_CHILD = PathElement.pathElement("non-ordered-child");
     private static final AttributeDefinition ATTR = new SimpleAttributeDefinitionBuilder("attr", ModelType.STRING, true).build();
     private static final AttributeDefinition[] REQUEST_ATTRIBUTES = new AttributeDefinition[]{ATTR};
 
@@ -76,6 +80,21 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
         attributes = result.get(CHILDREN, "child", MODEL_DESCRIPTION, "*", ATTRIBUTES);
         Assert.assertTrue(attributes.hasDefined("attr"));
         Assert.assertFalse(attributes.hasDefined("index"));
+
+        //The parent registers an ordered child type, so it must list it, and only it
+        Assert.assertTrue("Parent description should have " + ORDERED_CHILDREN, result.hasDefined(ORDERED_CHILDREN));
+        Assert.assertEquals(Collections.singletonList(new ModelNode(CHILD.getKey())),
+                result.get(ORDERED_CHILDREN).asList());
+
+        //The non-ordered child type of the same parent must not be listed
+        Assert.assertTrue(result.hasDefined(CHILDREN, NON_ORDERED_CHILD.getKey()));
+
+        //The root registers 'parent' as a non-ordered child type, so its list must be present but empty
+        ModelNode rootRrd = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, PathAddress.EMPTY_ADDRESS);
+        ModelNode rootResult = executeForResult(rootRrd);
+        Assert.assertTrue(rootResult.hasDefined(CHILDREN, PARENT_MAIN.getKey()));
+        Assert.assertEquals(ModelType.LIST, rootResult.get(ORDERED_CHILDREN).getType());
+        Assert.assertEquals(Collections.emptyList(), rootResult.get(ORDERED_CHILDREN).asList());
     }
 
     @Test
@@ -153,6 +172,16 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
         @Override
         public void registerChildren(ManagementResourceRegistration resourceRegistration) {
             resourceRegistration.registerSubModel(new OrderedChildResourceDefinition());
+            resourceRegistration.registerSubModel(new NonOrderedChildResourceDefinition());
+        }
+    }
+
+    private static class NonOrderedChildResourceDefinition extends SimpleResourceDefinition {
+
+        NonOrderedChildResourceDefinition() {
+            super(new Parameters(NON_ORDERED_CHILD, NonResolvingResourceDescriptionResolver.INSTANCE)
+                    .setAddHandler(ModelOnlyAddStepHandler.INSTANCE)
+                    .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE));
         }
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
@@ -42,6 +42,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NO_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ORDERED_CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ONLY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REASON;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
@@ -106,6 +107,7 @@ public class ModelTestModelDescriptionValidator {
         validResourceKeys.put(OPERATIONS, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(NOTIFICATIONS, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(CHILDREN, NullDescriptorValidator.INSTANCE);
+        validResourceKeys.put(ORDERED_CHILDREN, StringListValidator.INSTANCE);
         validResourceKeys.put(DEPRECATED, DeprecatedDescriptorValidator.INSTANCE);
         validResourceKeys.put(ACCESS_CONSTRAINTS, AccessConstraintValidator.INSTANCE);
         validResourceKeys.put(STORAGE, NullDescriptorValidator.INSTANCE);


### PR DESCRIPTION
Resources now report their ordered child types in the management resource description under the 'ordered-children' key, as a list of child type names. This allows management clients to represent children accurately. Akin to other description keys, it is always present, and is an empty list for resources with no ordered child types. The registration stores the ordered child types sorted by name, so that the description is stable across invocations without having to sort on every call.

Resolves
https://redhat.atlassian.net/browse/WFCORE-7453

Today's discussion on the call @hpehl @bstansberry @yersan reminded me that I had a branch for this. Upon further inspection I have redone it completely – rather than the child exposing an ordered? flag – it should be resposibility of the parent, to describe its ordered children. 

Not a priority, just throwing it out there if people have time while I will be on PTO to think about this.