### PR TITLE
WFCORE-7683 Fixup - Deprecate setStartupTimeoutInSeconds and replace …

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultInterfaceOverridingDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultInterfaceOverridingDomainTestCase.java
@@ -97,7 +97,7 @@ public class DefaultInterfaceOverridingDomainTestCase {
         hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
         hostConfig.setHostName("secondary");
         hostConfig.setHostControllerManagementPort(9999);
-        hostConfig.setStartupTimeoutInSeconds((int) TimeoutUtil.adjust(Duration.ofSeconds(120)).toSeconds());
+        hostConfig.setStartupTimeout(TimeoutUtil.adjust(Duration.ofSeconds(120)));
         hostConfig.setBackupDC(true);
         File usersFile = new File(hostConfigDir, "mgmt-users.properties");
         Files.write(usersFile.toPath(),

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainControllerMigrationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainControllerMigrationTestCase.java
@@ -120,7 +120,7 @@ public class DomainControllerMigrationTestCase {
         hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
         hostConfig.setHostName("failover-h" + String.valueOf(host));
         hostConfig.setHostControllerManagementPort(MGMT_PORTS[host - 1]);
-        hostConfig.setStartupTimeoutInSeconds((int) TimeoutUtil.adjust(Duration.ofSeconds(120)).toSeconds());
+        hostConfig.setStartupTimeout(TimeoutUtil.adjust(Duration.ofSeconds(120)));
         hostConfig.setBackupDC(true);
         File usersFile = new File(hostConfigDir, "mgmt-users.properties");
         Files.write(usersFile.toPath(),

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SecondarySynchronizationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SecondarySynchronizationTestCase.java
@@ -134,7 +134,7 @@ public class SecondarySynchronizationTestCase {
         hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
         hostConfig.setHostName(HOSTS[host]);
         hostConfig.setHostControllerManagementPort(MGMT_PORTS[host]);
-        hostConfig.setStartupTimeoutInSeconds((int) TimeoutUtil.adjust(Duration.ofSeconds(120)).toSeconds());
+        hostConfig.setStartupTimeout(TimeoutUtil.adjust(Duration.ofSeconds(120)));
         hostConfig.setBackupDC(true);
         File usersFile = new File(hostConfigDir, "mgmt-users.properties");
         Files.write(usersFile.toPath(),

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SimpleDomainControllerMigrationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SimpleDomainControllerMigrationTestCase.java
@@ -117,7 +117,7 @@ public class SimpleDomainControllerMigrationTestCase {
         hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
         hostConfig.setHostName("failover-h" + String.valueOf(host));
         hostConfig.setHostControllerManagementPort(MGMT_PORTS[host - 1]);
-        hostConfig.setStartupTimeoutInSeconds((int) TimeoutUtil.adjust(Duration.ofSeconds(120)).toSeconds());
+        hostConfig.setStartupTimeout(TimeoutUtil.adjust(Duration.ofSeconds(120)));
         hostConfig.setBackupDC(true);
         File usersFile = new File(hostConfigDir, "mgmt-users.properties");
         Files.write(usersFile.toPath(),

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
@@ -458,7 +458,7 @@ public class DomainLifecycleUtil implements AutoCloseable {
         op.get(RESTART_SERVERS).set(parameters.restartServers);
         long startupTimeout;
         if (parameters.timeout == null) {
-            startupTimeout = configuration.getStartupTimeoutInSeconds();
+            startupTimeout = configuration.getStartupTimeout().toSeconds();
         } else {
             startupTimeout = parameters.timeout;
         }
@@ -543,7 +543,7 @@ public class DomainLifecycleUtil implements AutoCloseable {
          * Sets the timeout
          *
          * @param timeout maximum time to wait for the Host Controller and Servers reload to complete, in milliseconds,
-         *                if {@code null} {@link WildFlyManagedConfiguration.startupTimeoutInSeconds} will be used
+         *                if {@code null} {@link WildFlyManagedConfiguration#getStartupTimeout()} will be used
          * @return this ReloadParameters object
          */
         public ReloadParameters setTimeout(Long timeout) {
@@ -748,7 +748,7 @@ public class DomainLifecycleUtil implements AutoCloseable {
 
     /**
      * Poll until {@link #areServersStarted()} returns {@code true} or the
-     * {@link WildFlyManagedConfiguration#getStartupTimeoutInSeconds() configured timeout} is reached.
+     * {@link WildFlyManagedConfiguration#getStartupTimeout() configured timeout} is reached.
      *
      * @param start time in milliseconds that should be used as the starting time for the timeout check.
      *
@@ -756,7 +756,7 @@ public class DomainLifecycleUtil implements AutoCloseable {
      * @throws TimeoutException if no call {@link #areServersStarted()} returns {@code true} before the timeout
      */
     public void awaitServers(long start) throws InterruptedException, TimeoutException {
-        awaitServers(start, configuration.getStartupTimeoutInSeconds());
+        awaitServers(start, configuration.getStartupTimeout().toSeconds());
     }
 
     public void awaitServers(long start, long timeout) throws InterruptedException, TimeoutException {
@@ -778,7 +778,7 @@ public class DomainLifecycleUtil implements AutoCloseable {
 
     /**
      * Poll until {@link #isHostControllerStarted()} returns {@code true} or the
-     * {@link WildFlyManagedConfiguration#getStartupTimeoutInSeconds() configured timeout} is reached.
+     * {@link WildFlyManagedConfiguration#getStartupTimeout() configured timeout} is reached.
      *
      * @param start time in milliseconds that should be used as the starting time for the timeout check.
      *
@@ -795,7 +795,7 @@ public class DomainLifecycleUtil implements AutoCloseable {
 
     /**
      * Poll until {@link #isHostControllerInState(ControlledProcessState.State)} returns {@code true} or the
-     * {@link WildFlyManagedConfiguration#getStartupTimeoutInSeconds() configured timeout} is reached.
+     * {@link WildFlyManagedConfiguration#getStartupTimeout() configured timeout} is reached.
      *
      * @param start time in milliseconds that should be used as the starting time for the timeout check.
      * @param state The {@link ControlledProcessState.State} to compare.
@@ -804,8 +804,9 @@ public class DomainLifecycleUtil implements AutoCloseable {
      * @throws TimeoutException      if no call {@link #isHostControllerStarted()} returns {@code true} before the timeout
      */
     public void awaitHostController(long start, ControlledProcessState.State state) throws InterruptedException, TimeoutException {
-        awaitHostController(start, configuration.getStartupTimeoutInSeconds(), state);
+        awaitHostController(start, configuration.getStartupTimeout().toSeconds(), state);
     }
+
     public void awaitHostController(long start, long timeout, ControlledProcessState.State state) throws InterruptedException, TimeoutException {
         checkClosed();
         boolean hcAvailable = false;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/WildFlyManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/WildFlyManagedConfiguration.java
@@ -58,7 +58,7 @@ public class WildFlyManagedConfiguration {
 
     private String javaVmArguments = System.getProperty("server.jvm.args", "-Xmx512m");
 
-    private int startupTimeoutInSeconds = (int) TimeoutUtil.adjust(Duration.ofMinutes(2)).toSeconds();
+    private Duration startupTimeout = TimeoutUtil.adjust(Duration.ofMinutes(2));
 
     private boolean outputToConsole = true;
 
@@ -181,18 +181,35 @@ public class WildFlyManagedConfiguration {
     }
 
     /**
-     * @param startupTimeoutInSeconds the startupTimeoutInSeconds to set
+     * @param startupTimeout the maximum time to wait for startup
      */
-    public WildFlyManagedConfiguration setStartupTimeoutInSeconds(int startupTimeoutInSeconds) {
-        this.startupTimeoutInSeconds = startupTimeoutInSeconds;
+    public WildFlyManagedConfiguration setStartupTimeout(Duration startupTimeout) {
+        this.startupTimeout = startupTimeout;
         return this;
     }
 
     /**
-     * @return the startupTimeoutInSeconds
+     * @return the maximum time to wait for startup
      */
+    public Duration getStartupTimeout() {
+        return startupTimeout;
+    }
+
+    /**
+     * @deprecated Use {@link #setStartupTimeout(Duration)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public WildFlyManagedConfiguration setStartupTimeoutInSeconds(int startupTimeoutInSeconds) {
+        this.startupTimeout = Duration.ofSeconds(startupTimeoutInSeconds);
+        return this;
+    }
+
+    /**
+     * @deprecated Use {@link #getStartupTimeout()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public int getStartupTimeoutInSeconds() {
-        return startupTimeoutInSeconds;
+        return (int) startupTimeout.toSeconds();
     }
 
     /**


### PR DESCRIPTION
…with Duration-based API; i.e. setStartupTimeout(Duration)

https://redhat.atlassian.net/browse/WFCORE-7683

Certainly, this can cleanup the messy DomainLifecycleUtil, but that's for another day.