### PR TITLE
[WFCORE-7347] Add public-key-url attribute to token realm jwt configuration

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -390,8 +390,9 @@
                                 <exclude>jacc-with-providers.xml</exclude>
                                 <exclude>legacy*.xml</exclude>
                                 <exclude>elytron-subsystem-community*.xml</exclude>
+                                <exclude>elytron-subsystem-19.0.xml</exclude>
                             </excludes>
-                            <systemId>src/main/resources/schema/wildfly-elytron_19_0.xsd</systemId>
+                            <systemId>src/main/resources/schema/wildfly-elytron_20_0.xsd</systemId>
                         </validationSet>
                         <validationSet>
                             <dir>src/main/resources/schema</dir>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -430,6 +430,7 @@ interface ElytronDescriptionConstants {
     String PROVIDER_VERSION = "provider-version";
     String PROVIDERS = "providers";
     String PUBLIC_KEY = "public-key";
+    String PUBLIC_KEY_URL = "public-key-url";
 
     String RDN_IDENTIFIER = "rdn-identifier";
     String READ_ALIAS = "read-alias";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -42,8 +42,9 @@ public class ElytronExtension implements Extension {
      * The current name space used for the {@code subsystem} element
      */
     static final String NAMESPACE_18_0 = "urn:wildfly:elytron:18.0";
+    static final String NAMESPACE_20_0 = "urn:wildfly:elytron:20.0";
 
-    static final String CURRENT_NAMESPACE = NAMESPACE_18_0;
+    static final String CURRENT_NAMESPACE = NAMESPACE_20_0;
 
     /**
      * The name of our subsystem within the model.
@@ -76,8 +77,9 @@ public class ElytronExtension implements Extension {
     static final ModelVersion ELYTRON_17_0_0 = ModelVersion.create(17);
     static final ModelVersion ELYTRON_18_0_0 = ModelVersion.create(18);
     static final ModelVersion ELYTRON_19_0_0 = ModelVersion.create(19);
+    static final ModelVersion ELYTRON_20_0_0 = ModelVersion.create(20);
 
-    private static final ModelVersion ELYTRON_CURRENT = ELYTRON_19_0_0;
+    private static final ModelVersion ELYTRON_CURRENT = ELYTRON_20_0_0;
 
     static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemSchema.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemSchema.java
@@ -55,8 +55,9 @@ public enum ElytronSubsystemSchema implements PersistentSubsystemSchema<ElytronS
     VERSION_18_0(18),
     VERSION_18_0_COMMUNITY(18, Stability.COMMUNITY),
     VERSION_19_0(19),
+    VERSION_20_0(20),
     ;
-    static final Map<Stability, ElytronSubsystemSchema> CURRENT = Feature.map(EnumSet.of(VERSION_19_0));
+    static final Map<Stability, ElytronSubsystemSchema> CURRENT = Feature.map(EnumSet.of(VERSION_20_0));
 
     private final VersionedNamespace<IntVersion, ElytronSubsystemSchema> namespace;
 
@@ -234,7 +235,9 @@ public enum ElytronSubsystemSchema implements PersistentSubsystemSchema<ElytronS
 
     private void addRealmParser(PersistentResourceXMLDescription.PersistentResourceXMLBuilder builder) {
         RealmParser realmParser = new RealmParser();
-        if (this.since(ElytronSubsystemSchema.VERSION_18_0)) {
+        if (this.since(ElytronSubsystemSchema.VERSION_20_0)) {
+            builder.addChild(realmParser.realmParser_20);
+        } else if (this.since(ElytronSubsystemSchema.VERSION_18_0)) {
             builder.addChild(realmParser.realmParser_18);
         } else if (this.since(ElytronSubsystemSchema.VERSION_16_0)) {
             builder.addChild(realmParser.realmParser_16);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RealmParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RealmParser.java
@@ -112,6 +112,9 @@ class RealmParser {
     private final PersistentResourceXMLDescription tokenRealmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM))
             .addAttributes(TokenRealmDefinition.ATTRIBUTES)
             .build();
+    private final PersistentResourceXMLDescription tokenRealmParser_20 = builder(PathElement.pathElement(ElytronDescriptionConstants.TOKEN_REALM))
+            .addAttributes(TokenRealmDefinition.ATTRIBUTES)
+            .build();
     private final PersistentResourceXMLDescription cachingRealmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.CACHING_REALM))
             .addAttributes(CachingRealmDefinition.ATTRIBUTES)
             .build();
@@ -266,6 +269,23 @@ class RealmParser {
             .addChild(ldapRealmParser)
             .addChild(filesystemRealmParser_16)
             .addChild(tokenRealmParser)
+            .addChild(cachingRealmParser)
+            .addChild(distributedRealmParser_18)
+            .addChild(failoverRealmParser)
+            .addChild(jaasRealmParser)
+            .build();
+
+    final PersistentResourceXMLDescription realmParser_20 = decorator(ElytronDescriptionConstants.SECURITY_REALMS)
+            .addChild(aggregateRealmParser_8_0)
+            .addChild(customRealmParser)
+            .addChild(customModifiableRealmParser)
+            .addChild(identityRealmParser)
+            .addChild(jdbcRealmParser_14_0)
+            .addChild(keyStoreRealmParser)
+            .addChild(propertiesRealmParser_14_0)
+            .addChild(ldapRealmParser)
+            .addChild(filesystemRealmParser_16)
+            .addChild(tokenRealmParser_20)
             .addChild(cachingRealmParser)
             .addChild(distributedRealmParser_18)
             .addChild(failoverRealmParser)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -19,6 +19,7 @@ import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAtt
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.KEY_MAP;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.KEY_STORE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.PUBLIC_KEY;
+import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.PUBLIC_KEY_URL;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
 import java.net.MalformedURLException;
@@ -129,6 +130,14 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .build();
 
+        static final SimpleAttributeDefinition PUBLIC_KEY_URL = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PUBLIC_KEY_URL, ModelType.STRING, true)
+                .setAlternatives(ElytronDescriptionConstants.KEY_STORE, ElytronDescriptionConstants.CERTIFICATE)
+                .setAllowExpression(true)
+                .setValidator(new URLValidator())
+                .setMinSize(1)
+                .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                .build();
+
         static final SimpleAttributeDefinition KEY_STORE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_STORE, ModelType.STRING, true)
                 .setAlternatives(ElytronDescriptionConstants.PUBLIC_KEY)
                 .setRequires(ElytronDescriptionConstants.CERTIFICATE)
@@ -169,7 +178,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .setRestartAllServices()
                 .build();
 
-        static final ObjectTypeAttributeDefinition JWT_VALIDATOR = new ObjectTypeAttributeDefinition.Builder(JWT, ISSUER, AUDIENCE, PUBLIC_KEY, KEY_STORE, CERTIFICATE, SSL_CONTEXT, HOSTNAME_VERIFICATION_POLICY, KEY_MAP)
+        static final ObjectTypeAttributeDefinition JWT_VALIDATOR = new ObjectTypeAttributeDefinition.Builder(JWT, ISSUER, AUDIENCE, PUBLIC_KEY, PUBLIC_KEY_URL, KEY_STORE, CERTIFICATE, SSL_CONTEXT, HOSTNAME_VERIFICATION_POLICY, KEY_MAP)
                 .setRequired(false)
                 .setRestartAllServices()
                 .build();
@@ -262,6 +271,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 String[] issuer = asStringArrayIfDefined(context, ISSUER, jwtValidatorNode);
                 String[] audience = asStringArrayIfDefined(context, AUDIENCE, jwtValidatorNode);
                 String publicKey = PUBLIC_KEY.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
+                String publicKeyUrl = PUBLIC_KEY_URL.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
                 InjectedValue<KeyStore> keyStoreInjector = new InjectedValue<>();
                 String keyStoreName = KEY_STORE.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
                 String certificateAlias = CERTIFICATE.resolveModelAttribute(context, jwtValidatorNode).asStringOrNull();
@@ -307,6 +317,10 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                         }
                         if (publicKey != null) {
                             jwtValidatorBuilder.publicKey(publicKey.getBytes(StandardCharsets.UTF_8));
+                        }
+                        if (publicKeyUrl != null) {
+                            // TODO: wire up once wildfly-elytron ships JwtValidator.Builder.publicKeyUrl() (WFCORE-7347)
+                            // jwtValidatorBuilder.publicKeyUrl(new URL(publicKeyUrl));
                         }
                         if (sslContextRef != null) {
                             jwtValidatorBuilder.useSslContext(sslContextInjector.getOptionalValue());

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -746,6 +746,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
 
     // Message ID 1221 Mistakenly used for DynamicSSLContext - Moved above.
 
+    @Message(id = 1222, value = "Failed to parse public-key-url '%s'")
+    OperationFailedException invalidPublicKeyUrl(String url, @Cause Exception cause);
+
 
     /*
      * Don't just add new errors to the end of the file, there may be an appropriate section above for the resource.

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -927,6 +927,7 @@ elytron.token-realm.jwt=A token validator to be used in conjunction with a token
 elytron.token-realm.jwt.issuer=A list of strings representing the issuers supported by this configuration. During validation JWT tokens must have an 'iss' claim that contains one of the values defined here.
 elytron.token-realm.jwt.audience=A list of strings representing the audiences supported by this configuration. During validation JWT tokens must have an 'aud' claim that contains one of the values defined here.
 elytron.token-realm.jwt.public-key=A public key in PEM Format. During validation, if a public key is provided, signature will be verified based on the key you provided here.
+elytron.token-realm.jwt.public-key-url=A remote URL from which to retrieve a PEM-encoded public key. This is an alternative to inlining a public key for cases where JKU is not used. The key is cached and refreshed on expiry or after a failed verification, subject to a minimum-time guard to prevent DoS of the key server.
 elytron.token-realm.jwt.key-store=A key store from where the certificate with a public key should be loaded from.
 elytron.token-realm.jwt.key-map=A map of named public keys for token verification.
 elytron.token-realm.jwt.certificate=The name of the certificate with a public key to load from the key store.

--- a/elytron/src/main/resources/schema/wildfly-elytron_20_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_20_0.xsd
@@ -1,0 +1,6448 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:wildfly:elytron:20.0"
+           xmlns="urn:wildfly:elytron:20.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <!-- Need to include the path to the schema location here in order for the xml-validation that's defined in
+         elytron/pom.xml to succeed. -->
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="../controller/src/main/resources/schema/wildfly-credential-reference_1_1.xsd"/>
+
+    <!-- The subsystem root element -->
+    <xs:element name="subsystem" type="subsystemType"/>
+
+    <xs:complexType name="subsystemType">
+        <xs:all>
+            <xs:element name="security-properties" type="securityPropertiesType" minOccurs="0" />
+            <xs:element name="authentication-client" type="authenticationClientType" minOccurs="0" />
+            <xs:element name="providers" type="providersType" minOccurs="0" />
+            <xs:element name="audit-logging" type="auditLoggingType" minOccurs="0" />
+            <xs:element name="security-domains" type="securityDomainsType" minOccurs="0" />
+            <xs:element name="security-realms" type="realmsType" minOccurs="0" />
+            <xs:element name="credential-security-factories" type="credentialSecurityFactoriesType" minOccurs="0" />
+            <xs:element name="mappers" type="mappersType" minOccurs="0" />
+            <xs:element name="permission-sets" type="permissionSetsType" minOccurs="0" />
+            <xs:element name="http" type="httpType" minOccurs="0" />
+            <xs:element name="sasl" type="saslType" minOccurs="0" />
+            <xs:element name="tls" type="tlsType" minOccurs="0" />
+            <xs:element name="credential-stores" type="credentialStoresType" minOccurs="0" />
+            <xs:element name="expression-resolver" type="expressionResolverType" minOccurs="0" />
+            <xs:element name="dir-contexts" type="dirContextsType" minOccurs="0" />
+            <xs:element name="policy" type="policyType" minOccurs="0" />
+            <xs:element name="jaspi" type="jaspiType" minOccurs="0" />
+        </xs:all>
+        <xs:attribute name="default-authentication-context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the default authentication context to be associated with all deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-providers" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a capability providing a Provider[] which will be registered globally ahead of all existing Provider registrations.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-providers" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a capability providing a Provider[] which will be registered globally after all existing Provider registrations.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="disallowed-providers" type="stringListType">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of providers that are disallowed, and will be removed from the providers list.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="register-jaspi-factory" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Should the WildFly Elytron AuthConfigFactory implementation be automatically registered.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-ssl-context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to an SSLContext which should be globally registered as the default.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Security Properties
+     -->
+
+    <xs:complexType name="securityPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Type to contain a list of security properties to be set.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="security-property" type="propertyType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:annotation>
+            <xs:documentation>
+                Representation of a key/value property pair.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The key for this property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The value for this property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <!--
+        Authentication Client
+     -->
+
+    <xs:complexType name="webservicesType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a Web Services configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="http-mechanism" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    HTTP mechanism web services client will use when connecting to the server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ws-security-type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    WS-security method web services client will use when connecting to the server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationClientType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the authentication client definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="authentication-configuration" type="authenticationConfigurationType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="authentication-context" type="authenticationContextType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationConfigurationType">
+        <xs:annotation>
+            <xs:documentation>
+                Authentication configuration definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        An ordered list of properties to be used to configure all of the providers.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="webservices" type="webservicesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Web Services client configuration definition.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the authentication-configuration, note names used for authentication-configurations must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extends" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a previously defined authentication configuration to extend.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="anonymous" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enables anonymous authentication.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use for authentication.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authorization-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use for authorization.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the host to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocol" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The protocol to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    The port to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The realm to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a security domain to use for a forwarded identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="forwarding-mode" default="authentication">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation>
+                        The type of identity forwarding to use when security-domain is specified. The value "authenticaiton" forwards
+                        the identity of the currently authenticated user, including credentials. The value "authorization" forwards
+                        the underlying authorization identity, which allows for a different identity to be used for authentication.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="authentication" />
+                    <xs:enumeration value="authorization" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name = "sasl-mechanism-selector" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The SASL mechanism selector string. Allows to specify allowed/forbidden SASL mechanisms.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="kerberos-security-factory" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a kerberos security factory used to obtain a GSS kerberos credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Authentication context definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="match-rule" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        An ordered list of match-rules to be defined on this authentication context.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="match-abstract-type" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on abstract type.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-abstract-type-authority" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on abstract type authority.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-host" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on host.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-local-security-domain" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on local security domain.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-no-user" type="xs:boolean" default="false">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on no user.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-path" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on path.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-port" type="xs:int">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on port.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-protocol" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on protocol.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-urn" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on urn.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-user" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on user.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="authentication-configuration" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The AuthenticationConfiguration to use with this match.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="ssl-context" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The SSLContext to use with this match.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the authentication-context, note names used for authentication-contexts must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extends" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a previously defined authentication context to extend.
+
+                    match-rules defined here are added after the rules of the parent.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Providers
+     -->
+
+    <xs:complexType name="providersType">
+        <xs:annotation>
+            <xs:documentation>
+                Container of Provider configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="aggregate-providers" type="aggregateProvidersType" />
+            <xs:element name="provider-loader" type="providerLoaderType" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateProvidersType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition that is actually an aggregation of other PrincipalDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="providers" type="providersRefType" minOccurs="2" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use to represent this provider loader in the management model.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="providersRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a Provider[] resource.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="providerLoaderType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single provider loader.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="configuration" minOccurs="0" >
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use to represent this provider loader in the management model.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the module to use to load the providers.
+
+                    If this is not specified the ClassLoader used to load the service will be used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="class-names" type="stringListType">
+            <xs:annotation>
+                <xs:documentation>
+                    The fully qualified class names of the providers to load.
+
+                    If this attribute is not specified then service loader based discovery will be used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The path to the configuration to use to initialise the provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the path of the configuration is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="argument" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Argument to pass into the constructor as the Provider is instantiated.
+
+                    Can only be used where the class names to load are specified.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Audit Logging
+     -->
+
+    <xs:complexType name="auditLoggingType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the security domain definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="aggregate-security-event-listener" type="aggregateSecurityEventListenerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-security-event-listener" type="customSecurityEventListenerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="file-audit-log" type="fileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="periodic-rotating-file-audit-log" type="periodicRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="size-rotating-file-audit-log" type="sizeRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="syslog-audit-log" type="syslogAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="formatType">
+        <xs:annotation>
+            <xs:documentation>
+                The format type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SIMPLE" />
+            <xs:enumeration value="JSON" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transportType">
+        <xs:annotation>
+            <xs:documentation>
+                The syslog transport method type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="TCP" />
+            <xs:enumeration value="UDP" />
+            <xs:enumeration value="SSL_TCP" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="auditLogType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all audit log types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the audit log.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateSecurityEventListenerType">
+        <xs:annotation>
+            <xs:documentation>
+                A security event listener definition that is actually an aggregation of other security event listeners.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:sequence>
+                    <xs:element name="security-event-listener" type="securityEventListenerRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="securityEventListenerRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a security event listener.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="fileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path to write the audit log to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to a previously defined path that the path of the audit log is
+                            relative to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="synchronized" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether every event should be immediately synchronised to disk.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="autoflush" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether every event should be immediately flushed to output stream.
+                            When not specified, "synchronized" value is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="format" default="SIMPLE" type="formatType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The format to use to log the event.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="encoding" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The file encoding to use.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="periodicRotatingFileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file rotating the log after a time period
+                derived from the given suffix string, which should be in a format understood by java.time.format.DateTimeFormatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fileAuditLogType">
+                <xs:attribute name="suffix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The suffix string in a format which can be understood by java.time.format.DateTimeFormatter.
+                            The period of the rotation is automatically calculated based on the suffix.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sizeRotatingFileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file rotating the log after the
+                size of the file grows beyond a certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fileAuditLogType">
+                <xs:attribute name="max-backup-index" default="1" type="xs:long" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of files to backup when rotating.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="rotate-on-boot" type="xs:boolean" default="false" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the file should be rotated before the a new file is set.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="rotate-size" default="10m" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The log file size the file should rotate at.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="suffix" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Format of date used as suffix of log file names in java.time.format.DateTimeFormatter.
+                            The suffix does not play a role in determining when the file should be rotated.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="syslogAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:attribute name="server-address" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Address of the server to send syslog messages to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="port" type="xs:int" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The port number the remote syslog server is listening on.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="transport" type="transportType" default="TCP">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The transport to use to communicate with the syslog server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="format" type="formatType" default="SIMPLE">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The format to use to log the event.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="host-name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The host name to send within all events sent to the syslog server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of ssl-context used to secure connection to the syslog server.
+                            Applies only when SSL_TCP transport is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="syslog-format" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The RFC format to be used for formatting the log entry, default value of RFC5424.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="reconnect-attempts" type="xs:int">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum amount of failed reconnect attempts that should be made for sending messages to a syslog server before the endpoint is closed, default value of 0 (no reconnect attempts).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customSecurityEventListenerType">
+        <xs:annotation>
+            <xs:documentation>
+                A security event listener definition for a custom security event listener implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the security event listener implementation.
+
+                                Note: If configuration is supplied the listener MUST implement a void initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--
+        Domains and Realms
+     -->
+
+    <xs:complexType name="securityDomainsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the security domain definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="security-domain" type="securityDomainType" maxOccurs="unbounded" />
+            <xs:element name="virtual-security-domain" type="virtualSecurityDomainType" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="securityDomainType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type for the definition of a single security domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="realm" type="realmRefType" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="default-realm" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Which of the listed realms should be the default?
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PrincipalTransformer to be applied before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PrincipalTransformer to be applied after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="principal-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PrincipalDecoder to be used by this domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="evidence-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to an EvidenceDecoder to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RoleDecoder to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this security domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RoleMapper to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="permission-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PermissionMapper to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trusted-security-domains" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of references to security domains that are trusted by this security domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trusted-virtual-security-domains" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of references to virtual security domains that are trusted by this security domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="outflow-anonymous" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where automatic outflow to a security domain is configured, if outflowing
+                    the current identity is not authorized should the
+                    anonymous identity of that domain be used instead?
+
+                    Outflowing an identity replaces any previously
+                    established identity for the outflow domain for the
+                    ongoing call, outflowing anonymous has the effect of
+                    clearing the identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="outflow-security-domains" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of references to security domains that any identity established for this
+                    domain should automatically outflow to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-event-listener" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a security event listener to be notified of security events
+                    emitted from this domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="realmRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a security realm.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The PrincipalTransformer to be associated with this realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The RoleDecoder to be associated with this realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The RoleMapper to be associated with this realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="realmsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the security realm definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="aggregate-realm" type="aggregateRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-realm" type="customRealmType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Custom realm definitions can implement either the SecurityRealm interface or the ModifiableSecurityRealm interface.
+
+                        Regardless of which interface is implemented management operations will not be exposed to manage the realm.  However other
+                        services that depend on the realm will still be able to perform a type check and cast to gain access to the modification API.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="custom-modifiable-realm" type="customRealmType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Custom realm configured as being modifiable will be expected to implement the ModifiableSecurityRealm interface.
+
+                        By configuring a realm as being modifiable management operations will be made available to manipulate the realm.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="identity-realm" type="identityRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="jdbc-realm" type="jdbcRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="key-store-realm" type="keyStoreRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="properties-realm" type="propertiesRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ldap-realm" type="ldapRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="filesystem-realm" type="fileSystemRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="token-realm" type="tokenRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="caching-realm" type="cachingRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="distributed-realm" type="distributedRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="failover-realm" type="failoverRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="jaas-realm" type="jaasRealmType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="realmType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all realm definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the realm, note names used for realms must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition that is an aggregation of two realms, one for the authentication steps
+                and one for loading the identity for the authorization steps.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="authentication-realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the realm to use for the authentication steps (obtaining or validating credentials).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="authorization-realm" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the realm to use for the authorization steps (loading of the identity).
+
+                            Exactly one of 'authorization-realm' and 'authorization-realms' must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="authorization-realms" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A list of security realms that should be used for the authorizations steps resulting in an
+                            aggregation of attributes if the identity is contained in multiple realms.
+
+                            Exactly one of 'authorization-realm' and 'authorization-realms' must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="principal-transformer" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A principal transformer to be applied after the authentication steps but before the authorization
+                            steps.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="cachingRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition that enables caching to another security realm. Caching strategy is LRU (Least Recently Used) where least accessed entries are discarded when maximum number of entries is reached.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to a cacheable security realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-entries" type="xs:int" use="optional" default="16">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of entries to keep in the cache.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-age" type="xs:long" use="optional" default="-1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The time in milliseconds that an item can stay in the cache.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a custom realm implementation.
+
+                Generally subsystems that provide security realms should make them available
+                using the capabilities and requirements features of the application
+                server, this custom mechanism is provided for truly isolated realm implementations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:sequence>
+                    <xs:element name="configuration" type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the SecurityRealm implementation.
+
+                                Note: If configuration is supplied the realm MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="distributedRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition for authentication and authorization of identities distributed between multiple realms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="realms" type="stringListType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A list of security realms that should be used for authentication until one succeeds.
+                            At least one realm must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="ignore-unavailable-realms" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether subsequent realms should be checked after an unavailable realm is reached.
+                            If set to false or not set, when the unavailable realm is reached org.wildfly.security.auth.server.RealmUnavailableException is thrown and the search stops.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="emit-events" type="xs:boolean" use="optional" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether a SecurityEvent signifying realm unavailability should be emitted.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="failoverRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition which wraps one realm and delegates to another in case the first is unavailable.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="delegate-realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the realm to use as a default.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="failover-realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the realm to use in case the default realm is unavailable.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="emit-events" type="xs:boolean" use="optional" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whenever security events should be emitted when failover takes place.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="identityRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a realm which contains a single pre-defined identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="identity" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the identity available from the security realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="attribute-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the attribute associated with this identity.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="attribute-values" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The values associated with the identity attributes.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A security realm definition backed by database using JDBC.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:sequence>
+                    <xs:element name="principal-query" type="authenticationQueryType" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="hash-charset" default="UTF-8" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The character set to use when converting the password string
+                            to a byte array.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jaasRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition which uses JAAS Login Context to verify user's credentials.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all minOccurs="0">
+                    <xs:element name="file" type="basicFileTypeOptional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the file with JAAS Login Context configuration.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="entry" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the entry defined in JAAS configuration file that should be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="module" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The module with custom login module classes and optional custom callback handler class.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="callback-handler" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The class name of the callback handler to pass to JAAS Login Context.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationQueryType">
+        <xs:annotation>
+            <xs:documentation>
+                The authentication query used to authenticate users based on specific key types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="clear-password-mapper" type="clearPasswordMapperType" minOccurs="0"/>
+            <xs:element name="bcrypt-mapper" type="bcryptMapperType" minOccurs="0"/>
+            <xs:element name="simple-digest-mapper" type="simpleDigestMapperType" minOccurs="0"/>
+            <xs:element name="salted-simple-digest-mapper" type="saltedSimpleDigestMapperType" minOccurs="0"/>
+            <xs:element name="scram-mapper" type="scramMapperType" minOccurs="0"/>
+            <xs:element name="modular-crypt-mapper" type="modularCryptMapperType" minOccurs="0"/>
+            <xs:element name="attribute-mapping" type="jdbcAttributeMappingType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="sql" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The SQL statement used to obtain the keys(as table columns) for a specific user and map them accordingly with their type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="data-source" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the datasource used to connect to the database.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcAttributeMappingType">
+        <xs:sequence>
+            <xs:element name="attribute" type="jdbcAttributeType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcAttributeType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration used to map a specific column in a table as an identity attribute.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from a query that representing the mapped attribute.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="to" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the identity attribute mapped from a column returned from a SQL query.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="clearPasswordMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Clear Password key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bcryptMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Bcrypt key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's salt, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="iteration-count-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's iteration count, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="hash-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password hash.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64"/>
+                    <xs:enumeration value="hex"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password salt.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64"/>
+                    <xs:enumeration value="hex"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="saltedSimpleDigestMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Salted Simple Digest key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The encryption algorithm name to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="password-salt-digest-md5" />
+                    <xs:enumeration value="password-salt-digest-sha-1" />
+                    <xs:enumeration value="password-salt-digest-sha-256" />
+                    <xs:enumeration value="password-salt-digest-sha-384" />
+                    <xs:enumeration value="password-salt-digest-sha-512" />
+                    <xs:enumeration value="salt-password-digest-md5" />
+                    <xs:enumeration value="salt-password-digest-sha-1" />
+                    <xs:enumeration value="salt-password-digest-sha-256" />
+                    <xs:enumeration value="salt-password-digest-sha-384" />
+                    <xs:enumeration value="salt-password-digest-sha-512" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's salt, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="hash-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password hash.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64" />
+                    <xs:enumeration value="hex" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password salt.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64" />
+                    <xs:enumeration value="hex" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="simpleDigestMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Simple Digest key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The encryption algorithm name to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="simple-digest-md2" />
+                    <xs:enumeration value="simple-digest-md5" />
+                    <xs:enumeration value="simple-digest-sha-1" />
+                    <xs:enumeration value="simple-digest-sha-256" />
+                    <xs:enumeration value="simple-digest-sha-384" />
+                    <xs:enumeration value="simple-digest-sha-512" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="hash-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password hash.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64" />
+                    <xs:enumeration value="hex" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="scramMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Scram key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The encryption algorithm name to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="scram-sha-1" />
+                    <xs:enumeration value="scram-sha-256" />
+                    <xs:enumeration value="scram-sha-384" />
+                    <xs:enumeration value="scram-sha-512" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's salt, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="iteration-count-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's iteration count, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="hash-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password hash.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64" />
+                    <xs:enumeration value="hex" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-encoding" default="base64">
+            <xs:annotation>
+                <xs:documentation>
+                    The encoding of the password salt.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="base64" />
+                    <xs:enumeration value="hex" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="modularCryptMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Modular Crypt key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user password in Modular Crypt Format.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoreRealmType">
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the KeyStore to be used by this realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a realm backed by a properties file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all>
+                    <xs:element name="users-properties">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the properties file containing the users and their passwords.
+                                The file should contain realm name declaration.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType >
+                            <xs:complexContent>
+                                <xs:extension base="basicFileType">
+                                    <xs:attribute name="plain-text" type="xs:boolean" default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Are the passwords in properties file stored in plain text or pre-hashed?
+                                                (Pre-hashed form: HEX( MD5( username ":" realm ":" password ) ) )
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="digest-realm-name" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The realm name to use for digested passwords if one is not discovered in the properties file.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:extension>
+                            </xs:complexContent>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="groups-properties" type="basicFileType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the properties file containing the users and their groups.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="groups-attribute" type="xs:string" default="groups">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the attribute in the returned AuthorizationIdentity that should contain the group membership information for the identity.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="hash-encoding" default="hex" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The string format for the password in the properties file if they are not
+                            stored in plain text.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="base64"/>
+                            <xs:enumeration value="hex"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="hash-charset" default="UTF-8" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The character set to use when converting the password string
+                            to a byte array.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- Ldap Security Realm -->
+
+    <xs:complexType name="ldapRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A security realm definition backed by LDAP.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all>
+                    <xs:element name="identity-mapping" type="identityMappingType" nillable="false"/>
+                </xs:all>
+                <xs:attribute name="dir-context" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of dir-context used to connect to the LDAP server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="direct-verification" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should this realm instance support verification of credentials by directly connecting to LDAP as the account being authenticated?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="allow-blank-password" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should direct verification in this realm to allow login attempt with blank password?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="hash-encoding" default="base64" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The string format for the password in the properties file if they are not
+                            stored in plain text.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="base64"/>
+                            <xs:enumeration value="hex"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="hash-charset" default="UTF-8" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The character set to use when converting the password string
+                            to a byte array.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- FileSystem Security Realm -->
+    <xs:complexType name="fileSystemRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple security realm definition backed by the filesystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all>
+                    <xs:element name="file" type="basicFileType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the file to use to handle the security realm.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="levels" type="xs:int" default="2">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The number of levels of directory hashing to apply
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="encoded" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the identity names should be stored encoded (Base32) in file names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="hash-encoding" default="base64" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The string format for the password in the properties file if they are not
+                            stored in plain text.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="base64"/>
+                            <xs:enumeration value="hex"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="hash-charset" default="UTF-8" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The character set to use when converting the password string
+                            to a byte array.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="credential-store" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to the credential store that contains the secret key used to encrypt and decrypt the filesystem-realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="secret-key" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            An alias to the secret key used to encrypt and decrypt the filesystem-realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-store" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to the key store that contains the key pair to perform filesystem integrity checks.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-store-alias" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The alias within the key-store that identifies the PrivateKeyEntry to use to perform filesystem integrity checks
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="tokenRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a token realm where authentication and authorization are handled by
+                a given token validator.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:choice>
+                    <xs:element name="jwt" type="jwtTokenRealmValidatorType"/>
+                    <xs:element name="oauth2-introspection" type="oauth2IntrospectionTokenRealmValidatorType"/>
+                </xs:choice>
+                <xs:attribute name="principal-claim" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the claim that should be used to obtain the principal's name. Defaults to 'username'.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jwtTokenRealmValidatorType">
+        <xs:annotation>
+            <xs:documentation>
+                A token validator to be used in conjunction with a token-based realm that handles security tokens based on the JWT/JWS standard.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="key" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="kid" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The JWK kid. Tokens with the same kid will use this public key for signature verification.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="public-key" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                RSA public key in PEM format.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="issuer" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of strings representing the issuers supported by this configuration. During validation JWT tokens must have an "iss" claim that contains one of the values defined here.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="audience" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of strings representing the audiences supported by this configuration. During validation JWT tokens must have an "aud" claim that contains one of the values defined here.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="public-key" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A public key in PEM Format. During validation, if a public key is provided, signature will be verified based on the key you provided here.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="public-key-url" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A remote URL from which to retrieve a PEM-encoded public key. This is an alternative to inlining a
+                    public key in the configuration via public-key, for cases where JKU is not used.
+                    The key is fetched and cached; it is refreshed on cache expiry or after a failed signature
+                    verification (subject to a minimum-time-between-requests guard to prevent DoS of the key server).
+                    Both HTTP and HTTPS URLs are supported. For HTTPS, configure a client-ssl-context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-store" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A key store from where the certificate with a public key should be loaded from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="certificate" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the certificate with a public key to load from the key store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="client-ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A predefined client-ssl-context that will be used to connect to the jwks endpoint specified in the jku token claim. This configuration is mandatory if you want to use remote keys with jku.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host-name-verification-policy" type="verificationPolicy" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A policy that defines how host names should be verified when using HTTPS for fetching jwks.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="oauth2IntrospectionTokenRealmValidatorType">
+        <xs:annotation>
+            <xs:documentation>
+                A token validator to be used in conjunction with a token-based realm that handles OAuth2 Access Tokens and validate them based on RFC-7662 (OAuth2 Token Introspection).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="client-id" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The identifier of a client registered within the OAuth2 Authorization Server that will be used to authenticate this server in order to validate bearer tokens arriving to this server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="client-secret" type="stringListType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The secret of the client identified by the given client-id.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="introspection-url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An URL pointing to a RFC-7662 OAuth2 Token Introspection compatible endpoint.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="client-ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A predefined client-ssl-context that will be used to connect to the token introspection endpoint when using SSL/TLS. This configuration is mandatory if the given token introspection url is using SSL/TLS.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host-name-verification-policy" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A policy that defines how host names should be verified when using HTTPS. Allowed values: "ANY".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="dirContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how to connect to the LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="dir-context" type="dirContextType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="dirContextType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how to connect to the LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The credential reference to credential store or clear text (password)
+                        to use to authenticate and connect to the LDAP server.
+                        Can be omitted if authentication-level is "none" (anonymous).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the connection. Allows to refer the DirContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The connection url.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-level" type="xs:string" use="optional" default="simple">
+            <xs:annotation>
+                <xs:documentation>
+                    The authentication level (security level/authentication mechanism) to use.
+                    Corresponds to SECURITY_AUTHENTICATION ("java.naming.security.authentication") environment property.
+                    Allowed values: "none", "simple", sasl_mech, where sasl_mech is a space-separated list of SASL mechanism names.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="principal" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The principal to authenticate and connect to the LDAP server.
+                    Can be omitted if authentication-level is "none" (anonymous).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-connection-pooling" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates if connection pooling is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="referral-mode" type="xs:string" default="ignore" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If LDAP referrals should be followed.
+                    Corresponds to REFERRAL ("java.naming.referral") environment property.
+                    Allowed values: "ignore", "follow", "throw".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of ssl-context used to secure connection to the LDAP server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of authentication-context used to secure connection and to authenticate to the LDAP server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connection-timeout" type="xs:integer" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The timeout for connecting to the LDAP server in milliseconds.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="read-timeout" type="xs:integer" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The read timeout for an LDAP operation in milliseconds.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of module that will be used to load custom context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="identityMappingType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how principals are mapped to their corresponding entries in the underlying LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="attribute-mapping" type="ldapAttributeMappingType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The attribute mappings defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="user-password-mapper" type="userPasswordMapperType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The user password credential mapping defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="otp-credential-mapper" type="otpCredentialMapperType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The user password credential mapping defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="x509-credential-mapper" type="x509CredentialMapperType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The X509 user certificate credential mapping defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="new-identity-attributes" type="ldapNewIdentityAttributesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The attributes of newly created identities. Required for modifiability.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="rdn-identifier" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The RDN part of the principal's DN to be used to obtain the principal's name from an LDAP entry.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-base-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The base DN to be used when executing queries.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="use-recursive-search" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates if queries are recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filter-name" type="xs:string" use="optional" default="(rdn_identifier={0})">
+            <xs:annotation>
+                <xs:documentation>
+                    The LDAP filter for getting identity by name.
+                    The string "{0}" will be replaced by searched identity name and the "rdn_identifier" will be the value of the attribute "rdn-identifier".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="iterator-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The LDAP filter for iterating over identities of the realm. Optional, but required for modifiability.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="new-identity-parent-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The DN of parent of newly created identities. Optional, but required for modifiability.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAttributeMappingType">
+        <xs:sequence>
+            <xs:element name="attribute" type="ldapAttributeType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAttributeType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration used to map a specific LDAP attribute as an identity attribute.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an identity attribute.
+                    If not defined, DN of the whole entry is used as value.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the identity attribute mapped from a specific LDAP attribute.
+                    If not provided, the name of the attribute is the same as define in 'from'.
+                    If the 'from' is not defined too, value 'dn' is used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="reference" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of LDAP attribute containing DN of entry to obtain value from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to use to obtain the values for a specific attribute.
+                    String "{0}" will be replaced by username, "{1}" by user identity DN.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filter-base-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the context where the filter should be performed.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-recursive" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates if attribute LDAP search queries are recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-recursion" type="xs:int" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets recursive roles assignment - value determine maximum depth of recursion. (0 for no recursion)
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-recursion-name" type="xs:string" use="optional" default="cn">
+            <xs:annotation>
+                <xs:documentation>
+                    Determine LDAP attribute of role entry which will be substitute for "{0}" in filter-name when searching roles of role.
+                    Used only when role-recursion is set.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extract-rdn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The RDN key to use as the value for an attribute, in case the value in its raw form is in X.500 format.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="userPasswordMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration used to map a specific LDAP attribute (userPassword usually) as an identity password credential.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an identity user password credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writable" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If the password credential is writable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="verifiable" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If the password credential is verifiable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="otpCredentialMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration allowing to use the LDAP as storage of one time password (OTP) credentials.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an OTP credential algorithm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="hash-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a Base64 encoded OTP credential hash.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="seed-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an OTP credential seed.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sequence-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an OTP credential sequence number.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="x509CredentialMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration allowing to use LDAP as storage of X509 credentials.
+                X509 credential is user certificate or information allowing to identify it.
+                (serial number, subject DN, digest of certificate)
+                At least one *-from attribute should be specified. This definition will be ignored otherwise.
+                If more *-from attributes is defined, user certificate must match all defined criteria.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="digest-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a user certificate digest.
+                    If not defined, certificate digest will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="digest-algorithm" type="xs:string" use="optional" default="SHA-1">
+            <xs:annotation>
+                <xs:documentation>
+                    The digest algorithm (hash function) used to compute digest of the user certificate.
+                    Will be used only if digest-from have been defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="certificate-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an encoded user certificate.
+                    If not defined, encoded certificate will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="serial-number-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a serial number of user certificate.
+                    If not defined, serial number will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="subject-dn-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a subject DN of user certificate.
+                    If not defined, subject DN will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapNewIdentityAttributesType">
+        <xs:sequence>
+            <xs:element name="attribute" type="ldapNewIdentityAttributeType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ldapNewIdentityAttributeType">
+        <xs:annotation>
+            <xs:documentation>
+                Attribute of newly created LDAP identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="value" type="stringListType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The value(s) of LDAP attribute delimited by space.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="credentialSecurityFactoriesType">
+        <xs:annotation>
+            <xs:documentation>
+                A container type to hold SecurityFactory definitions to obtain Credential instances.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="custom-credential-security-factory" type="customCredentialSecurityFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="kerberos-security-factory" type="kerberosSecurityFactory" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="credentialSecurityFactoryType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all SecurityFactory definitions which return a Credential.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the SecurityFactory, note names used for SecurityFactories must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customCredentialSecurityFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom credential SecurityFactory implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="credentialSecurityFactoryType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the SecurityFactory implementation.
+
+                                Note: If configuration is supplied the SecurityFactory MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="kerberosSecurityFactory">
+        <xs:complexContent>
+            <xs:extension base="credentialSecurityFactoryType">
+                <xs:sequence>
+                    <xs:element name="option" maxOccurs="unbounded" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The Krb5LoginModule additional option.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:attribute name="name" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The key of the option.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="value" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The value of the option.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="principal" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The principal represented by the KeyTab
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path to the KeyTab to use to obtain the credential.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the standard paths provided by the system.
+                            If 'relative-to' is provided, the value of the 'path' attribute is treated as relative
+                            to the path specified by this attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="minimum-remaining-lifetime" type="xs:int" default="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            How much lifetime (in seconds) should a cached credential have remaining before it is recreated.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="request-lifetime" type="xs:int">
+                    <xs:annotation>
+                        <xs:documentation>
+                            How much lifetime (in seconds) should be requested for newly created credentials.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="fail-cache" type="xs:int">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Amount of seconds before new try to obtain server credential should be done if it has failed last time.
+                            Allows to prevent long waiting to unavailable KDC on every authentication.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="server" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If this for use server side or client side?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="obtain-kerberos-ticket" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should the KerberosTicket also be obtained and associated with the credential.
+
+                            This is required to be true where credentials are delegated to the server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="debug" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should the JAAS step of obtaining the credential have debug logging enabled.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="wrap-gss-credential" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should generated GSS credentials be wrapped to prevent improper disposal or not?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Is the keytab file with adequate principal required to exist at the time the service starts?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="mechanism-names" type="stringListType" default="KRB5 SPNEGO">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The mechanism names the credential should be usable with.
+                            Names will be converted to OIDs and used together with OIDs from mechanism-oids attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="mechanism-oids" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The mechanism OIDs the credential should be usable with.
+                            Will be used together with OIDs derived from names from mechanism-names attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--
+        General Mappers and Rewriters
+     -->
+
+    <xs:complexType name="mappersType">
+        <xs:annotation>
+            <xs:documentation>
+                A general container type to hold the various name rewriter and mapper definitions
+                as used within the subsystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="aggregate-principal-decoder" type="aggregatePrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="concatenating-principal-decoder" type="concatenatingPrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-principal-decoder" type="constantPrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-principal-decoder" type="customPrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="x500-attribute-principal-decoder" type="x500AttributePrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-principal-transformer" type="aggregatePrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="chained-principal-transformer" type="chainedPrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-principal-transformer" type="constantPrincipalTransformer" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-principal-transformer" type="customPrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="regex-principal-transformer" type="regexPrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="case-principal-transformer" type="casePrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="regex-validating-principal-transformer" type="regexValidatingPrincipalTransformer" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-permission-mapper" type="customPermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="logical-permission-mapper" type="logicalPermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="simple-permission-mapper" type="simplePermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-permission-mapper" type="constantPermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-realm-mapper" type="constantRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-realm-mapper" type="customRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="simple-regex-realm-mapper" type="simpleRegexRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mapped-regex-realm-mapper" type="mappedRegexRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-role-decoder" type="customRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="simple-role-decoder" type="simpleRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="source-address-role-decoder" type="sourceAddressRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-role-decoder" type="aggregateRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="add-prefix-role-mapper" type="addPrefixRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="add-suffix-role-mapper" type="addSuffixRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-role-mapper" type="aggregateRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-role-mapper" type="constantRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-role-mapper" type="customRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="logical-role-mapper" type="logicalRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mapped-role-mapper" type="mappedRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="x500-subject-evidence-decoder" type="x500SubjectEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="x509-subject-alt-name-evidence-decoder" type="x509SubjectAltNameEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-evidence-decoder" type="customEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-evidence-decoder" type="aggregateEvidenceDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="regex-role-mapper" type="regexRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="permissionMapperType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all PermissionMapper definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the PermissionMapper, note names used for PermissionMappers must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customPermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom PermissionMapper implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the PermissionMapper implementation.
+
+                                Note: If configuration is supplied the PermissionMapper MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="logicalPermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A PermissionMapper definition for a PermissionMapper that performs a logical operation using two referenced PermissionMappers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:attribute name="logical-operation" type="logicalPermissionMappingsType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The logical operation to perform using the two referenced PermissionMappers.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="left" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the PermissionMapper to use to the left of the operation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="right" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the PermissionMapper to use to the right of the operation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="logicalPermissionMappingsType">
+        <xs:annotation>
+            <xs:documentation>
+                The supported set of logical operations.
+                "and" assigns permissions which was assigned by both mappers
+                "or" assigns permissions which was assigned by at least one of mappers
+                "xor" assigns permissions which was assigned by exactly one of mappers
+                "unless" assigns permissions which was assigned by left mapper but not by right mapper
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="and" />
+            <xs:enumeration value="or" />
+            <xs:enumeration value="xor" />
+            <xs:enumeration value="unless" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="simplePermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple permission mapper that maps from defined principal and role names to predefined permissions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:sequence>
+                    <xs:element name="permission-mapping" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="principal" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the principal.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element name="role" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the role.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element name="permission" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Deprecated. Use a reference to a 'permission-set' instead.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:attribute name="class-name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The fully qualified class name of the permission.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="module" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The module to use to load the permission class.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="target-name" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The target-name to pass to the constructor of the permission.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="action" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The action to pass to the constructor of the permission.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element name="permission-set" type="permissionSetRefType" minOccurs="0" maxOccurs="unbounded" />
+                            </xs:sequence>
+                            <xs:attribute name="match-all" type="xs:boolean" default="false" />
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="mapping-mode" type="simpleMappingMode" default="first" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantPermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that always returns a pre-defined set of permissions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:choice maxOccurs="unbounded">
+                    <xs:element name="permission" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Deprecated. Use a reference to a 'permission-set' instead.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:attribute name="class-name" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The fully qualified class name of the permission.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="module" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The module to use to load the permission class.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="target-name" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The target-name to pass to the constructor of the permission.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="action" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The action to pass to the constructor of the permission.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="permission-set" type="permissionSetRefType" maxOccurs="unbounded" />
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="permissionSetRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a permission set.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:simpleType name="simpleMappingMode">
+        <xs:annotation>
+            <xs:documentation>
+                How multiple matching permission mappings will be combined.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="and" />
+            <xs:enumeration value="or" />
+            <xs:enumeration value="xor" />
+            <xs:enumeration value="unless" />
+            <xs:enumeration value="first" />
+        </xs:restriction>
+    </xs:simpleType>
+
+
+    <xs:complexType name="principalDecoderType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all PrincipalDecoder definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the PrincipalDecoder, note names used for PrincipalDecoders must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customPrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom PrincipalDecoder implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the PrincipalDecoder implementation.
+
+                                Note: If configuration is supplied the PrincipalDecoder MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregatePrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition that is actually an aggregation of other PrincipalDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:sequence>
+                    <xs:element name="principal-decoder" type="principalDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="principalDecoderRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a PrincipalDecoder
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="concatenatingPrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition that is actually a concatenation of other PrincipalDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:sequence>
+                    <xs:element name="principal-decoder" type="principalDecoderRefType" minOccurs="2" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="joiner" type="xs:string" default=".">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The string to use to join the results of the other PrincipalDecoders.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantPrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder that always returns the same constant.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:attribute name="constant" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The constant value that will always be returned by this PrincipalDecoder.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="x500AttributePrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition based on a X500 attribute.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:attribute name="oid" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The oid of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="attribute-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The oid of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <!-- exactly one of [oid, attribute-name] must be defined -->
+                <!--<xs:assert test="(@oid and not(@attribute-name)) or (not(@oid) and @attribute-name)"/>--><!-- require XSD 1.1 -->
+                <xs:attribute name="joiner" type="xs:string" default=".">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The joining string.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="start-segment" type="xs:int" default="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The 0-based starting occurrence of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-segments" type="xs:int" default="2147483647">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of occurrences of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="reverse" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            When set to true, the attribute values will be processed and returned in reverse order.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="convert" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If the Principal is not already an X500Principal should conversion be attempted?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required-oids" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The OIDs of the attributes that must be present in the principal.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required-attributes" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The attribute names of the attributes that must be present in the principal.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="principalTransformerType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all PrincipalTransformer definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the PrincipalTransformer, note names used for PrincipalTransformer must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="regexPrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer definition using regular expressions and Matcher based
+                replacement.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression to use for this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="replacement" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The replacement string for this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="replace-all" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should all occurrences be replaced or just the first?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="regexValidatingPrincipalTransformer">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer that instead of rewriting the name validates that it is
+                correct according to the supplied regular expression.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="pattern" type="xs:string"
+                              use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression to use for this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="match" type="xs:boolean"
+                              default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If set to true, the name must match the given pattern to make validation successful.
+                            If set to false, the name must not match the given pattern to make validation successful.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantPrincipalTransformer">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer that always returns the same constant.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="constant" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The constant value that will always be returned by this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customPrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom PrincipalTransformer implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the PrincipalTransformer implementation.
+
+                                Note: If configuration is supplied the PrincipalTransformer MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregatePrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer aggregating more PrincipalTransformers - original principal is tried to be transformed
+                by individual transformers in given order until some of them return non-null principal - that is returned.
+
+                Typically can be used with chained principal transformers beginning with validating principal
+                transformer - to transform principals in different forms differently.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:sequence>
+                    <xs:element name="principal-transformer" type="principalTransformerRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="chainedPrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer definition that is actually a chain of other PrincipalTransformers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:sequence>
+                    <xs:element name="principal-transformer" type="principalTransformerRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="casePrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer that adjusts a principal to upper or lower case.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="upper-case" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If set to true, principal is adjusted to upper case. If set to false, principal is adjusted
+                            to lower case.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="principalTransformerRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a PrincipalTransformer.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="realmMapperType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all RealmMapper definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the RealmMapper, note names used for RealmMappers must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom RealmMapper implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the RealmMapper implementation.
+
+                                Note: If configuration is supplied the RealmMapper MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RealmMapper that always returns the same constant.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:attribute name="realm-name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The constant value that will always be returned by this RealmMapper.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="simpleRegexRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple RealmMapper definition that attempts to extract the realm name using the capture group from the regular expression, if that does not provide a
+                match then the delegate RealmMapper is used instead.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression which must contain at least one capture group to extract the realm from the name.
+                            If the regular expression matches more than one capture group, the first capture group is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delegate-realm-mapper" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The RealmMapper to delegate to if the pattern does not match.  If no delegate is specified then the default realm on
+                            the domain will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="mappedRegexRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RealmMapper implementation that first uses a regular expression to extract the realm name, this is then converted using the configured mapping of realm names.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:sequence>
+                    <xs:element name="realm-mapping" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="from" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The realm name to map from.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="to" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The realm name to map to.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression which must contain at least one capture group to extract the realm from the name.
+                            If the regular expression matches more than one capture group, the first capture group is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delegate-realm-mapper" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The RealmMapper to delegate to if the pattern does not match.  If no delegate is specified then the default realm on
+                            the domain will be used instead.
+                            If the username does not match the pattern and a delegate realm-mapper is present, the result of delegate-realm-mapper is mapped via the realm-map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleDecoderType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all RoleDecoder definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the RoleDecoder, note names used for RoleDecoders must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom RoleDecoder implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the RoleDecoder implementation.
+
+                                Note: If configuration is supplied the RoleDecoder MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="simpleRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleDecoder definition that maps a single attribute to roles.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:attribute name="attribute" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The attribute to take from the identity and map directly to roles.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sourceAddressRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleDecoder definition that maps roles based on the IP address of a remote client.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:attribute name="source-address" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The IP address to match.
+
+                            Exactly one of 'source-address' and 'pattern' must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="pattern" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A regular expression that specifies the IP address to match.
+
+                            Exactly one of 'source-address' and 'pattern' must be specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="roles" type="stringListType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The list of roles to assign if the IP address of the remote client matches.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleDecoder definition that is actually an aggregation of other RoleDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:sequence>
+                    <xs:element name="role-decoder" type="roleDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleDecoderRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a RoleDecoder.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the referenced RoleDecoder.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="roleMapperType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all RoleMapper definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the RoleMapper, note names used for RoleMappers must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="addPrefixRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that adds a specified prefix to every role.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="prefix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The prefix to add to each role.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="addSuffixRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that adds a specified suffix to every role.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="suffix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The suffix to add to each role.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that is actually an aggregation of other RoleMappers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="role-mapper" type="roleMapperRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom RoleMapper implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the RoleMapper implementation.
+
+                                Note: If configuration is supplied the RoleMapper MUST implement initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that always returns a pre-defined set of roles.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="role" minOccurs="1" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="name" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The role to be returned by the RoleMapper.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="logicalRoleMappingsType">
+        <xs:annotation>
+            <xs:documentation>
+                The supported set of logical operations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="and" />
+            <xs:enumeration value="minus" />
+            <xs:enumeration value="or" />
+            <xs:enumeration value="xor" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="logicalRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition for a RoleMapper that performs a logical operation using two refereced RoleMappers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="logical-operation" type="logicalRoleMappingsType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The logicial operation to perform using the two referenced RoleMappers.
+
+                            Allowed values: "and", "minus", "or", "xor".
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="left" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the RoleMapper to use to the left of the operation.
+
+                            If not set the identity role mapper will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="right" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the RoleMapper to use to the right of the operation.
+
+                            If not set the identity role mapper will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="mappedRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper implementation that uses the configured mapping of role names.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="role-mapping" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="from" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The role name to map from.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="to" type="stringListType" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Space separated list of roles to map to.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="keep-mapped" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            When set to 'true' the mapped roles will retain all roles, that have defined mappings.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="keep-non-mapped" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            When set to 'true' the mapped roles will retain all roles, that have no defined mappings.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="regexRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that uses pattern to find matching roles and then replaces these roles with replacement pattern.
+                Role matches the pattern in given pattern can be found in any substring of the role name.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The pattern used for matching. Can capture groups.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="replacement" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The replacement string. Can make use of captured groups.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="keep-non-mapped" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If true, keep roles that did not match the provided pattern.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="replace-all" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If true, replace all occurrences of pattern and not only the first one.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleMapperRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a RoleMapper
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the referenced RoleMapper.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="x500SubjectEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                An EvidenceDecoder that derives the principal associated with the given evidence from the subject from
+                the first certificate in the certificate chain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="x509SubjectAltNameEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                An EvidenceDecoder that derives the principal associated with the given evidence from an X.509 subject
+                alternative name from the first certificate in the given evidence.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType">
+                <xs:attribute name="alt-name-type" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The subject alternative name type to decode from the given evidence.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="rfc822Name" />
+                            <xs:enumeration value="dNSName" />
+                            <xs:enumeration value="directoryName" />
+                            <xs:enumeration value="uniformResourceIdentifier" />
+                            <xs:enumeration value="iPAddress" />
+                            <xs:enumeration value="registeredID" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="segment" type="xs:int" default="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The 0-based occurrence of the subject alternative name to map. This attribute is optional and only
+                            used when there is more than one subject alternative name of the given alt-name-type
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                An EvidenceDecoder definition that is an aggregation of other EvidenceDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType">
+                <xs:sequence>
+                    <xs:element name="evidence-decoder" type="evidenceDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customEvidenceDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom EvidenceDecoder implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="evidenceDecoderType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the EvidenceDecoder implementation.
+
+                                Note: If configuration is supplied the EvidenceDecoder MUST implement the initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="evidenceDecoderRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to an EvidenceDecoder
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="evidenceDecoderType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all EvidenceDecoder definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the EvidenceDecoder, note names used for EvidenceDecoder must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Mechanism Configuration
+    -->
+
+    <xs:complexType name="mechanismConfigurationType">
+        <xs:annotation>
+            <xs:documentation>
+                Wrapper type to contain the configuration of the authentication mechanisms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism" type="mechanismType" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        An ordered list of mechanism configurations, at the time of authentication the mechanism name,
+                        host name, and protocol as specified by the mechanism will be compared against this list
+                        for a first match.
+
+                        To configure a default configuration provide a definition with no mechanism-name, host-name, or
+                        protocol and place it at the end of the list. Any definitions after a default definition will
+                        never match.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mechanismType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of configuration to be used by authentication mechanisms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-realm" type="mechanismRealmType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="mechanism-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    This configuration will only apply where a mechanism with the name specified is used.
+
+                    If this attribute is omitted then this will match any mechanism name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    This configuration will only apply when the host name specified is provided by the mechanism.
+
+                    If this attribute is omitted then this will match any host name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocol" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    This configuration will only apply when the protocol specified is provided by the mechanism.
+
+                    If this attributed is omitted then this will match any protocol.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A final principal transformer to apply for this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this mechanism.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="credential-security-factory" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to the security factory to obtain the credential for this mechanism.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="mechanismRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a realm name specific to the mechanism.
+
+                This is the realm name that a mechanism may present to the remote client being authenticated, if a mechanism
+                only supports a single realm then only the first will be used and the remainder ignored.
+
+                If a mechanism does not support realm names then the entire list will be ignored.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="realm-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A final principal transformer to apply for this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="permissionSetsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the permission set definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="permission-set" type="permissionSetType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="permissionSetType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a permission set.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="permission" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="class-name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully qualified class name of the permission.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="module" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The module to use to load the permission class.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="target-name" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The target-name to pass to the constructor of the permission.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="action" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The action to pass to the constructor of the permission.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the permission set, note names used for permission sets must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        HTTP Components
+     -->
+
+    <xs:complexType name="httpType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type definition to hold the various HTTP definitions within the subsystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="http-authentication-factory" type="httpAuthenticationFactoryType" minOccurs="0"/>
+            <xs:element name="aggregate-http-server-mechanism-factory" type="aggregateHttpServerMechanismFactoryType" minOccurs="0" />
+            <xs:element name="configurable-http-server-mechanism-factory" type="configurableHttpServerMechanismFactoryType" minOccurs="0" />
+            <xs:element name="provider-http-server-mechanism-factory" type="providerHttpServerMechanismFactoryType" minOccurs="0" />
+            <xs:element name="service-loader-http-server-mechanism-factory" type="serviceLoaderHttpServerMechanismFactoryType" minOccurs="0" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="httpAuthenticationFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type for the definition of the server side HTTP authentication policy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-configuration" minOccurs="0" type="mechanismConfigurationType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="security-domain" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The security-domain referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="http-server-mechanism-factory" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The http-server-mechanism-factory referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="httpServerMechanismFactoryType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all http server factory definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the http server factory, note names used for http server factories must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that is actually an aggregation of other HTTP server factories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:sequence>
+                    <xs:element name="http-server-mechanism-factory" type="httpServerMechanismFactoryRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="configurableHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that wraps another HTTP server factory and applies the specified configuration and filtering.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:all>
+                    <xs:element name="filters" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Filters to be applied to the available mechanisms by name.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="filter" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="pattern" type="xs:string" >
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A regular expression that filters mechanism names using a regular expression pattern.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="enabling" type="xs:boolean" default="true">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    When set to true all mechanisms are disabled unless enabled by matching one of the defined filters.
+
+                                                    When set to false all mechanisms are enabled unless disabled by matching one of the defined filters.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="properties" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Additional properties that should be passed to the factory for HTTP mechanism detection and creation.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="http-server-mechanism-factory" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the HTTP server factory to be wrapped by this configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="providerHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that searches an array of Provider instances for all available HTTP server factories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:attribute name="providers" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the Provider[] capability to obtain the array of Providers to use.
+
+                            If not specified the system registered Providers are used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serviceLoaderHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that uses a ServiceLoader to search for HTTP server factory implementations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:attribute name="module" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the module to use.
+
+                            If this is not specified the ClassLoader used to load the service will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="httpServerMechanismFactoryRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a HTTP server mechanism factory.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <!--
+        SASL Components
+     -->
+
+    <xs:complexType name="saslType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type definition type to hold the various SASL definitions within the subsystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="sasl-authentication-factory" type="saslAuthenticationFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-sasl-server-factory" type="aggregateSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="configurable-sasl-server-factory" type="configurableSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mechanism-provider-filtering-sasl-server-factory" type="mechanismProviderFilteringSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="provider-sasl-server-factory" type="providerSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="service-loader-sasl-server-factory" type="serviceLoaderSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="saslAuthenticationFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                The SASL authentication policy for the server side.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-configuration" minOccurs="0" type="mechanismConfigurationType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="security-domain" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The security-domain referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-server-factory" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The sasl-server-factory referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="saslServerFactoryType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all sasl server factory definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the sasl server factory, note names used for sasl server factories must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SASL server factory definition that is actually an aggregation of other SASL server factories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:sequence>
+                    <xs:element name="sasl-server-factory" type="saslServerFactoryRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="configurableSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that wraps another SaslServerFactory and applies the specified configuration and filtering.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:all>
+                    <xs:element name="filters" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Filters to be applied to the available mechanisms by name.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="filter" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="enabling" type="xs:boolean" default="true">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    When set to true all mechanisms are disabled unless enabled by matching one of the defined filters.
+                                                    When set to false all mechanisms are enabled unless disabled by matching one of the defined filters.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="pattern" type="xs:string" >
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A regular expression filter that filters mechanism names using a regular expression pattern.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="predefined" type="xs:string" >
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A predefined filter to filter mechanisms.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="properties" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Additional properties that should be passed to the factory for SASL mechanism detection and creation.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="sasl-server-factory" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SaslServerFactory to be wrapped by this configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="protocol" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Override the protocol specified when creating a SASL mechanism.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="server-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Override the server name specified when creating a SASL mechanism.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="predefinedFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                The supported set of predefined filters.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="HASH_MD5" />
+            <xs:enumeration value="HASH_SHA" />
+            <xs:enumeration value="HASH_SHA_256" />
+            <xs:enumeration value="HASH_SHA_384" />
+            <xs:enumeration value="HASH_SHA_512" />
+            <xs:enumeration value="GS2" />
+            <xs:enumeration value="SCRAM" />
+            <xs:enumeration value="DIGEST" />
+            <xs:enumeration value="IEC_ISO_9798" />
+            <xs:enumeration value="EAP" />
+            <xs:enumeration value="MUTUAL" />
+            <xs:enumeration value="BINDING" />
+            <xs:enumeration value="RECOMMENDED" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="mechanismProviderFilteringSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that wraps another SaslServerFactory and enables filtering of mechanisms based on the mechanism name and Provider name and version.
+
+                Any mechanisms loaded by factories not located using a Provider will not be filtered by this definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:sequence>
+                    <xs:element name="filters" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Filters to be applied to the available mechanisms by name.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="filter" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="mechanism-name" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    This configuration will only apply where a mechanism with the name specified is used.
+
+                                                    If this attribute is omitted then this will match any mechanism name.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="provider-name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the provider to match against.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="provider-version" type="xs:double">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    Version to compare against the version reported by the provider.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="version-comparison" type="inequalityType" default="less-than">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    When set to 'less-than' a Provider will match against the filter if the Provider's version is less-than the version specified here.
+
+                                                    Setting to 'greater-than' has the opposite effect.
+
+                                                    Has no effect if a provider-version has not been specified in the filter.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="sasl-server-factory" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SaslServerFactory to be wrapped by this configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="enabling" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            When set to true all provider loaded mechanisms are disabled unless macthed by one of the filters defined here.
+
+                            When set to false all provider loaded mechanisms are enabled unless matched.
+
+                            Any mechanisms from a factory not loaded by a Provider are unaffected.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="inequalityType">
+        <xs:annotation>
+            <xs:documentation>
+                The type of equality check to use in a comparison.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="less-than" />
+            <xs:enumeration value="greater-than" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="providerSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that searches an array of Provider instances for all available SaslServerFactories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:attribute name="providers" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the Provider[] capability to obtain the array of Providers to use.
+
+                            If not specified the system registered Providers are used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serviceLoaderSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that uses a ServiceLoader to search for SaslServerFactory implementations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:attribute name="module" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the module to use.
+
+                            If this is not specified the ClassLoader used to load the service will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="saslServerFactoryRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a SaslServerFactory
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <!--
+        TLS Components
+     -->
+
+    <xs:complexType name="tlsType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type to contain the definitions of the various components needed
+                for SSL, the end result being that these components can be combined together to
+                create a fully defined SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="key-stores" type="keyStoresType" minOccurs="0" />
+            <xs:element name="key-managers" type="keyManagersType" minOccurs="0" />
+            <xs:element name="trust-managers" type="trustManagersType" minOccurs="0"/>
+            <xs:element name="server-ssl-contexts" type="serverSSLContextsType" minOccurs="0" />
+            <xs:element name="client-ssl-contexts" type="clientSSLContextsType" minOccurs="0" />
+            <xs:element name="certificate-authorities" type="certificateAuthoritiesType" minOccurs="0" />
+            <xs:element name="certificate-authority-accounts" type="certificateAuthorityAccountsType" minOccurs="0" />
+            <xs:element name="server-ssl-sni-contexts" type="serverSSLSNIContextsType" minOccurs="0" />
+            <xs:element name="dynamic-client-ssl-contexts" type="dynamicClientSSLContextsType" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="keyManagersType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for KeyManager definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="key-manager" type="keyManagerType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="keyManagerType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single KeyManager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the underlying KeyManager when accessing the entries in the underlying KeyStore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this KeyManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="algorithm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The algorithm name to use to initialise the KeyManagerFactory.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyStore to use with the KeyManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases provided by KeyStore to choose key to use from keys in KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to
+                    instantiate the KeyManagerFactory, if the provider is not
+                    specified then the first provider found that can
+                    create an instance of the specified 'type' will be
+                    used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required KeyManagerFactory type.
+
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="generate-self-signed-certificate-host" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If this attribute is set and if the file that backs the KeyStore does not exist, then
+                    a self-signed certificate will be generated on first use and it will be persisted to
+                    the file that backs the KeyStore. The value of this attribute will be used for the
+                    Common Name value in the self-signed certificate.
+
+                    The use of this attribute is intended for testing purposes only. This attribute is not
+                    intended for production use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="trustManagersType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for TrustManager definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="trust-manager" type="trustManagerType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="trustManagerType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single TrustManager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="certificate-revocation-list" type="certificateRevocationListType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="certificate-revocation-lists" type="certificateRevocationListsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ocsp" type="ocspType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this TrustManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="algorithm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The algorithm name to use to initialise the TrustManagerFactory.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyStore to use with the TrustManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases provided by KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to
+                    instantiate the TrustManagerFactory, if the provider is not
+                    specified then the first provider found that can
+                    create an instance of the specified 'type' will be
+                    used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required TrustManagerFactory type.
+
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maximum-cert-path" type="xs:int" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of non-self-issued intermediate certificates that may exist in a certification path for OCSP and CRL checks. If neither OCSP and CRL is configured, this attribute has no effect.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="only-leaf-cert" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Check revocation status only of leaf certificates.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="soft-fail" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Accept certificate if revocation status is unknown.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="certificateRevocationListType">
+        <xs:annotation>
+            <xs:documentation>
+                Enables certificate revocation list checks to a trust manager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The path to the configuration to use to initialise the provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The base path of the certificate revocation list file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maximum-cert-path" type="xs:int" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of non-self-issued intermediate certificates that may exist in a certification path.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="certificateRevocationListsType">
+        <xs:annotation>
+            <xs:documentation>
+                The presence of this element enables checking the peer's certificate against multiple certificate revocation lists.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="certificate-revocation-list" type="certificateRevocationListNoMaxCertPathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="certificateRevocationListNoMaxCertPathType">
+        <xs:annotation>
+            <xs:documentation>
+                The presence of this element enables checking the peer's certificate against a certificate revocation list.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Path to the certificate revocation list.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The base path of the certificate revocation list file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ocspType">
+        <xs:annotation>
+            <xs:documentation>
+                Enables online certificate status protocol checks to a trust manager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="responder" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    OCSP responder URI to override those extracted from certificate.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="prefer-crls" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Prefer certificate revocation list revocation over OCSP if certificate-revocation-list is defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="responder-certificate" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The alias for OCSP Responder certificate. Keep undefined to use the issuer of certificate being validated.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="responder-keystore" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The keystore for responder-certificate. Keep undefined to use trust-manager keystore. Requires responder-certificate to be defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLSNIContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for Server SNI SSLContext definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-ssl-sni-context" type="serverSSLSNIContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLSNIContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single server side SNI SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="sni-mapping" type="serverSSLSNIMappingType" minOccurs="0" maxOccurs="unbounded"  />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this Server side SNI SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-ssl-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The SSLContext to use if SNI is not in use
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLSNIMappingType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single server side SNI SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The host name that this element matches. If it begins with a '*' it is considered a wildcard match.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The SSLContext to use if the name matches.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for Server SSLContext definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-ssl-context" type="serverSSLContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single server side SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this Server side SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-domain" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the SecurityDomain to use for authentication during SSL session establishment.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-filter" type="xs:string" use="optional" default="DEFAULT">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the TLSv1.3 cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocols" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    List of protocols supported by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="want-client-auth" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    To request (but not to require) a client certificate on SSL handshake.
+                    If a security domain is referenced and supports X509 evidence, this will be set to true automatically.
+                    Ignored when need-client-auth is set.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="need-client-auth" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    To require a client certificate on SSL handshake.
+                    Connection without trusted client certificate (see trust-manager) will be rejected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-optional" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Rejecting of the client certificate by the security domain will not prevent the connection.
+                    Allows a fall through to use other authentication mechanisms (like form login) when the client certificate is rejected by security domain.
+                    Has an effect only when the security domain is set.
+                    This does not bypass the underlying trust manager check - see need-client-auth to allow connection without client certificate.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="use-cipher-suites-order" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Configure the SSLContext to honor local cipher suites preference.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maximum-session-cache-size" type="xs:int" default="-1">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="session-timeout" type="xs:int" default="-1">
+            <xs:annotation>
+                <xs:documentation>
+                    The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="wrap" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should the resulting SSLEngine, SSLSocketFactory, and SSLSocket instances returned by this SSLContext
+                    be wrapped to prevent further configuration changes.
+
+                    Note:  The WildFly HTTP2 support requires raw access to these objects so if HTTP2 is being used this
+                    should be set to false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyManager to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trust-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the TrustManager to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-principal-transformer" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A final principal transformer to apply for this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this mechanism.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use.
+                    If not specified, all providers from providers will be passed to the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers to obtain the Provider[] to use to load the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="clientSSLContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for client SSLContext definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="client-ssl-context" type="clientSSLContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="clientSSLContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single client side SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this client side SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-filter" type="xs:string" use="optional" default="DEFAULT">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-names" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the TLSv1.3 cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocols" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    List of protocols supported by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyManager to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trust-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the TrustManagers to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use.
+                    If not specified, all providers from providers will be passed to the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers to obtain the Provider[] to use to load the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoresType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the KeyStore definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence maxOccurs="unbounded">
+            <xs:choice>
+                <xs:element name="key-store" type="keyStoreType" />
+                <xs:element name="ldap-key-store" type="ldapKeyStoreType" />
+                <xs:element name="filtering-key-store" type="filteringKeyStoreType" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoreImplementationType">
+        <xs:annotation>
+            <xs:documentation>
+                keystore implementation details
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The KeyStore type, e.g. jks, pkcs#12.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to
+                    instantiate the KeyStore, if the provider is not
+                    specified then the first provider found that can
+                    create an instance of the specified 'type' will be
+                    used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required KeyStore type.
+
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="keyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual names KeyStore definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The credential reference to credential store or clear text (password)
+                        to use to initialize or load the KeyStore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="implementation" type="keyStoreImplementationType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Implementation details
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="file" type="fileType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The location of the file to use to initialise the KeyStore instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="alias-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases made available by this KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual names LdapKeyStore definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="new-item-template" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration for item creation. Define how will look LDAP entry of newly created keystore item.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Attribute of newly created entry. At least objectClass attribute and required
+                                    attributes (which are not part of keystore item) should be defined here.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The LDAP attribute name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="value" type="stringListType" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The default value(s) of LDAP attribute delimited by space.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="new-item-path" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP path, where will be newly created keystore items created.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="new-item-rdn" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute name, which will be part of new entry path.
+                                Into value of this attribute will be passed alias of the keystore item.
+                                (Can be independent on alias-attribute - alias is used here only as initial entry name,
+                                as it is only identification of item, which keystore has.)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="search" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Search LDAP configuration
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="path" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP path, where will be keystore items searched.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="recursive" type="xs:boolean" use="optional" default="true">
+                        <xs:annotation>
+                            <xs:documentation>
+                                If the search in search-path should be recursive.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="time-limit" type="xs:integer" use="optional" default="10000">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The time limit for LDAP search in milliseconds.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="filter-alias" type="xs:string" use="optional" default="(alias_attribute={0})">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP filter, which will be used to obtain keystore item by alias.
+                                The string "{0}" will be replaced by the searched alias and the "alias_attribute" value will be the value of the attribute "alias-attribute".
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="filter-certificate" type="xs:string" use="optional" default="(certificate_attribute={0})">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP filter, which will be used to obtain keystore item by certificate.
+                                The string "{0}" will be replaced by searched encoded certificate and the "certificate_attribute" will be the value of the attribute "certificate-attribute".
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="filter-iterate" type="xs:string" use="optional" default="(alias_attribute=*)">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP filter, which will be used to obtain keystore item by certificate.
+                                The "alias_attribute" will be the value of the attribute "alias-attribute".
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="attribute-mapping" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Mapping of keystore item parts to LDAP attributes.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="alias-attribute" type="xs:string" use="optional" default="cn">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is item alias expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-attribute" type="xs:string" use="optional" default="usercertificate">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is encoded certificate expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-type" type="xs:string" use="optional" default="X.509">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The type of certificate. Used for decoding of byte array from certificate-attribute.
+                                For possible certificate types see Java documentation of CertificateFactory.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-chain-attribute" type="xs:string" use="optional" default="userSMIMECertificate">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is encoded certificate expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-chain-encoding" type="xs:string" use="optional" default="PKCS7">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The encoding of CertPath, which is used to store certificate chain into certificate-chain-attribute.
+                                For possible chain encodings see Java documentation of CertPath.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+
+                    <xs:attribute name="key-attribute" type="xs:string" use="optional" default="userPKCS12">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is encoded key expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="key-type" type="xs:string" use="optional" default="PKCS12">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The type of key. Used for decoding of byte array from key-attribute.
+                                For possible KeyStore types see Java documentation of KeyStore.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of ldap-key-store used to referencing it.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="dir-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of dir-context used to connect to the LDAP server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="filteringKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual names filtering KeyStore definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of key-store, which will be used as source of data.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias-filter" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases made available by this KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="certificateAuthorityAccountsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for certificate authority account definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="certificate-authority-account" type="certificateAuthorityAccountType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="certificateAuthorityAccountType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single certificate authority account.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="account-key" type="accountKeyType" minOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this certificate authority account.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="certificate-authority" type="xs:string" default="LetsEncrypt">
+            <xs:annotation>
+                <xs:documentation>
+                    The reference to certificate authority to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="contact-urls" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of URLs that the certificate authority can contact about any issues related to this account.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="certificateAuthoritiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for certificate authority definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="certificate-authority" type="certificateAuthorityType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="certificateAuthorityType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single certificate authority.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this certificate authority.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    URL of the certificate authority.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="staging-url" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    URL of the certificate authority to use in pre-production.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="accountKeyType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a certificate authority account key.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used when accessing the certificate authority account key.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyStore that contains the certificate authority account key.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The alias of the certificate authority account key in the KeyStore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Credential Store Components
+     -->
+
+    <xs:complexType name="credentialStoresType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type to contain the definitions of the credential stores.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="credential-store" type="credentialStoreType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="secret-key-credential-store" type="secretKeyCredentialStoreType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="credentialStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual credential store definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="implementation-properties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Map of credentials store implementation specific properties.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by as protection parameter for the Credential Store.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The credential store type, e.g. KeyStoreCredentialStore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to instantiate the CredentialStoreSpi.
+                    If the provider is not specified then the first provider found that can
+                    create an instance of the specified 'type' will be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required CredentialStore type.
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="other-providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required JCA objects within credential store.
+                    This is valid only for key-store based  CredentialStore.
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the file name is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="location" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    File name of credential store storage.
+
+                    Deprecated: Use "path" attribute instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    File name of credential store storage.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modifiable" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether credential store is modifiable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="create" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether credential store should create storage when it doesn't exist.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="secretKeyCredentialStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple credential store which stores SecretKeyCredential instances in a properties file.
+
+                This credential store does not encrypt the stored keys, the purpose of this credential store is
+                to provide initial access to keys used to protect other configuration values.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this credential store definition.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the file name is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The path to the credential store file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="create" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether credential store should create storage when it doesn't exist.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="populate" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    If an entry with the default-alias does not exist should one be dynamically added using the
+                    configured key-size?
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-size" type="keySizeType" default="256">
+            <xs:annotation>
+                <xs:documentation>
+                    The default key size when generating secret keys.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-alias" type="xs:string" default="key">
+            <xs:annotation>
+                <xs:documentation>
+                    The default alias to use if dynamically adding an entry.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Expression Resolver Types
+     -->
+
+    <xs:complexType name="expressionResolverType">
+        <xs:annotation>
+            <xs:documentation>
+                An expression resolver backed by a list of sub-expression resolvers which can be used to decrypt encrypted expressions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="resolver" type="resolverType" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="default-resolver" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The default resolver to use for expressions which do not specify the name of the resolver.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="prefix" type="xs:string" default="ENC">
+            <xs:annotation>
+                <xs:documentation>
+                    The prefix for expressions that should be resolved using this expression resolver.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="resolverType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single expression resolver.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this expression resolver.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="credential-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the credential store which contains the secret key to be used by this resolver.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="secret-key" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The alias of the secret key contained within the credential store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+       General Types
+    -->
+
+    <xs:complexType name="basicFileType">
+        <xs:annotation>
+            <xs:documentation>
+                Minimal attributes required to specify the location to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the file name is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remaining path to the file referenced.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="basicFileTypeOptional">
+        <xs:annotation>
+            <xs:documentation>
+                Minimal attributes required to specify the location to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the file name is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The remaining path to the file referenced.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="fileType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="basicFileType">
+                <xs:attribute name="required" type="xs:boolean"
+                              use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            It is possible that a KeyStore definition can be created to a
+                            non-existent file and the file be automatically created when the store is saved, however
+                            no error will be reported where the file does not exist to begin with.
+
+                            If the intent is that the store will always exist in advance set
+                            this to 'true' so that an error will be reported if the file is missing.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:attributeGroup name="customComponentAttributes">
+        <xs:annotation>
+            <xs:documentation>The attributes required for a custom component.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="module" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The module to use to load the custom component.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The fully qualified class name of the custom component implementation to
+                    load.
+
+                    The specified class must have a public no-args constructor.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:complexType name="customComponentConfiguration">
+        <xs:annotation>
+            <xs:documentation>
+                The optional configuration for a custom component.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="stringListType">
+        <xs:annotation>
+            <xs:documentation>A list of String.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="policyType">
+        <xs:annotation>
+            <xs:documentation>
+                A definition that sets up a policy provider.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="jacc-policy" type="jaccPolicyType" minOccurs="1" />
+            <xs:element name="custom-policy" type="customPolicyType" minOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the policy provider definition.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jaccPolicyType">
+        <xs:annotation>
+            <xs:documentation>
+                A policy provider definition that sets up JACC and related services.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="policy" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a java.security.Policy implementation referencing a policy provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="configuration-factory" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a javax.security.jacc.PolicyConfigurationFactory implementation referencing a policy configuration factory provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the module to load the provider from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customPolicyType">
+        <xs:annotation>
+            <xs:documentation>
+                A custom policy provider definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a java.security.Policy implementation referencing a policy provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the module to load the provider from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jaspiType">
+        <xs:annotation>
+            <xs:documentation>
+                JASPI Configurations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="jaspi-configuration" type="jaspiConfigurationType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jaspiConfigurationType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual JASPI configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-auth-modules">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="server-auth-module" type="serverAuthModuleType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this JASPI configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layer" type="xs:string" default="*">
+            <xs:annotation>
+                <xs:documentation>
+                    The layer this configuration should be associated with.
+
+                    If set to '*' this configuration will be associated with all layers and resolved according the the
+                    resolution rules defined within the JSR-196 specification.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="application-context" type="xs:string" default="*">
+            <xs:annotation>
+                <xs:documentation>
+                    The application context this configuration should be associated with.
+
+                    If set to '*' this configuration will be associated with all application contexts and resolved according the the
+                    resolution rules defined within the JSR-196 specification.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="description" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Descrption for this JASPI configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverAuthModuleType">
+        <xs:sequence>
+            <xs:element name="options" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration options to be passed into the ServerAuthModule during initialisation.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The fully qualified class name of the class implementing the ServerAuthModule interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the module to use to load the ServerAuthModule.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="flag" type="flagType" default="REQUIRED">
+            <xs:annotation>
+                <xs:documentation>
+                    The control flag to control how the response from this module is interpreted.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="flagType">
+        <xs:annotation>
+            <xs:documentation>
+                The control flag for JASPI modules.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="REQUIRED" />
+            <xs:enumeration value="REQUISITE" />
+            <xs:enumeration value="SUFFICIENT" />
+            <xs:enumeration value="OPTIONAL" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="keySizeType">
+        <xs:annotation>
+            <xs:documentation>
+                Allowed key sizes.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="128" />
+            <xs:enumeration value="192" />
+            <xs:enumeration value="256" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="verificationPolicy">
+        <xs:annotation>
+            <xs:documentation>
+                A host name verification policy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ANY" />
+            <xs:enumeration value="DEFAULT" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="virtualSecurityDomainType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type for the definition of a single virtual security domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="outflow-anonymous" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where automatic outflow to a security domain is configured, if outflowing
+                    the current identity is not authorized should the
+                    anonymous identity of that domain be used instead?
+
+                    Outflowing an identity replaces any previously
+                    established identity for the outflow domain for the
+                    ongoing call, outflowing anonymous has the effect of
+                    clearing the identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="outflow-security-domains" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of references to security domains that any identity established for this
+                    virtual domain should automatically outflow to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="auth-method" type="xs:string" default="OIDC" >
+            <xs:annotation>
+                <xs:documentation>
+                    The authentication mechanism that will be used with the virtual security domain.
+                    Allowed values: 'OIDC', 'MP-JWT'.
+                    The default value is 'OIDC'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="dynamicClientSSLContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for client dynamic SSL context definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="dynamic-client-ssl-context" type="dynamicClientSSLContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="dynamicClientSSLContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single client side dynamic SSL context. This context chooses SSL context based on peer's host and port information.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this client side dynamic SSL context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The authentication context that will be used to query for rules when deciding which ssl context to use when connecting to a peer.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/JwtSecurityRealmTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/JwtSecurityRealmTestCase.java
@@ -58,6 +58,7 @@ public class JwtSecurityRealmTestCase extends AbstractElytronSubsystemBaseTest {
     private static final Provider wildFlyElytronProvider = new WildFlyElytronProvider();
     private static final String JWT_REALM_TEST = "jwt-realm-test.xml";
     private static final MockWebServer server = new MockWebServer();
+    private static final MockWebServer publicKeyUrlServer = new MockWebServer();
     private static final String JKU_ALLOWED_VALUES_PROPERTY = "wildfly.elytron.jwt.allowed.jku.values.JwtRealm";
 
     private static KeyPair keyPair1;
@@ -88,6 +89,7 @@ public class JwtSecurityRealmTestCase extends AbstractElytronSubsystemBaseTest {
 
         server.setDispatcher(createTokenDispatcher(jwksResponse));
         server.start(50831);
+        publicKeyUrlServer.start(50833);
 
         System.setProperty(JKU_ALLOWED_VALUES_PROPERTY, "https://localhost:50832 https://localhost:50831");
     }
@@ -96,6 +98,7 @@ public class JwtSecurityRealmTestCase extends AbstractElytronSubsystemBaseTest {
     public static void cleanUp() throws IOException {
         System.clearProperty(JKU_ALLOWED_VALUES_PROPERTY);
         server.shutdown();
+        publicKeyUrlServer.shutdown();
     }
 
     @Override
@@ -156,6 +159,20 @@ public class JwtSecurityRealmTestCase extends AbstractElytronSubsystemBaseTest {
         // token validation should succeed
         assertTrue(identityExists(securityRealm, evidence1));
         assertTrue(identityExists(securityRealm, evidence2));
+    }
+
+    @Test
+    public void testPublicKeyUrl() throws Exception {
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        publicKeyUrlServer.setDispatcher(createPemDispatcher(getPemStringFromPublicKey(keyPair)));
+
+        KernelServices services = createKernelServices();
+        SecurityRealm securityRealm = assertSecurityRealmNotNull(services, "JwtRealmWithPublicKeyUrl");
+
+        // Verify the realm can be created with a public-key-url attribute (WFCORE-7347).
+        // Full signature-verification behaviour is pending the wildfly-elytron library
+        // shipping JwtValidator.Builder.publicKeyUrl() (see performRuntime TODO in TokenRealmDefinition).
+        assertNotNull(securityRealm);
     }
 
     private SecurityRealm assertSecurityRealmNotNull(KernelServices services, String securityRealmName) {
@@ -227,5 +244,14 @@ public class JwtSecurityRealmTestCase extends AbstractElytronSubsystemBaseTest {
         pemWriter.flush();
         pemWriter.close();
         return writer.toString();
+    }
+
+    private static okhttp3.mockwebserver.Dispatcher createPemDispatcher(String pem) {
+        return new okhttp3.mockwebserver.Dispatcher() {
+            @Override
+            public okhttp3.mockwebserver.MockResponse dispatch(okhttp3.mockwebserver.RecordedRequest request) {
+                return new okhttp3.mockwebserver.MockResponse().setBody(pem);
+            }
+        };
     }
 }

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0" default-authentication-context="child">
+<subsystem xmlns="urn:wildfly:elytron:20.0" default-authentication-context="child">
     <authentication-client>
         <authentication-context name="child"/>
     </authentication-client>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/authentication-client.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/authentication-client.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0" default-authentication-context="child">
+<subsystem xmlns="urn:wildfly:elytron:20.0" default-authentication-context="child">
     <authentication-client>
         <authentication-configuration name="base" anonymous="true" />
         <authentication-configuration name="most"

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <mappers>
         <custom-permission-mapper name="CustomPermissionMapper" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />
         <custom-permission-mapper name="CustomPermissionMapper2" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/credential-security-factories.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/credential-security-factories.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <credential-security-factories>
         <custom-credential-security-factory name="CustomFactory" module="a.b.c" class-name="org.wildfly.security.ElytronFactory">
             <configuration>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/credential-store-updates.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/credential-store-updates.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <credential-stores>
         <credential-store name="store1" location="target/test.credential.store1" create="true">
             <credential-reference clear-text="super_secret1"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/credential-store.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/credential-store.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- Initial configuration as used by the CredentailStoreTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <credential-stores>
         <credential-store name="test" relative-to="jboss.server.config.dir" location="test.cs" create="true">
             <credential-reference clear-text="password"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/credential-stores.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/credential-stores.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <credential-stores>
         <credential-store name="test1" relative-to="jboss.server.data.dir" location="test1.store" create="true">
             <implementation-properties>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/custom-policy.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/custom-policy.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <policy name="custom-b">
         <custom-policy class-name="a.b.c.CustomPolicy" module="a.b.c.custom"/>
     </policy>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of DomainTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <security-domains>
         <security-domain name="MyDomain" default-realm="FileRealm" realm-mapper="MyRealmMapper" permission-mapper="MyPermissionMapper"
                          pre-realm-principal-transformer="NameRewriterXY" post-realm-principal-transformer="NameRewriterYU" trusted-security-domains="AnotherDomain">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <audit-logging>
         <file-audit-log name="local-file" path="audit.log" relative-to="jboss.home.dir" synchronized="false" format="JSON" />
     </audit-logging>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-20.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-20.0.xml
@@ -4,18 +4,7 @@
   -->
 
 <!-- for needs of DomainTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:20.0" register-jaspi-factory="${exp.jaspi:false}" default-ssl-context="client" disallowed-providers="${exp.providers:test}">
-    <authentication-client>
-        <authentication-context name="myAC" />
-    </authentication-client>
-    <providers>
-        <provider-loader name="openssl" module="org.wildfly.openssl">
-            <configuration>
-                <property name="prop" value="${exp.value:val}"/>
-            </configuration>
-        </provider-loader>
-        <provider-loader name="elytron" module="org.wildfly.security.elytron" argument="${exp.argument:arg}"/>
-    </providers>
+<subsystem xmlns="urn:wildfly:elytron:20.0" register-jaspi-factory="false" default-ssl-context="client">
     <security-domains>
         <security-domain name="MyDomain" default-realm="FileRealm" realm-mapper="MyRealmMapper" permission-mapper="MyPermissionMapper"
                          pre-realm-principal-transformer="NameRewriterXY" post-realm-principal-transformer="NameRewriterYU" trusted-security-domains="AnotherDomain">
@@ -43,13 +32,12 @@
         <security-domain name="TestDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" trusted-virtual-security-domains="VirtualDomain">
             <realm name="PropRealm"/>
         </security-domain>
-        <virtual-security-domain name="VirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="${exp.anonymous:true}" />
-        <virtual-security-domain name="AnotherVirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="${exp.anonymous:true}" auth-method="OIDC"/>
+        <virtual-security-domain name="VirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="true" />
+        <virtual-security-domain name="AnotherVirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="true" auth-method="OIDC"/>
     </security-domains>
     <security-realms>
-        <aggregate-realm name="AggregateOne" authentication-realm="PropRealm" authorization-realm="FileRealm" principal-transformer="${exp.transformer:NameRewriterXY}"/>
+        <aggregate-realm name="AggregateOne" authentication-realm="PropRealm" authorization-realm="FileRealm" />
         <aggregate-realm name="AggregateTwo" authentication-realm="JdbcRealm" authorization-realms="AggregateOne FileRealm" />
-        <identity-realm name="local" identity="${exp.identity:$local}" attribute-name="${exp.name:groups}" attribute-values="${exp.values:SuperUser}" />
         <jdbc-realm name="NewJdbcScramSha384">
             <principal-query sql="SELECT" data-source="ExampleDS">
                 <scram-mapper algorithm="scram-sha-384" password-index="1" salt-index="2" iteration-count-index="10000"/>
@@ -60,17 +48,12 @@
                 <scram-mapper algorithm="scram-sha-512" password-index="1" salt-index="2" iteration-count-index="10000"/>
             </principal-query>
         </jdbc-realm>
-        <jdbc-realm name="JdbcScram">
-            <principal-query sql="SELECT" data-source="ExampleDS">
-                <scram-mapper password-index="${exp.password:2}" salt-index="${exp.salt:3}" iteration-count-index="${exp.iteration:4}" hash-encoding="${exp.encoding:hex}" salt-encoding="${exp.encoding:hex}" algorithm="${exp.algorithm:scram-sha-1}"/>
-            </principal-query>
-        </jdbc-realm>
         <jdbc-realm name="JdbcRealmBcrypt">
             <principal-query sql="SELECT role, password, salt, ic FROM User WHERE username = ?" data-source="ExampleDS">
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <bcrypt-mapper password-index="${exp.password:2}" salt-index="${exp.salt:3}" iteration-count-index="${exp.iteration:4}" hash-encoding="${exp.encoding:hex}" salt-encoding="${exp.encoding:hex}"/>
+                <bcrypt-mapper password-index="2" salt-index="3" iteration-count-index="4" hash-encoding="hex" salt-encoding="hex"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmClearPassword">
@@ -78,7 +61,7 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <clear-password-mapper password-index="${exp.password:2}"/>
+                <clear-password-mapper password-index="2"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmSalted">
@@ -86,7 +69,7 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <salted-simple-digest-mapper password-index="${exp.password:2}" salt-index="${exp.salt:3}" algorithm="${exp.algo:password-salt-digest-sha-1}" hash-encoding="${exp.encoding:hex}" salt-encoding="${exp.encoding:hex}"/>
+                <salted-simple-digest-mapper password-index="2" salt-index="3" algorithm="password-salt-digest-sha-1" hash-encoding="hex" salt-encoding="hex"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmSimple">
@@ -94,7 +77,7 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                 <simple-digest-mapper password-index="${exp.password:2}" hash-encoding="${exp.encoding:hex}" algorithm="simple-digest-sha-1"/>
+                <simple-digest-mapper password-index="2" hash-encoding="hex" algorithm="simple-digest-sha-1"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmModular">
@@ -102,48 +85,20 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <modular-crypt-mapper password-index="${exp.password:2}"/>
+                <modular-crypt-mapper password-index="2"/>
             </principal-query>
         </jdbc-realm>
-        
-        <properties-realm name="PropRealm" groups-attribute="${exp.groups:groups}">
-            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir" digest-realm-name="${exp.digest.realm:FileRealm}" plain-text="${exp.plain:false}"/>
+        <properties-realm name="PropRealm">
+            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
         </properties-realm>
         <properties-realm name="NonDomainRealm">
             <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
         </properties-realm>
-        <ldap-realm name="LdapRealmWithAttributeMapping" dir-context="dircontext1" allow-blank-password="${exp.blank:true}" direct-verification="${exp.verification:false}">
-            <identity-mapping rdn-identifier="${exp.rdn:uid}" use-recursive-search="${exp.recursive:true}" search-base-dn="${exp.search:dc=elytron,dc=wildfly,dc=org}" filter-name="${exp.filter:(rdn_identifier={0})}" iterator-filter="${exp.filter:(uid=*)}" new-identity-parent-dn="${exp.parent:dc=elytron,dc=wildfly,dc=org}">
-                <attribute-mapping>
-                    <attribute filter-base-dn="${exp.base:ou=Finance,dc=elytron,dc=wildfly,dc=org}" filter="${exp.filter:(&amp;(objectClass=groupOfNames)(member={0}))}" from="${exp.from:CN}" extract-rdn="OU" to="${exp.to:businessUnit}"
-                               reference="${exp.reference:ref}" search-recursive="${exp.recursive:true}" role-recursion="${exp.role:0}" role-recursion-name="${exp.name:cn}"/>
-                    <attribute filter-base-dn="ou=Sales,dc=elytron,dc=wildfly,dc=org" filter="(&amp;(objectClass=groupOfNames)(member={0}))" from="CN" extract-rdn="${exp.extract:OU}" to="businessUnit"/>
-                </attribute-mapping>
-                <new-identity-attributes>
-                    <attribute name="${exp.name:sn}" value="${exp.value:BlankSurname}"/>
-                </new-identity-attributes>
-                <user-password-mapper from="${exp.from:userPassword}" writable="${exp.writable:true}" verifiable="${exp.verifiable:true}" />
-                <otp-credential-mapper algorithm-from="${exp.alg:otpAlgorithm}" hash-from="${exp.hash:otpHash}" seed-from="${exp.seed:otpSeed}" sequence-from="${exp.sequence:otpSequenc}e"/>
-                <x509-credential-mapper digest-from="${exp.digest:x509digest}" certificate-from="${exp.certificate:usercertificate}" subject-dn-from="${exp.subject:x509subject}" serial-number-from="${exp.serial:x509serialNumber}" digest-algorithm="${exp.algo:SHA-1}" />
-            </identity-mapping>
-        </ldap-realm>
-        <filesystem-realm name="FileRealm" levels="${exp.levels:2}" encoded="${exp.encoded:false}">
+        <filesystem-realm name="FileRealm" levels="2" encoded="false">
             <file path="filesystem-realm" relative-to="jboss.server.config.dir"/>
         </filesystem-realm>
-        <filesystem-realm name="FileSystemRealmEncrypted" levels="${exp.levels:2}" encoded="${exp.encoded:false}" credential-store="${exp.credstore:secretkeycredstore}" secret-key="${exp.secretkey:key}">
-            <file path="filesystem-realm-encrypted" relative-to="jboss.server.config.dir"/>
-        </filesystem-realm>
-        <token-realm name="JwtRealmOne" principal-claim="${exp.principal:sub}" >
-            <jwt issuer="${exp.issuer:some-issuer-a}" audience="${exp.audience:some-audience-a}" public-key="${exp.key:MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqP}"
-                 certificate="${exp.cert:cert}">
-                <key kid="kid" public-key="${exp.public:public}"/>
-            </jwt>
-        </token-realm>
-        <token-realm name="OAuth2Realm" principal-claim="sub">
-            <oauth2-introspection client-id="${exp.id:a}" client-secret="${exp.secret:b}" introspection-url="${exp.url:https://localhost/token/introspect}" host-name-verification-policy="${exp.host:host}"/>
-        </token-realm>
-        <distributed-realm name="DistributedRealm" realms="FileRealm PropRealm" ignore-unavailable-realms="${exp.ignore:true}" emit-events="${exp.emit:true}"/>
-        <failover-realm name="FailoverRealm" delegate-realm="JdbcRealm" failover-realm="PropRealm" emit-events="${exp.emit:true}"/>
+        <distributed-realm name="DistributedRealm" realms="FileRealm PropRealm"/>
+        <failover-realm name="FailoverRealm" delegate-realm="JdbcRealm" failover-realm="PropRealm"/>
     </security-realms>
     <credential-security-factories>
         <custom-credential-security-factory name="CustomFactory" module="a.b.c" class-name="org.wildfly.security.ElytronFactory">
@@ -154,19 +109,18 @@
         </custom-credential-security-factory>
 
         <kerberos-security-factory name="KerberosFactory"
-                                   principal="${exp.principal:bob@Elytron.org}"
+                                   principal="bob@Elytron.org"
                                    path="bob.keytab"
                                    relative-to="server.config.dir"
-                                   minimum-remaining-lifetime="${exp.life:10}"
-                                   request-lifetime="${exp.request:120}"
-                                   server="${exp.server:false}"
-                                   obtain-kerberos-ticket="${exp.ticket:true}"
-                                   debug="${exp.debug:true}"
-                                   wrap-gss-credential="${exp.wrap:true}"
-                                   required="${exp.required:true}"
-                                   mechanism-names="${exp.test:KRB5} ${exp.legacy:KRB5LEGACY}"
-                                   mechanism-oids="${exp.oid:1.2.840.113554.1.2.2} ${exp.oid:1.3.6.1.5.5.2}"
-                                   fail-cache="${exp.fail:100}">
+                                   minimum-remaining-lifetime="10"
+                                   request-lifetime="120"
+                                   server="false"
+                                   obtain-kerberos-ticket="true"
+                                   debug="true"
+                                   wrap-gss-credential="true"
+                                   required="true"
+                                   mechanism-names="KRB5 KRB5LEGACY"
+                                   mechanism-oids="1.2.840.113554.1.2.2 1.3.6.1.5.5.2">
             <option name="a" value="b"/>
             <option name="c" value="d"/>
         </kerberos-security-factory>
@@ -183,20 +137,16 @@
                                    mechanism-oids="1.2.840.113554.1.2.2 1.3.6.1.5.5.2"/>
     </credential-security-factories>
     <mappers>
-        <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$MyPermissionMapper" name="MyPermissionMapper" module="a.b.c">
-            <configuration>
-                <property name="test" value="${exp.value:value}"/>
-            </configuration>
-        </custom-permission-mapper>
+        <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$MyPermissionMapper" name="MyPermissionMapper" module="a.b.c"/>
         <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$LoginPermissionMapper" name="LoginPermissionMapper" module="a.b.c"/>
-        <simple-permission-mapper name="SimplePermissionMapperLegacy" mapping-mode="${exp.mapping:and}">
+        <simple-permission-mapper name="SimplePermissionMapperLegacy" mapping-mode="and">
             <permission-mapping>
                 <principal name="John"/>
                 <principal name="Joe"/>
                 <role name="User"/>
                 <role name="Administrator"/>
                 <permission class-name="a.b.MyPermission"/>
-                <permission class-name="a.b.MyOtherPermission" target-name="${exp.target:../c}" action="${exp.action:delete}"/>
+                <permission class-name="a.b.MyOtherPermission" target-name="../c" action="delete"/>
             </permission-mapping>
             <permission-mapping>
                 <principal name="John Doe"/>
@@ -237,53 +187,40 @@
             <principal-decoder name="MyCnDecoder"/>
             <principal-decoder name="MyDcDecoder"/>
         </concatenating-principal-decoder>
-        <constant-principal-decoder name="ConstantDecoder" constant="${exp.constant:test}"/>
         <x500-attribute-principal-decoder joiner="," maximum-segments="6" name="MyX500PrincipalDecoder" oid="2.5.4.3"/>
-        <x500-attribute-principal-decoder joiner="${exp.joiner:,}" maximum-segments="${exp.map:1}" name="MyX500PrincipalDecoderTwo" oid="${exp.oid:2.5.4.3}" required-oids="${exp.required.oids:2.5.4.3} ${exp.oids:2.5.4.11}"
-                                          required-attributes="cN" reverse="${exp.reverse:true}"
-                                          start-segment="${exp.start:2}"
-                                          convert="${exp.convert:true}"/>
-        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="${exp.attribute:Cn}" start-segment="1"/>
+        <x500-attribute-principal-decoder joiner="," maximum-segments="1" name="MyX500PrincipalDecoderTwo" oid="2.5.4.3" required-oids="2.5.4.3 2.5.4.11"
+                                          required-attributes="cN" reverse="true"
+                                          start-segment="2"/>
+        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="Cn" start-segment="1"/>
         <x500-attribute-principal-decoder name="MyDcDecoder" oid="0.9.2342.19200300.100.1.25"/>
-        <constant-principal-transformer name="ConstantNameRewriter" constant="${exp.constant:test}"/>
-        <regex-principal-transformer name="NameRewriterXY" pattern="${exp.pattern:x(.*)}" replacement="${exp.replacement:y$1}" replace-all="${exp.replace:false}"/>
+        <regex-principal-transformer name="NameRewriterXY" pattern="x(.*)" replacement="y$1"/>
         <regex-principal-transformer name="NameRewriterYU" pattern="y(.*)" replacement="u$1"/>
         <regex-principal-transformer name="NameRewriterRealmRemover" pattern="(.*)@.*" replacement="$1"/>
-        <regex-validating-principal-transformer name="RegexValidateNameRewriter" pattern="x(.*)" match="${exp.match:true}"/>
         <simple-regex-realm-mapper name="MyRealmMapper" pattern=".*@(.*)"/>
-        <mapped-regex-realm-mapper name="MappedRealmMapper" pattern="${exp.pattern:.*@(.*)}">
-            <realm-mapping from="test" to="${exp.to:test}"/>
-        </mapped-regex-realm-mapper>
         <simple-role-decoder attribute="roles" name="MyRoleDecoder"/>
-        <add-prefix-role-mapper name="RolePrefixer" prefix="${exp.prefix:prefix}"/>
-        <add-suffix-role-mapper name="RoleSuffixer" suffix="${exp.suffix:suffix}"/>
+        <add-prefix-role-mapper name="RolePrefixer" prefix="prefix"/>
+        <add-suffix-role-mapper name="RoleSuffixer" suffix="suffix"/>
         <aggregate-role-mapper name="MyRoleMapper">
             <role-mapper name="RolePrefixer"/>
             <role-mapper name="RoleSuffixer"/>
         </aggregate-role-mapper>
-        <constant-role-mapper name="ConstantRoleMapper">
-            <role name="${exp.role:role}"/>
-        </constant-role-mapper>
-        <logical-role-mapper name="LogicalRoleMapper" logical-operation="${exp.logical:and}" />
-        <mapped-role-mapper name="MappedRoleMapper" keep-mapped="${exp.mapped:false}" keep-non-mapped="${exp.non.mapped:true}">
+        <mapped-role-mapper name="MappedRoleMapper" keep-mapped="false" keep-non-mapped="true">
             <role-mapping from="Admin" to="Administrator"/>
             <role-mapping from="foo" to="bar baz"/>
         </mapped-role-mapper>
         <x500-subject-evidence-decoder name="subjectDecoder" />
-        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="${exp.alt.name:rfc822Name}" segment="${exp.segment:1}" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
         <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
-        <source-address-role-decoder name="ipRoleDecoder" source-address="${exp.source:10.12.14.16}" roles="${exp.admin:admin} ${exp.user:user}"/>
-        <source-address-role-decoder name="regexRoleDecoder" pattern="${exp.pattern:10\.12\.14\.\d+$}" roles="employee"/>
+        <source-address-role-decoder name="ipRoleDecoder" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="employee"/>
         <aggregate-role-decoder name="aggregateRoleDecoder">
             <role-decoder name="ipRoleDecoder"/>
             <role-decoder name="regexRoleDecoder"/>
         </aggregate-role-decoder>
-        <regex-role-mapper name="RegexRoleMapper" pattern="${exp.pattern:*(x.)}" replacement="${exp.replacement:false}" replace-all="${exp.replace.all:false}"/>
-        <case-principal-transformer name="CaseNameRewriter" upper-case="${exp.upper:true}" />
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">
@@ -300,9 +237,9 @@
     <sasl>
         <sasl-authentication-factory name="SaslAuthenticationDefinition" security-domain="MyDomain" sasl-server-factory="ConfigurableSaslServerFactory">
             <mechanism-configuration>
-                <mechanism mechanism-name="${exp.mech.name:PLAIN}" pre-realm-principal-transformer="PreRealmNameRewriter" post-realm-principal-transformer="PostRealmNameRewriter"
-                           final-principal-transformer="FinalNameRewriter" realm-mapper="RegexMapper" host-name="${exp.host:host}" protocol="${exp.protocol:protocol}">
-                    <mechanism-realm realm-name="${exp.realm.name:Test Realm}" pre-realm-principal-transformer="PreRealmNameRewriter_II"
+                <mechanism mechanism-name="PLAIN" pre-realm-principal-transformer="PreRealmNameRewriter" post-realm-principal-transformer="PostRealmNameRewriter"
+                           final-principal-transformer="FinalNameRewriter" realm-mapper="RegexMapper">
+                    <mechanism-realm realm-name="Test Realm" pre-realm-principal-transformer="PreRealmNameRewriter_II"
                                      post-realm-principal-transformer="PostRealmNameRewriter_II" final-principal-transformer="FinalNameRewriter_II"
                                      realm-mapper="RegexMapper_II"/>
                 </mechanism>
@@ -351,10 +288,10 @@
                 <credential-reference clear-text="password"/>
                 <implementation type="PKCS#11" provider-name="SunPKCS#11"/>
             </key-store>
-            <key-store name="jks_store" alias-filter="${exp.alias.filter:one,two,three}">
+            <key-store name="jks_store" alias-filter="one,two,three">
                 <credential-reference clear-text="password"/>
-                <implementation type="${exp.type:jks}" provider-name="${exp.provider:SunJSSE}"/>
-                <file relative-to="jboss.server.config.dir" path="keystore.jks" required="${exp.required:true}"/>
+                <implementation type="jks"/>
+                <file relative-to="jboss.server.config.dir" path="keystore.jks" required="true"/>
             </key-store>
             <key-store name="jceks_store">
                 <credential-reference clear-text="password"/>
@@ -375,23 +312,13 @@
                 <implementation type="PKCS12"/>
                 <file path="test.keystore" relative-to="jboss.server.config.dir"/>
             </key-store>
-            <ldap-key-store name="LdapKeyStore" dir-context="DirContextSsl" >
-                <new-item-template new-item-path="${exp.path:ou=keystore,dc=elytron,dc=wildfly,dc=org}" new-item-rdn="${exp.item:cn}">
-                    <attribute name="${exp.name:objectClass}" value="${exp.value:top} ${exp.value2:inetOrgPerson}"/>
-                    <attribute name="sn" value="NewKeyStoreItem"/>
-                </new-item-template>
-                <search path="${exp.path:dc=elytron,dc=wildfly,dc=org}" recursive="${exp.recursive:true}" time-limit="${exp.time:1000}" filter-alias="${exp.filter:(&amp;(objectClass=inetOrgPerson)(sn={0}))}"
-                        filter-certificate="${exp.filter:(&amp;(objectClass=inetOrgPerson)(usercertificate={0}))}" filter-iterate="${exp.iterate:(sn=serenity*)}"/>
-                <attribute-mapping alias-attribute="${exp.alias:sn}" certificate-attribute="${exp.certificate:usercertificate}" certificate-chain-attribute="${exp.chain:userSMIMECertificate}" certificate-chain-encoding="${exp.encoding:PKCS7}" certificate-type="${exp.type:X.509}" key-attribute="${exp.key:userPKCS12}"
-                                   key-type="${exp.type:PKCS12}"/>
-            </ldap-key-store>
-            <filtering-key-store name="FilteringKeyStore" key-store="Custom_PKCS_11" alias-filter="${exp.alias.filter:NONE:+firefly}"/>
+            <filtering-key-store name="FilteringKeyStore" key-store="Custom_PKCS_11" alias-filter="NONE:+firefly"/>
         </key-stores>
         <key-managers>
             <key-manager name="serverKey" algorithm="SunX509" key-store="jks_store">
                 <credential-reference clear-text="password"/>
             </key-manager>
-            <key-manager name="serverKey2" algorithm="${exp.algo:SunX509}" key-store="jks_store" providers="custom-loader" provider-name="first" alias-filter="${exp.alias:one,two,three}" generate-self-signed-certificate-host="${exp.generate:localhost}">
+            <key-manager name="serverKey2" algorithm="SunX509" key-store="jks_store" providers="custom-loader" provider-name="first">
                 <credential-reference store="credstore1" alias="password-alias" type="PasswordCredential"/>
             </key-manager>
             <key-manager name="clientKey" algorithm="SunX509" key-store="jks_store">
@@ -405,20 +332,20 @@
             <trust-manager name="serverTrust" algorithm="SunX509" key-store="jks_store"/>
             <trust-manager name="serverTrust2" algorithm="SunX509" key-store="jks_store" providers="custom-loader" provider-name="first"/>
             <trust-manager name="trust-with-crl" algorithm="SunX509" key-store="jks_store">
-                <certificate-revocation-list path="${exp.path:crl.pem}" relative-to="jboss.server.config.dir" maximum-cert-path="${exp.max:2}"/>
+                <certificate-revocation-list path="crl.pem" relative-to="jboss.server.config.dir" maximum-cert-path="2"/>
             </trust-manager>
             <trust-manager name="trust-with-crl-dp" algorithm="SunX509" key-store="jks_store">
                 <certificate-revocation-list/>
             </trust-manager>
-            <trust-manager name="trust-with-ocsp" algorithm="${exp.algorithm:PKIX}" key-store="jks_store">
-                <ocsp responder="${exp.responder:http://localhost/ocsp}" responder-keystore="${exp.responder.keystore:jceks_store}" responder-certificate="${exp.responder.certificate:responder-alias}"/>
+            <trust-manager name="trust-with-ocsp" algorithm="PKIX" key-store="jks_store">
+                <ocsp responder="http://localhost/ocsp" responder-keystore="jceks_store" responder-certificate="responder-alias"/>
             </trust-manager>
         </trust-managers>
         <server-ssl-contexts>
-            <server-ssl-context name="server" protocols="${exp.protocols:TLSv1.2}" want-client-auth="${exp.client.auth:true}" need-client-auth="${exp.need.client:true}" authentication-optional="${exp.authentication:true}"
-                                use-cipher-suites-order="${exp.cipher.suites:false}" maximum-session-cache-size="${exp.cache:10}" cipher-suite-filter="${exp.filter:DEFAULT}" cipher-suite-names="${exp.names:name}"
-                                session-timeout="${exp.session:120}" wrap="${exp.wrap:false}" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
-                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="${exp.provider.name:first}"/>
+            <server-ssl-context name="server" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true"
+                                use-cipher-suites-order="false" maximum-session-cache-size="10"
+                                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
+                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
             <server-ssl-context name="server2" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true"
                                 use-cipher-suites-order="false" maximum-session-cache-size="10"
                                 session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
@@ -429,11 +356,11 @@
                                 provider-name="first"/>
         </client-ssl-contexts>
         <certificate-authorities>
-            <certificate-authority name="testCA" url="${exp.url:https://www.test.com}" staging-url="${exp.staging.url:https://www.test.com}"/>
+            <certificate-authority name="testCA" url="https://www.test.com"/>
         </certificate-authorities>
         <certificate-authority-accounts>
-            <certificate-authority-account name="MyCA" certificate-authority="${exp.certificate.authority:LetsEncrypt}" contact-urls="${exp.contact.urls:https://www.test.com}">
-                <account-key key-store="accounts.keystore" alias="${exp.alias:server}">
+            <certificate-authority-account name="MyCA" certificate-authority="LetsEncrypt">
+                <account-key key-store="accounts.keystore" alias="server">
                     <credential-reference clear-text="elytron"/>
                 </account-key>
             </certificate-authority-account>
@@ -449,12 +376,9 @@
                 <sni-mapping host=".*\.server" ssl-context="server2" />
             </server-ssl-sni-context>
         </server-ssl-sni-contexts>
-        <dynamic-client-ssl-contexts>
-            <dynamic-client-ssl-context name="dynamicClient" authentication-context="${exp.auth.context:myAC}"/>
-        </dynamic-client-ssl-contexts>
     </tls>
     <credential-stores>
-        <credential-store name="test1" relative-to="jboss.server.data.dir" location="${exp.location:test1.store}" create="true" type="${exp.type:JCEKS}" provider-name="${exp.provider:provider}">
+        <credential-store name="test1" relative-to="jboss.server.data.dir" location="test1.store" create="true">
             <implementation-properties>
                 <property name="keyStoreType" value="JCEKS"/>
                 <property name="keyAlias" value="adminKey"/>
@@ -464,31 +388,21 @@
         <credential-store name="test2" relative-to="jboss.server.data.dir" modifiable="true">
             <credential-reference store="test1" alias="to_open_test2"/>
         </credential-store>
-        <credential-store name="test4" relative-to="jboss.server.data.dir" path="${exp.path:test1.store}" create="true">
+        <credential-store name="test4" relative-to="jboss.server.data.dir" path="test1.store" create="true">
             <credential-reference clear-text="secret2"/>
         </credential-store>
-        <secret-key-credential-store name="secretkeycredstore" relative-to="jboss.server.data.dir" path="mysecretkeycredstore.cs" create="${exp.create:true}" populate="${exp.populate:true}" />
-        <secret-key-credential-store name="test3" relative-to="jboss.server.data.dir" path="test3.cs"
-                                     create="${exp.create:false}" populate="${exp.populate:false}"
-                                     key-size="${exp.key:192}" default-alias="${exp.alias:test3}" />
+        <secret-key-credential-store name="test3" relative-to="jboss.server.data.dir" path="test3.cs" create="false" populate="false" key-size="192" default-alias="test3" />
     </credential-stores>
     <expression-resolver default-resolver="A" prefix="G">
         <resolver name="A" credential-store="test1" secret-key="C"/>
         <resolver name="D" credential-store="test2" secret-key="F"/>
     </expression-resolver>
-    <dir-contexts>
-        <dir-context name="DirContextSsl" authentication-context="ldapAuthContext" referral-mode="throw" url="ldaps://localhost:11391/" connection-timeout="6000" read-timeout="10000">
-            <properties>
-                <property name="java.naming.dns.url" value="dns://dnsserver/wiz.com"/>
-            </properties>
-        </dir-context>
-    </dir-contexts>
     <jaspi>
-        <jaspi-configuration name="test" layer="${exp.layer:HttpServlet}" application-context="${exp.app.context:default /test}" description="${exp.description:Test Definition}">
+        <jaspi-configuration name="test" layer="HttpServlet" application-context="default /test" description="Test Definition">
             <server-auth-modules>
-                <server-auth-module class-name="org.wildfly.Test" module="org.test" flag="${exp.flag:REQUISITE}">
+                <server-auth-module class-name="org.wildfly.Test" module="org.test" flag="REQUISITE">
                     <options>
-                        <property name="a" value="${exp.b:b}"/>
+                        <property name="a" value="b"/>
                         <property name="c" value="d"/>
                     </options>
                 </server-auth-module>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-13.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-13.0-reject.xml
@@ -9,7 +9,7 @@
     TODO Keep the from version up to date with later releases.
  -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <authentication-client>
         <authentication-context name="myAC" />
     </authentication-client>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-13.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-13.0.xml
@@ -9,7 +9,7 @@
     TODO Keep the from version up to date with later releases.
  -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <mappers>
         <mapped-role-mapper name="MappedRoleMapper">
             <role-mapping from="admin" to="manager user"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/expression-encryption.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/expression-encryption.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- Initial configuration as used by the ExpressionResolutionTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <tls>
         <key-stores>
             <key-store name="KeyStoreOne">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/http.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/http.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <providers>
         <provider-loader name="TestProviderLoader" module="test.module" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/identity-management.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/identity-management.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:20.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/jacc-provider.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/jacc-provider.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <policy name="elytron-a">
         <jacc-policy policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
     </policy>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/jaspi.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/jaspi.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0" register-jaspi-factory="false">
+<subsystem xmlns="urn:wildfly:elytron:20.0" register-jaspi-factory="false">
     <jaspi>
         <jaspi-configuration name="test" layer="HttpServlet" application-context="default /test" description="Test Definition">
             <server-auth-modules>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/jwt-realm-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/jwt-realm-test.xml
@@ -1,5 +1,5 @@
 <!-- for JwtSecurityRealmTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:20.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>
@@ -10,6 +10,9 @@
         </token-realm>
         <token-realm name="JwtRealmWithoutAllowedJkuValues" principal-claim="sub">
             <jwt issuer="elytron-oauth2-realm" audience="my-app-valid" client-ssl-context="ClientCaSslContext" />
+        </token-realm>
+        <token-realm name="JwtRealmWithPublicKeyUrl" principal-claim="sub">
+            <jwt issuer="elytron-oauth2-realm" audience="my-app-valid" public-key-url="http://localhost:50833/publickey" />
         </token-realm>
     </security-realms>
 

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of LdapTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:20.0" initial-providers="elytron">
    <authentication-client>
       <authentication-configuration name="ldapAuthConfig" authentication-name="uid=server,dc=users,dc=elytron,dc=wildfly,dc=org">
          <credential-reference clear-text="serverPassword"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/legacy-elytron-subsystem-19.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/legacy-elytron-subsystem-19.0.xml
@@ -4,18 +4,7 @@
   -->
 
 <!-- for needs of DomainTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:20.0" register-jaspi-factory="${exp.jaspi:false}" default-ssl-context="client" disallowed-providers="${exp.providers:test}">
-    <authentication-client>
-        <authentication-context name="myAC" />
-    </authentication-client>
-    <providers>
-        <provider-loader name="openssl" module="org.wildfly.openssl">
-            <configuration>
-                <property name="prop" value="${exp.value:val}"/>
-            </configuration>
-        </provider-loader>
-        <provider-loader name="elytron" module="org.wildfly.security.elytron" argument="${exp.argument:arg}"/>
-    </providers>
+<subsystem xmlns="urn:wildfly:elytron:19.0" register-jaspi-factory="false" default-ssl-context="client">
     <security-domains>
         <security-domain name="MyDomain" default-realm="FileRealm" realm-mapper="MyRealmMapper" permission-mapper="MyPermissionMapper"
                          pre-realm-principal-transformer="NameRewriterXY" post-realm-principal-transformer="NameRewriterYU" trusted-security-domains="AnotherDomain">
@@ -43,13 +32,12 @@
         <security-domain name="TestDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" trusted-virtual-security-domains="VirtualDomain">
             <realm name="PropRealm"/>
         </security-domain>
-        <virtual-security-domain name="VirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="${exp.anonymous:true}" />
-        <virtual-security-domain name="AnotherVirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="${exp.anonymous:true}" auth-method="OIDC"/>
+        <virtual-security-domain name="VirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="true" />
+        <virtual-security-domain name="AnotherVirtualDomain" outflow-security-domains="MyDomain" outflow-anonymous="true" auth-method="OIDC"/>
     </security-domains>
     <security-realms>
-        <aggregate-realm name="AggregateOne" authentication-realm="PropRealm" authorization-realm="FileRealm" principal-transformer="${exp.transformer:NameRewriterXY}"/>
+        <aggregate-realm name="AggregateOne" authentication-realm="PropRealm" authorization-realm="FileRealm" />
         <aggregate-realm name="AggregateTwo" authentication-realm="JdbcRealm" authorization-realms="AggregateOne FileRealm" />
-        <identity-realm name="local" identity="${exp.identity:$local}" attribute-name="${exp.name:groups}" attribute-values="${exp.values:SuperUser}" />
         <jdbc-realm name="NewJdbcScramSha384">
             <principal-query sql="SELECT" data-source="ExampleDS">
                 <scram-mapper algorithm="scram-sha-384" password-index="1" salt-index="2" iteration-count-index="10000"/>
@@ -60,17 +48,12 @@
                 <scram-mapper algorithm="scram-sha-512" password-index="1" salt-index="2" iteration-count-index="10000"/>
             </principal-query>
         </jdbc-realm>
-        <jdbc-realm name="JdbcScram">
-            <principal-query sql="SELECT" data-source="ExampleDS">
-                <scram-mapper password-index="${exp.password:2}" salt-index="${exp.salt:3}" iteration-count-index="${exp.iteration:4}" hash-encoding="${exp.encoding:hex}" salt-encoding="${exp.encoding:hex}" algorithm="${exp.algorithm:scram-sha-1}"/>
-            </principal-query>
-        </jdbc-realm>
         <jdbc-realm name="JdbcRealmBcrypt">
             <principal-query sql="SELECT role, password, salt, ic FROM User WHERE username = ?" data-source="ExampleDS">
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <bcrypt-mapper password-index="${exp.password:2}" salt-index="${exp.salt:3}" iteration-count-index="${exp.iteration:4}" hash-encoding="${exp.encoding:hex}" salt-encoding="${exp.encoding:hex}"/>
+                <bcrypt-mapper password-index="2" salt-index="3" iteration-count-index="4" hash-encoding="hex" salt-encoding="hex"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmClearPassword">
@@ -78,7 +61,7 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <clear-password-mapper password-index="${exp.password:2}"/>
+                <clear-password-mapper password-index="2"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmSalted">
@@ -86,7 +69,7 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <salted-simple-digest-mapper password-index="${exp.password:2}" salt-index="${exp.salt:3}" algorithm="${exp.algo:password-salt-digest-sha-1}" hash-encoding="${exp.encoding:hex}" salt-encoding="${exp.encoding:hex}"/>
+                <salted-simple-digest-mapper password-index="2" salt-index="3" algorithm="password-salt-digest-sha-1" hash-encoding="hex" salt-encoding="hex"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmSimple">
@@ -94,7 +77,7 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                 <simple-digest-mapper password-index="${exp.password:2}" hash-encoding="${exp.encoding:hex}" algorithm="simple-digest-sha-1"/>
+                <simple-digest-mapper password-index="2" hash-encoding="hex" algorithm="simple-digest-sha-1"/>
             </principal-query>
         </jdbc-realm>
         <jdbc-realm name="JdbcRealmModular">
@@ -102,48 +85,20 @@
                 <attribute-mapping>
                     <attribute index="1" to="role"/>
                 </attribute-mapping>
-                <modular-crypt-mapper password-index="${exp.password:2}"/>
+                <modular-crypt-mapper password-index="2"/>
             </principal-query>
         </jdbc-realm>
-        
-        <properties-realm name="PropRealm" groups-attribute="${exp.groups:groups}">
-            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir" digest-realm-name="${exp.digest.realm:FileRealm}" plain-text="${exp.plain:false}"/>
+        <properties-realm name="PropRealm">
+            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
         </properties-realm>
         <properties-realm name="NonDomainRealm">
             <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
         </properties-realm>
-        <ldap-realm name="LdapRealmWithAttributeMapping" dir-context="dircontext1" allow-blank-password="${exp.blank:true}" direct-verification="${exp.verification:false}">
-            <identity-mapping rdn-identifier="${exp.rdn:uid}" use-recursive-search="${exp.recursive:true}" search-base-dn="${exp.search:dc=elytron,dc=wildfly,dc=org}" filter-name="${exp.filter:(rdn_identifier={0})}" iterator-filter="${exp.filter:(uid=*)}" new-identity-parent-dn="${exp.parent:dc=elytron,dc=wildfly,dc=org}">
-                <attribute-mapping>
-                    <attribute filter-base-dn="${exp.base:ou=Finance,dc=elytron,dc=wildfly,dc=org}" filter="${exp.filter:(&amp;(objectClass=groupOfNames)(member={0}))}" from="${exp.from:CN}" extract-rdn="OU" to="${exp.to:businessUnit}"
-                               reference="${exp.reference:ref}" search-recursive="${exp.recursive:true}" role-recursion="${exp.role:0}" role-recursion-name="${exp.name:cn}"/>
-                    <attribute filter-base-dn="ou=Sales,dc=elytron,dc=wildfly,dc=org" filter="(&amp;(objectClass=groupOfNames)(member={0}))" from="CN" extract-rdn="${exp.extract:OU}" to="businessUnit"/>
-                </attribute-mapping>
-                <new-identity-attributes>
-                    <attribute name="${exp.name:sn}" value="${exp.value:BlankSurname}"/>
-                </new-identity-attributes>
-                <user-password-mapper from="${exp.from:userPassword}" writable="${exp.writable:true}" verifiable="${exp.verifiable:true}" />
-                <otp-credential-mapper algorithm-from="${exp.alg:otpAlgorithm}" hash-from="${exp.hash:otpHash}" seed-from="${exp.seed:otpSeed}" sequence-from="${exp.sequence:otpSequenc}e"/>
-                <x509-credential-mapper digest-from="${exp.digest:x509digest}" certificate-from="${exp.certificate:usercertificate}" subject-dn-from="${exp.subject:x509subject}" serial-number-from="${exp.serial:x509serialNumber}" digest-algorithm="${exp.algo:SHA-1}" />
-            </identity-mapping>
-        </ldap-realm>
-        <filesystem-realm name="FileRealm" levels="${exp.levels:2}" encoded="${exp.encoded:false}">
+        <filesystem-realm name="FileRealm" levels="2" encoded="false">
             <file path="filesystem-realm" relative-to="jboss.server.config.dir"/>
         </filesystem-realm>
-        <filesystem-realm name="FileSystemRealmEncrypted" levels="${exp.levels:2}" encoded="${exp.encoded:false}" credential-store="${exp.credstore:secretkeycredstore}" secret-key="${exp.secretkey:key}">
-            <file path="filesystem-realm-encrypted" relative-to="jboss.server.config.dir"/>
-        </filesystem-realm>
-        <token-realm name="JwtRealmOne" principal-claim="${exp.principal:sub}" >
-            <jwt issuer="${exp.issuer:some-issuer-a}" audience="${exp.audience:some-audience-a}" public-key="${exp.key:MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqP}"
-                 certificate="${exp.cert:cert}">
-                <key kid="kid" public-key="${exp.public:public}"/>
-            </jwt>
-        </token-realm>
-        <token-realm name="OAuth2Realm" principal-claim="sub">
-            <oauth2-introspection client-id="${exp.id:a}" client-secret="${exp.secret:b}" introspection-url="${exp.url:https://localhost/token/introspect}" host-name-verification-policy="${exp.host:host}"/>
-        </token-realm>
-        <distributed-realm name="DistributedRealm" realms="FileRealm PropRealm" ignore-unavailable-realms="${exp.ignore:true}" emit-events="${exp.emit:true}"/>
-        <failover-realm name="FailoverRealm" delegate-realm="JdbcRealm" failover-realm="PropRealm" emit-events="${exp.emit:true}"/>
+        <distributed-realm name="DistributedRealm" realms="FileRealm PropRealm"/>
+        <failover-realm name="FailoverRealm" delegate-realm="JdbcRealm" failover-realm="PropRealm"/>
     </security-realms>
     <credential-security-factories>
         <custom-credential-security-factory name="CustomFactory" module="a.b.c" class-name="org.wildfly.security.ElytronFactory">
@@ -154,19 +109,18 @@
         </custom-credential-security-factory>
 
         <kerberos-security-factory name="KerberosFactory"
-                                   principal="${exp.principal:bob@Elytron.org}"
+                                   principal="bob@Elytron.org"
                                    path="bob.keytab"
                                    relative-to="server.config.dir"
-                                   minimum-remaining-lifetime="${exp.life:10}"
-                                   request-lifetime="${exp.request:120}"
-                                   server="${exp.server:false}"
-                                   obtain-kerberos-ticket="${exp.ticket:true}"
-                                   debug="${exp.debug:true}"
-                                   wrap-gss-credential="${exp.wrap:true}"
-                                   required="${exp.required:true}"
-                                   mechanism-names="${exp.test:KRB5} ${exp.legacy:KRB5LEGACY}"
-                                   mechanism-oids="${exp.oid:1.2.840.113554.1.2.2} ${exp.oid:1.3.6.1.5.5.2}"
-                                   fail-cache="${exp.fail:100}">
+                                   minimum-remaining-lifetime="10"
+                                   request-lifetime="120"
+                                   server="false"
+                                   obtain-kerberos-ticket="true"
+                                   debug="true"
+                                   wrap-gss-credential="true"
+                                   required="true"
+                                   mechanism-names="KRB5 KRB5LEGACY"
+                                   mechanism-oids="1.2.840.113554.1.2.2 1.3.6.1.5.5.2">
             <option name="a" value="b"/>
             <option name="c" value="d"/>
         </kerberos-security-factory>
@@ -183,20 +137,16 @@
                                    mechanism-oids="1.2.840.113554.1.2.2 1.3.6.1.5.5.2"/>
     </credential-security-factories>
     <mappers>
-        <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$MyPermissionMapper" name="MyPermissionMapper" module="a.b.c">
-            <configuration>
-                <property name="test" value="${exp.value:value}"/>
-            </configuration>
-        </custom-permission-mapper>
+        <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$MyPermissionMapper" name="MyPermissionMapper" module="a.b.c"/>
         <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$LoginPermissionMapper" name="LoginPermissionMapper" module="a.b.c"/>
-        <simple-permission-mapper name="SimplePermissionMapperLegacy" mapping-mode="${exp.mapping:and}">
+        <simple-permission-mapper name="SimplePermissionMapperLegacy" mapping-mode="and">
             <permission-mapping>
                 <principal name="John"/>
                 <principal name="Joe"/>
                 <role name="User"/>
                 <role name="Administrator"/>
                 <permission class-name="a.b.MyPermission"/>
-                <permission class-name="a.b.MyOtherPermission" target-name="${exp.target:../c}" action="${exp.action:delete}"/>
+                <permission class-name="a.b.MyOtherPermission" target-name="../c" action="delete"/>
             </permission-mapping>
             <permission-mapping>
                 <principal name="John Doe"/>
@@ -237,53 +187,40 @@
             <principal-decoder name="MyCnDecoder"/>
             <principal-decoder name="MyDcDecoder"/>
         </concatenating-principal-decoder>
-        <constant-principal-decoder name="ConstantDecoder" constant="${exp.constant:test}"/>
         <x500-attribute-principal-decoder joiner="," maximum-segments="6" name="MyX500PrincipalDecoder" oid="2.5.4.3"/>
-        <x500-attribute-principal-decoder joiner="${exp.joiner:,}" maximum-segments="${exp.map:1}" name="MyX500PrincipalDecoderTwo" oid="${exp.oid:2.5.4.3}" required-oids="${exp.required.oids:2.5.4.3} ${exp.oids:2.5.4.11}"
-                                          required-attributes="cN" reverse="${exp.reverse:true}"
-                                          start-segment="${exp.start:2}"
-                                          convert="${exp.convert:true}"/>
-        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="${exp.attribute:Cn}" start-segment="1"/>
+        <x500-attribute-principal-decoder joiner="," maximum-segments="1" name="MyX500PrincipalDecoderTwo" oid="2.5.4.3" required-oids="2.5.4.3 2.5.4.11"
+                                          required-attributes="cN" reverse="true"
+                                          start-segment="2"/>
+        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="Cn" start-segment="1"/>
         <x500-attribute-principal-decoder name="MyDcDecoder" oid="0.9.2342.19200300.100.1.25"/>
-        <constant-principal-transformer name="ConstantNameRewriter" constant="${exp.constant:test}"/>
-        <regex-principal-transformer name="NameRewriterXY" pattern="${exp.pattern:x(.*)}" replacement="${exp.replacement:y$1}" replace-all="${exp.replace:false}"/>
+        <regex-principal-transformer name="NameRewriterXY" pattern="x(.*)" replacement="y$1"/>
         <regex-principal-transformer name="NameRewriterYU" pattern="y(.*)" replacement="u$1"/>
         <regex-principal-transformer name="NameRewriterRealmRemover" pattern="(.*)@.*" replacement="$1"/>
-        <regex-validating-principal-transformer name="RegexValidateNameRewriter" pattern="x(.*)" match="${exp.match:true}"/>
         <simple-regex-realm-mapper name="MyRealmMapper" pattern=".*@(.*)"/>
-        <mapped-regex-realm-mapper name="MappedRealmMapper" pattern="${exp.pattern:.*@(.*)}">
-            <realm-mapping from="test" to="${exp.to:test}"/>
-        </mapped-regex-realm-mapper>
         <simple-role-decoder attribute="roles" name="MyRoleDecoder"/>
-        <add-prefix-role-mapper name="RolePrefixer" prefix="${exp.prefix:prefix}"/>
-        <add-suffix-role-mapper name="RoleSuffixer" suffix="${exp.suffix:suffix}"/>
+        <add-prefix-role-mapper name="RolePrefixer" prefix="prefix"/>
+        <add-suffix-role-mapper name="RoleSuffixer" suffix="suffix"/>
         <aggregate-role-mapper name="MyRoleMapper">
             <role-mapper name="RolePrefixer"/>
             <role-mapper name="RoleSuffixer"/>
         </aggregate-role-mapper>
-        <constant-role-mapper name="ConstantRoleMapper">
-            <role name="${exp.role:role}"/>
-        </constant-role-mapper>
-        <logical-role-mapper name="LogicalRoleMapper" logical-operation="${exp.logical:and}" />
-        <mapped-role-mapper name="MappedRoleMapper" keep-mapped="${exp.mapped:false}" keep-non-mapped="${exp.non.mapped:true}">
+        <mapped-role-mapper name="MappedRoleMapper" keep-mapped="false" keep-non-mapped="true">
             <role-mapping from="Admin" to="Administrator"/>
             <role-mapping from="foo" to="bar baz"/>
         </mapped-role-mapper>
         <x500-subject-evidence-decoder name="subjectDecoder" />
-        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="${exp.alt.name:rfc822Name}" segment="${exp.segment:1}" />
+        <x509-subject-alt-name-evidence-decoder name="rfc822Decoder" alt-name-type="rfc822Name" segment="1" />
         <custom-evidence-decoder name="customEvidenceDecoder" class-name="org.wildfly.elytron.CustomEvidenceDecoder" module="l.m" />
         <aggregate-evidence-decoder name="aggregateEvidenceDecoder">
             <evidence-decoder name="rfc822Decoder"/>
             <evidence-decoder name="subjectDecoder"/>
         </aggregate-evidence-decoder>
-        <source-address-role-decoder name="ipRoleDecoder" source-address="${exp.source:10.12.14.16}" roles="${exp.admin:admin} ${exp.user:user}"/>
-        <source-address-role-decoder name="regexRoleDecoder" pattern="${exp.pattern:10\.12\.14\.\d+$}" roles="employee"/>
+        <source-address-role-decoder name="ipRoleDecoder" source-address="10.12.14.16" roles="admin user"/>
+        <source-address-role-decoder name="regexRoleDecoder" pattern="10\.12\.14\.\d+$" roles="employee"/>
         <aggregate-role-decoder name="aggregateRoleDecoder">
             <role-decoder name="ipRoleDecoder"/>
             <role-decoder name="regexRoleDecoder"/>
         </aggregate-role-decoder>
-        <regex-role-mapper name="RegexRoleMapper" pattern="${exp.pattern:*(x.)}" replacement="${exp.replacement:false}" replace-all="${exp.replace.all:false}"/>
-        <case-principal-transformer name="CaseNameRewriter" upper-case="${exp.upper:true}" />
     </mappers>
     <permission-sets>
         <permission-set name="my-permissions">
@@ -300,9 +237,9 @@
     <sasl>
         <sasl-authentication-factory name="SaslAuthenticationDefinition" security-domain="MyDomain" sasl-server-factory="ConfigurableSaslServerFactory">
             <mechanism-configuration>
-                <mechanism mechanism-name="${exp.mech.name:PLAIN}" pre-realm-principal-transformer="PreRealmNameRewriter" post-realm-principal-transformer="PostRealmNameRewriter"
-                           final-principal-transformer="FinalNameRewriter" realm-mapper="RegexMapper" host-name="${exp.host:host}" protocol="${exp.protocol:protocol}">
-                    <mechanism-realm realm-name="${exp.realm.name:Test Realm}" pre-realm-principal-transformer="PreRealmNameRewriter_II"
+                <mechanism mechanism-name="PLAIN" pre-realm-principal-transformer="PreRealmNameRewriter" post-realm-principal-transformer="PostRealmNameRewriter"
+                           final-principal-transformer="FinalNameRewriter" realm-mapper="RegexMapper">
+                    <mechanism-realm realm-name="Test Realm" pre-realm-principal-transformer="PreRealmNameRewriter_II"
                                      post-realm-principal-transformer="PostRealmNameRewriter_II" final-principal-transformer="FinalNameRewriter_II"
                                      realm-mapper="RegexMapper_II"/>
                 </mechanism>
@@ -351,10 +288,10 @@
                 <credential-reference clear-text="password"/>
                 <implementation type="PKCS#11" provider-name="SunPKCS#11"/>
             </key-store>
-            <key-store name="jks_store" alias-filter="${exp.alias.filter:one,two,three}">
+            <key-store name="jks_store" alias-filter="one,two,three">
                 <credential-reference clear-text="password"/>
-                <implementation type="${exp.type:jks}" provider-name="${exp.provider:SunJSSE}"/>
-                <file relative-to="jboss.server.config.dir" path="keystore.jks" required="${exp.required:true}"/>
+                <implementation type="jks"/>
+                <file relative-to="jboss.server.config.dir" path="keystore.jks" required="true"/>
             </key-store>
             <key-store name="jceks_store">
                 <credential-reference clear-text="password"/>
@@ -375,23 +312,13 @@
                 <implementation type="PKCS12"/>
                 <file path="test.keystore" relative-to="jboss.server.config.dir"/>
             </key-store>
-            <ldap-key-store name="LdapKeyStore" dir-context="DirContextSsl" >
-                <new-item-template new-item-path="${exp.path:ou=keystore,dc=elytron,dc=wildfly,dc=org}" new-item-rdn="${exp.item:cn}">
-                    <attribute name="${exp.name:objectClass}" value="${exp.value:top} ${exp.value2:inetOrgPerson}"/>
-                    <attribute name="sn" value="NewKeyStoreItem"/>
-                </new-item-template>
-                <search path="${exp.path:dc=elytron,dc=wildfly,dc=org}" recursive="${exp.recursive:true}" time-limit="${exp.time:1000}" filter-alias="${exp.filter:(&amp;(objectClass=inetOrgPerson)(sn={0}))}"
-                        filter-certificate="${exp.filter:(&amp;(objectClass=inetOrgPerson)(usercertificate={0}))}" filter-iterate="${exp.iterate:(sn=serenity*)}"/>
-                <attribute-mapping alias-attribute="${exp.alias:sn}" certificate-attribute="${exp.certificate:usercertificate}" certificate-chain-attribute="${exp.chain:userSMIMECertificate}" certificate-chain-encoding="${exp.encoding:PKCS7}" certificate-type="${exp.type:X.509}" key-attribute="${exp.key:userPKCS12}"
-                                   key-type="${exp.type:PKCS12}"/>
-            </ldap-key-store>
-            <filtering-key-store name="FilteringKeyStore" key-store="Custom_PKCS_11" alias-filter="${exp.alias.filter:NONE:+firefly}"/>
+            <filtering-key-store name="FilteringKeyStore" key-store="Custom_PKCS_11" alias-filter="NONE:+firefly"/>
         </key-stores>
         <key-managers>
             <key-manager name="serverKey" algorithm="SunX509" key-store="jks_store">
                 <credential-reference clear-text="password"/>
             </key-manager>
-            <key-manager name="serverKey2" algorithm="${exp.algo:SunX509}" key-store="jks_store" providers="custom-loader" provider-name="first" alias-filter="${exp.alias:one,two,three}" generate-self-signed-certificate-host="${exp.generate:localhost}">
+            <key-manager name="serverKey2" algorithm="SunX509" key-store="jks_store" providers="custom-loader" provider-name="first">
                 <credential-reference store="credstore1" alias="password-alias" type="PasswordCredential"/>
             </key-manager>
             <key-manager name="clientKey" algorithm="SunX509" key-store="jks_store">
@@ -405,20 +332,20 @@
             <trust-manager name="serverTrust" algorithm="SunX509" key-store="jks_store"/>
             <trust-manager name="serverTrust2" algorithm="SunX509" key-store="jks_store" providers="custom-loader" provider-name="first"/>
             <trust-manager name="trust-with-crl" algorithm="SunX509" key-store="jks_store">
-                <certificate-revocation-list path="${exp.path:crl.pem}" relative-to="jboss.server.config.dir" maximum-cert-path="${exp.max:2}"/>
+                <certificate-revocation-list path="crl.pem" relative-to="jboss.server.config.dir" maximum-cert-path="2"/>
             </trust-manager>
             <trust-manager name="trust-with-crl-dp" algorithm="SunX509" key-store="jks_store">
                 <certificate-revocation-list/>
             </trust-manager>
-            <trust-manager name="trust-with-ocsp" algorithm="${exp.algorithm:PKIX}" key-store="jks_store">
-                <ocsp responder="${exp.responder:http://localhost/ocsp}" responder-keystore="${exp.responder.keystore:jceks_store}" responder-certificate="${exp.responder.certificate:responder-alias}"/>
+            <trust-manager name="trust-with-ocsp" algorithm="PKIX" key-store="jks_store">
+                <ocsp responder="http://localhost/ocsp" responder-keystore="jceks_store" responder-certificate="responder-alias"/>
             </trust-manager>
         </trust-managers>
         <server-ssl-contexts>
-            <server-ssl-context name="server" protocols="${exp.protocols:TLSv1.2}" want-client-auth="${exp.client.auth:true}" need-client-auth="${exp.need.client:true}" authentication-optional="${exp.authentication:true}"
-                                use-cipher-suites-order="${exp.cipher.suites:false}" maximum-session-cache-size="${exp.cache:10}" cipher-suite-filter="${exp.filter:DEFAULT}" cipher-suite-names="${exp.names:name}"
-                                session-timeout="${exp.session:120}" wrap="${exp.wrap:false}" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
-                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="${exp.provider.name:first}"/>
+            <server-ssl-context name="server" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true"
+                                use-cipher-suites-order="false" maximum-session-cache-size="10"
+                                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
+                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
             <server-ssl-context name="server2" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true"
                                 use-cipher-suites-order="false" maximum-session-cache-size="10"
                                 session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
@@ -429,11 +356,11 @@
                                 provider-name="first"/>
         </client-ssl-contexts>
         <certificate-authorities>
-            <certificate-authority name="testCA" url="${exp.url:https://www.test.com}" staging-url="${exp.staging.url:https://www.test.com}"/>
+            <certificate-authority name="testCA" url="https://www.test.com"/>
         </certificate-authorities>
         <certificate-authority-accounts>
-            <certificate-authority-account name="MyCA" certificate-authority="${exp.certificate.authority:LetsEncrypt}" contact-urls="${exp.contact.urls:https://www.test.com}">
-                <account-key key-store="accounts.keystore" alias="${exp.alias:server}">
+            <certificate-authority-account name="MyCA" certificate-authority="LetsEncrypt">
+                <account-key key-store="accounts.keystore" alias="server">
                     <credential-reference clear-text="elytron"/>
                 </account-key>
             </certificate-authority-account>
@@ -449,12 +376,9 @@
                 <sni-mapping host=".*\.server" ssl-context="server2" />
             </server-ssl-sni-context>
         </server-ssl-sni-contexts>
-        <dynamic-client-ssl-contexts>
-            <dynamic-client-ssl-context name="dynamicClient" authentication-context="${exp.auth.context:myAC}"/>
-        </dynamic-client-ssl-contexts>
     </tls>
     <credential-stores>
-        <credential-store name="test1" relative-to="jboss.server.data.dir" location="${exp.location:test1.store}" create="true" type="${exp.type:JCEKS}" provider-name="${exp.provider:provider}">
+        <credential-store name="test1" relative-to="jboss.server.data.dir" location="test1.store" create="true">
             <implementation-properties>
                 <property name="keyStoreType" value="JCEKS"/>
                 <property name="keyAlias" value="adminKey"/>
@@ -464,31 +388,21 @@
         <credential-store name="test2" relative-to="jboss.server.data.dir" modifiable="true">
             <credential-reference store="test1" alias="to_open_test2"/>
         </credential-store>
-        <credential-store name="test4" relative-to="jboss.server.data.dir" path="${exp.path:test1.store}" create="true">
+        <credential-store name="test4" relative-to="jboss.server.data.dir" path="test1.store" create="true">
             <credential-reference clear-text="secret2"/>
         </credential-store>
-        <secret-key-credential-store name="secretkeycredstore" relative-to="jboss.server.data.dir" path="mysecretkeycredstore.cs" create="${exp.create:true}" populate="${exp.populate:true}" />
-        <secret-key-credential-store name="test3" relative-to="jboss.server.data.dir" path="test3.cs"
-                                     create="${exp.create:false}" populate="${exp.populate:false}"
-                                     key-size="${exp.key:192}" default-alias="${exp.alias:test3}" />
+        <secret-key-credential-store name="test3" relative-to="jboss.server.data.dir" path="test3.cs" create="false" populate="false" key-size="192" default-alias="test3" />
     </credential-stores>
     <expression-resolver default-resolver="A" prefix="G">
         <resolver name="A" credential-store="test1" secret-key="C"/>
         <resolver name="D" credential-store="test2" secret-key="F"/>
     </expression-resolver>
-    <dir-contexts>
-        <dir-context name="DirContextSsl" authentication-context="ldapAuthContext" referral-mode="throw" url="ldaps://localhost:11391/" connection-timeout="6000" read-timeout="10000">
-            <properties>
-                <property name="java.naming.dns.url" value="dns://dnsserver/wiz.com"/>
-            </properties>
-        </dir-context>
-    </dir-contexts>
     <jaspi>
-        <jaspi-configuration name="test" layer="${exp.layer:HttpServlet}" application-context="${exp.app.context:default /test}" description="${exp.description:Test Definition}">
+        <jaspi-configuration name="test" layer="HttpServlet" application-context="default /test" description="Test Definition">
             <server-auth-modules>
-                <server-auth-module class-name="org.wildfly.Test" module="org.test" flag="${exp.flag:REQUISITE}">
+                <server-auth-module class-name="org.wildfly.Test" module="org.test" flag="REQUISITE">
                     <options>
-                        <property name="a" value="${exp.b:b}"/>
+                        <property name="a" value="b"/>
                         <property name="c" value="d"/>
                     </options>
                 </server-auth-module>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <security-domains>
         <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree" evidence-decoder="aggregateEvidenceDecoder" role-decoder="ipRoleDecoder1">
             <realm name="PropRealm"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <mappers>
         <custom-permission-mapper name="CustomPermissionMapper" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />
         <custom-permission-mapper name="CustomPermissionMapper2" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/providers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/providers.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0" disallowed-providers="a b c">
+<subsystem xmlns="urn:wildfly:elytron:20.0" disallowed-providers="a b c">
     <providers>
         <aggregate-providers name="AggregateProviders">
             <providers name="ModelConfigured" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of RealmsTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:20.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/role-mappers-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/role-mappers-test.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of RealmsTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:20.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/sasl-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/sasl-test.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of TlsTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:20.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/sasl.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/sasl.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <providers>
          <provider-loader name="TestProviderLoader" module="test.module" />
      </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/security-properties.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/security-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <security-properties>
         <security-property name="a" value="b" />
         <security-property name="c" value="d" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
     <security-realms>
         <aggregate-realm name="AggregateOne" authentication-realm="RealmThree" authorization-realm="RealmFour" />
         <aggregate-realm name="AggregateTwo" authentication-realm="RealmThree" authorization-realms="AggregateOne RealmFour" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/syslog-audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/syslog-audit-logging.xml
@@ -3,5 +3,5 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0">
+<subsystem xmlns="urn:wildfly:elytron:20.0">
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" default-ssl-context="ClientSslContextNoAuth">
+<subsystem xmlns="urn:wildfly:elytron:20.0" default-ssl-context="ClientSslContextNoAuth">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="com.ibm.crypto.provider.IBMJCE com.ibm.jsse.IBMJSSEProvider com.ibm.jsse2.IBMJSSEProvider2 com.ibm.security.jgss.IBMJGSSProvider com.ibm.security.cert.IBMCertPath com.ibm.security.cmskeystore.CMSProvider com.ibm.security.jgss.mech.spnego.IBMSPNEGO" />
         <provider-loader name="openssl" module="org.wildfly.openssl"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-oracle13plus.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-oracle13plus.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" default-ssl-context="ClientSslContextNoAuth">
+<subsystem xmlns="urn:wildfly:elytron:20.0" default-ssl-context="ClientSslContextNoAuth">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="sun.security.ssl.SunJSSE"/>
         <provider-loader name="openssl" module="org.wildfly.openssl"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -4,7 +4,7 @@
   -->
 
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:19.0" default-ssl-context="ClientSslContextNoAuth">
+<subsystem xmlns="urn:wildfly:elytron:20.0" default-ssl-context="ClientSslContextNoAuth">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="com.sun.net.ssl.internal.ssl.Provider" />
         <provider-loader name="openssl" module="org.wildfly.openssl"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:elytron:19.0" default-ssl-context="client">
+<subsystem xmlns="urn:wildfly:elytron:20.0" default-ssl-context="client">
     <providers>
         <provider-loader name="custom-loader" />
     </providers>


### PR DESCRIPTION
issue: https://redhat.atlassian.net/browse/WFCORE-7347

The performRuntime wiring to JwtValidator.Builder.publicKeyUrl() is left as a TODO comment in TokenRealmDefinition. This will be fixed once the companion library change [ELY-3066](https://github.com/wildfly-security/wildfly-elytron/pull/2493) ships in a new wildfly-elytron release.
